### PR TITLE
feat: Add local HTTPS via Caddy reverse proxy

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,14 @@
+# Local HTTPS reverse proxy for run-kit
+# Usage: just https (requires caddy: brew install caddy)
+#
+# Proxies both Next.js and the terminal relay through a single HTTPS port.
+# Caddy auto-generates and trusts local TLS certs — no mkcert needed.
+
+{$RK_HTTPS_HOST:localhost}:{$RK_HTTPS_PORT:3443} {
+	handle /relay/* {
+		uri strip_prefix /relay
+		reverse_proxy localhost:{$RK_RELAY_PORT:3001}
+	}
+
+	reverse_proxy localhost:{$RK_PORT:3000}
+}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ Web-based agent orchestration dashboard. Monitor and interact with tmux sessions
 - [Node.js](https://nodejs.org/) (v20+)
 - [pnpm](https://pnpm.io/)
 - [tmux](https://github.com/tmux/tmux) installed and on your `PATH`
+- [just](https://github.com/casey/just) task runner
+- [Caddy](https://caddyserver.com/) *(optional, for local HTTPS)*
+
+```sh
+brew install node pnpm tmux just caddy
+```
+
+Run `just doctor` to verify all dependencies are installed.
 
 ## Getting Started
 

--- a/justfile
+++ b/justfile
@@ -38,17 +38,27 @@ down:
 
 # Signal a restart (build + health-check + auto-rollback); starts supervisor if not running
 restart:
-    #!/usr/bin/env bash
-    if tmux has-session -t runK 2>/dev/null; then
-        touch .restart-requested
-        echo "Restart signaled — supervisor will pick it up within 2s"
-    else
-        echo "Supervisor not running — starting it (includes build)..."
-        tmux new-session -d -s runK 'pnpm supervisor'
-        echo "Supervisor running in tmux session 'runK'"
-        echo "  Attach: just logs"
-        echo "  Stop:   just down"
-    fi
+    src/scripts/restart.sh
+
+# ─── HTTPS ────────────────────────────────────────────────────
+
+# Start Caddy HTTPS proxy in front of dev server (requires caddy: brew install caddy)
+https:
+    caddy run --config Caddyfile
+
+# Start supervisor + Caddy HTTPS proxy together
+up-https:
+    pnpm concurrently -n super,caddy -c blue,green "pnpm supervisor" "caddy run --config Caddyfile"
+
+# One-time: install Caddy's local CA into system trust store
+trust:
+    caddy trust
+
+# ─── Setup ────────────────────────────────────────────────────
+
+# Check that all system dependencies are installed
+doctor:
+    src/scripts/doctor.sh
 
 # ─── Quality ──────────────────────────────────────────────────
 

--- a/src/app/p/[project]/[window]/terminal-client.tsx
+++ b/src/app/p/[project]/[window]/terminal-client.tsx
@@ -180,9 +180,14 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
       fitAddon.fit();
 
       // Connect WebSocket — derive from current host, use correct protocol
-      const wsProto = window.location.protocol === "https:" ? "wss:" : "ws:";
+      // When served over HTTPS (e.g. via Caddy), use wss: on the same host/port
+      // with /relay/ prefix. Over HTTP, connect directly to the relay port.
+      const isSecure = window.location.protocol === "https:";
+      const wsProto = isSecure ? "wss:" : "ws:";
       const wsHost = window.location.hostname;
-      const wsUrl = `${wsProto}//${wsHost}:${relayPort}/${projectName}/${windowIndex}`;
+      const wsUrl = isSecure
+        ? `${wsProto}//${wsHost}:${window.location.port || "443"}/relay/${projectName}/${windowIndex}`
+        : `${wsProto}//${wsHost}:${relayPort}/${projectName}/${windowIndex}`;
       const ws = new WebSocket(wsUrl);
       wsRef.current = ws;
 

--- a/src/scripts/doctor.sh
+++ b/src/scripts/doctor.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check that all required system dependencies are installed.
+
+ok=0
+warn=0
+
+check() {
+  if command -v "$1" &>/dev/null; then
+    printf "  ✓ %s\n" "$1"
+  else
+    printf "  ✗ %s — %s\n" "$1" "$2"
+    (( "$3" )) && ok=1 || warn=1
+  fi
+}
+
+echo "Required:"
+check node    "https://nodejs.org/"         1
+check pnpm    "https://pnpm.io/"            1
+check tmux    "https://github.com/tmux/tmux" 1
+check just    "https://github.com/casey/just" 1
+
+echo ""
+echo "Optional (HTTPS):"
+check caddy   "brew install caddy"          0
+
+echo ""
+if (( ok )); then
+  echo "Some required dependencies are missing."
+  echo "Install all at once:  brew install node pnpm tmux just caddy"
+  exit 1
+elif (( warn )); then
+  echo "All required dependencies found. Some optional ones are missing."
+  exit 0
+else
+  echo "All dependencies found."
+  exit 0
+fi

--- a/src/scripts/restart.sh
+++ b/src/scripts/restart.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Signal a restart if supervisor is running, otherwise start it.
+
+if tmux has-session -t runK 2>/dev/null; then
+  touch .restart-requested
+  echo "Restart signaled — supervisor will pick it up within 2s"
+else
+  echo "Supervisor not running — starting it (includes build)..."
+  tmux new-session -d -s runK 'pnpm supervisor'
+  echo "Supervisor running in tmux session 'runK'"
+  echo "  Attach: just logs"
+  echo "  Stop:   just down"
+fi


### PR DESCRIPTION
## Summary

Adds optional local HTTPS support using Caddy as a reverse proxy — replacing the more complex approach in PR #9 (mkcert + custom HTTPS server + config extensions) with a single Caddyfile and zero changes to the Node.js servers.

## Changes

- **Caddyfile** — single HTTPS port (`:3443`) proxying Next.js and terminal relay (via `/relay/` path prefix)
- **terminal-client.tsx** — route WebSocket through `/relay/` prefix when page is served over HTTPS
- **justfile** — new `https`, `up-https`, `trust`, `doctor` recipes; extracted `restart` to script
- **src/scripts/doctor.sh** — system dependency checker (node, pnpm, tmux, just, caddy)
- **src/scripts/restart.sh** — extracted from inline justfile recipe
- **README** — updated prerequisites with `brew install` one-liner and `just doctor`

## Stats
| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| feat | — | — | — | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)