### PR TITLE
fix: Mobile UI fixes, accessibility improvements, and bottom bar redesign

### DIFF
--- a/fab/changes/260306-0ahl-perf-sse-chrome-sessions/.history.jsonl
+++ b/fab/changes/260306-0ahl-perf-sse-chrome-sessions/.history.jsonl
@@ -1,0 +1,5 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-03-06T22:16:33+05:30"}
+{"args":"Performance improvements: parallelize session enrichment, fix SSE lifecycle, split ChromeContext","cmd":"fab-new","event":"command","ts":"2026-03-06T22:16:33+05:30"}
+{"delta":"+2.8","event":"confidence","score":2.8,"trigger":"calc-score","ts":"2026-03-06T22:17:40+05:30"}
+{"delta":"+0.0","event":"confidence","score":2.8,"trigger":"calc-score","ts":"2026-03-06T22:17:47+05:30"}
+{"cmd":"fab-clarify","event":"command","ts":"2026-03-06T22:18:27+05:30"}

--- a/fab/changes/260306-0ahl-perf-sse-chrome-sessions/.status.yaml
+++ b/fab/changes/260306-0ahl-perf-sse-chrome-sessions/.status.yaml
@@ -1,0 +1,36 @@
+name: 260306-0ahl-perf-sse-chrome-sessions
+created: 2026-03-06T22:16:33+05:30
+created_by: sahil-weaver
+change_type: refactor
+issues: []
+progress:
+    intake: ready
+    spec: pending
+    tasks: pending
+    apply: pending
+    review: pending
+    hydrate: pending
+    ship: pending
+    review-pr: pending
+checklist:
+    generated: false
+    path: checklist.md
+    completed: 0
+    total: 0
+confidence:
+    certain: 5
+    confident: 4
+    tentative: 1
+    unresolved: 0
+    score: 2.8
+    indicative: true
+    fuzzy: true
+    dimensions:
+        signal: 79.5
+        reversibility: 87.5
+        competence: 82.0
+        disambiguation: 76.5
+stage_metrics:
+    intake: {started_at: "2026-03-06T22:16:33+05:30", driver: fab-new, iterations: 1}
+prs: []
+last_updated: 2026-03-06T22:17:52+05:30

--- a/fab/changes/260306-0ahl-perf-sse-chrome-sessions/intake.md
+++ b/fab/changes/260306-0ahl-perf-sse-chrome-sessions/intake.md
@@ -1,0 +1,133 @@
+# Intake: Performance — SSE, Chrome Context, and Session Enrichment
+
+**Change**: 260306-0ahl-perf-sse-chrome-sessions
+**Created**: 2026-03-06
+**Status**: Draft
+
+## Origin
+
+> Performance review of `src/` using parallel review agents. Two agents audited server-side (lib/, API routes, terminal relay) and client-side (components, hooks, contexts) code independently, producing a consolidated report with 4 high, 9 medium, and 6 low severity findings.
+
+Conversational mode — findings discussed and triaged before creating this change. The top 3 recommendations were selected for this change based on impact and feasibility.
+
+## Why
+
+1. **Serial session enrichment blocks page loads.** `fetchSessions()` checks `hasFabKit()` sequentially for each tmux session, then enriches windows serially. With 10 sessions, this serializes 10+ subprocess calls that could run in parallel. Every SSE poll and every page load pays this cost.
+
+2. **SSE connections leak resources.** Each browser tab opens an independent `EventSource` and triggers independent polling. If a client disconnects without clean `cancel()` (browser crash, network drop), the polling loop runs forever — spawning `execFile` subprocesses every 2.5s. With 3 tabs open, that's 3x the subprocess load for identical data.
+
+3. **ChromeContext causes cascade re-renders.** All chrome state (breadcrumbs, line2Left, line2Right, bottomBar, isConnected, fullbleed) lives in one context. Any state change re-renders every consumer. The dashboard's search input calls `setLine2Left()` with new JSX on every keystroke, triggering a full chrome re-render cascade per keypress.
+
+If left unfixed: performance degrades linearly with session count and open tabs. Resource leaks from orphaned SSE connections accumulate over time. Keystroke latency on the dashboard search becomes noticeable with complex chrome trees.
+
+## What Changes
+
+### Server-Side: Parallelize Session Enrichment
+
+Replace the serial `for...of` loop in `src/lib/sessions.ts` (lines 46-57) with `Promise.all`:
+
+```typescript
+// Before: serial
+for (const { sessionName, windows } of sessionWindows) {
+  const projectRoot = windows[0]?.worktreePath ?? "";
+  if (projectRoot && (await hasFabKit(projectRoot))) {
+    await Promise.all(windows.map((win) => enrichWindow(win, projectRoot)));
+  }
+  result.push({ name: sessionName, windows });
+}
+
+// After: parallel across sessions
+await Promise.all(
+  sessionWindows.map(async ({ sessionName, windows }) => {
+    const projectRoot = windows[0]?.worktreePath ?? "";
+    if (projectRoot && (await hasFabKit(projectRoot))) {
+      await Promise.all(windows.map((win) => enrichWindow(win, projectRoot)));
+    }
+    result.push({ name: sessionName, windows });
+  }),
+);
+```
+
+Note: push order becomes non-deterministic. Sort by session name afterward if ordering matters.
+
+### Server-Side: SSE Connection Lifecycle
+
+In `src/app/api/sessions/stream/route.ts`:
+
+1. **Timer cleanup**: Capture the `setTimeout` handle and `clearTimeout` in `cancel()` to prevent dangling polls after client disconnect.
+2. **Connection lifetime cap**: Add a maximum lifetime (e.g., 30 minutes) after which the stream self-closes, forcing clients to reconnect.
+3. **Deduplicate polling across clients**: Implement a simple pub/sub pattern — one shared poll loop that fans out to all connected SSE streams. When no clients are connected, polling stops.
+
+### Client-Side: Split ChromeContext
+
+Split `src/contexts/chrome-context.tsx` into narrower contexts to prevent cross-slot re-renders:
+
+- **ChromeStateContext** — read-only state values (breadcrumbs, line2Left, line2Right, bottomBar, isConnected, fullbleed)
+- **ChromeDispatchContext** — stable setter functions (setBreadcrumbs, setLine2Left, etc.)
+
+Consumers that only call setters (most page `useEffect` hooks) subscribe to dispatch context only — no re-renders when state changes. Consumers that read state (TopBarChrome, BottomSlot) subscribe to the state they need.
+
+Additionally, fix the dashboard search input pattern: stop pumping new JSX into the chrome context on every `filterQuery` change. Options:
+- Render the search input inline in the dashboard component instead of via chrome slot
+- Or store `filterQuery` as a string in context and render the input inside TopBarChrome
+
+### Client-Side: Lift useSessions to Layout Level
+
+Move the SSE connection from per-page `useSessions()` hooks to a `SessionProvider` at the layout level (`src/app/layout.tsx`). Benefits:
+
+- Exactly one `EventSource` for the entire app
+- Eliminates the `setIsConnected(isConnected)` forwarding in all three page components
+- Session data available immediately on route transitions (no flash of stale data)
+- Cleaner separation: pages consume session data, layout owns the connection
+
+### Client-Side: Additional Optimizations
+
+1. **Debounce ResizeObserver** in `src/app/p/[project]/[window]/terminal-client.tsx` (lines 223-234): Wrap `fitAddon.fit()` + WS resize message in a ~100ms debounce or `requestAnimationFrame` to prevent dozens of reflows during window resize.
+
+2. **Memoize `useModifierState` return** in `src/hooks/use-modifier-state.ts` (lines 33-41): Wrap the return object in `useMemo` to prevent cascading callback recreation (`sendWithMods`, `sendSpecial`, `sendArrow`).
+
+3. **Stabilize shortcuts objects** in `src/app/dashboard-client.tsx` (lines 87-91) and `src/app/p/[project]/project-client.tsx` (lines 52-63): Wrap in `useMemo` to prevent `useKeyboardNav` from detaching/re-attaching keydown listeners every render.
+
+4. **WebSocket reconnection** in `src/app/p/[project]/[window]/terminal-client.tsx` (lines 205-213): Add exponential backoff reconnection when the WebSocket closes unexpectedly, with a visual indicator. Re-send resize on reconnect.
+
+## Affected Memory
+
+- `run-kit/architecture`: (modify) Update SSE design decision to reflect pub/sub dedup, document SessionProvider pattern, update ChromeProvider section for split contexts
+- `run-kit/ui-patterns`: (modify) Update ChromeProvider section to reflect split contexts, add note about SessionProvider
+
+## Impact
+
+- **`src/lib/sessions.ts`** — `fetchSessions` parallelization
+- **`src/app/api/sessions/stream/route.ts`** — SSE lifecycle, pub/sub polling
+- **`src/contexts/chrome-context.tsx`** — split into multiple contexts
+- **`src/app/layout.tsx`** — add SessionProvider
+- **`src/hooks/use-sessions.ts`** — refactor for shared connection
+- **`src/app/dashboard-client.tsx`** — consume from SessionProvider, fix search input pattern, stabilize shortcuts
+- **`src/app/p/[project]/project-client.tsx`** — consume from SessionProvider, stabilize shortcuts
+- **`src/app/p/[project]/[window]/terminal-client.tsx`** — consume from SessionProvider, debounce ResizeObserver, add WS reconnect
+- **`src/hooks/use-modifier-state.ts`** — memoize return value
+- **`src/components/top-bar-chrome.tsx`** — consume split context
+- **`src/components/bottom-bar.tsx`** — consume split context
+
+## Open Questions
+
+- Should the SSE pub/sub dedup use a module-level singleton or a more structured pattern (e.g., `BroadcastChannel`)? Module-level singleton is simpler for a single-process Next.js server.
+- Should `SessionProvider` expose the full `ProjectSession[]` or also provide per-project/per-window selectors to further reduce re-renders?
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Use `Promise.all` for session enrichment parallelization | Discussed — direct replacement of serial loop, no ordering dependency | S:95 R:90 A:95 D:95 |
+| 2 | Certain | Split ChromeContext into state/dispatch contexts | Discussed — standard React pattern for avoiding re-render cascades | S:90 R:85 A:90 D:90 |
+| 3 | Certain | Lift useSessions to layout-level SessionProvider | Discussed — eliminates redundant SSE connections and forwarding boilerplate | S:90 R:80 A:90 D:85 |
+| 4 | Certain | Debounce ResizeObserver fitAddon.fit at ~100ms | Discussed — prevents reflow storms during window resize | S:85 R:95 A:90 D:90 |
+| 5 | Certain | Memoize useModifierState return value | Discussed — prevents cascading callback recreation | S:85 R:95 A:90 D:95 |
+| 6 | Confident | SSE pub/sub uses module-level singleton pattern | Module-level singleton is simplest for single-process Next.js; BroadcastChannel adds complexity without benefit | S:75 R:80 A:75 D:65 |
+| 7 | Confident | Add 30-minute SSE connection lifetime cap | Reasonable default; forces reconnect to prevent indefinite orphan accumulation. Exact value can be tuned | S:70 R:90 A:70 D:65 |
+| 8 | Confident | WebSocket reconnection uses exponential backoff (1s, 2s, 4s, max 30s) | Standard pattern; exact intervals are tunable | S:70 R:85 A:80 D:70 |
+| 9 | Confident | Dashboard search input rendered inline instead of via chrome slot | Simpler fix than storing filterQuery in context; avoids per-keystroke context updates | S:75 R:85 A:80 D:60 |
+| 10 | Tentative | Session push order preserved via post-sort by session name | Parallel `Promise.all` makes push order non-deterministic; sorting by name provides stable UI order. Alternative: use indexed assignment | S:60 R:90 A:60 D:50 |
+<!-- assumed: Sort by session name — parallel push makes order non-deterministic, name sort provides stable display order -->
+
+10 assumptions (5 certain, 4 confident, 1 tentative, 0 unresolved).

--- a/src/app/dashboard-client.tsx
+++ b/src/app/dashboard-client.tsx
@@ -311,7 +311,7 @@ export function DashboardClient({ initialSessions }: Props) {
 
           if (sessionWindows.length === 0 && filterQuery) return null;
           return (
-            <section key={session.name} className="mb-6">
+            <section key={session.name} className="mb-6 min-w-0">
               <div className="flex items-center justify-between mb-3">
                 <button
                   onClick={() => navigateToProject(session.name)}

--- a/src/app/dashboard-client.tsx
+++ b/src/app/dashboard-client.tsx
@@ -130,6 +130,7 @@ export function DashboardClient({ initialSessions }: Props) {
               (e.target as HTMLInputElement).blur();
             }
           }}
+          aria-label="Search windows"
           placeholder="Search windows..."
           className="bg-bg-card text-text-primary text-sm px-3 py-1 border border-border rounded outline-none placeholder:text-text-secondary w-48 focus:border-text-secondary"
         />
@@ -330,8 +331,8 @@ export function DashboardClient({ initialSessions }: Props) {
                       windowCount: session.windows.length,
                     })
                   }
+                  aria-label={`Kill session ${session.name}`}
                   className="text-text-secondary hover:text-red-400 transition-colors text-sm px-1"
-                  title="Kill session"
                 >
                   ✕
                 </button>
@@ -409,11 +410,12 @@ export function DashboardClient({ initialSessions }: Props) {
                   setAutocompleteSuggestions([]);
                 }
               }}
+              aria-label="Project path"
               placeholder="~/code/..."
               className="w-full bg-transparent text-text-primary text-sm p-2 border border-border rounded outline-none placeholder:text-text-secondary"
             />
             {autocompleteSuggestions.length > 0 && (
-              <div className="absolute left-0 right-0 top-full mt-1 bg-bg-primary border border-border rounded shadow-lg max-h-48 overflow-y-auto z-50">
+              <div role="listbox" aria-label="Directory suggestions" className="absolute left-0 right-0 top-full mt-1 bg-bg-primary border border-border rounded shadow-lg max-h-48 overflow-y-auto z-50">
                 {autocompleteSuggestions.map((dir) => (
                   <button
                     key={dir}
@@ -435,6 +437,7 @@ export function DashboardClient({ initialSessions }: Props) {
               value={createSessionName}
               onChange={(e) => setCreateSessionName(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && handleCreateSession()}
+              aria-label="Session name"
               placeholder="Session name..."
               className="w-full bg-transparent text-text-primary text-sm p-2 border border-border rounded outline-none placeholder:text-text-secondary"
             />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -22,6 +22,16 @@ body {
   color: var(--color-text-primary);
 }
 
+/* Clickable elements should feel clickable */
+button,
+[role="button"],
+[role="option"],
+[role="menuitem"],
+a,
+summary {
+  cursor: pointer;
+}
+
 /* Scrollbar styling */
 ::-webkit-scrollbar {
   width: 6px;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
-import { ChromeProvider, BottomSlot } from "@/contexts/chrome-context";
+import { ChromeProvider, ContentSlot, BottomSlot } from "@/contexts/chrome-context";
 import { TopBarChrome } from "@/components/top-bar-chrome";
 
 export const metadata: Metadata = {
@@ -25,12 +25,8 @@ export default function RootLayout({
               </div>
             </div>
 
-            {/* Content — flex-1, scrollable */}
-            <div className="flex-1 overflow-y-auto min-h-0">
-              <div className="max-w-4xl mx-auto w-full px-6 min-h-full flex flex-col">
-                {children}
-              </div>
-            </div>
+            {/* Content — flex-1, scrollable (overflow controlled by fullbleed) */}
+            <ContentSlot>{children}</ContentSlot>
 
             {/* Bottom slot — shrink-0, rendered by future changes via context */}
             <BottomSlot />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,6 +17,9 @@ export default function RootLayout({
     <html lang="en" className="dark">
       <body className="h-screen antialiased">
         <ChromeProvider>
+          <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-2 focus:bg-bg-primary focus:text-text-primary">
+            Skip to content
+          </a>
           <div className="flex flex-col" style={{ height: 'var(--app-height, 100vh)' }}>
             {/* Top chrome — fixed height, shrink-0 */}
             <div className="shrink-0">

--- a/src/app/p/[project]/[window]/terminal-client.tsx
+++ b/src/app/p/[project]/[window]/terminal-client.tsx
@@ -27,7 +27,7 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
   const wsRef = useRef<WebSocket | null>(null);
   const escTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { sessions, isConnected } = useSessions();
-  const { setBreadcrumbs, setLine2Left, setLine2Right, setBottomBar, setIsConnected } = useChrome();
+  const { setBreadcrumbs, setLine2Left, setLine2Right, setBottomBar, setIsConnected, setFullbleed } = useChrome();
   const [showKillConfirm, setShowKillConfirm] = useState(false);
   const [composeOpen, setComposeOpen] = useState(false);
 
@@ -41,16 +41,18 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
 
   // Set chrome slots
   useEffect(() => {
+    setFullbleed(true);
     setBreadcrumbs([
       { icon: "⬡", label: projectName, href: `/p/${projectName}` },
       { icon: "❯", label: windowName },
     ]);
     return () => {
+      setFullbleed(false);
       setBreadcrumbs([]);
       setLine2Left(null);
       setLine2Right(null);
     };
-  }, [projectName, windowName, setBreadcrumbs, setLine2Left, setLine2Right]);
+  }, [projectName, windowName, setBreadcrumbs, setLine2Left, setLine2Right, setFullbleed]);
 
   useEffect(() => {
     setIsConnected(isConnected);

--- a/src/app/p/[project]/[window]/terminal-client.tsx
+++ b/src/app/p/[project]/[window]/terminal-client.tsx
@@ -295,6 +295,8 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
     <>
       <div
         ref={terminalRef}
+        role="application"
+        aria-label={`Terminal: ${projectName}/${windowName}`}
         className={`flex-1 min-h-0 transition-opacity ${composeOpen ? "opacity-50" : ""}`}
       />
 

--- a/src/app/p/[project]/[window]/terminal-client.tsx
+++ b/src/app/p/[project]/[window]/terminal-client.tsx
@@ -100,7 +100,7 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
     setBottomBar(
       <BottomBar
         wsRef={wsRef}
-        onOpenCompose={() => setComposeOpen(true)}
+        onOpenCompose={() => setComposeOpen((v) => !v)}
       />,
     );
     return () => setBottomBar(null);

--- a/src/app/p/[project]/project-client.tsx
+++ b/src/app/p/[project]/project-client.tsx
@@ -249,6 +249,7 @@ export function ProjectClient({ projectName, initialWindows }: Props) {
             value={createName}
             onChange={(e) => setCreateName(e.target.value)}
             onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+            aria-label="Window name"
             placeholder="Window name..."
             className="w-full bg-transparent text-text-primary text-sm p-2 border border-border rounded outline-none placeholder:text-text-secondary"
           />
@@ -306,6 +307,7 @@ export function ProjectClient({ projectName, initialWindows }: Props) {
             value={sendMessage}
             onChange={(e) => setSendMessage(e.target.value)}
             onKeyDown={(e) => e.key === "Enter" && handleSend()}
+            aria-label="Message to send"
             placeholder="Message..."
             className="w-full bg-transparent text-text-primary text-sm p-2 border border-border rounded outline-none placeholder:text-text-secondary"
           />

--- a/src/components/arrow-pad.tsx
+++ b/src/components/arrow-pad.tsx
@@ -11,7 +11,7 @@ type ArrowPadProps = {
 };
 
 const ARROW_BTN =
-  "min-h-[40px] min-w-[40px] flex items-center justify-center text-sm text-text-secondary border border-border rounded select-none active:bg-bg-card hover:border-text-secondary focus-visible:outline-2 focus-visible:outline-accent";
+  "min-h-[34px] min-w-[34px] flex items-center justify-center text-sm text-text-secondary border border-border rounded select-none active:bg-bg-card hover:border-text-secondary focus-visible:outline-2 focus-visible:outline-accent";
 
 /**
  * Combined arrow key control:
@@ -102,14 +102,14 @@ export function ArrowPad({ onArrow, className }: ArrowPadProps) {
         aria-label="Arrow keys"
         aria-haspopup="true"
         aria-expanded={open}
-        className="min-h-[44px] px-2.5 py-1.5 text-sm border border-border rounded select-none transition-colors hover:border-text-secondary active:bg-bg-card focus-visible:outline-2 focus-visible:outline-accent text-text-secondary touch-none"
+        className="min-h-[36px] px-2 py-1 text-sm border border-border rounded select-none transition-colors hover:border-text-secondary active:bg-bg-card focus-visible:outline-2 focus-visible:outline-accent text-text-secondary touch-none"
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
         onMouseDown={handleMouseDown}
         onMouseUp={handleMouseUp}
         onClick={handleClick}
       >
-        <kbd aria-hidden="true">{"\u2BC6"}</kbd>
+        <kbd aria-hidden="true">{"\u25B2"}</kbd>
       </button>
 
       {/* Arrow popup — inverted-T layout like physical keyboard */}

--- a/src/components/arrow-pad.tsx
+++ b/src/components/arrow-pad.tsx
@@ -11,7 +11,7 @@ type ArrowPadProps = {
 };
 
 const ARROW_BTN =
-  "min-h-[34px] min-w-[34px] flex items-center justify-center text-sm text-text-secondary border border-border rounded select-none active:bg-bg-card hover:border-text-secondary focus-visible:outline-2 focus-visible:outline-accent";
+  "min-h-[30px] min-w-[30px] flex items-center justify-center text-sm text-text-secondary border border-border rounded select-none active:bg-bg-card hover:border-text-secondary focus-visible:outline-2 focus-visible:outline-accent";
 
 /**
  * Combined arrow key control:
@@ -102,14 +102,14 @@ export function ArrowPad({ onArrow, className }: ArrowPadProps) {
         aria-label="Arrow keys"
         aria-haspopup="true"
         aria-expanded={open}
-        className="min-h-[36px] px-2 py-1 text-sm border border-border rounded select-none transition-colors hover:border-text-secondary active:bg-bg-card focus-visible:outline-2 focus-visible:outline-accent text-text-secondary touch-none"
+        className="min-h-[30px] px-2 py-0.5 text-sm border border-border rounded select-none transition-colors hover:border-text-secondary active:bg-bg-card focus-visible:outline-2 focus-visible:outline-accent text-text-secondary touch-none"
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
         onMouseDown={handleMouseDown}
         onMouseUp={handleMouseUp}
         onClick={handleClick}
       >
-        <kbd aria-hidden="true">{"\u25B2"}</kbd>
+        <kbd aria-hidden="true">{"\u2191"}</kbd>
       </button>
 
       {/* Arrow popup — inverted-T layout like physical keyboard */}

--- a/src/components/arrow-pad.tsx
+++ b/src/components/arrow-pad.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useState, useRef, useCallback, useEffect } from "react";
+
+/** Minimum drag distance (px) to register a swipe vs a tap. */
+const DRAG_THRESHOLD = 20;
+
+type ArrowPadProps = {
+  onArrow: (code: string) => void;
+  className?: string;
+};
+
+const ARROW_BTN =
+  "min-h-[40px] min-w-[40px] flex items-center justify-center text-sm text-text-secondary border border-border rounded select-none active:bg-bg-card hover:border-text-secondary focus-visible:outline-2 focus-visible:outline-accent";
+
+/**
+ * Combined arrow key control:
+ * - Tap: opens a popup with 4 directional arrow buttons
+ * - Drag/swipe: sends the arrow matching the drag direction
+ */
+export function ArrowPad({ onArrow, className }: ArrowPadProps) {
+  const [open, setOpen] = useState(false);
+  const padRef = useRef<HTMLDivElement>(null);
+  const startRef = useRef<{ x: number; y: number } | null>(null);
+  const didDragRef = useRef(false);
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    const t = e.touches[0];
+    startRef.current = { x: t.clientX, y: t.clientY };
+    didDragRef.current = false;
+  }, []);
+
+  const handleTouchEnd = useCallback(
+    (e: React.TouchEvent) => {
+      if (!startRef.current) return;
+      const t = e.changedTouches[0];
+      const dx = t.clientX - startRef.current.x;
+      const dy = t.clientY - startRef.current.y;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+
+      if (dist >= DRAG_THRESHOLD) {
+        // Swipe detected — determine direction
+        didDragRef.current = true;
+        if (Math.abs(dx) > Math.abs(dy)) {
+          onArrow(dx > 0 ? "C" : "D"); // Right : Left
+        } else {
+          onArrow(dy > 0 ? "B" : "A"); // Down : Up
+        }
+      }
+      // If below threshold, it's a tap — handled by onClick
+      startRef.current = null;
+    },
+    [onArrow],
+  );
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    startRef.current = { x: e.clientX, y: e.clientY };
+    didDragRef.current = false;
+  }, []);
+
+  const handleMouseUp = useCallback(
+    (e: React.MouseEvent) => {
+      if (!startRef.current) return;
+      const dx = e.clientX - startRef.current.x;
+      const dy = e.clientY - startRef.current.y;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+
+      if (dist >= DRAG_THRESHOLD) {
+        didDragRef.current = true;
+        if (Math.abs(dx) > Math.abs(dy)) {
+          onArrow(dx > 0 ? "C" : "D");
+        } else {
+          onArrow(dy > 0 ? "B" : "A");
+        }
+      }
+      startRef.current = null;
+    },
+    [onArrow],
+  );
+
+  const handleClick = useCallback(() => {
+    if (didDragRef.current) return; // Was a drag, not a tap
+    setOpen((v) => !v);
+  }, []);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (padRef.current && !padRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  return (
+    <div ref={padRef} className={`relative ${className ?? ""}`}>
+      {/* Main trigger button — drag or tap */}
+      <button
+        aria-label="Arrow keys"
+        aria-haspopup="true"
+        aria-expanded={open}
+        className="min-h-[44px] px-2.5 py-1.5 text-sm border border-border rounded select-none transition-colors hover:border-text-secondary active:bg-bg-card focus-visible:outline-2 focus-visible:outline-accent text-text-secondary touch-none"
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
+        onMouseDown={handleMouseDown}
+        onMouseUp={handleMouseUp}
+        onClick={handleClick}
+      >
+        <kbd aria-hidden="true">{"\u2BC6"}</kbd>
+      </button>
+
+      {/* Arrow popup — inverted-T layout like physical keyboard */}
+      {open && (
+        <div
+          className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 bg-bg-primary border border-border rounded-lg shadow-2xl p-1 z-50"
+          role="group"
+          aria-label="Arrow keys"
+        >
+          {/* Row 1: Up */}
+          <div className="flex justify-center mb-0.5">
+            <button
+              aria-label="Up arrow"
+              className={ARROW_BTN}
+              onClick={() => { onArrow("A"); setOpen(false); }}
+            >
+              ↑
+            </button>
+          </div>
+          {/* Row 2: Left Down Right */}
+          <div className="flex gap-0.5">
+            <button
+              aria-label="Left arrow"
+              className={ARROW_BTN}
+              onClick={() => { onArrow("D"); setOpen(false); }}
+            >
+              ←
+            </button>
+            <button
+              aria-label="Down arrow"
+              className={ARROW_BTN}
+              onClick={() => { onArrow("B"); setOpen(false); }}
+            >
+              ↓
+            </button>
+            <button
+              aria-label="Right arrow"
+              className={ARROW_BTN}
+              onClick={() => { onArrow("C"); setOpen(false); }}
+            >
+              →
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -47,7 +47,7 @@ const EXT_KEYS = [
 ] as const;
 
 const KBD_CLASS =
-  "min-h-[36px] px-2 py-1 text-sm border border-border rounded select-none transition-colors hover:border-text-secondary active:bg-bg-card focus-visible:outline-2 focus-visible:outline-accent";
+  "min-h-[30px] px-2 py-0.5 text-sm border border-border rounded select-none transition-colors hover:border-text-secondary active:bg-bg-card focus-visible:outline-2 focus-visible:outline-accent";
 
 const MODIFIER_LABELS: Record<string, string> = {
   ctrl: "Control",
@@ -125,7 +125,7 @@ export function BottomBar({ wsRef, onOpenCompose }: BottomBarProps) {
   );
 
   return (
-    <div className="flex items-center gap-1.5 py-1.5 flex-wrap" role="toolbar" aria-label="Terminal keys">
+    <div className="flex items-center gap-1.5 py-0.5 flex-wrap" role="toolbar" aria-label="Terminal keys">
       {/* Special keys */}
       <button
         aria-label="Escape"
@@ -184,7 +184,7 @@ export function BottomBar({ wsRef, onOpenCompose }: BottomBarProps) {
                 key={fk.label}
                 role="menuitem"
                 aria-label={fk.label}
-                className="px-2 py-1.5 min-h-[36px] flex items-center justify-center text-xs text-text-secondary hover:text-text-primary hover:bg-bg-card rounded focus-visible:outline-2 focus-visible:outline-accent"
+                className="px-2 py-1 min-h-[30px] flex items-center justify-center text-xs text-text-secondary hover:text-text-primary hover:bg-bg-card rounded focus-visible:outline-2 focus-visible:outline-accent"
                 onClick={() => {
                   sendWithMods(fk.plain, fk.mod);
                   setFnOpen(false);
@@ -219,7 +219,7 @@ export function BottomBar({ wsRef, onOpenCompose }: BottomBarProps) {
                 key={ek.label}
                 role="menuitem"
                 aria-label={ek.label}
-                className="px-2 py-1.5 min-h-[36px] flex items-center justify-center text-xs text-text-secondary hover:text-text-primary hover:bg-bg-card rounded focus-visible:outline-2 focus-visible:outline-accent"
+                className="px-2 py-1 min-h-[30px] flex items-center justify-center text-xs text-text-secondary hover:text-text-primary hover:bg-bg-card rounded focus-visible:outline-2 focus-visible:outline-accent"
                 onClick={() => {
                   sendWithMods(ek.plain, ek.mod);
                   setExtOpen(false);

--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -238,7 +238,7 @@ export function BottomBar({ wsRef, onOpenCompose }: BottomBarProps) {
         className={`${KBD_CLASS} text-text-secondary ml-auto`}
         onClick={onOpenCompose}
       >
-        <kbd aria-hidden="true">&#x270E;</kbd>
+        <kbd aria-hidden="true">&gt;_</kbd>
       </button>
     </div>
   );

--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -117,13 +117,13 @@ export function BottomBar({ wsRef, onOpenCompose }: BottomBarProps) {
   return (
     <div className="flex items-center gap-1.5 py-1.5 flex-wrap">
       {/* Modifier toggles */}
-      {(["ctrl", "alt", "cmd"] as const).map((key) => (
+      {([["ctrl", "^"], ["alt", "\u2325"], ["cmd", "\u2318"]] as const).map(([key, symbol]) => (
         <button
           key={key}
           className={`${KBD_CLASS} ${mods[key] ? "bg-accent/20 border-accent text-accent" : "text-text-secondary"}`}
           onClick={() => mods.toggle(key)}
         >
-          <kbd>{key.charAt(0).toUpperCase() + key.slice(1)}</kbd>
+          <kbd>{symbol}</kbd>
         </button>
       ))}
 
@@ -173,13 +173,13 @@ export function BottomBar({ wsRef, onOpenCompose }: BottomBarProps) {
         className={`${KBD_CLASS} text-text-secondary`}
         onClick={() => sendSpecial("\x1b")}
       >
-        <kbd>Esc</kbd>
+        <kbd>{"\u238B"}</kbd>
       </button>
       <button
         className={`${KBD_CLASS} text-text-secondary`}
         onClick={() => sendSpecial("\t")}
       >
-        <kbd>Tab</kbd>
+        <kbd>{"\u21E5"}</kbd>
       </button>
 
       {/* Compose toggle */}

--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useRef, useEffect } from "react";
 import { useModifierState, type ModifierSnapshot } from "@/hooks/use-modifier-state";
+import { ArrowPad } from "@/components/arrow-pad";
 
 type BottomBarProps = {
   wsRef: React.RefObject<WebSocket | null>;
@@ -20,13 +21,6 @@ function modParam(mods: ModifierSnapshot): number {
 function hasModifiers(mods: ModifierSnapshot): boolean {
   return mods.ctrl || mods.alt || mods.cmd;
 }
-
-const ARROWS = [
-  { label: "\u2190", name: "Left", code: "D" },
-  { label: "\u2192", name: "Right", code: "C" },
-  { label: "\u2191", name: "Up", code: "A" },
-  { label: "\u2193", name: "Down", code: "B" },
-] as const;
 
 const FN_KEYS = [
   { label: "F1", plain: "\x1bOP", mod: (p: number) => `\x1b[1;${p}P` },
@@ -137,17 +131,8 @@ export function BottomBar({ wsRef, onOpenCompose }: BottomBarProps) {
 
       <div className="w-px h-6 bg-border mx-1" aria-hidden="true" />
 
-      {/* Arrow keys */}
-      {ARROWS.map(({ label, name, code }) => (
-        <button
-          key={code}
-          aria-label={`${name} arrow`}
-          className={`${KBD_CLASS} text-text-secondary`}
-          onClick={() => sendArrow(code)}
-        >
-          <kbd aria-hidden="true">{label}</kbd>
-        </button>
-      ))}
+      {/* Arrow keys — combined pad: drag to send, tap to open popup */}
+      <ArrowPad onArrow={sendArrow} />
 
       <div className="w-px h-6 bg-border mx-1" aria-hidden="true" />
 

--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -35,14 +35,19 @@ const FN_KEYS = [
   { label: "F10", plain: "\x1b[21~", mod: (p: number) => `\x1b[21;${p}~` },
   { label: "F11", plain: "\x1b[23~", mod: (p: number) => `\x1b[23;${p}~` },
   { label: "F12", plain: "\x1b[24~", mod: (p: number) => `\x1b[24;${p}~` },
+] as const;
+
+const EXT_KEYS = [
   { label: "PgUp", plain: "\x1b[5~", mod: (p: number) => `\x1b[5;${p}~` },
   { label: "PgDn", plain: "\x1b[6~", mod: (p: number) => `\x1b[6;${p}~` },
   { label: "Home", plain: "\x1b[H", mod: (p: number) => `\x1b[1;${p}H` },
   { label: "End", plain: "\x1b[F", mod: (p: number) => `\x1b[1;${p}F` },
+  { label: "Ins", plain: "\x1b[2~", mod: (p: number) => `\x1b[2;${p}~` },
+  { label: "Del", plain: "\x1b[3~", mod: (p: number) => `\x1b[3;${p}~` },
 ] as const;
 
 const KBD_CLASS =
-  "min-h-[44px] px-2.5 py-1.5 text-sm border border-border rounded select-none transition-colors hover:border-text-secondary active:bg-bg-card focus-visible:outline-2 focus-visible:outline-accent";
+  "min-h-[36px] px-2 py-1 text-sm border border-border rounded select-none transition-colors hover:border-text-secondary active:bg-bg-card focus-visible:outline-2 focus-visible:outline-accent";
 
 const MODIFIER_LABELS: Record<string, string> = {
   ctrl: "Control",
@@ -53,29 +58,34 @@ const MODIFIER_LABELS: Record<string, string> = {
 export function BottomBar({ wsRef, onOpenCompose }: BottomBarProps) {
   const mods = useModifierState();
   const [fnOpen, setFnOpen] = useState(false);
+  const [extOpen, setExtOpen] = useState(false);
   const fnRef = useRef<HTMLDivElement>(null);
+  const extRef = useRef<HTMLDivElement>(null);
 
-  // Close Fn dropdown on outside click
+  // Close dropdowns on outside click
   useEffect(() => {
-    if (!fnOpen) return;
+    if (!fnOpen && !extOpen) return;
     function handleClick(e: MouseEvent) {
-      if (fnRef.current && !fnRef.current.contains(e.target as Node)) {
+      if (fnOpen && fnRef.current && !fnRef.current.contains(e.target as Node)) {
         setFnOpen(false);
+      }
+      if (extOpen && extRef.current && !extRef.current.contains(e.target as Node)) {
+        setExtOpen(false);
       }
     }
     document.addEventListener("mousedown", handleClick);
     return () => document.removeEventListener("mousedown", handleClick);
-  }, [fnOpen]);
+  }, [fnOpen, extOpen]);
 
-  // Close Fn dropdown on Escape
+  // Close dropdowns on Escape
   useEffect(() => {
-    if (!fnOpen) return;
+    if (!fnOpen && !extOpen) return;
     function handleKey(e: KeyboardEvent) {
-      if (e.key === "Escape") setFnOpen(false);
+      if (e.key === "Escape") { setFnOpen(false); setExtOpen(false); }
     }
     document.addEventListener("keydown", handleKey);
     return () => document.removeEventListener("keydown", handleKey);
-  }, [fnOpen]);
+  }, [fnOpen, extOpen]);
 
   const send = useCallback(
     (data: string) => {
@@ -116,61 +126,6 @@ export function BottomBar({ wsRef, onOpenCompose }: BottomBarProps) {
 
   return (
     <div className="flex items-center gap-1.5 py-1.5 flex-wrap" role="toolbar" aria-label="Terminal keys">
-      {/* Modifier toggles */}
-      {([["ctrl", "^"], ["alt", "\u2325"], ["cmd", "\u2318"]] as const).map(([key, symbol]) => (
-        <button
-          key={key}
-          aria-label={MODIFIER_LABELS[key]}
-          aria-pressed={mods[key]}
-          className={`${KBD_CLASS} ${mods[key] ? "bg-accent/20 border-accent text-accent" : "text-text-secondary"}`}
-          onClick={() => mods.toggle(key)}
-        >
-          <kbd aria-hidden="true">{symbol}</kbd>
-        </button>
-      ))}
-
-      <div className="w-px h-6 bg-border mx-1" aria-hidden="true" />
-
-      {/* Arrow keys — combined pad: drag to send, tap to open popup */}
-      <ArrowPad onArrow={sendArrow} />
-
-      <div className="w-px h-6 bg-border mx-1" aria-hidden="true" />
-
-      {/* Fn dropdown */}
-      <div ref={fnRef} className="relative">
-        <button
-          aria-label="Function keys"
-          aria-haspopup="true"
-          aria-expanded={fnOpen}
-          className={`${KBD_CLASS} text-text-secondary`}
-          onClick={() => setFnOpen((v) => !v)}
-        >
-          <kbd aria-hidden="true">Fn&#x25BE;</kbd>
-        </button>
-        {fnOpen && (
-          <div
-            role="menu"
-            aria-label="Function and navigation keys"
-            className="absolute bottom-full left-0 mb-1 bg-bg-primary border border-border rounded-lg shadow-2xl py-1 grid grid-cols-4 gap-0.5 min-w-[200px] z-50"
-          >
-            {FN_KEYS.map((fk) => (
-              <button
-                key={fk.label}
-                role="menuitem"
-                aria-label={fk.label}
-                className="px-2 py-1.5 min-h-[44px] flex items-center justify-center text-xs text-text-secondary hover:text-text-primary hover:bg-bg-card rounded focus-visible:outline-2 focus-visible:outline-accent"
-                onClick={() => {
-                  sendWithMods(fk.plain, fk.mod);
-                  setFnOpen(false);
-                }}
-              >
-                {fk.label}
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
-
       {/* Special keys */}
       <button
         aria-label="Escape"
@@ -186,6 +141,98 @@ export function BottomBar({ wsRef, onOpenCompose }: BottomBarProps) {
       >
         <kbd aria-hidden="true">{"\u21E5"}</kbd>
       </button>
+
+      <div className="w-px h-5 bg-border mx-0.5" aria-hidden="true" />
+
+      {/* Modifier toggles */}
+      {([["ctrl", "^"], ["alt", "\u2325"], ["cmd", "\u2318"]] as const).map(([key, symbol]) => (
+        <button
+          key={key}
+          aria-label={MODIFIER_LABELS[key]}
+          aria-pressed={mods[key]}
+          className={`${KBD_CLASS} ${mods[key] ? "bg-accent/20 border-accent text-accent" : "text-text-secondary"}`}
+          onClick={() => mods.toggle(key)}
+        >
+          <kbd aria-hidden="true">{symbol}</kbd>
+        </button>
+      ))}
+
+      <div className="w-px h-5 bg-border mx-0.5" aria-hidden="true" />
+
+      {/* Arrow keys — combined pad: drag to send, tap to open popup */}
+      <ArrowPad onArrow={sendArrow} />
+
+      {/* Fn dropdown */}
+      <div ref={fnRef} className="relative">
+        <button
+          aria-label="Function keys"
+          aria-haspopup="true"
+          aria-expanded={fnOpen}
+          className={`${KBD_CLASS} text-text-secondary`}
+          onClick={() => setFnOpen((v) => !v)}
+        >
+          <kbd aria-hidden="true">Fn</kbd>
+        </button>
+        {fnOpen && (
+          <div
+            role="menu"
+            aria-label="Function keys"
+            className="absolute bottom-full left-0 mb-1 bg-bg-primary border border-border rounded-lg shadow-2xl py-1 grid grid-cols-4 gap-0.5 min-w-[200px] z-50"
+          >
+            {FN_KEYS.map((fk) => (
+              <button
+                key={fk.label}
+                role="menuitem"
+                aria-label={fk.label}
+                className="px-2 py-1.5 min-h-[36px] flex items-center justify-center text-xs text-text-secondary hover:text-text-primary hover:bg-bg-card rounded focus-visible:outline-2 focus-visible:outline-accent"
+                onClick={() => {
+                  sendWithMods(fk.plain, fk.mod);
+                  setFnOpen(false);
+                }}
+              >
+                {fk.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Extended keys dropdown */}
+      <div ref={extRef} className="relative">
+        <button
+          aria-label="Extended keys"
+          aria-haspopup="true"
+          aria-expanded={extOpen}
+          className={`${KBD_CLASS} text-text-secondary`}
+          onClick={() => setExtOpen((v) => !v)}
+        >
+          <kbd aria-hidden="true">{"\u22EF"}</kbd>
+        </button>
+        {extOpen && (
+          <div
+            role="menu"
+            aria-label="Extended keys"
+            className="absolute bottom-full left-0 mb-1 bg-bg-primary border border-border rounded-lg shadow-2xl py-1 grid grid-cols-3 gap-0.5 min-w-[150px] z-50"
+          >
+            {EXT_KEYS.map((ek) => (
+              <button
+                key={ek.label}
+                role="menuitem"
+                aria-label={ek.label}
+                className="px-2 py-1.5 min-h-[36px] flex items-center justify-center text-xs text-text-secondary hover:text-text-primary hover:bg-bg-card rounded focus-visible:outline-2 focus-visible:outline-accent"
+                onClick={() => {
+                  sendWithMods(ek.plain, ek.mod);
+                  setExtOpen(false);
+                }}
+              >
+                {ek.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="w-px h-5 bg-border mx-0.5" aria-hidden="true" />
 
       {/* Compose toggle */}
       <button

--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -22,10 +22,10 @@ function hasModifiers(mods: ModifierSnapshot): boolean {
 }
 
 const ARROWS = [
-  { label: "\u2190", code: "D" }, // ←
-  { label: "\u2192", code: "C" }, // →
-  { label: "\u2191", code: "A" }, // ↑
-  { label: "\u2193", code: "B" }, // ↓
+  { label: "\u2190", name: "Left", code: "D" },
+  { label: "\u2192", name: "Right", code: "C" },
+  { label: "\u2191", name: "Up", code: "A" },
+  { label: "\u2193", name: "Down", code: "B" },
 ] as const;
 
 const FN_KEYS = [
@@ -48,7 +48,13 @@ const FN_KEYS = [
 ] as const;
 
 const KBD_CLASS =
-  "min-h-[44px] px-2.5 py-1.5 text-sm border border-border rounded select-none transition-colors hover:border-text-secondary active:bg-bg-card";
+  "min-h-[44px] px-2.5 py-1.5 text-sm border border-border rounded select-none transition-colors hover:border-text-secondary active:bg-bg-card focus-visible:outline-2 focus-visible:outline-accent";
+
+const MODIFIER_LABELS: Record<string, string> = {
+  ctrl: "Control",
+  alt: "Option",
+  cmd: "Command",
+};
 
 export function BottomBar({ wsRef, onOpenCompose }: BottomBarProps) {
   const mods = useModifierState();
@@ -115,47 +121,59 @@ export function BottomBar({ wsRef, onOpenCompose }: BottomBarProps) {
   );
 
   return (
-    <div className="flex items-center gap-1.5 py-1.5 flex-wrap">
+    <div className="flex items-center gap-1.5 py-1.5 flex-wrap" role="toolbar" aria-label="Terminal keys">
       {/* Modifier toggles */}
       {([["ctrl", "^"], ["alt", "\u2325"], ["cmd", "\u2318"]] as const).map(([key, symbol]) => (
         <button
           key={key}
+          aria-label={MODIFIER_LABELS[key]}
+          aria-pressed={mods[key]}
           className={`${KBD_CLASS} ${mods[key] ? "bg-accent/20 border-accent text-accent" : "text-text-secondary"}`}
           onClick={() => mods.toggle(key)}
         >
-          <kbd>{symbol}</kbd>
+          <kbd aria-hidden="true">{symbol}</kbd>
         </button>
       ))}
 
-      <div className="w-px h-6 bg-border mx-1" />
+      <div className="w-px h-6 bg-border mx-1" aria-hidden="true" />
 
       {/* Arrow keys */}
-      {ARROWS.map(({ label, code }) => (
+      {ARROWS.map(({ label, name, code }) => (
         <button
           key={code}
+          aria-label={`${name} arrow`}
           className={`${KBD_CLASS} text-text-secondary`}
           onClick={() => sendArrow(code)}
         >
-          <kbd>{label}</kbd>
+          <kbd aria-hidden="true">{label}</kbd>
         </button>
       ))}
 
-      <div className="w-px h-6 bg-border mx-1" />
+      <div className="w-px h-6 bg-border mx-1" aria-hidden="true" />
 
       {/* Fn dropdown */}
       <div ref={fnRef} className="relative">
         <button
+          aria-label="Function keys"
+          aria-haspopup="true"
+          aria-expanded={fnOpen}
           className={`${KBD_CLASS} text-text-secondary`}
           onClick={() => setFnOpen((v) => !v)}
         >
-          <kbd>Fn&#x25BE;</kbd>
+          <kbd aria-hidden="true">Fn&#x25BE;</kbd>
         </button>
         {fnOpen && (
-          <div className="absolute bottom-full left-0 mb-1 bg-bg-primary border border-border rounded-lg shadow-2xl py-1 grid grid-cols-4 gap-0.5 min-w-[200px] z-50">
+          <div
+            role="menu"
+            aria-label="Function and navigation keys"
+            className="absolute bottom-full left-0 mb-1 bg-bg-primary border border-border rounded-lg shadow-2xl py-1 grid grid-cols-4 gap-0.5 min-w-[200px] z-50"
+          >
             {FN_KEYS.map((fk) => (
               <button
                 key={fk.label}
-                className="px-2 py-1.5 min-h-[44px] flex items-center justify-center text-xs text-text-secondary hover:text-text-primary hover:bg-bg-card rounded"
+                role="menuitem"
+                aria-label={fk.label}
+                className="px-2 py-1.5 min-h-[44px] flex items-center justify-center text-xs text-text-secondary hover:text-text-primary hover:bg-bg-card rounded focus-visible:outline-2 focus-visible:outline-accent"
                 onClick={() => {
                   sendWithMods(fk.plain, fk.mod);
                   setFnOpen(false);
@@ -170,24 +188,27 @@ export function BottomBar({ wsRef, onOpenCompose }: BottomBarProps) {
 
       {/* Special keys */}
       <button
+        aria-label="Escape"
         className={`${KBD_CLASS} text-text-secondary`}
         onClick={() => sendSpecial("\x1b")}
       >
-        <kbd>{"\u238B"}</kbd>
+        <kbd aria-hidden="true">{"\u238B"}</kbd>
       </button>
       <button
+        aria-label="Tab"
         className={`${KBD_CLASS} text-text-secondary`}
         onClick={() => sendSpecial("\t")}
       >
-        <kbd>{"\u21E5"}</kbd>
+        <kbd aria-hidden="true">{"\u21E5"}</kbd>
       </button>
 
       {/* Compose toggle */}
       <button
+        aria-label="Compose text"
         className={`${KBD_CLASS} text-text-secondary`}
         onClick={onOpenCompose}
       >
-        <kbd>&#x270E;</kbd>
+        <kbd aria-hidden="true">&#x270E;</kbd>
       </button>
     </div>
   );

--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -171,7 +171,7 @@ export function BottomBar({ wsRef, onOpenCompose }: BottomBarProps) {
           className={`${KBD_CLASS} text-text-secondary`}
           onClick={() => setFnOpen((v) => !v)}
         >
-          <kbd aria-hidden="true">Fn</kbd>
+          <kbd aria-hidden="true">F&#x25B4;</kbd>
         </button>
         {fnOpen && (
           <div
@@ -232,12 +232,10 @@ export function BottomBar({ wsRef, onOpenCompose }: BottomBarProps) {
         )}
       </div>
 
-      <div className="w-px h-5 bg-border mx-0.5" aria-hidden="true" />
-
-      {/* Compose toggle */}
+      {/* Compose toggle — right-aligned */}
       <button
         aria-label="Compose text"
-        className={`${KBD_CLASS} text-text-secondary`}
+        className={`${KBD_CLASS} text-text-secondary ml-auto`}
         onClick={onOpenCompose}
       >
         <kbd aria-hidden="true">&#x270E;</kbd>

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useId } from "react";
 
 export type PaletteAction = {
   id: string;
@@ -18,6 +18,7 @@ export function CommandPalette({ actions }: CommandPaletteProps) {
   const [query, setQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
+  const listId = useId();
 
   const filtered = actions.filter((a) =>
     a.label.toLowerCase().includes(query.toLowerCase()),
@@ -66,6 +67,10 @@ export function CommandPalette({ actions }: CommandPaletteProps) {
 
   if (!open) return null;
 
+  const activeDescendant = filtered[selectedIndex]
+    ? `${listId}-option-${filtered[selectedIndex].id}`
+    : undefined;
+
   return (
     <div
       data-testid="palette-overlay"
@@ -73,10 +78,13 @@ export function CommandPalette({ actions }: CommandPaletteProps) {
       onClick={() => setOpen(false)}
     >
       {/* Backdrop */}
-      <div className="fixed inset-0 bg-black/50" />
+      <div className="fixed inset-0 bg-black/50" aria-hidden="true" />
 
       {/* Modal */}
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Command palette"
         className="relative w-full max-w-lg bg-bg-primary border border-border rounded-lg shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
@@ -90,19 +98,33 @@ export function CommandPalette({ actions }: CommandPaletteProps) {
           }}
           onKeyDown={handleKeyDown}
           placeholder="Type a command..."
+          aria-label="Search commands"
+          aria-autocomplete="list"
+          aria-controls={listId}
+          aria-activedescendant={activeDescendant}
+          role="combobox"
+          aria-expanded="true"
           className="w-full bg-transparent text-text-primary text-sm p-3 border-b border-border outline-none placeholder:text-text-secondary"
         />
-        <div className="max-h-64 overflow-y-auto py-1">
+        <div
+          id={listId}
+          role="listbox"
+          aria-label="Commands"
+          className="max-h-64 overflow-y-auto py-1"
+        >
           {filtered.length === 0 ? (
             <div className="px-3 py-2 text-xs text-text-secondary">
               No results
             </div>
           ) : (
             filtered.map((action, i) => (
-              <button
+              <div
                 key={action.id}
+                id={`${listId}-option-${action.id}`}
+                role="option"
+                aria-selected={i === selectedIndex}
                 onClick={() => handleSelect(action)}
-                className={`w-full text-left px-3 py-2 text-sm flex items-center justify-between ${
+                className={`w-full text-left px-3 py-2 text-sm flex items-center justify-between cursor-pointer ${
                   i === selectedIndex
                     ? "bg-bg-card text-text-primary"
                     : "text-text-secondary hover:text-text-primary hover:bg-bg-card/50"
@@ -114,7 +136,7 @@ export function CommandPalette({ actions }: CommandPaletteProps) {
                     {action.shortcut}
                   </kbd>
                 )}
-              </button>
+              </div>
             ))
           )}
         </div>

--- a/src/components/compose-buffer.tsx
+++ b/src/components/compose-buffer.tsx
@@ -36,6 +36,10 @@ export function ComposeBuffer({ wsRef, onClose }: ComposeBufferProps) {
       <textarea
         ref={textareaRef}
         autoFocus
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck={false}
         placeholder="Compose text..."
         className="w-full bg-bg-card text-text-primary text-sm p-3 rounded border border-border outline-none resize-y min-h-[80px] max-h-[200px] placeholder:text-text-secondary focus:border-text-secondary"
         onKeyDown={handleKeyDown}

--- a/src/components/compose-buffer.tsx
+++ b/src/components/compose-buffer.tsx
@@ -40,6 +40,7 @@ export function ComposeBuffer({ wsRef, onClose }: ComposeBufferProps) {
         autoCorrect="off"
         autoCapitalize="off"
         spellCheck={false}
+        aria-label="Compose text to send to terminal"
         placeholder="Compose text..."
         className="w-full bg-bg-card text-text-primary text-sm p-3 rounded border border-border outline-none resize-y min-h-[80px] max-h-[200px] placeholder:text-text-secondary focus:border-text-secondary"
         onKeyDown={handleKeyDown}

--- a/src/components/dialog.tsx
+++ b/src/components/dialog.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useRef, useId } from "react";
+
 type DialogProps = {
   title: string;
   onClose: () => void;
@@ -7,17 +9,58 @@ type DialogProps = {
 };
 
 export function Dialog({ title, onClose, children }: DialogProps) {
+  const titleId = useId();
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Focus trap + Escape to close
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    const focusable = dialog.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    );
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    // Focus first focusable element
+    first?.focus();
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key === "Tab" && focusable.length > 0) {
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last?.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first?.focus();
+        }
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
   return (
     <div
       className="fixed inset-0 z-40 flex items-center justify-center"
       onClick={onClose}
     >
-      <div className="fixed inset-0 bg-black/50" />
+      <div className="fixed inset-0 bg-black/50" aria-hidden="true" />
       <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
         className="relative bg-bg-primary border border-border rounded-lg p-4 w-full max-w-sm shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
-        <h2 className="text-sm font-medium mb-3">{title}</h2>
+        <h2 id={titleId} className="text-sm font-medium mb-3">{title}</h2>
         {children}
       </div>
     </div>

--- a/src/components/session-card.tsx
+++ b/src/components/session-card.tsx
@@ -20,7 +20,8 @@ export function SessionCard({
   return (
     <button
       onClick={onClick}
-      className={`group w-full text-left p-3 rounded border transition-colors ${
+      aria-label={`${win.name} — ${projectName}, ${win.activity}`}
+      className={`group w-full text-left p-3 rounded border transition-colors focus-visible:outline-2 focus-visible:outline-accent ${
         focused
           ? "border-accent bg-bg-card/80"
           : "border-border bg-bg-card hover:border-text-secondary"
@@ -40,21 +41,20 @@ export function SessionCard({
             className={`w-2 h-2 rounded-full ${
               win.activity === "active" ? "bg-accent-green" : "bg-text-secondary"
             }`}
-            title={win.activity}
+            aria-label={win.activity}
           />
           {onKill && (
-            <span
-              role="button"
-              tabIndex={-1}
+            <button
+              type="button"
               onClick={(e) => {
                 e.stopPropagation();
                 onKill(e);
               }}
-              className="text-text-secondary hover:text-text-primary transition-colors ml-1 text-xs"
-              title="Kill window"
+              aria-label={`Kill window ${win.name}`}
+              className="text-text-secondary hover:text-text-primary transition-colors ml-1 text-xs focus-visible:outline-2 focus-visible:outline-accent"
             >
               ✕
-            </span>
+            </button>
           )}
         </div>
       </div>

--- a/src/components/top-bar-chrome.tsx
+++ b/src/components/top-bar-chrome.tsx
@@ -7,10 +7,10 @@ export function TopBarChrome() {
   const { breadcrumbs, line2Left, line2Right, isConnected } = useChrome();
 
   return (
-    <div>
+    <header>
       {/* Line 1: Breadcrumbs + Status */}
       <div className="flex items-center justify-between py-2">
-        <nav className="flex items-center gap-1.5 text-sm">
+        <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-sm">
           <Link
             href="/"
             className="font-bold text-text-primary hover:text-accent transition-colors"
@@ -19,9 +19,9 @@ export function TopBarChrome() {
           </Link>
           {breadcrumbs.map((crumb, i) => (
             <span key={i} className="flex items-center gap-1.5">
-              <span className="text-text-secondary">›</span>
+              <span className="text-text-secondary" aria-hidden="true">›</span>
               {crumb.icon && (
-                <span className="text-text-secondary">{crumb.icon}</span>
+                <span className="text-text-secondary" aria-hidden="true">{crumb.icon}</span>
               )}
               {crumb.href ? (
                 <Link
@@ -31,18 +31,19 @@ export function TopBarChrome() {
                   {crumb.label}
                 </Link>
               ) : (
-                <span className="text-text-primary font-medium">
+                <span className="text-text-primary font-medium" aria-current="page">
                   {crumb.label}
                 </span>
               )}
             </span>
           ))}
         </nav>
-        <div className="flex items-center gap-3 text-xs text-text-secondary">
+        <div className="flex items-center gap-3 text-xs text-text-secondary" role="status" aria-live="polite">
           <span
             className={`w-2 h-2 rounded-full ${
               isConnected ? "bg-accent-green" : "bg-text-secondary"
             }`}
+            aria-hidden="true"
           />
           <span>{isConnected ? "live" : "disconnected"}</span>
           <kbd className="px-1.5 py-0.5 rounded border border-border text-text-secondary">
@@ -56,6 +57,6 @@ export function TopBarChrome() {
         <div>{line2Left}</div>
         <div>{line2Right}</div>
       </div>
-    </div>
+    </header>
   );
 }

--- a/src/components/top-bar-chrome.tsx
+++ b/src/components/top-bar-chrome.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import { useChrome } from "@/contexts/chrome-context";
 
@@ -13,9 +14,10 @@ export function TopBarChrome() {
         <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-sm">
           <Link
             href="/"
-            className="font-bold text-text-primary hover:text-accent transition-colors"
+            className="hover:opacity-80 transition-opacity"
+            aria-label="RunKit home"
           >
-            RK
+            <Image src="/logo.svg" alt="RunKit" width={20} height={20} />
           </Link>
           {breadcrumbs.map((crumb, i) => (
             <span key={i} className="flex items-center gap-1.5">

--- a/src/contexts/chrome-context.tsx
+++ b/src/contexts/chrome-context.tsx
@@ -70,7 +70,7 @@ export function BottomSlot() {
   const { bottomBar } = useChrome();
   return (
     <div className="shrink-0">
-      <div className="max-w-4xl mx-auto w-full px-6">{bottomBar}</div>
+      <div className="max-w-4xl mx-auto w-full px-6 pb-1">{bottomBar}</div>
     </div>
   );
 }

--- a/src/contexts/chrome-context.tsx
+++ b/src/contexts/chrome-context.tsx
@@ -58,11 +58,11 @@ export function useChrome() {
 export function ContentSlot({ children }: { children: React.ReactNode }) {
   const { fullbleed } = useChrome();
   return (
-    <div className={`flex-1 min-h-0 overflow-x-hidden ${fullbleed ? "overflow-hidden" : "overflow-y-auto"}`}>
+    <main id="main-content" className={`flex-1 min-h-0 overflow-x-hidden ${fullbleed ? "overflow-hidden" : "overflow-y-auto"}`}>
       <div className={`max-w-4xl mx-auto w-full px-6 min-w-0 min-h-full flex flex-col ${fullbleed ? "overflow-hidden" : ""}`}>
         {children}
       </div>
-    </div>
+    </main>
   );
 }
 

--- a/src/contexts/chrome-context.tsx
+++ b/src/contexts/chrome-context.tsx
@@ -19,6 +19,8 @@ type ChromeContextType = {
   setBottomBar: (node: React.ReactNode) => void;
   isConnected: boolean;
   setIsConnected: (connected: boolean) => void;
+  fullbleed: boolean;
+  setFullbleed: (v: boolean) => void;
 };
 
 const ChromeContext = createContext<ChromeContextType | null>(null);
@@ -29,6 +31,7 @@ export function ChromeProvider({ children }: { children: React.ReactNode }) {
   const [line2Right, setLine2Right] = useState<React.ReactNode>(null);
   const [bottomBar, setBottomBar] = useState<React.ReactNode>(null);
   const [isConnected, setIsConnected] = useState(false);
+  const [fullbleed, setFullbleed] = useState(false);
 
   const value = useMemo(() => ({
     breadcrumbs, setBreadcrumbs,
@@ -36,7 +39,8 @@ export function ChromeProvider({ children }: { children: React.ReactNode }) {
     line2Right, setLine2Right,
     bottomBar, setBottomBar,
     isConnected, setIsConnected,
-  }), [breadcrumbs, line2Left, line2Right, bottomBar, isConnected]);
+    fullbleed, setFullbleed,
+  }), [breadcrumbs, line2Left, line2Right, bottomBar, isConnected, fullbleed]);
 
   return (
     <ChromeContext.Provider value={value}>
@@ -49,6 +53,17 @@ export function useChrome() {
   const ctx = useContext(ChromeContext);
   if (!ctx) throw new Error("useChrome must be used within ChromeProvider");
   return ctx;
+}
+
+export function ContentSlot({ children }: { children: React.ReactNode }) {
+  const { fullbleed } = useChrome();
+  return (
+    <div className={`flex-1 min-h-0 overflow-x-hidden ${fullbleed ? "overflow-hidden" : "overflow-y-auto"}`}>
+      <div className={`max-w-4xl mx-auto w-full px-6 min-w-0 min-h-full flex flex-col ${fullbleed ? "overflow-hidden" : ""}`}>
+        {children}
+      </div>
+    </div>
+  );
 }
 
 export function BottomSlot() {


### PR DESCRIPTION
## Summary

Fix mobile UI issues (iOS autofill bar, scroll behavior, content overflow) and comprehensively improve accessibility across all components. Redesign the terminal bottom bar with compact layout, combined arrow pad, and split key menus.

## Changes

- Fix iOS password autofill bar on compose textarea
- Abbreviate modifier key labels to symbols (^, ⌥, ⌘, ⎋, ⇥)
- Add fullbleed mode to prevent page scroll on terminal view
- Fix content bleeding right on mobile viewports
- Add ARIA attributes, roles, and labels across all components
- Add focus trapping and dialog semantics to Dialog and CommandPalette
- Add skip-to-content link and main landmark
- Add cursor: pointer globally for all clickable elements
- Replace RK text with logo.svg in top bar
- Replace 4 arrow buttons with combined ArrowPad (drag + tap popup)
- Split Fn keys from extended navigation keys (⋯ menu)
- Reorder bottom bar: ⎋ ⇥ | ^ ⌥ ⌘ | ↑ F▴ ⋯ | >_
- Compact button heights and bar padding
- Toggle compose buffer on repeated >_ click

## Stats
| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| fix | — | — | — | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)