### PR TITLE
Add bottom bar with modifier keys, compose buffer, and iOS keyboard support

### DIFF
--- a/docs/memory/run-kit/architecture.md
+++ b/docs/memory/run-kit/architecture.md
@@ -60,17 +60,23 @@ Signal trapping: SIGINT/SIGTERM → `stop_services` → clean exit.
 
 ## Chrome Architecture
 
-The root layout (`src/app/layout.tsx`) owns a fixed `h-screen flex-col` skeleton with three zones:
+The root layout (`src/app/layout.tsx`) owns a flex-col skeleton (height: `var(--app-height, 100vh)`) with three zones:
 
 1. **Top chrome** (`shrink-0`) — `TopBarChrome` component, always-rendered two-line top bar
 2. **Content** (`flex-1 overflow-y-auto min-h-0`) — page content, scrollable
-3. **Bottom slot** (`shrink-0`) — `BottomSlot` component for future bottom bar injection
+3. **Bottom slot** (`shrink-0`) — `BottomSlot` component, renders bottom bar on terminal page via ChromeProvider
 
 All three zones use `max-w-4xl mx-auto w-full px-6` for identical width/padding — pages cannot override this.
 
 **ChromeProvider** (`src/contexts/chrome-context.tsx`) — React Context for slot injection. Pages set breadcrumbs, line2Left, line2Right, bottomBar, and isConnected via `useChrome()` setters in `useEffect`, with cleanup on unmount. Context value is memoized to prevent unnecessary re-renders.
 
 **TopBarChrome** (`src/components/top-bar-chrome.tsx`) — reads from ChromeProvider. Line 1: icon breadcrumbs + connection indicator + ⌘K badge. Line 2: always rendered with `min-h-[36px]`, even when slots are empty (prevents layout shift).
+
+**BottomBar** (`src/components/bottom-bar.tsx`) — injected by `TerminalClient` via `setBottomBar()`. Single row of `<kbd>` buttons: modifier toggles (Ctrl/Alt/Cmd with sticky armed state), arrow keys, Fn dropdown (F1-F12, PgUp/PgDn, Home/End), Esc, Tab, and compose toggle. All buttons 44px min-height for mobile touch targets. Sends ANSI escape sequences through the WebSocket ref. Modifier state managed by `useModifierState` hook.
+
+**ComposeBuffer** (`src/components/compose-buffer.tsx`) — native `<textarea>` overlay triggered by the compose button. Supports iOS dictation, autocorrect, paste, multiline. Send button (or Cmd/Ctrl+Enter) transmits entire text as a single WebSocket message. Terminal dims (`opacity-50`) while compose is open. Escape dismisses without sending.
+
+**iOS Keyboard Support** — `useVisualViewport` hook (`src/hooks/use-visual-viewport.ts`) sets `--app-height` CSS custom property from `window.visualViewport.height`. The layout flex container uses `var(--app-height, 100vh)`, constraining the app to the visible viewport when the iOS keyboard is open. The bottom bar stays pinned above the keyboard; the terminal shrinks via `flex-1` and xterm refits via `ResizeObserver`.
 
 Pages do NOT render their own top bar or outer containers — they set chrome slots and render only their content area.
 
@@ -83,6 +89,9 @@ Pages do NOT render their own top bar or outer containers — they set chrome sl
 - **Config resolution: CLI > YAML > defaults** — `src/lib/config.ts` reads `run-kit.yaml` (optional, gitignored) and CLI args. Relay port delivered to client via server component prop (runtime, not build-time)
 - **Byobu session-group filtering** — `listSessions()` filters out derived session-group copies to avoid duplicate projects. See `docs/memory/run-kit/tmux-sessions.md`
 - **Layout-owned chrome (not per-page TopBar)** — React Context for slot injection. Pages inject content via `useEffect` setters; layout renders it in fixed positions. Prevents layout shift and ensures consistent width/padding across all pages. Old `TopBar` component deleted.
+- **Sticky modifier state via useRef + forceUpdate** — `useModifierState` uses a ref for the authoritative state and a counter state to trigger re-renders. Ensures `consume()` reads the latest value atomically without stale closure issues.
+- **Compose buffer as native textarea (not xterm input)** — xterm renders to `<canvas>`, blocking OS-level input features. The compose buffer provides a real `<textarea>` where dictation, autocorrect, paste, and IME all work. Text sent as a single WebSocket message.
+- **`i` key intercepted in capture phase** — Must prevent xterm from receiving the keystroke. Capture phase handler fires before xterm's internal textarea, allowing `stopPropagation()` to block it.
 
 ## Testing
 
@@ -115,3 +124,4 @@ Current coverage: `validate.ts` (input validation + tilde expansion), `config.ts
 | 2026-03-05 | Added feature tests for tmux.ts, use-keyboard-nav.ts, and api/sessions POST handler | `260305-vq7h-feature-tests-tmux-keyboard-api` |
 | 2026-03-05 | Added `/api/directories` endpoint, `createSession` CWD support, `expandTilde` security boundary | `260305-zkem-session-folder-picker` |
 | 2026-03-06 | Chrome architecture — layout-owned flex-col skeleton, ChromeProvider context, TopBarChrome, icon breadcrumbs, always-visible kill buttons | `260305-emla-fixed-chrome-architecture` |
+| 2026-03-06 | Bottom bar (modifier toggles, arrow keys, Fn dropdown, Esc/Tab, compose buffer), iOS keyboard support via visualViewport, `i` key compose toggle | `260305-fjh1-bottom-bar-compose-buffer` |

--- a/docs/memory/run-kit/ui-patterns.md
+++ b/docs/memory/run-kit/ui-patterns.md
@@ -45,6 +45,33 @@ Line 2 renders even when empty — prevents layout shift during navigation and b
 - **Window card ✕**: Every `SessionCard` has an always-visible ✕ button (no hover-reveal — accessible on touch devices). Click opens confirmation dialog. Click uses `stopPropagation` to prevent card navigation.
 - **Session group ✕** (dashboard only): Always-visible button on session group headers with red hover. Click opens confirmation dialog: "Kill session **{name}** and all {N} windows?"
 
+## Bottom Bar (Terminal Page Only)
+
+Single row of `<kbd>` styled buttons, injected by `TerminalClient` via `setBottomBar()` from ChromeProvider. Layout: `Ctrl Alt Cmd | <- -> up down | Fn Esc Tab compose`.
+
+**Modifier toggles** (Ctrl, Alt, Cmd): Sticky armed state with visual indicator (`accent` bg). Click to arm, auto-clears after next key is sent. Click again while armed to disarm. Multiple modifiers can be armed simultaneously.
+
+**Arrow keys**: Send ANSI escape sequences (`[A/B/C/D`). With modifiers, use xterm parameter encoding (`[1;{mod}X`). Modifier parameter: 1 + (alt?2:0) + (ctrl?4:0) + (cmd?8:0).
+
+**Function key dropdown** (Fn): Opens a grid dropdown above the button. Contains F1-F12, PgUp, PgDn, Home, End. Closes after each selection, on outside click, or on Escape.
+
+**Special keys** (Esc, Tab): Direct send. Ctrl is not consumed for Esc/Tab (Esc IS Ctrl+[, Tab IS Ctrl+I in terminal semantics) — Ctrl stays armed for the next key. Alt/Cmd prefix with ESC (Meta convention).
+
+**All buttons**: 44px minimum height (Apple HIG touch target). `<kbd>` element styling consistent with the existing `Cmd+K` badge.
+
+### Compose Buffer
+
+Native `<textarea>` overlay triggered by the compose button. Appears above the bottom bar inside the content area. Terminal dims (`opacity-50`) while compose is open.
+
+- **Open**: Tap compose button, or press `i` on desktop (intercepted in capture phase before xterm)
+- **Send**: Click Send button or press Cmd/Ctrl+Enter — entire text transmitted as one WebSocket message
+- **Dismiss**: Press Escape — closes without sending, text discarded
+- **Why**: xterm is a `<canvas>`, not a native text input. iOS dictation, autocorrect, paste, IME all require a real DOM element. Also useful on desktop for pasting large text blocks over a laggy WebSocket.
+
+### iOS Keyboard Support
+
+`useVisualViewport` hook sets `--app-height` CSS custom property from `window.visualViewport.height`. Layout flex container uses `var(--app-height, 100vh)`. When the iOS keyboard appears, the bottom bar stays pinned above it, the terminal shrinks, and xterm refits via the existing `ResizeObserver`.
+
 ## Keyboard Shortcuts
 
 ### Global
@@ -54,6 +81,7 @@ Line 2 renders even when empty — prevents layout shift during navigation and b
 | `j` / `k` | Navigate cards down/up | Dashboard, Project view |
 | `Enter` | Drill into focused item | Dashboard, Project view |
 | `Esc Esc` | Navigate back | Terminal view (300ms window) |
+| `i` | Open compose buffer | Terminal view (capture phase, prevents xterm from receiving) |
 
 ### Dashboard
 | Key | Action |
@@ -122,3 +150,4 @@ Windows are `"active"` (last tmux activity within 10 seconds) or `"idle"`. No "e
 | 2026-03-03 | Unified top bar — shared breadcrumb + action bar, inline kill controls, command palette on terminal, always-visible search | `260303-vag8-unified-top-bar` |
 | 2026-03-05 | Create Session dialog with folder picker — quick picks, server-side autocomplete, name auto-derivation | `260305-zkem-session-folder-picker` |
 | 2026-03-06 | Chrome architecture — layout-owned skeleton, ChromeProvider context, TopBarChrome, icon breadcrumbs, always-visible kill buttons | `260305-emla-fixed-chrome-architecture` |
+| 2026-03-06 | Bottom bar with modifier toggles, arrow keys, Fn dropdown, compose buffer, iOS keyboard support | `260305-fjh1-bottom-bar-compose-buffer` |

--- a/fab/changes/260305-fjh1-bottom-bar-compose-buffer/.history.jsonl
+++ b/fab/changes/260305-fjh1-bottom-bar-compose-buffer/.history.jsonl
@@ -1,3 +1,17 @@
 {"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-03-05T22:43:01+05:30"}
 {"args":"2/3 Bottom Bar + Compose Buffer — modifier keys, arrow keys, Fn dropdown, sticky states, compose textarea overlay, visualViewport iOS keyboard detection","cmd":"fab-new","event":"command","ts":"2026-03-05T22:43:01+05:30"}
 {"delta":"+4.1","event":"confidence","score":4.1,"trigger":"calc-score","ts":"2026-03-05T22:44:01+05:30"}
+{"cmd":"fab-switch","event":"command","ts":"2026-03-06T03:32:29+05:30"}
+{"action":"enter","driver":"fab-continue","event":"stage-transition","stage":"spec","ts":"2026-03-06T03:33:51+05:30"}
+{"cmd":"fab-continue","event":"command","ts":"2026-03-06T03:33:52+05:30"}
+{"delta":"+0.0","event":"confidence","score":4.1,"trigger":"calc-score","ts":"2026-03-06T03:36:04+05:30"}
+{"cmd":"fab-ff","event":"command","ts":"2026-03-06T03:37:29+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"tasks","ts":"2026-03-06T03:37:37+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"apply","ts":"2026-03-06T03:38:52+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"review","ts":"2026-03-06T03:47:06+05:30"}
+{"event":"review","result":"failed","ts":"2026-03-06T03:50:45+05:30"}
+{"action":"re-entry","driver":"fab-ff","event":"stage-transition","stage":"apply","ts":"2026-03-06T03:50:45+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"review","ts":"2026-03-06T03:52:10+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"hydrate","ts":"2026-03-06T03:53:59+05:30"}
+{"event":"review","result":"passed","ts":"2026-03-06T03:53:59+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"ship","ts":"2026-03-06T03:56:08+05:30"}

--- a/fab/changes/260305-fjh1-bottom-bar-compose-buffer/.status.yaml
+++ b/fab/changes/260305-fjh1-bottom-bar-compose-buffer/.status.yaml
@@ -4,33 +4,40 @@ created_by: sahil-weaver
 change_type: feat
 issues: []
 progress:
-    intake: ready
-    spec: pending
-    tasks: pending
-    apply: pending
-    review: pending
-    hydrate: pending
-    ship: pending
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
     review-pr: pending
 checklist:
-    generated: false
+    generated: true
     path: checklist.md
-    completed: 0
-    total: 0
+    completed: 26
+    total: 26
 confidence:
-    certain: 6
+    certain: 9
     confident: 3
     tentative: 0
     unresolved: 0
     score: 4.1
-    indicative: true
     fuzzy: true
     dimensions:
-        signal: 80.6
-        reversibility: 88.3
-        competence: 85.0
-        disambiguation: 87.2
+        signal: 84.1
+        reversibility: 89.5
+        competence: 88.2
+        disambiguation: 89.1
 stage_metrics:
-    intake: {started_at: "2026-03-05T22:43:01+05:30", driver: fab-new, iterations: 1}
+    intake: {started_at: "2026-03-05T22:43:01+05:30", driver: fab-new, iterations: 1, completed_at: "2026-03-06T03:33:51+05:30"}
+    spec: {started_at: "2026-03-06T03:33:51+05:30", driver: fab-continue, iterations: 1, completed_at: "2026-03-06T03:37:37+05:30"}
+    tasks: {started_at: "2026-03-06T03:37:37+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-06T03:38:52+05:30"}
+    apply: {started_at: "2026-03-06T03:50:45+05:30", driver: fab-ff, iterations: 2, completed_at: "2026-03-06T03:52:10+05:30"}
+    review: {started_at: "2026-03-06T03:52:10+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-06T03:53:59+05:30"}
+    hydrate: {started_at: "2026-03-06T03:53:59+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-06T03:56:08+05:30"}
+    ship: {started_at: "2026-03-06T03:56:08+05:30", driver: fab-ff, iterations: 1}
 prs: []
-last_updated: 2026-03-05T22:44:01+05:30
+last_updated: 2026-03-06T03:56:08+05:30
+agent:
+    idle_since: 1772748387

--- a/fab/changes/260305-fjh1-bottom-bar-compose-buffer/checklist.md
+++ b/fab/changes/260305-fjh1-bottom-bar-compose-buffer/checklist.md
@@ -1,0 +1,55 @@
+# Quality Checklist: Bottom Bar + Compose Buffer
+
+**Change**: 260305-fjh1-bottom-bar-compose-buffer
+**Generated**: 2026-03-06
+**Spec**: `spec.md`
+
+## Functional Completeness
+
+- [x] CHK-001 Bottom bar rendering: All button groups present (modifiers, arrows, Fn, Esc, Tab, compose) in correct order
+- [x] CHK-002 Modifier toggles: Ctrl/Alt/Cmd arm on tap, show visual armed state, auto-clear after key send
+- [x] CHK-003 Arrow keys: Each sends correct ANSI sequence, respects armed modifiers with xterm parameter encoding
+- [x] CHK-004 Function key dropdown: Opens on Fn tap, contains F1-F12/PgUp/PgDn/Home/End, closes after selection
+- [x] CHK-005 Special keys: Esc sends `\x1b`, Tab sends `\t`, both respect armed modifiers — Ctrl re-armed after Esc/Tab since terminal semantics treat them as already-Ctrl characters
+- [x] CHK-006 Compose buffer: Opens on compose tap, textarea with autoFocus, Send transmits as single WebSocket message
+- [x] CHK-007 Visual viewport: Hook constrains height when iOS keyboard appears, no-op on desktop
+- [x] CHK-008 Terminal integration: setBottomBar called on mount, cleared on unmount
+
+## Behavioral Correctness
+
+- [x] CHK-009 Modifier consume atomicity: `consume()` returns all armed modifiers and clears them in one call
+- [x] CHK-010 Multiple modifiers: Arming Ctrl then Alt results in both being applied to next key
+- [x] CHK-011 Compose send: Text sent as raw string (not JSON), relay writes to pty in one call
+- [x] CHK-012 Compose dismiss: Escape closes compose without sending, text discarded
+
+## Scenario Coverage
+
+- [x] CHK-013 Bottom bar absent on Dashboard/Project pages: No bottom bar content when not on terminal page
+- [x] CHK-014 Desktop `i` key toggle: Opens compose when terminal focused, doesn't fire when compose already open or input focused
+- [x] CHK-015 Compose Cmd/Ctrl+Enter: Keyboard shortcut sends text and closes compose
+- [x] CHK-016 Fn dropdown dismiss: Clicking outside closes dropdown without sending keystrokes
+
+## Edge Cases & Error Handling
+
+- [x] CHK-017 WebSocket closed: Bottom bar buttons are no-op when `wsRef.current` is null or not OPEN
+- [x] CHK-018 `i` key vs double-Esc: No conflict — compose Escape consumed before double-Esc timer
+
+## Code Quality
+
+- [x] CHK-019 Pattern consistency: New code follows existing naming and structural patterns (hooks in `src/hooks/`, components in `src/components/`, Client Component directive)
+- [x] CHK-020 No unnecessary duplication: Existing utilities reused (ChromeProvider setBottomBar, existing wsRef pattern)
+- [x] CHK-021 **N/A**: No subprocess calls in this change — pure client-side code
+- [x] CHK-022 Server Components default: Bottom bar and compose buffer are Client Components only because they need interactivity — justified per code-quality principles
+- [x] CHK-023 No `useEffect` for data fetching: Data flows from props/context, not effect-based fetching
+- [x] CHK-024 Functions focused: No god functions >50 lines without clear reason
+- [x] CHK-025 No magic strings: ANSI sequences defined as named constants (`ARROWS`, `FN_KEYS`) and lookup objects
+
+## Security
+
+- [x] CHK-026 No shell injection: All WebSocket sends are raw strings to pty, no subprocess construction from user input
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] CHK-008 **N/A**: {reason}`

--- a/fab/changes/260305-fjh1-bottom-bar-compose-buffer/spec.md
+++ b/fab/changes/260305-fjh1-bottom-bar-compose-buffer/spec.md
@@ -1,0 +1,332 @@
+# Spec: Bottom Bar + Compose Buffer
+
+**Change**: 260305-fjh1-bottom-bar-compose-buffer
+**Created**: 2026-03-06
+**Affected memory**: `docs/memory/run-kit/architecture.md`, `docs/memory/run-kit/ui-patterns.md`
+
+## Non-Goals
+
+- Modifying the terminal relay (`src/terminal-relay/server.ts`) — it already handles burst text via `ptyProcess.write(message)`
+- Mobile Line 2 collapse (`...` button) — separate design concern per `docs/specs/design.md`
+- E2E / Playwright tests for mobile viewport — called out as a separate change in design spec
+
+## Bottom Bar
+
+### Requirement: Bottom Bar Rendering
+
+The bottom bar component (`src/components/bottom-bar.tsx`) SHALL render a single row of `<kbd>` styled buttons on the terminal page only. The bar SHALL be injected into the layout's bottom slot via `setBottomBar()` from `ChromeProvider`.
+
+The bar SHALL contain, in order: modifier toggles (`Ctrl`, `Alt`, `Cmd`), a visual separator, arrow keys (`←`, `→`, `↑`, `↓`), a visual separator, `Fn▾` dropdown, `Esc`, `Tab`, and `✎` (compose toggle).
+
+All buttons SHALL have a minimum height of 44px (Apple HIG touch target).
+
+The component SHALL be a Client Component (`"use client"`) that receives a WebSocket ref (`wsRef: React.RefObject<WebSocket | null>`) to send keystrokes directly.
+
+#### Scenario: Bottom bar appears on terminal page
+
+- **GIVEN** a user navigates to a terminal page (`/p/:project/:window`)
+- **WHEN** the `TerminalClient` component mounts
+- **THEN** `setBottomBar(<BottomBar ... />)` is called with the WebSocket ref
+- **AND** the bottom bar renders in the layout's bottom slot with all button groups visible
+
+#### Scenario: Bottom bar absent on non-terminal pages
+
+- **GIVEN** a user is on the Dashboard (`/`) or Project page (`/p/:project`)
+- **WHEN** the page renders
+- **THEN** the bottom slot is empty (no bottom bar content)
+
+#### Scenario: Bottom bar clears on navigation away
+
+- **GIVEN** the user is on a terminal page with the bottom bar visible
+- **WHEN** the user navigates to the Dashboard or Project page
+- **THEN** `setBottomBar(null)` is called during cleanup
+- **AND** the bottom slot becomes empty
+
+### Requirement: Modifier Toggles
+
+The modifier state SHALL be managed by a custom hook (`src/hooks/use-modifier-state.ts`) exposing `ctrl`, `alt`, `cmd` boolean flags plus `arm`, `disarm`, `toggle`, and `consume` functions.
+
+Clicking a modifier button SHALL toggle its armed state. An armed modifier SHALL display a visual "armed" indicator (accent background or bright border). Armed modifiers SHALL combine with the next key sent through the WebSocket.
+
+`consume()` SHALL return the current modifier state (`{ ctrl, alt, cmd }`) and clear all armed modifiers atomically. It SHALL be called by key-sending functions before transmitting each keystroke.
+
+#### Scenario: Arm and auto-clear a modifier
+
+- **GIVEN** no modifiers are armed
+- **WHEN** the user taps `Ctrl`
+- **THEN** the `Ctrl` button shows an armed visual state
+- **AND** when the user taps `↑` (arrow up)
+- **THEN** the ANSI sequence for Ctrl+Up is sent through the WebSocket
+- **AND** the `Ctrl` button returns to its default (disarmed) visual state
+
+#### Scenario: Disarm a modifier without sending a key
+
+- **GIVEN** `Alt` is armed
+- **WHEN** the user taps `Alt` again
+- **THEN** `Alt` is disarmed and returns to default visual state
+- **AND** no keystroke is sent
+
+#### Scenario: Multiple modifiers armed simultaneously
+
+- **GIVEN** no modifiers are armed
+- **WHEN** the user taps `Ctrl` then taps `Alt`
+- **THEN** both `Ctrl` and `Alt` show armed visual state
+- **AND** when the user sends any key, both modifiers are combined with that key
+- **AND** both modifiers clear after the key is sent
+
+### Requirement: Arrow Keys
+
+The arrow key buttons (`←`, `→`, `↑`, `↓`) SHALL each send the corresponding ANSI escape sequence through the WebSocket when tapped. Arrow keys SHALL respect armed modifiers — e.g., tapping `Ctrl` then `↑` sends the Ctrl+Up sequence.
+
+The ANSI sequences SHALL be:
+- `←`: `\x1b[D` (with modifiers: `\x1b[1;{mod}D`)
+- `→`: `\x1b[C` (with modifiers: `\x1b[1;{mod}C`)
+- `↑`: `\x1b[A` (with modifiers: `\x1b[1;{mod}A`)
+- `↓`: `\x1b[B` (with modifiers: `\x1b[1;{mod}B`)
+
+Where `{mod}` is the xterm modifier parameter: 2=Shift, 3=Alt, 4=Shift+Alt, 5=Ctrl, 6=Ctrl+Shift, 7=Ctrl+Alt, 8=Ctrl+Shift+Alt, 9=Cmd (mapped to Meta where applicable).
+
+#### Scenario: Arrow key sends plain sequence
+
+- **GIVEN** no modifiers are armed
+- **WHEN** the user taps `↑`
+- **THEN** `\x1b[A` is sent through the WebSocket
+
+#### Scenario: Arrow key with armed modifier
+
+- **GIVEN** `Ctrl` is armed
+- **WHEN** the user taps `↑`
+- **THEN** `\x1b[1;5A` is sent through the WebSocket (Ctrl+Up)
+- **AND** `Ctrl` is disarmed
+
+### Requirement: Function Key Dropdown
+
+A `Fn▾` button SHALL open a dropdown menu containing F1-F12, PgUp, PgDn, Home, and End. Each item SHALL send its corresponding ANSI escape sequence when selected. The dropdown SHALL close after each selection.
+
+The dropdown SHALL also close when clicking outside of it or pressing `Escape`.
+
+#### Scenario: Select a function key
+
+- **GIVEN** the `Fn▾` dropdown is closed
+- **WHEN** the user taps `Fn▾`
+- **THEN** the dropdown opens showing F1-F12, PgUp, PgDn, Home, End
+- **AND** when the user taps `F5`
+- **THEN** the F5 escape sequence (`\x1b[15~`) is sent through the WebSocket
+- **AND** the dropdown closes
+
+#### Scenario: Function key respects armed modifiers
+
+- **GIVEN** `Ctrl` is armed and the `Fn▾` dropdown is open
+- **WHEN** the user taps `F5`
+- **THEN** the Ctrl+F5 escape sequence (`\x1b[15;5~`) is sent
+- **AND** `Ctrl` is disarmed
+- **AND** the dropdown closes
+
+#### Scenario: Dismiss dropdown without selection
+
+- **GIVEN** the `Fn▾` dropdown is open
+- **WHEN** the user taps outside the dropdown
+- **THEN** the dropdown closes
+- **AND** no keystrokes are sent
+
+### Requirement: Special Keys
+
+`Esc` and `Tab` buttons SHALL send their respective characters directly through the WebSocket. `Esc` sends `\x1b`. `Tab` sends `\t`. Both SHALL respect armed modifiers.
+
+#### Scenario: Send Esc
+
+- **GIVEN** no modifiers are armed
+- **WHEN** the user taps `Esc`
+- **THEN** `\x1b` is sent through the WebSocket
+
+#### Scenario: Send Tab
+
+- **GIVEN** no modifiers are armed
+- **WHEN** the user taps `Tab`
+- **THEN** `\t` is sent through the WebSocket
+
+## Compose Buffer
+
+### Requirement: Compose Buffer Overlay
+
+The compose buffer component (`src/components/compose-buffer.tsx`) SHALL render a native `<textarea>` overlay triggered by the `✎` button on the bottom bar.
+
+When opened, the terminal SHALL dim (`opacity-50`) and the textarea SHALL slide up from the bottom bar. The textarea SHALL receive `autoFocus`. A `Send` button SHALL appear within the compose overlay.
+
+When the compose buffer is visible, the bottom bar SHALL remain visible below it.
+
+#### Scenario: Open compose buffer
+
+- **GIVEN** the user is on a terminal page with the bottom bar visible
+- **WHEN** the user taps the `✎` button
+- **THEN** a `<textarea>` overlay appears above the bottom bar
+- **AND** the terminal output dims to `opacity-50`
+- **AND** the textarea is auto-focused
+
+#### Scenario: Compose and send text
+
+- **GIVEN** the compose buffer is open
+- **WHEN** the user types "ls -la" and taps the `Send` button
+- **THEN** the string "ls -la" is sent as a single WebSocket message
+- **AND** the compose buffer closes
+- **AND** the terminal output restores to full opacity
+
+#### Scenario: Send via keyboard shortcut (desktop)
+
+- **GIVEN** the compose buffer is open on a desktop browser
+- **WHEN** the user types text and presses `Cmd+Enter` (or `Ctrl+Enter` on non-Mac)
+- **THEN** the text is sent as a single WebSocket message
+- **AND** the compose buffer closes
+
+#### Scenario: Dismiss compose without sending
+
+- **GIVEN** the compose buffer is open
+- **WHEN** the user presses `Escape`
+- **THEN** the compose buffer closes without sending
+- **AND** the terminal output restores to full opacity
+- **AND** any typed text is discarded
+
+### Requirement: Desktop Compose Toggle
+
+On desktop, pressing `i` when the terminal has focus (and the compose buffer is not already open) SHALL open the compose buffer. This provides a vim-like "insert mode" mental model.
+
+The `i` key SHALL NOT trigger when the compose buffer is already open (it is a regular character in the textarea). The `i` key SHALL NOT trigger when focus is in another input element (e.g., command palette search).
+
+#### Scenario: Toggle compose with `i` key
+
+- **GIVEN** the terminal page is active and the compose buffer is closed
+- **WHEN** the user presses `i` on their physical keyboard
+- **THEN** the compose buffer opens with the textarea focused
+- **AND** the `i` keypress is NOT sent to the terminal
+
+#### Scenario: `i` key inside compose textarea
+
+- **GIVEN** the compose buffer is open and the textarea is focused
+- **WHEN** the user presses `i`
+- **THEN** the character `i` is typed into the textarea (normal input behavior)
+- **AND** the compose buffer does NOT close
+
+### Requirement: Native Input Features
+
+The compose buffer textarea SHALL support all OS-level input features including:
+- iOS dictation (microphone button)
+- Autocorrect and predictive text
+- Clipboard paste (including large text blocks)
+- Multiline input
+- IME (Input Method Editor) for CJK languages
+
+These features work because the compose buffer is a real DOM `<textarea>` element, not a canvas.
+
+#### Scenario: Paste large text block
+
+- **GIVEN** the compose buffer is open
+- **WHEN** the user pastes a 500-line heredoc from the clipboard
+- **THEN** the text appears in the textarea
+- **AND** on `Send`, the entire 500 lines are transmitted as one WebSocket message
+- **AND** the relay writes it to the pty in a single `write()` call
+
+## iOS Keyboard Detection
+
+### Requirement: Visual Viewport Constraint
+
+A custom hook (`src/hooks/use-visual-viewport.ts`) SHALL use the `window.visualViewport` API to detect the iOS on-screen keyboard and constrain the app's height.
+
+When the visual viewport height changes (keyboard appears/disappears), the hook SHALL set the document's height to match `visualViewport.height`. This keeps the bottom bar pinned above the iOS keyboard.
+
+The terminal (`flex-1`) SHALL shrink as the keyboard takes space. xterm's `FitAddon` SHALL refit to the remaining height automatically (via the existing `ResizeObserver` in `terminal-client.tsx`).
+
+The hook SHALL be a no-op on desktop browsers where the visual viewport matches the layout viewport.
+
+#### Scenario: iOS keyboard appears
+
+- **GIVEN** the user is on a terminal page on an iOS device
+- **WHEN** the iOS on-screen keyboard opens (e.g., by tapping the compose textarea)
+- **THEN** the app's height is constrained to `visualViewport.height`
+- **AND** the bottom bar remains visible above the keyboard
+- **AND** the terminal shrinks to fit the reduced space
+- **AND** xterm refits its rows/columns to the smaller area
+
+#### Scenario: iOS keyboard dismisses
+
+- **GIVEN** the iOS keyboard is open and the app height is constrained
+- **WHEN** the keyboard dismisses
+- **THEN** the app height expands back to the full viewport height
+- **AND** the terminal and bottom bar resume their normal sizes
+
+#### Scenario: Desktop browser (no-op)
+
+- **GIVEN** the user is on a desktop browser
+- **WHEN** the hook is active
+- **THEN** no height constraints are applied (visual viewport matches layout viewport)
+
+## Terminal Page Integration
+
+### Requirement: Bottom Bar Injection
+
+The `TerminalClient` component (`src/app/p/[project]/[window]/terminal-client.tsx`) SHALL call `setBottomBar(<BottomBar wsRef={wsRef} />)` in a `useEffect` on mount. It SHALL call `setBottomBar(null)` on cleanup (unmount/navigation away).
+
+The `BottomBar` component SHALL receive the WebSocket ref from `TerminalClient` to send keystrokes and compose buffer text directly through the existing WebSocket connection.
+
+#### Scenario: Mount terminal with bottom bar
+
+- **GIVEN** the WebSocket connection to the relay is established
+- **WHEN** the `TerminalClient` mounts
+- **THEN** the bottom bar appears in the layout's bottom slot
+- **AND** bottom bar buttons can send keystrokes through the WebSocket
+
+#### Scenario: Navigate away clears bottom bar
+
+- **GIVEN** the user is on a terminal page with the bottom bar visible
+- **WHEN** the user navigates to `/p/:project` or `/`
+- **THEN** the bottom bar is removed from the layout's bottom slot
+
+### Requirement: Compose `i`-key Integration
+
+The `i` key handler for compose toggle SHALL be integrated into `TerminalClient`'s existing keyboard handling. It SHALL NOT conflict with the double-Esc detection or command palette keyboard shortcuts.
+
+The `i` key SHALL be intercepted at the document level (same as double-Esc) and SHALL prevent the keystroke from reaching xterm when opening compose.
+
+#### Scenario: `i` key does not conflict with double-Esc
+
+- **GIVEN** the terminal is active
+- **WHEN** the user presses `i` followed by `Esc` `Esc`
+- **THEN** the compose buffer opens on `i`
+- **AND** the compose buffer closes on the first `Esc` (dismissing compose)
+- **AND** the second `Esc` starts a new double-Esc timer (does not navigate back, since the first Esc was consumed by compose dismiss)
+
+## Design Decisions
+
+1. **No relay changes needed**: The existing relay writes any non-JSON WebSocket message to the pty via `ptyProcess.write(message)` (line 93 of `server.ts`). A compose buffer "Send" simply transmits the text as a plain string — the relay handles it naturally.
+   - *Why*: Avoids adding a new message type or protocol change.
+   - *Rejected*: Adding a `{ type: "compose", text: "..." }` JSON envelope — unnecessary complexity since raw text already works.
+
+2. **Modifier state as a hook, not a component**: Modifiers are reactive state consumed by multiple button groups (arrows, Fn, special keys). A hook is the natural React pattern for shared state without UI.
+   - *Why*: Clean separation between state logic and rendering. Testable in isolation.
+   - *Rejected*: Context provider for modifiers — overkill for state used only within the bottom bar component tree.
+
+3. **`i` key for compose toggle (vim-like)**: Terminal users expect `i` for "insert mode". Since the terminal is a canvas (not a text input), the `i` key is available for interception at the document level.
+   - *Why*: Familiar to the target audience, discoverable via muscle memory.
+   - *Rejected*: `Cmd+Shift+Enter` — requires three keys, unfamiliar.
+
+4. **visualViewport API for iOS keyboard**: This is the standard approach for detecting the iOS virtual keyboard. No reliable `keyboard-show` event exists in mobile Safari.
+   - *Why*: Works in Safari/Chrome iOS, standard API, no hacks.
+   - *Rejected*: `window.innerHeight` comparison — unreliable, doesn't update on keyboard show/hide in all browsers.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Bottom bar layout: `Ctrl Alt Cmd \| <- -> up down \| Fn Esc Tab compose` | Confirmed from intake #1 — Resolved Decision #10 in design spec | S:95 R:90 A:90 D:95 |
+| 2 | Certain | Sticky modifiers with visual armed state, auto-clear on next key | Confirmed from intake #2 — Resolved Decision #3 | S:90 R:90 A:85 D:90 |
+| 3 | Certain | Fn dropdown closes after each selection | Confirmed from intake #3 — Resolved Decision #6 | S:90 R:95 A:90 D:95 |
+| 4 | Certain | Compose buffer as native textarea overlay with dim terminal | Confirmed from intake #4 — full design in spec | S:95 R:85 A:90 D:90 |
+| 5 | Certain | Bottom bar terminal page only, injected via ChromeProvider | Confirmed from intake #5 — Resolved Decision #1, ChromeProvider exists | S:90 R:90 A:95 D:95 |
+| 6 | Certain | Modifier bar pins above iOS keyboard via visualViewport | Confirmed from intake #6 — Resolved Decision #7 | S:90 R:80 A:80 D:85 |
+| 7 | Certain | No relay changes needed — existing relay handles burst text | Verified from source: `server.ts` line 93, `ptyProcess.write(message)` handles any string. Upgraded from intake Confident #9 | S:95 R:95 A:95 D:95 |
+| 8 | Confident | 44px minimum tap height for all bottom bar buttons | Apple HIG standard — confirmed from intake #7. Not verified against actual rendering | S:70 R:90 A:90 D:85 |
+| 9 | Confident | Desktop compose toggle via `i` key | Vim-like mental model from intake #8. Easily changed, but untested with real users | S:55 R:95 A:75 D:70 |
+| 10 | Confident | ANSI escape sequences use xterm modifier parameter encoding | Standard xterm encoding `\x1b[1;{mod}X` — well-documented but needs testing with actual terminals | S:65 R:85 A:80 D:85 |
+| 11 | Certain | Compose sends text as raw WebSocket string (not JSON envelope) | Relay already parses JSON for resize only, falls through to raw write. No new protocol needed | S:95 R:90 A:95 D:95 |
+| 12 | Certain | WebSocket ref passed as prop from TerminalClient to BottomBar | Existing pattern — TerminalClient owns the WS connection via `wsRef`, natural to pass down | S:90 R:90 A:95 D:95 |
+
+12 assumptions (9 certain, 3 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260305-fjh1-bottom-bar-compose-buffer/tasks.md
+++ b/fab/changes/260305-fjh1-bottom-bar-compose-buffer/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: Bottom Bar + Compose Buffer
+
+**Change**: 260305-fjh1-bottom-bar-compose-buffer
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+## Phase 1: Hooks
+
+- [x] T001 [P] Create `src/hooks/use-modifier-state.ts` — custom hook managing sticky modifier state (ctrl/alt/cmd booleans, arm/disarm/toggle/consume functions). `consume()` returns current state and clears all modifiers atomically.
+- [x] T002 [P] Create `src/hooks/use-visual-viewport.ts` — custom hook using `window.visualViewport` API to constrain app height when iOS keyboard appears. Sets document element height to `visualViewport.height` on resize events. No-op on desktop.
+
+## Phase 2: Components
+
+- [x] T003 Create `src/components/bottom-bar.tsx` — Client Component rendering a single row of `<kbd>` buttons: modifier toggles (Ctrl/Alt/Cmd with armed visual state), arrow keys (←→↑↓ sending ANSI sequences), Fn dropdown (F1-F12, PgUp, PgDn, Home, End — closes after selection), Esc, Tab, and ✎ compose toggle. All buttons 44px min-height. Uses `useModifierState()` hook. Receives `wsRef: React.RefObject<WebSocket | null>` and `onToggleCompose: () => void`. Builds ANSI sequences with xterm modifier parameters when modifiers are armed.
+- [x] T004 Create `src/components/compose-buffer.tsx` — Client Component rendering a native `<textarea>` overlay. Receives `wsRef: React.RefObject<WebSocket | null>` and `onClose: () => void`. Textarea gets `autoFocus`. Send button (or Cmd/Ctrl+Enter) transmits entire text as one WebSocket message then calls `onClose()`. Escape dismisses without sending.
+
+## Phase 3: Integration
+
+- [x] T005 Integrate bottom bar and compose buffer into `src/app/p/[project]/[window]/terminal-client.tsx` — add `composeOpen` state, call `setBottomBar(<BottomBar wsRef={wsRef} onToggleCompose={...} />)` via useEffect with cleanup. Render `<ComposeBuffer>` conditionally inside content area. Apply `opacity-50` to terminal div when compose is open. Add `i` key handler to open compose (intercept at document level, prevent reaching xterm, respect compose-already-open and active input elements). Hook up `useVisualViewport()`.
+- [x] T006 Run verification: `npx tsc --noEmit` and `pnpm build` must both pass.
+
+---
+
+## Execution Order
+
+- T001 and T002 are independent (parallel)
+- T003 depends on T001 (uses useModifierState)
+- T004 is independent of T003 (no shared deps beyond wsRef prop)
+- T005 depends on T002, T003, T004 (wires everything together)
+- T006 depends on T005

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
     <html lang="en" className="dark">
       <body className="h-screen antialiased">
         <ChromeProvider>
-          <div className="h-screen flex flex-col">
+          <div className="flex flex-col" style={{ height: 'var(--app-height, 100vh)' }}>
             {/* Top chrome — fixed height, shrink-0 */}
             <div className="shrink-0">
               <div className="max-w-4xl mx-auto w-full px-6">

--- a/src/app/p/[project]/[window]/terminal-client.tsx
+++ b/src/app/p/[project]/[window]/terminal-client.tsx
@@ -109,9 +109,9 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
     function handleIKey(e: KeyboardEvent) {
       if (composeOpen) return;
       if (e.key !== "i") return;
+      // Only intercept when focus is within the terminal (xterm's internal elements)
       const target = e.target as HTMLElement;
-      if (target.tagName === "INPUT" || target.isContentEditable) return;
-      if (target.tagName === "TEXTAREA" && !terminalRef.current?.contains(target)) return;
+      if (!terminalRef.current?.contains(target)) return;
       e.preventDefault();
       e.stopPropagation();
       setComposeOpen(true);

--- a/src/app/p/[project]/[window]/terminal-client.tsx
+++ b/src/app/p/[project]/[window]/terminal-client.tsx
@@ -4,7 +4,10 @@ import "@xterm/xterm/css/xterm.css";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useCallback, useState, useMemo } from "react";
 import { useSessions } from "@/hooks/use-sessions";
+import { useVisualViewport } from "@/hooks/use-visual-viewport";
 import { useChrome } from "@/contexts/chrome-context";
+import { BottomBar } from "@/components/bottom-bar";
+import { ComposeBuffer } from "@/components/compose-buffer";
 import { Dialog } from "@/components/dialog";
 import { CommandPalette, type PaletteAction } from "@/components/command-palette";
 
@@ -24,8 +27,11 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
   const wsRef = useRef<WebSocket | null>(null);
   const escTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { sessions, isConnected } = useSessions();
-  const { setBreadcrumbs, setLine2Left, setLine2Right, setIsConnected } = useChrome();
+  const { setBreadcrumbs, setLine2Left, setLine2Right, setBottomBar, setIsConnected } = useChrome();
   const [showKillConfirm, setShowKillConfirm] = useState(false);
+  const [composeOpen, setComposeOpen] = useState(false);
+
+  useVisualViewport();
 
   // Look up current window's status from session data
   const currentWindow = useMemo(() => {
@@ -86,6 +92,33 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
       </div>,
     );
   }, [currentWindow, setLine2Right]);
+
+  // Bottom bar injection
+  useEffect(() => {
+    setBottomBar(
+      <BottomBar
+        wsRef={wsRef}
+        onOpenCompose={() => setComposeOpen(true)}
+      />,
+    );
+    return () => setBottomBar(null);
+  }, [setBottomBar]);
+
+  // Desktop `i` key → open compose (capture phase to intercept before xterm)
+  useEffect(() => {
+    function handleIKey(e: KeyboardEvent) {
+      if (composeOpen) return;
+      if (e.key !== "i") return;
+      const target = e.target as HTMLElement;
+      if (target.tagName === "INPUT" || target.isContentEditable) return;
+      if (target.tagName === "TEXTAREA" && !terminalRef.current?.contains(target)) return;
+      e.preventDefault();
+      e.stopPropagation();
+      setComposeOpen(true);
+    }
+    document.addEventListener("keydown", handleIKey, { capture: true });
+    return () => document.removeEventListener("keydown", handleIKey, { capture: true });
+  }, [composeOpen]);
 
   // Double-Esc detection
   const handleKeyDown = useCallback(
@@ -258,7 +291,14 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
 
   return (
     <>
-      <div ref={terminalRef} className="flex-1 min-h-0" />
+      <div
+        ref={terminalRef}
+        className={`flex-1 min-h-0 transition-opacity ${composeOpen ? "opacity-50" : ""}`}
+      />
+
+      {composeOpen && (
+        <ComposeBuffer wsRef={wsRef} onClose={() => setComposeOpen(false)} />
+      )}
 
       {/* Kill confirmation dialog */}
       {showKillConfirm && (

--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -155,7 +155,7 @@ export function BottomBar({ wsRef, onOpenCompose }: BottomBarProps) {
             {FN_KEYS.map((fk) => (
               <button
                 key={fk.label}
-                className="px-2 py-1.5 text-xs text-text-secondary hover:text-text-primary hover:bg-bg-card rounded text-center"
+                className="px-2 py-1.5 min-h-[44px] flex items-center justify-center text-xs text-text-secondary hover:text-text-primary hover:bg-bg-card rounded"
                 onClick={() => {
                   sendWithMods(fk.plain, fk.mod);
                   setFnOpen(false);

--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useState, useCallback, useRef, useEffect } from "react";
+import { useModifierState, type ModifierSnapshot } from "@/hooks/use-modifier-state";
+
+type BottomBarProps = {
+  wsRef: React.RefObject<WebSocket | null>;
+  onOpenCompose: () => void;
+};
+
+/** xterm modifier parameter: 1 + (alt?2:0) + (ctrl?4:0) + (meta?8:0) */
+function modParam(mods: ModifierSnapshot): number {
+  let p = 1;
+  if (mods.alt) p += 2;
+  if (mods.ctrl) p += 4;
+  if (mods.cmd) p += 8;
+  return p;
+}
+
+function hasModifiers(mods: ModifierSnapshot): boolean {
+  return mods.ctrl || mods.alt || mods.cmd;
+}
+
+const ARROWS = [
+  { label: "\u2190", code: "D" }, // ←
+  { label: "\u2192", code: "C" }, // →
+  { label: "\u2191", code: "A" }, // ↑
+  { label: "\u2193", code: "B" }, // ↓
+] as const;
+
+const FN_KEYS = [
+  { label: "F1", plain: "\x1bOP", mod: (p: number) => `\x1b[1;${p}P` },
+  { label: "F2", plain: "\x1bOQ", mod: (p: number) => `\x1b[1;${p}Q` },
+  { label: "F3", plain: "\x1bOR", mod: (p: number) => `\x1b[1;${p}R` },
+  { label: "F4", plain: "\x1bOS", mod: (p: number) => `\x1b[1;${p}S` },
+  { label: "F5", plain: "\x1b[15~", mod: (p: number) => `\x1b[15;${p}~` },
+  { label: "F6", plain: "\x1b[17~", mod: (p: number) => `\x1b[17;${p}~` },
+  { label: "F7", plain: "\x1b[18~", mod: (p: number) => `\x1b[18;${p}~` },
+  { label: "F8", plain: "\x1b[19~", mod: (p: number) => `\x1b[19;${p}~` },
+  { label: "F9", plain: "\x1b[20~", mod: (p: number) => `\x1b[20;${p}~` },
+  { label: "F10", plain: "\x1b[21~", mod: (p: number) => `\x1b[21;${p}~` },
+  { label: "F11", plain: "\x1b[23~", mod: (p: number) => `\x1b[23;${p}~` },
+  { label: "F12", plain: "\x1b[24~", mod: (p: number) => `\x1b[24;${p}~` },
+  { label: "PgUp", plain: "\x1b[5~", mod: (p: number) => `\x1b[5;${p}~` },
+  { label: "PgDn", plain: "\x1b[6~", mod: (p: number) => `\x1b[6;${p}~` },
+  { label: "Home", plain: "\x1b[H", mod: (p: number) => `\x1b[1;${p}H` },
+  { label: "End", plain: "\x1b[F", mod: (p: number) => `\x1b[1;${p}F` },
+] as const;
+
+const KBD_CLASS =
+  "min-h-[44px] px-2.5 py-1.5 text-sm border border-border rounded select-none transition-colors hover:border-text-secondary active:bg-bg-card";
+
+export function BottomBar({ wsRef, onOpenCompose }: BottomBarProps) {
+  const mods = useModifierState();
+  const [fnOpen, setFnOpen] = useState(false);
+  const fnRef = useRef<HTMLDivElement>(null);
+
+  // Close Fn dropdown on outside click
+  useEffect(() => {
+    if (!fnOpen) return;
+    function handleClick(e: MouseEvent) {
+      if (fnRef.current && !fnRef.current.contains(e.target as Node)) {
+        setFnOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [fnOpen]);
+
+  // Close Fn dropdown on Escape
+  useEffect(() => {
+    if (!fnOpen) return;
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setFnOpen(false);
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [fnOpen]);
+
+  const send = useCallback(
+    (data: string) => {
+      if (wsRef.current?.readyState === WebSocket.OPEN) {
+        wsRef.current.send(data);
+      }
+    },
+    [wsRef],
+  );
+
+  const sendWithMods = useCallback(
+    (plain: string, modified: (p: number) => string) => {
+      const snapshot = mods.consume();
+      send(hasModifiers(snapshot) ? modified(modParam(snapshot)) : plain);
+    },
+    [mods, send],
+  );
+
+  const sendArrow = useCallback(
+    (code: string) => {
+      sendWithMods(`\x1b[${code}`, (p) => `\x1b[1;${p}${code}`);
+    },
+    [sendWithMods],
+  );
+
+  const sendSpecial = useCallback(
+    (char: string) => {
+      const snapshot = mods.consume();
+      // Alt/Cmd: prefix with ESC (standard Meta convention)
+      const prefix = snapshot.alt || snapshot.cmd ? "\x1b" : "";
+      // Ctrl doesn't modify Esc/Tab in terminal semantics (Esc IS Ctrl+[, Tab IS Ctrl+I).
+      // Re-arm Ctrl so it stays armed for the next real key.
+      if (snapshot.ctrl) mods.arm("ctrl");
+      send(prefix + char);
+    },
+    [mods, send],
+  );
+
+  return (
+    <div className="flex items-center gap-1.5 py-1.5 flex-wrap">
+      {/* Modifier toggles */}
+      {(["ctrl", "alt", "cmd"] as const).map((key) => (
+        <button
+          key={key}
+          className={`${KBD_CLASS} ${mods[key] ? "bg-accent/20 border-accent text-accent" : "text-text-secondary"}`}
+          onClick={() => mods.toggle(key)}
+        >
+          <kbd>{key.charAt(0).toUpperCase() + key.slice(1)}</kbd>
+        </button>
+      ))}
+
+      <div className="w-px h-6 bg-border mx-1" />
+
+      {/* Arrow keys */}
+      {ARROWS.map(({ label, code }) => (
+        <button
+          key={code}
+          className={`${KBD_CLASS} text-text-secondary`}
+          onClick={() => sendArrow(code)}
+        >
+          <kbd>{label}</kbd>
+        </button>
+      ))}
+
+      <div className="w-px h-6 bg-border mx-1" />
+
+      {/* Fn dropdown */}
+      <div ref={fnRef} className="relative">
+        <button
+          className={`${KBD_CLASS} text-text-secondary`}
+          onClick={() => setFnOpen((v) => !v)}
+        >
+          <kbd>Fn&#x25BE;</kbd>
+        </button>
+        {fnOpen && (
+          <div className="absolute bottom-full left-0 mb-1 bg-bg-primary border border-border rounded-lg shadow-2xl py-1 grid grid-cols-4 gap-0.5 min-w-[200px] z-50">
+            {FN_KEYS.map((fk) => (
+              <button
+                key={fk.label}
+                className="px-2 py-1.5 text-xs text-text-secondary hover:text-text-primary hover:bg-bg-card rounded text-center"
+                onClick={() => {
+                  sendWithMods(fk.plain, fk.mod);
+                  setFnOpen(false);
+                }}
+              >
+                {fk.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Special keys */}
+      <button
+        className={`${KBD_CLASS} text-text-secondary`}
+        onClick={() => sendSpecial("\x1b")}
+      >
+        <kbd>Esc</kbd>
+      </button>
+      <button
+        className={`${KBD_CLASS} text-text-secondary`}
+        onClick={() => sendSpecial("\t")}
+      >
+        <kbd>Tab</kbd>
+      </button>
+
+      {/* Compose toggle */}
+      <button
+        className={`${KBD_CLASS} text-text-secondary`}
+        onClick={onOpenCompose}
+      >
+        <kbd>&#x270E;</kbd>
+      </button>
+    </div>
+  );
+}

--- a/src/components/compose-buffer.tsx
+++ b/src/components/compose-buffer.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useRef, useCallback } from "react";
+
+type ComposeBufferProps = {
+  wsRef: React.RefObject<WebSocket | null>;
+  onClose: () => void;
+};
+
+export function ComposeBuffer({ wsRef, onClose }: ComposeBufferProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const send = useCallback(() => {
+    const text = textareaRef.current?.value;
+    if (text && wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(text);
+    }
+    onClose();
+  }, [wsRef, onClose]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      } else if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        send();
+      }
+    },
+    [onClose, send],
+  );
+
+  return (
+    <div className="shrink-0 border-t border-border bg-bg-primary p-3">
+      <textarea
+        ref={textareaRef}
+        autoFocus
+        placeholder="Compose text..."
+        className="w-full bg-bg-card text-text-primary text-sm p-3 rounded border border-border outline-none resize-y min-h-[80px] max-h-[200px] placeholder:text-text-secondary focus:border-text-secondary"
+        onKeyDown={handleKeyDown}
+      />
+      <div className="flex justify-end mt-2">
+        <button
+          onClick={send}
+          className="text-sm px-4 py-1.5 bg-accent/20 border border-accent text-accent rounded hover:bg-accent/30 transition-colors"
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/use-modifier-state.ts
+++ b/src/hooks/use-modifier-state.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+type Modifier = "ctrl" | "alt" | "cmd";
+
+export type ModifierSnapshot = { ctrl: boolean; alt: boolean; cmd: boolean };
+
+export function useModifierState() {
+  const stateRef = useRef<ModifierSnapshot>({ ctrl: false, alt: false, cmd: false });
+  const [, rerender] = useState(0);
+
+  const set = useCallback((mod: Modifier, value: boolean) => {
+    stateRef.current = { ...stateRef.current, [mod]: value };
+    rerender((n) => n + 1);
+  }, []);
+
+  const arm = useCallback((mod: Modifier) => set(mod, true), [set]);
+  const disarm = useCallback((mod: Modifier) => set(mod, false), [set]);
+
+  const toggle = useCallback(
+    (mod: Modifier) => set(mod, !stateRef.current[mod]),
+    [set],
+  );
+
+  const consume = useCallback((): ModifierSnapshot => {
+    const snapshot = { ...stateRef.current };
+    stateRef.current = { ctrl: false, alt: false, cmd: false };
+    rerender((n) => n + 1);
+    return snapshot;
+  }, []);
+
+  return {
+    ctrl: stateRef.current.ctrl,
+    alt: stateRef.current.alt,
+    cmd: stateRef.current.cmd,
+    arm,
+    disarm,
+    toggle,
+    consume,
+  };
+}

--- a/src/hooks/use-visual-viewport.ts
+++ b/src/hooks/use-visual-viewport.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function useVisualViewport() {
+  useEffect(() => {
+    const vv = window.visualViewport;
+    if (!vv) return;
+
+    function update() {
+      if (!vv) return;
+      document.documentElement.style.setProperty(
+        "--app-height",
+        `${vv.height}px`,
+      );
+    }
+
+    update();
+    vv.addEventListener("resize", update);
+
+    return () => {
+      vv.removeEventListener("resize", update);
+      document.documentElement.style.removeProperty("--app-height");
+    };
+  }, []);
+}


### PR DESCRIPTION
## Summary

- **Bottom bar** on terminal page: modifier toggles (Ctrl/Alt/Cmd with sticky armed state), arrow keys (ANSI sequences with xterm modifier encoding), Fn dropdown (F1-F12, PgUp/PgDn/Home/End), Esc, Tab, and compose toggle
- **Compose buffer**: native `<textarea>` overlay for latency-tolerant input — supports iOS dictation, autocorrect, paste, IME. Sends text as a single WebSocket message. Desktop shortcut: `i` key
- **iOS keyboard support**: `useVisualViewport` hook constrains app height via CSS custom property, keeping bottom bar pinned above the on-screen keyboard

Part 2/3 of UI design philosophy implementation. Depends on #8 (chrome architecture).

## New files

| File | Purpose |
|------|---------|
| `src/components/bottom-bar.tsx` | Bottom bar with all button groups |
| `src/components/compose-buffer.tsx` | Native textarea overlay |
| `src/hooks/use-modifier-state.ts` | Sticky modifier state (arm/disarm/toggle/consume) |
| `src/hooks/use-visual-viewport.ts` | iOS keyboard detection via visualViewport API |

## Modified files

- `src/app/p/[project]/[window]/terminal-client.tsx` — integrates bottom bar, compose buffer, `i` key handler, visual viewport
- `src/app/layout.tsx` — flex container uses `var(--app-height, 100vh)` for iOS keyboard support

## Test plan

- [ ] Terminal page shows bottom bar with all button groups
- [ ] Modifier toggles arm/disarm on tap with visual feedback
- [ ] Arrow keys send correct ANSI sequences (verify with `cat -v` or similar)
- [ ] Fn dropdown opens, selects key, closes after selection
- [ ] Compose buffer opens on compose button tap and `i` key
- [ ] Compose buffer sends text on Send button and Cmd/Ctrl+Enter
- [ ] Compose buffer dismisses on Escape without sending
- [ ] Dashboard and Project pages have no bottom bar
- [ ] `pnpm build` passes

Generated with [Claude Code](https://claude.com/claude-code)