### PR TITLE
Add rename window action, shorten kill label

### DIFF
--- a/docs/memory/run-kit/architecture.md
+++ b/docs/memory/run-kit/architecture.md
@@ -36,7 +36,7 @@ The tmux server is an external dependency — never started or stopped by run-ki
 |----------|--------|---------|
 | `/api/health` | GET | Returns `200 { "status": "ok" }` for supervisor health checks |
 | `/api/sessions` | GET | Returns `ProjectSession[]` — one per tmux session, with auto-detected fab enrichment |
-| `/api/sessions` | POST | Actions: `createSession` (with optional `cwd`), `createWindow`, `killSession`, `killWindow`, `sendKeys` |
+| `/api/sessions` | POST | Actions: `createSession` (with optional `cwd`), `createWindow`, `killSession`, `killWindow`, `renameWindow`, `sendKeys` |
 | `/api/directories` | GET | Server-side directory listing for autocomplete — `?prefix=~/code/wvr` returns matching dirs under `$HOME` |
 | `/api/sessions/stream` | GET | SSE — module-level singleton polls tmux every 2.5s, fans out full snapshots to all connected clients on change. Deduplicates polling across browser tabs. 30-minute lifetime cap per connection. |
 

--- a/docs/memory/run-kit/ui-patterns.md
+++ b/docs/memory/run-kit/ui-patterns.md
@@ -35,8 +35,8 @@ Connection indicator: green/gray dot with "live"/"disconnected" label, driven by
 | Page | Left content | Right content |
 |------|-------------|---------------|
 | Dashboard | "+ New Session" button (via chrome slot) | `{N} sessions, {M} windows` |
-| Project | "+ New Window" button, "Send Message" button (disabled when no windows) | `{N} windows` |
-| Terminal | "Kill Window" button (red hover) | Activity dot + fab stage badge |
+| Project | "+ New Window" button, "Send Message" button, "Rename" button (disabled when no windows) | `{N} windows` |
+| Terminal | "Rename" button, "Kill" button (red hover) | Activity dot + fab stage badge |
 
 Line 2 renders even when empty — prevents layout shift during navigation and before `useEffect` fires.
 
@@ -95,6 +95,12 @@ Native `<textarea>` overlay triggered by the compose button. Appears above the b
 | `n` | Create new window |
 | `x` | Kill focused window (confirmation) |
 | `s` | Send message to focused window's agent |
+| `r` | Rename focused window |
+
+### Terminal View
+| Key | Action |
+|-----|--------|
+| `r` | Rename window |
 
 All keyboard shortcuts are registered in the command palette.
 
@@ -153,3 +159,4 @@ Windows are `"active"` (last tmux activity within 10 seconds) or `"idle"`. No "e
 | 2026-03-06 | Chrome architecture — layout-owned skeleton, ChromeProvider context, TopBarChrome, icon breadcrumbs, always-visible kill buttons | `260305-emla-fixed-chrome-architecture` |
 | 2026-03-06 | Bottom bar with modifier toggles, arrow keys, Fn dropdown, compose buffer, iOS keyboard support | `260305-fjh1-bottom-bar-compose-buffer` |
 | 2026-03-06 | Performance: split ChromeContext (state/dispatch), layout-level SessionProvider, inline dashboard search, memoized shortcuts | `260306-0ahl-perf-sse-chrome-sessions` |
+| 2026-03-07 | Rename window action (both pages), kill button label shortened to "Kill" | `260307-r3yv-action-buttons-rename-kill` |

--- a/fab/changes/260307-r3yv-action-buttons-rename-kill/.history.jsonl
+++ b/fab/changes/260307-r3yv-action-buttons-rename-kill/.history.jsonl
@@ -1,0 +1,15 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-03-07T00:19:57+05:30"}
+{"args":"Add new action buttons, both to project and terminal page: Rename. And change Kill Window to just Kill. What else can we add?","cmd":"fab-new","event":"command","ts":"2026-03-07T00:19:57+05:30"}
+{"delta":"+1.8","event":"confidence","score":1.8,"trigger":"calc-score","ts":"2026-03-07T00:20:43+05:30"}
+{"delta":"+0.0","event":"confidence","score":1.8,"trigger":"calc-score","ts":"2026-03-07T00:20:52+05:30"}
+{"delta":"+2.9","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-07T00:25:51+05:30"}
+{"delta":"+0.0","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-07T00:25:55+05:30"}
+{"cmd":"fab-ff","event":"command","ts":"2026-03-07T00:27:47+05:30"}
+{"delta":"+0.0","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-07T00:28:44+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"spec","ts":"2026-03-07T00:28:48+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"tasks","ts":"2026-03-07T00:29:34+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"apply","ts":"2026-03-07T00:29:34+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"review","ts":"2026-03-07T00:32:36+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"hydrate","ts":"2026-03-07T00:33:14+05:30"}
+{"event":"review","result":"passed","ts":"2026-03-07T00:33:14+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"ship","ts":"2026-03-07T00:33:53+05:30"}

--- a/fab/changes/260307-r3yv-action-buttons-rename-kill/.status.yaml
+++ b/fab/changes/260307-r3yv-action-buttons-rename-kill/.status.yaml
@@ -1,0 +1,41 @@
+name: 260307-r3yv-action-buttons-rename-kill
+created: 2026-03-07T00:19:57+05:30
+created_by: sahil-weaver
+change_type: refactor
+issues: []
+progress:
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+checklist:
+    generated: true
+    path: checklist.md
+    completed: 23
+    total: 23
+confidence:
+    certain: 6
+    confident: 1
+    tentative: 0
+    unresolved: 0
+    score: 4.7
+    fuzzy: true
+    dimensions:
+        signal: 80.0
+        reversibility: 92.9
+        competence: 90.7
+        disambiguation: 90.7
+stage_metrics:
+    intake: {started_at: "2026-03-07T00:19:57+05:30", driver: fab-new, iterations: 1, completed_at: "2026-03-07T00:28:48+05:30"}
+    spec: {started_at: "2026-03-07T00:28:48+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T00:29:34+05:30"}
+    tasks: {started_at: "2026-03-07T00:29:34+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T00:29:34+05:30"}
+    apply: {started_at: "2026-03-07T00:29:34+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T00:32:36+05:30"}
+    review: {started_at: "2026-03-07T00:32:36+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T00:33:14+05:30"}
+    hydrate: {started_at: "2026-03-07T00:33:14+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T00:33:53+05:30"}
+    ship: {started_at: "2026-03-07T00:33:53+05:30", driver: fab-ff, iterations: 1}
+prs: []
+last_updated: 2026-03-07T00:33:53+05:30

--- a/fab/changes/260307-r3yv-action-buttons-rename-kill/checklist.md
+++ b/fab/changes/260307-r3yv-action-buttons-rename-kill/checklist.md
@@ -1,0 +1,40 @@
+# Quality Checklist: Rename Action + Kill Label Cleanup
+
+**Change**: 260307-r3yv-action-buttons-rename-kill
+**Generated**: 2026-03-07
+**Spec**: `spec.md`
+
+## Functional Completeness
+- [x] CHK-001 tmux.ts renameWindow: Function exported, calls `rename-window` with correct `-t session:index name` args
+- [x] CHK-002 API renameWindow action: POST handler accepts `renameWindow`, validates all inputs, calls tmux function
+- [x] CHK-003 Project page rename dialog: Opens pre-filled with current name, auto-selected, submits via API, closes on success
+- [x] CHK-004 Project page rename button: Visible in Line 2 left, disabled when no windows
+- [x] CHK-005 Project page rename palette action: "Rename focused window" with shortcut `r`
+- [x] CHK-006 Terminal page rename dialog: Same behavior as project page, focus returns to terminal after close
+- [x] CHK-007 Terminal page rename button: Visible in Line 2 left alongside kill button
+- [x] CHK-008 Terminal page rename palette action: "Rename window" with shortcut `r`
+- [x] CHK-009 Terminal kill button label: Shows "Kill" not "Kill Window"
+- [x] CHK-010 Terminal kill palette label: Shows "Kill window" not "Kill this window"
+
+## Behavioral Correctness
+- [x] CHK-011 Kill button label changed: Terminal page button text is "Kill", no other kill behavior affected
+- [x] CHK-012 Rename updates propagate: After rename, SSE pushes updated window name to connected clients
+
+## Scenario Coverage
+- [x] CHK-013 Rename via keyboard shortcut `r` on project page opens dialog
+- [x] CHK-014 Rename via Cmd+K palette on terminal page opens dialog
+- [x] CHK-015 Cancel rename (Escape/backdrop click) closes dialog without API call
+- [x] CHK-016 Invalid rename name rejected by API (forbidden characters)
+
+## Edge Cases & Error Handling
+- [x] CHK-017 Rename button disabled when project page has zero windows
+- [x] CHK-018 Empty name submission prevented (empty string not sent to API)
+
+## Code Quality
+- [x] CHK-019 Pattern consistency: `renameWindow` follows same signature pattern as `killWindow(session, index)` in tmux.ts
+- [x] CHK-020 No unnecessary duplication: Reuses Dialog component, validateName, existing button styling
+- [x] CHK-021 execFile with argument arrays: renameWindow uses tmuxExec (no shell strings)
+- [x] CHK-022 No inline tmux commands: All tmux interaction via lib/tmux.ts
+
+## Security
+- [x] CHK-023 Input validation: New name validated via `validateName` before reaching tmux subprocess

--- a/fab/changes/260307-r3yv-action-buttons-rename-kill/intake.md
+++ b/fab/changes/260307-r3yv-action-buttons-rename-kill/intake.md
@@ -1,0 +1,62 @@
+# Intake: Rename Action + Kill Label Cleanup
+
+**Change**: 260307-r3yv-action-buttons-rename-kill
+**Created**: 2026-03-07
+**Status**: Draft
+
+## Origin
+
+> Add new action buttons, both to project and terminal page: Rename. And Change "Kill Window" to just "Kill".
+
+User scoped to two changes: add a Rename action on both pages, and shorten the Kill button label. Additional actions (respawn, clear scrollback, interrupt, kill session) were explored and deferred.
+
+## Why
+
+Renaming a tmux window currently requires dropping to the terminal and running `tmux rename-window` — there's no UI for it. The "Kill Window" label on the terminal page is verbose when the page context already makes "window" obvious.
+
+Both changes make the UI more self-sufficient and align with Constitution V (Keyboard-First) by exposing rename through the command palette.
+
+## What Changes
+
+### 1. Rename Window Action
+
+Add a "Rename" button and command palette entry on **both** pages:
+
+- **Project page**: Palette action "Rename focused window" (shortcut: `r`). Opens a dialog pre-filled with the current window name. On submit, calls `tmux rename-window`.
+- **Terminal page**: Line 2 button "Rename" + palette action. Same dialog behavior.
+- **API**: New `renameWindow` action in `POST /api/sessions` accepting `{ action: "renameWindow", session, index, name }`.
+- **tmux.ts**: New `renameWindow(session, index, name)` function wrapping `tmux rename-window -t {session}:{index} {name}`.
+- After rename, the URL `name` query parameter and breadcrumb should reflect the new name (SSE will push the update).
+
+### 2. Shorten "Kill Window" to "Kill"
+
+- **Terminal page**: Change the line 2 button label from "Kill Window" to "Kill".
+- **Command palette**: Change terminal page palette action label from "Kill this window" to "Kill window" (keep "window" in palette for searchability, but the button itself is just "Kill").
+
+## Affected Memory
+
+- `run-kit/ui-patterns`: (modify) Update Line 2 content table, keyboard shortcuts, and add rename dialog documentation
+
+## Impact
+
+- **API route** (`src/app/api/sessions/route.ts`): New `renameWindow` action case
+- **tmux.ts** (`src/lib/tmux.ts`): New `renameWindow` wrapper function
+- **project-client.tsx**: New palette action + rename dialog
+- **terminal-client.tsx**: New rename button + palette action + rename dialog, kill label change
+- **command-palette.tsx**: No structural changes — consumes palette actions from pages
+- **validate.ts**: Existing `validateName` reused for rename input
+
+## Open Questions
+
+None.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Use `tmux rename-window` for rename | Only tmux API for this operation; codebase pattern established in tmux.ts | S:80 R:90 A:95 D:95 |
+| 2 | Certain | Reuse existing Dialog component for rename input | All dialogs in the app use `src/components/dialog.tsx`; same pattern as create window | S:85 R:95 A:95 D:95 |
+| 3 | Certain | Register all new actions in command palette | Constitution V mandates keyboard-first; existing pattern for all actions | S:90 R:90 A:95 D:95 |
+| 4 | Confident | Shortcut `r` for rename on project page | Available key, mnemonic, consistent with existing single-char shortcuts (n, x, s) | S:70 R:90 A:80 D:75 |
+
+4 assumptions (3 certain, 1 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260307-r3yv-action-buttons-rename-kill/spec.md
+++ b/fab/changes/260307-r3yv-action-buttons-rename-kill/spec.md
@@ -1,0 +1,142 @@
+# Spec: Rename Action + Kill Label Cleanup
+
+**Change**: 260307-r3yv-action-buttons-rename-kill
+**Created**: 2026-03-07
+**Affected memory**: `docs/memory/run-kit/ui-patterns.md`
+
+## Backend: Rename Window
+
+### Requirement: tmux.ts renameWindow function
+
+`src/lib/tmux.ts` SHALL export an async function `renameWindow(session: string, index: number, name: string): Promise<void>` that executes `tmux rename-window -t {session}:{index} {name}` via `tmuxExec`.
+
+#### Scenario: Successful rename
+- **GIVEN** a tmux session `myproject` with window index `2` named `old-name`
+- **WHEN** `renameWindow("myproject", 2, "new-name")` is called
+- **THEN** tmux executes `rename-window -t myproject:2 new-name`
+- **AND** the function resolves without error
+
+### Requirement: API renameWindow action
+
+`POST /api/sessions` SHALL accept `{ action: "renameWindow", session, index, name }`. The handler SHALL validate `session` via `validateName(session, "Session name")`, validate `index` as a non-negative integer, and validate `name` via `validateName(name, "Window name")`. On success, it SHALL call `renameWindow(session, index, name)` and return `{ ok: true }`.
+
+#### Scenario: Valid rename request
+- **GIVEN** a running tmux session `myproject` with window index `1`
+- **WHEN** `POST /api/sessions` receives `{ action: "renameWindow", session: "myproject", index: 1, name: "agent" }`
+- **THEN** response is `200 { ok: true }`
+- **AND** the window is renamed in tmux
+
+#### Scenario: Invalid name rejected
+- **GIVEN** any request state
+- **WHEN** `POST /api/sessions` receives `{ action: "renameWindow", session: "myproject", index: 1, name: "bad;name" }`
+- **THEN** response is `400` with an error message from `validateName`
+
+## Project Page: Rename Action
+
+### Requirement: Rename palette action and shortcut
+
+The project page (`/p/:project`) SHALL register a palette action `"Rename focused window"` with shortcut `r`. The shortcut SHALL be added to the `shortcuts` map in `useKeyboardNav`. The action SHALL open a rename dialog when a window is focused.
+
+#### Scenario: Rename via keyboard shortcut
+- **GIVEN** the project page with windows, focus on window index 1 named `old-name`
+- **WHEN** the user presses `r`
+- **THEN** a rename dialog opens pre-filled with `old-name`
+
+#### Scenario: Rename via command palette
+- **GIVEN** the project page with windows
+- **WHEN** the user opens Cmd+K and selects "Rename focused window"
+- **THEN** a rename dialog opens pre-filled with the focused window's name
+
+### Requirement: Rename dialog behavior
+
+The rename dialog SHALL use the existing `Dialog` component with title `"Rename window"`. It SHALL contain a text input pre-filled with the current window name (auto-selected for easy replacement) and a "Rename" submit button. On submit, it SHALL call `POST /api/sessions` with `{ action: "renameWindow", session, index, name }`. The dialog SHALL close after successful submission. Pressing Enter in the input SHALL submit. The input SHALL be auto-focused.
+
+#### Scenario: Submit rename
+- **GIVEN** the rename dialog is open for window `old-name` at index `2` in session `myproject`
+- **WHEN** the user changes the name to `new-name` and presses Enter
+- **THEN** `POST /api/sessions` is called with `{ action: "renameWindow", session: "myproject", index: 2, name: "new-name" }`
+- **AND** the dialog closes
+
+#### Scenario: Cancel rename
+- **GIVEN** the rename dialog is open
+- **WHEN** the user clicks the backdrop or presses Escape
+- **THEN** the dialog closes without making any API call
+
+### Requirement: Rename button in Line 2
+
+The project page SHALL add a "Rename" button in the Line 2 left slot, alongside the existing "+ New Window" and "Send Message" buttons. The button SHALL be disabled when no windows exist. Clicking it SHALL open the rename dialog for the focused window.
+
+#### Scenario: Rename button visible
+- **GIVEN** the project page with at least one window
+- **WHEN** the page renders
+- **THEN** Line 2 left shows buttons: "+ New Window", "Send Message", "Rename"
+- **AND** the "Rename" button is enabled
+
+#### Scenario: Rename button disabled when no windows
+- **GIVEN** the project page with zero windows
+- **WHEN** the page renders
+- **THEN** the "Rename" button is disabled (same style as disabled "Send Message")
+
+## Terminal Page: Rename Action
+
+### Requirement: Rename button in Line 2
+
+The terminal page SHALL add a "Rename" button in the Line 2 left slot, alongside the existing kill button. Clicking it SHALL open a rename dialog pre-filled with the current window name.
+
+#### Scenario: Rename from terminal page
+- **GIVEN** the terminal page for window `agent` at index `1` in session `myproject`
+- **WHEN** the user clicks "Rename"
+- **THEN** a rename dialog opens pre-filled with `agent`
+
+### Requirement: Rename palette action on terminal page
+
+The terminal page SHALL register a palette action `"Rename window"` with shortcut `r`. Selecting it SHALL open the rename dialog.
+
+#### Scenario: Rename via palette on terminal page
+- **GIVEN** the terminal page for any window
+- **WHEN** the user opens Cmd+K and selects "Rename window"
+- **THEN** a rename dialog opens pre-filled with the current window name
+
+### Requirement: Rename dialog on terminal page
+
+The rename dialog on the terminal page SHALL behave identically to the project page rename dialog (same Dialog component, pre-filled input, auto-select, Enter to submit, Escape to cancel). On submit, it SHALL call `POST /api/sessions` with `{ action: "renameWindow", session, index, name }`. After submission, focus SHALL return to the terminal (via `xtermRef.current?.focus()`).
+
+#### Scenario: Focus returns to terminal after rename
+- **GIVEN** the rename dialog is open on the terminal page
+- **WHEN** the user submits a new name
+- **THEN** the dialog closes
+- **AND** the terminal regains focus
+
+## Terminal Page: Kill Label
+
+### Requirement: Shortened kill button label
+
+The terminal page Line 2 button label SHALL be `"Kill"` (not `"Kill Window"`).
+
+#### Scenario: Kill button displays shortened label
+- **GIVEN** the terminal page for any window
+- **WHEN** the page renders
+- **THEN** Line 2 left shows a button labeled `"Kill"` (not `"Kill Window"`)
+
+### Requirement: Kill palette action label
+
+The terminal page command palette entry for killing SHALL use the label `"Kill window"` (lowercase "w", retains "window" for palette searchability).
+
+#### Scenario: Kill palette label
+- **GIVEN** the terminal page command palette is open
+- **WHEN** the user sees the kill action
+- **THEN** it is labeled `"Kill window"`
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Use `tmux rename-window` for rename | Confirmed from intake #1 — only tmux API for window rename; codebase pattern in tmux.ts | S:80 R:90 A:95 D:95 |
+| 2 | Certain | Reuse existing Dialog component | Confirmed from intake #2 — all dialogs use `src/components/dialog.tsx` | S:85 R:95 A:95 D:95 |
+| 3 | Certain | Register all actions in command palette | Confirmed from intake #3 — Constitution V mandates keyboard-first | S:90 R:90 A:95 D:95 |
+| 4 | Confident | Shortcut `r` for rename | Confirmed from intake #4 — available key, mnemonic, consistent with n/x/s pattern | S:70 R:90 A:80 D:75 |
+| 5 | Certain | Auto-select input text in rename dialog | Pre-selecting the current name makes replacement faster — standard UX for rename operations | S:75 R:95 A:90 D:90 |
+| 6 | Certain | Rename button position: after existing buttons | Follows left-to-right importance: create > send > rename on project page; rename + kill on terminal | S:75 R:95 A:85 D:90 |
+| 7 | Certain | Validate new name via existing `validateName` | Same validation as create window — reuse, don't reinvent (Constitution III) | S:85 R:95 A:95 D:95 |
+
+7 assumptions (6 certain, 1 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260307-r3yv-action-buttons-rename-kill/tasks.md
+++ b/fab/changes/260307-r3yv-action-buttons-rename-kill/tasks.md
@@ -1,0 +1,32 @@
+# Tasks: Rename Action + Kill Label Cleanup
+
+**Change**: 260307-r3yv-action-buttons-rename-kill
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+## Phase 1: Backend
+
+- [x] T001 [P] Add `renameWindow(session, index, name)` to `src/lib/tmux.ts` — wraps `tmux rename-window -t {session}:{index} {name}` via `tmuxExec`
+- [x] T002 [P] Add `renameWindow` action case to `POST /api/sessions` in `src/app/api/sessions/route.ts` — validate session, index, name; call `renameWindow`; import the new function
+
+## Phase 2: UI — Terminal Page
+
+- [x] T003 Change kill button label from `"Kill Window"` to `"Kill"` in `src/app/p/[project]/[window]/terminal-client.tsx` (line 2 left slot)
+- [x] T004 Change kill palette action label from `"Kill this window"` to `"Kill window"` in `src/app/p/[project]/[window]/terminal-client.tsx` (paletteActions array)
+- [x] T005 Add rename state (`showRenameDialog`, `renameName`), rename handler, rename dialog, and "Rename" button to Line 2 left in `src/app/p/[project]/[window]/terminal-client.tsx` — pre-fill with `windowName`, auto-select, Enter to submit, focus terminal after close
+- [x] T006 Add `"Rename window"` palette action with shortcut `r` to terminal page paletteActions in `src/app/p/[project]/[window]/terminal-client.tsx`
+
+## Phase 3: UI — Project Page
+
+- [x] T007 Add rename state (`showRenameDialog`, `renameTarget`, `renameName`), rename handler, and rename dialog to `src/app/p/[project]/project-client.tsx` — pre-fill with focused window name, auto-select, Enter to submit
+- [x] T008 Add "Rename" button to Line 2 left slot in `src/app/p/[project]/project-client.tsx` — disabled when no windows, same styling as "Send Message" button
+- [x] T009 Add `"Rename focused window"` palette action with shortcut `r` to project page paletteActions, and add `r` to shortcuts map in `src/app/p/[project]/project-client.tsx`
+
+---
+
+## Execution Order
+
+- T001 and T002 are parallel (T002 depends on T001 being importable, but both are small — do T001 first)
+- T003, T004 are independent label changes — can run with T005/T006
+- T005 blocks T006 (state must exist before palette action references it)
+- T007 blocks T008 and T009 (state and handler must exist first)

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { fetchSessions } from "@/lib/sessions";
-import { createSession, createWindow, killSession, killWindow, sendKeys } from "@/lib/tmux";
+import { createSession, createWindow, killSession, killWindow, renameWindow, sendKeys } from "@/lib/tmux";
 import { validateName, validatePath, expandTilde } from "@/lib/validate";
 
 export const dynamic = "force-dynamic";
@@ -80,6 +80,22 @@ export async function POST(request: Request) {
         }
 
         await killWindow(session, index);
+        break;
+      }
+      case "renameWindow": {
+        const session = String(body.session ?? "");
+        const index = Number(body.index);
+        const name = String(body.name ?? "");
+
+        const sessionErr = validateName(session, "Session name");
+        if (sessionErr) return badRequest(sessionErr);
+        if (!Number.isInteger(index) || index < 0) {
+          return badRequest("Invalid window index");
+        }
+        const nameErr = validateName(name, "Window name");
+        if (nameErr) return badRequest(nameErr);
+
+        await renameWindow(session, index, name);
         break;
       }
       case "sendKeys": {

--- a/src/app/p/[project]/[window]/terminal-client.tsx
+++ b/src/app/p/[project]/[window]/terminal-client.tsx
@@ -30,6 +30,8 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
   const { sessions } = useSessions();
   const { setBreadcrumbs, setLine2Left, setLine2Right, setBottomBar, setFullbleed } = useChromeDispatch();
   const [showKillConfirm, setShowKillConfirm] = useState(false);
+  const [showRenameDialog, setShowRenameDialog] = useState(false);
+  const [renameName, setRenameName] = useState("");
   const [composeOpen, setComposeOpen] = useState(false);
 
   useVisualViewport();
@@ -59,14 +61,23 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
     setLine2Left(
       <div className="flex items-center gap-3">
         <button
+          onClick={() => {
+            setRenameName(windowName);
+            setShowRenameDialog(true);
+          }}
+          className="text-sm px-3 py-1 border border-border rounded hover:border-text-secondary"
+        >
+          Rename
+        </button>
+        <button
           onClick={() => setShowKillConfirm(true)}
           className="text-sm px-3 py-1 border border-border rounded hover:border-red-400 hover:text-red-400 transition-colors"
         >
-          Kill Window
+          Kill
         </button>
       </div>,
     );
-  }, [setLine2Left]);
+  }, [setLine2Left, windowName]);
 
   useEffect(() => {
     setLine2Right(
@@ -262,6 +273,26 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
     };
   }, [projectName, windowIndex, relayPort]);
 
+  async function handleRename() {
+    if (!renameName.trim()) return;
+    try {
+      await fetch("/api/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "renameWindow",
+          session: projectName,
+          index: parseInt(windowIndex, 10),
+          name: renameName.trim(),
+        }),
+      });
+    } catch {
+      // SSE will reflect actual state
+    }
+    setShowRenameDialog(false);
+    xtermRef.current?.focus();
+  }
+
   async function handleKillWindow() {
     try {
       await fetch("/api/sessions", {
@@ -283,8 +314,17 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
   const paletteActions: PaletteAction[] = useMemo(
     () => [
       {
+        id: "rename-window",
+        label: "Rename window",
+        shortcut: "r",
+        onSelect: () => {
+          setRenameName(windowName);
+          setShowRenameDialog(true);
+        },
+      },
+      {
         id: "kill-window",
-        label: "Kill this window",
+        label: "Kill window",
         onSelect: () => setShowKillConfirm(true),
       },
       {
@@ -298,7 +338,7 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
         onSelect: () => router.push("/"),
       },
     ],
-    [projectName, router],
+    [projectName, windowName, router],
   );
 
   return (
@@ -312,6 +352,29 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
 
       {composeOpen && (
         <ComposeBuffer wsRef={wsRef} onClose={() => { setComposeOpen(false); xtermRef.current?.focus(); }} />
+      )}
+
+      {/* Rename dialog */}
+      {showRenameDialog && (
+        <Dialog title="Rename window" onClose={() => { setShowRenameDialog(false); xtermRef.current?.focus(); }}>
+          <input
+            autoFocus
+            type="text"
+            value={renameName}
+            onChange={(e) => setRenameName(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleRename()}
+            onFocus={(e) => e.target.select()}
+            aria-label="Window name"
+            placeholder="Window name..."
+            className="w-full bg-transparent text-text-primary text-sm p-2 border border-border rounded outline-none placeholder:text-text-secondary"
+          />
+          <button
+            onClick={handleRename}
+            className="mt-3 w-full text-sm py-1.5 bg-bg-card border border-border rounded hover:border-text-secondary"
+          >
+            Rename
+          </button>
+        </Dialog>
       )}
 
       {/* Kill confirmation dialog */}

--- a/src/app/p/[project]/project-client.tsx
+++ b/src/app/p/[project]/project-client.tsx
@@ -25,6 +25,9 @@ export function ProjectClient({ projectName, initialWindows }: Props) {
   const [killWindowTarget, setKillWindowTarget] = useState<WindowInfo | null>(
     null,
   );
+  const [showRenameDialog, setShowRenameDialog] = useState(false);
+  const [renameTarget, setRenameTarget] = useState<WindowInfo | null>(null);
+  const [renameName, setRenameName] = useState("");
   const [createName, setCreateName] = useState("");
   const [sendMessage, setSendMessage] = useState("");
 
@@ -36,6 +39,7 @@ export function ProjectClient({ projectName, initialWindows }: Props) {
 
   const windowsRef = useRef(windows);
   windowsRef.current = windows;
+  const focusedIndexRef = useRef(0);
 
   const navigateToTerminal = useCallback(
     (index: number) => {
@@ -58,6 +62,16 @@ export function ProjectClient({ projectName, initialWindows }: Props) {
       s: () => {
         if (windowsRef.current.length > 0) setShowSendDialog(true);
       },
+      r: () => {
+        if (windowsRef.current.length > 0) {
+          const win = windowsRef.current[focusedIndexRef.current];
+          if (win) {
+            setRenameTarget(win);
+            setRenameName(win.name);
+            setShowRenameDialog(true);
+          }
+        }
+      },
     }),
     [],
   );
@@ -67,6 +81,7 @@ export function ProjectClient({ projectName, initialWindows }: Props) {
     onSelect: navigateToTerminal,
     shortcuts,
   });
+  focusedIndexRef.current = focusedIndex;
 
   // Set chrome slots
   useEffect(() => {
@@ -94,9 +109,25 @@ export function ProjectClient({ projectName, initialWindows }: Props) {
         >
           Send Message
         </button>
+        <button
+          onClick={() => {
+            if (windows.length > 0) {
+              const win = windows[focusedIndex];
+              if (win) {
+                setRenameTarget(win);
+                setRenameName(win.name);
+                setShowRenameDialog(true);
+              }
+            }
+          }}
+          disabled={windows.length === 0}
+          className="text-sm px-3 py-1 border border-border rounded hover:border-text-secondary disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          Rename
+        </button>
       </div>,
     );
-  }, [windows.length, setLine2Left]);
+  }, [windows.length, focusedIndex, windows, setLine2Left]);
 
   useEffect(() => {
     setLine2Right(
@@ -105,6 +136,27 @@ export function ProjectClient({ projectName, initialWindows }: Props) {
       </span>,
     );
   }, [windows.length, setLine2Right]);
+
+  async function handleRename() {
+    const win = renameTarget;
+    if (!win || !renameName.trim()) return;
+    try {
+      await fetch("/api/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "renameWindow",
+          session: projectName,
+          index: win.index,
+          name: renameName.trim(),
+        }),
+      });
+    } catch {
+      // SSE will reflect actual state
+    }
+    setShowRenameDialog(false);
+    setRenameTarget(null);
+  }
 
   async function handleCreate() {
     if (!createName.trim()) return;
@@ -191,6 +243,19 @@ export function ProjectClient({ projectName, initialWindows }: Props) {
         label: "Send message to agent",
         shortcut: "s",
         onSelect: () => windows.length > 0 && setShowSendDialog(true),
+      },
+      {
+        id: "rename-window",
+        label: "Rename focused window",
+        shortcut: "r",
+        onSelect: () => {
+          const win = windows[focusedIndex];
+          if (win) {
+            setRenameTarget(win);
+            setRenameName(win.name);
+            setShowRenameDialog(true);
+          }
+        },
       },
       {
         id: "back",
@@ -318,6 +383,35 @@ export function ProjectClient({ projectName, initialWindows }: Props) {
             className="mt-3 w-full text-sm py-1.5 bg-bg-card border border-border rounded hover:border-text-secondary"
           >
             Send
+          </button>
+        </Dialog>
+      )}
+
+      {/* Rename dialog */}
+      {showRenameDialog && renameTarget && (
+        <Dialog
+          title="Rename window"
+          onClose={() => {
+            setShowRenameDialog(false);
+            setRenameTarget(null);
+          }}
+        >
+          <input
+            autoFocus
+            type="text"
+            value={renameName}
+            onChange={(e) => setRenameName(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleRename()}
+            onFocus={(e) => e.target.select()}
+            aria-label="Window name"
+            placeholder="Window name..."
+            className="w-full bg-transparent text-text-primary text-sm p-2 border border-border rounded outline-none placeholder:text-text-secondary"
+          />
+          <button
+            onClick={handleRename}
+            className="mt-3 w-full text-sm py-1.5 bg-bg-card border border-border rounded hover:border-text-secondary"
+          >
+            Rename
           </button>
         </Dialog>
       )}

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -112,6 +112,15 @@ export async function killWindow(
   await tmuxExec(["kill-window", "-t", `${session}:${index}`]);
 }
 
+/** Rename a window by session and index. */
+export async function renameWindow(
+  session: string,
+  index: number,
+  name: string,
+): Promise<void> {
+  await tmuxExec(["rename-window", "-t", `${session}:${index}`, name]);
+}
+
 /** Send keystrokes to a tmux window. */
 export async function sendKeys(
   session: string,


### PR DESCRIPTION
## Summary
- Add **Rename** action on both project and terminal pages — dialog pre-filled with current name, auto-select, `r` keyboard shortcut, command palette entry
- Shorten terminal kill button from "Kill Window" to **"Kill"**, palette label to "Kill window"
- Backend: new `renameWindow` tmux wrapper + API action with full input validation

## Test plan
- [ ] Type check passes (`pnpm exec tsc --noEmit`)
- [ ] Build succeeds (`pnpm build`)
- [ ] All 85 tests pass (`pnpm test`)
- [ ] Rename window from project page via `r` shortcut and Cmd+K palette
- [ ] Rename window from terminal page via button, `r` shortcut, and Cmd+K palette
- [ ] Verify kill button on terminal page shows "Kill" (not "Kill Window")
- [ ] Verify rename dialog pre-fills and auto-selects current name

🤖 Generated with [Claude Code](https://claude.com/claude-code)