### PR TITLE
docs: Fix memory gaps and fill project context

### DIFF
--- a/docs/memory/index.md
+++ b/docs/memory/index.md
@@ -5,4 +5,4 @@
 
 | Domain | Description | Memory Files |
 |--------|-------------|------|
-| [run-kit](run-kit/index.md) | Web-based agent orchestration dashboard | [architecture](run-kit/architecture.md), [ui-patterns](run-kit/ui-patterns.md) |
+| [run-kit](run-kit/index.md) | Web-based agent orchestration dashboard | [architecture](run-kit/architecture.md), [tmux-sessions](run-kit/tmux-sessions.md), [ui-patterns](run-kit/ui-patterns.md) |

--- a/docs/memory/run-kit/architecture.md
+++ b/docs/memory/run-kit/architecture.md
@@ -96,7 +96,7 @@ Pages do NOT render their own top bar or outer containers — they set chrome sl
 - **Layout-level SessionProvider (not per-page SSE)** — Single `EventSource` connection at layout level, shared across all pages. Eliminates redundant connections and per-page `isConnected` forwarding boilerplate.
 - **Sticky modifier state via useRef + forceUpdate** — `useModifierState` uses a ref for the authoritative state and a counter state to trigger re-renders. Ensures `consume()` reads the latest value atomically without stale closure issues.
 - **Compose buffer as native textarea (not xterm input)** — xterm renders to `<canvas>`, blocking OS-level input features. The compose buffer provides a real `<textarea>` where dictation, autocorrect, paste, and IME all work. Text sent as a single WebSocket message.
-- **`i` key intercepted in capture phase** — Must prevent xterm from receiving the keystroke. Capture phase handler fires before xterm's internal textarea, allowing `stopPropagation()` to block it.
+- **Armed modifiers bridge to physical keyboard** — When bottom-bar modifiers (Ctrl/Alt/Cmd) are armed, a capture-phase `keydown` listener intercepts physical keypresses, translates them to terminal escape sequences (Ctrl+letter → control characters, Alt/Cmd → ESC prefix), and sends via WebSocket. Prevents xterm from receiving the unmodified key. Ignores real Cmd/Ctrl/Alt held by the OS.
 
 ## Testing
 

--- a/docs/memory/run-kit/ui-patterns.md
+++ b/docs/memory/run-kit/ui-patterns.md
@@ -18,11 +18,11 @@ The root layout renders `TopBarChrome` (`src/components/top-bar-chrome.tsx`) whi
 
 | Page | Breadcrumb |
 |------|-----------|
-| Dashboard | `RK` (logo placeholder only) |
-| Project | `RK › ⬡ {name}` |
-| Terminal | `RK › ⬡ {name} › ❯ {window}` |
+| Dashboard | `{logo}` (SVG logo only) |
+| Project | `{logo} › ⬡ {name}` |
+| Terminal | `{logo} › ⬡ {name} › ❯ {window}` |
 
-- `RK` — logo placeholder, always links to `/`
+- Logo SVG (`logo.svg`) — always links to `/`
 - ⬡ — Unicode hexagon (U+2B21), `text-text-secondary`, precedes project name
 - ❯ — Unicode heavy right angle (U+276F), `text-text-secondary`, precedes window name
 - All segments except the last are clickable links
@@ -47,13 +47,15 @@ Line 2 renders even when empty — prevents layout shift during navigation and b
 
 ## Bottom Bar (Terminal Page Only)
 
-Single row of `<kbd>` styled buttons, injected by `TerminalClient` via `setBottomBar()` from ChromeProvider. Layout: `Ctrl Alt Cmd | <- -> up down | Fn Esc Tab compose`.
+Single row of `<kbd>` styled buttons, injected by `TerminalClient` via `setBottomBar()` from ChromeProvider. Layout: `Ctrl Alt Cmd | ArrowPad | F▴ Esc Tab >_`.
 
 **Modifier toggles** (Ctrl, Alt, Cmd): Sticky armed state with visual indicator (`accent` bg). Click to arm, auto-clears after next key is sent. Click again while armed to disarm. Multiple modifiers can be armed simultaneously.
 
-**Arrow keys**: Send ANSI escape sequences (`[A/B/C/D`). With modifiers, use xterm parameter encoding (`[1;{mod}X`). Modifier parameter: 1 + (alt?2:0) + (ctrl?4:0) + (cmd?8:0).
+**Armed modifier bridging**: When modifiers are armed, a capture-phase `keydown` listener intercepts physical keypresses and translates them to terminal escape sequences (Ctrl+letter → control characters, Alt/Cmd → ESC prefix). Sends via WebSocket, preventing xterm from receiving the unmodified key. Ignores real Cmd/Ctrl/Alt held by the OS.
 
-**Function key dropdown** (Fn): Opens a grid dropdown above the button. Contains F1-F12, PgUp, PgDn, Home, End. Closes after each selection, on outside click, or on Escape.
+**ArrowPad** (`arrow-pad.tsx`): Combined directional pad replacing individual arrow buttons. Sends ANSI escape sequences (`[A/B/C/D`). With modifiers, use xterm parameter encoding (`[1;{mod}X`). Modifier parameter: 1 + (alt?2:0) + (ctrl?4:0) + (cmd?8:0).
+
+**Function key dropdown** (F▴): Opens a grid dropdown above the button. Contains F1-F12, PgUp, PgDn, Home, End. Closes after each selection, on outside click, or on Escape.
 
 **Special keys** (Esc, Tab): Direct send. Ctrl is not consumed for Esc/Tab (Esc IS Ctrl+[, Tab IS Ctrl+I in terminal semantics) — Ctrl stays armed for the next key. Alt/Cmd prefix with ESC (Meta convention).
 
@@ -63,7 +65,7 @@ Single row of `<kbd>` styled buttons, injected by `TerminalClient` via `setBotto
 
 Native `<textarea>` overlay triggered by the compose button. Appears above the bottom bar inside the content area. Terminal dims (`opacity-50`) while compose is open.
 
-- **Open**: Tap compose button, or press `i` on desktop (intercepted in capture phase before xterm)
+- **Open**: Tap compose button (`>_` icon)
 - **Send**: Click Send button or press Cmd/Ctrl+Enter — entire text transmitted as one WebSocket message
 - **Dismiss**: Press Escape — closes without sending, text discarded
 - **Why**: xterm is a `<canvas>`, not a native text input. iOS dictation, autocorrect, paste, IME all require a real DOM element. Also useful on desktop for pasting large text blocks over a laggy WebSocket.
@@ -81,7 +83,7 @@ Native `<textarea>` overlay triggered by the compose button. Appears above the b
 | `j` / `k` | Navigate cards down/up | Dashboard, Project view |
 | `Enter` | Drill into focused item | Dashboard, Project view |
 | `Esc Esc` | Navigate back | Terminal view (300ms window) |
-| `i` | Open compose buffer | Terminal view (capture phase, prevents xterm from receiving) |
+
 
 ### Dashboard
 | Key | Action |

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -23,3 +23,4 @@
 | Spec | Description |
 |------|-------------|
 | [Design Philosophy](design.md) | Core design principles and mental models behind fab-kit |
+| [Short-Term Goal](short-term-goal.md) | Minimum viable product requirements and priorities |

--- a/fab/project/context.md
+++ b/fab/project/context.md
@@ -15,4 +15,25 @@
          Python, FastAPI, SQLAlchemy, PostgreSQL
 -->
 
-{TECH_STACK_AND_CONVENTIONS}
+## Tech Stack
+
+- **Runtime**: Node.js (ESM)
+- **Framework**: Next.js 15 (App Router, Server Components by default)
+- **Language**: TypeScript 5.7+
+- **UI**: React 19, Tailwind CSS 4, shadcn/ui (generated into `components/ui/`)
+- **Terminal**: xterm.js 5 (`@xterm/xterm`) with FitAddon and WebLinks addon
+- **Terminal relay**: WebSocket server (`ws`) + `node-pty` for tmux pane I/O
+- **Testing**: Vitest 4, Testing Library (React + jest-dom), jsdom
+- **Package manager**: pnpm
+- **Build**: `pnpm build` (Next.js production build)
+- **Config parsing**: `yaml` package for `run-kit.yaml`
+
+## Conventions
+
+- Server Components by default; Client Components only for interactivity (keyboard handlers, xterm, SSE)
+- All subprocess calls via `execFile` with argument arrays + timeouts (never `exec` or shell strings)
+- State derived from tmux + filesystem at request time — no database, no in-memory caches
+- Fab-kit scripts wrapped in typed async functions in `src/lib/*.ts`
+- Dark theme only, monospace everywhere, `max-w-4xl` on all pages
+- Three routes: `/`, `/p/:project`, `/p/:project/:window`
+- SSE for real-time session state, WebSocket for terminal I/O


### PR DESCRIPTION
## Summary

Fix stale references, missing documentation, and empty placeholder files across memory and project docs. Removes deleted `i` key shortcut references, documents the armed-modifier keyboard bridging feature, and fills in the tech stack context that every fab skill reads.

## Changes

- Remove stale `i` key compose shortcut from architecture and UI patterns memory (removed in 078e432)
- Document armed-modifier physical keyboard bridging (added in 4ff8174)
- Fill `fab/project/context.md` with real tech stack (Next.js 15, React 19, TS 5.7, Tailwind 4, xterm.js, etc.)
- Update UI patterns for ArrowPad component, logo SVG, `>_` compose icon, `F▴` label
- Add `tmux-sessions` to top-level memory index (was in domain index but missing from parent)
- Add `short-term-goal.md` to specs index

## Stats
| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| docs | — | — | — | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)