### PR TITLE
fix: Fix iOS Terminal Touch Scroll

### DIFF
--- a/docs/memory/run-kit/architecture.md
+++ b/docs/memory/run-kit/architecture.md
@@ -82,6 +82,8 @@ All three zones use `max-w-4xl mx-auto w-full px-6` for identical width/padding 
 
 **iOS Keyboard Support** — `useVisualViewport` hook (`src/hooks/use-visual-viewport.ts`) sets `--app-height` CSS custom property from `window.visualViewport.height`. The layout flex container uses `var(--app-height, 100vh)`, constraining the app to the visible viewport when the iOS keyboard is open. The bottom bar stays pinned above the keyboard; the terminal shrinks via `flex-1` and xterm refits via `ResizeObserver`.
 
+**iOS Touch Scroll Prevention** — `ContentSlot` toggles a `fullbleed` CSS class on `document.documentElement` when the terminal page is active. `globals.css` applies `overflow: hidden` and `overscroll-behavior: none` to `html.fullbleed` and `html.fullbleed body`, preventing iOS Safari elastic bounce scrolling. The terminal container div uses `touch-none` (`touch-action: none`) so the browser yields touch gestures to xterm.js for scrollback handling.
+
 Pages do NOT render their own top bar or outer containers — they set chrome slots and render only their content area.
 
 ## Design Decisions
@@ -131,3 +133,4 @@ Current coverage: `validate.ts` (input validation + tilde expansion), `config.ts
 | 2026-03-06 | Chrome architecture — layout-owned flex-col skeleton, ChromeProvider context, TopBarChrome, icon breadcrumbs, always-visible kill buttons | `260305-emla-fixed-chrome-architecture` |
 | 2026-03-06 | Bottom bar (modifier toggles, arrow keys, Fn dropdown, Esc/Tab, compose buffer), iOS keyboard support via visualViewport, `i` key compose toggle | `260305-fjh1-bottom-bar-compose-buffer` |
 | 2026-03-06 | Performance: parallel session enrichment, SSE pub/sub singleton, split ChromeContext, layout-level SessionProvider, ResizeObserver debounce, useModifierState memoization, WS reconnection | `260306-0ahl-perf-sse-chrome-sessions` |
+| 2026-03-07 | iOS touch scroll prevention — fullbleed class toggle on html, touch-none on terminal container | `260307-8n60-fix-ios-terminal-touch-scroll` |

--- a/docs/memory/run-kit/ui-patterns.md
+++ b/docs/memory/run-kit/ui-patterns.md
@@ -74,6 +74,10 @@ Native `<textarea>` overlay triggered by the compose button. Appears above the b
 
 `useVisualViewport` hook sets `--app-height` CSS custom property from `window.visualViewport.height`. Layout flex container uses `var(--app-height, 100vh)`. When the iOS keyboard appears, the bottom bar stays pinned above it, the terminal shrinks, and xterm refits via the existing `ResizeObserver`.
 
+### iOS Touch Scroll Prevention
+
+The terminal container div has `touch-none` (CSS `touch-action: none`) to prevent the browser from handling touch gestures on the xterm canvas — xterm.js handles its own scrollback. When fullbleed is active, `ContentSlot` toggles a `fullbleed` class on `<html>`, which applies `overflow: hidden` and `overscroll-behavior: none` to both `html` and `body` (via `globals.css`), preventing iOS Safari elastic bounce scrolling. The class is removed on cleanup when navigating away. Non-terminal pages (dashboard, project) are unaffected — they don't set fullbleed. The compose buffer and bottom bar are siblings of the terminal container, not children, so their touch behavior is preserved.
+
 ## Keyboard Shortcuts
 
 ### Global
@@ -162,3 +166,4 @@ Windows are `"active"` (last tmux activity within 10 seconds) or `"idle"`. No "e
 | 2026-03-06 | Bottom bar with modifier toggles, arrow keys, Fn dropdown, compose buffer, iOS keyboard support | `260305-fjh1-bottom-bar-compose-buffer` |
 | 2026-03-06 | Performance: split ChromeContext (state/dispatch), layout-level SessionProvider, inline dashboard search, memoized shortcuts | `260306-0ahl-perf-sse-chrome-sessions` |
 | 2026-03-07 | Rename window action (both pages), kill button label shortened to "Kill" | `260307-r3yv-action-buttons-rename-kill` |
+| 2026-03-07 | iOS touch scroll fix — `touch-none` on terminal container, fullbleed class toggle for body overflow/overscroll prevention | `260307-8n60-fix-ios-terminal-touch-scroll` |

--- a/fab/changes/260307-8n60-fix-ios-terminal-touch-scroll/.history.jsonl
+++ b/fab/changes/260307-8n60-fix-ios-terminal-touch-scroll/.history.jsonl
@@ -12,3 +12,5 @@
 {"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"hydrate","ts":"2026-03-07T00:37:15+05:30"}
 {"event":"review","result":"passed","ts":"2026-03-07T00:37:15+05:30"}
 {"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"ship","ts":"2026-03-07T00:37:55+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"review-pr","ts":"2026-03-07T00:38:37+05:30"}
+{"event":"review","result":"passed","ts":"2026-03-07T00:38:51+05:30"}

--- a/fab/changes/260307-8n60-fix-ios-terminal-touch-scroll/.history.jsonl
+++ b/fab/changes/260307-8n60-fix-ios-terminal-touch-scroll/.history.jsonl
@@ -1,0 +1,14 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-03-07T00:28:29+05:30"}
+{"args":"I am unable to touch scroll the terminal on the phone (iOS) still. the whole page scrolls.","cmd":"fab-new","event":"command","ts":"2026-03-07T00:28:29+05:30"}
+{"delta":"+4.4","event":"confidence","score":4.4,"trigger":"calc-score","ts":"2026-03-07T00:29:03+05:30"}
+{"delta":"+0.0","event":"confidence","score":4.4,"trigger":"calc-score","ts":"2026-03-07T00:29:07+05:30"}
+{"cmd":"fab-switch","event":"command","ts":"2026-03-07T00:32:10+05:30"}
+{"cmd":"fab-ff","event":"command","ts":"2026-03-07T00:34:25+05:30"}
+{"delta":"+0.3","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-07T00:35:07+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"spec","ts":"2026-03-07T00:35:11+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"tasks","ts":"2026-03-07T00:35:41+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"apply","ts":"2026-03-07T00:35:41+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"review","ts":"2026-03-07T00:36:52+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"hydrate","ts":"2026-03-07T00:37:15+05:30"}
+{"event":"review","result":"passed","ts":"2026-03-07T00:37:15+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"ship","ts":"2026-03-07T00:37:55+05:30"}

--- a/fab/changes/260307-8n60-fix-ios-terminal-touch-scroll/.status.yaml
+++ b/fab/changes/260307-8n60-fix-ios-terminal-touch-scroll/.status.yaml
@@ -1,0 +1,41 @@
+name: 260307-8n60-fix-ios-terminal-touch-scroll
+created: 2026-03-07T00:28:29+05:30
+created_by: sahil-weaver
+change_type: fix
+issues: []
+progress:
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+checklist:
+    generated: true
+    path: checklist.md
+    completed: 13
+    total: 13
+confidence:
+    certain: 5
+    confident: 1
+    tentative: 0
+    unresolved: 0
+    score: 4.7
+    fuzzy: true
+    dimensions:
+        signal: 83.3
+        reversibility: 92.5
+        competence: 90.0
+        disambiguation: 87.5
+stage_metrics:
+    intake: {started_at: "2026-03-07T00:28:29+05:30", driver: fab-new, iterations: 1, completed_at: "2026-03-07T00:35:11+05:30"}
+    spec: {started_at: "2026-03-07T00:35:11+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T00:35:41+05:30"}
+    tasks: {started_at: "2026-03-07T00:35:41+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T00:35:41+05:30"}
+    apply: {started_at: "2026-03-07T00:35:41+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T00:36:52+05:30"}
+    review: {started_at: "2026-03-07T00:36:52+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T00:37:15+05:30"}
+    hydrate: {started_at: "2026-03-07T00:37:15+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T00:37:55+05:30"}
+    ship: {started_at: "2026-03-07T00:37:55+05:30", driver: fab-ff, iterations: 1}
+prs: []
+last_updated: 2026-03-07T00:37:55+05:30

--- a/fab/changes/260307-8n60-fix-ios-terminal-touch-scroll/.status.yaml
+++ b/fab/changes/260307-8n60-fix-ios-terminal-touch-scroll/.status.yaml
@@ -10,8 +10,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: done
 checklist:
     generated: true
     path: checklist.md
@@ -36,6 +36,8 @@ stage_metrics:
     apply: {started_at: "2026-03-07T00:35:41+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T00:36:52+05:30"}
     review: {started_at: "2026-03-07T00:36:52+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T00:37:15+05:30"}
     hydrate: {started_at: "2026-03-07T00:37:15+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T00:37:55+05:30"}
-    ship: {started_at: "2026-03-07T00:37:55+05:30", driver: fab-ff, iterations: 1}
-prs: []
-last_updated: 2026-03-07T00:37:55+05:30
+    ship: {started_at: "2026-03-07T00:37:55+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T00:38:37+05:30"}
+    review-pr: {started_at: "2026-03-07T00:38:37+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T00:38:51+05:30"}
+prs:
+    - https://github.com/wvrdz/run-kit/pull/17
+last_updated: 2026-03-07T00:38:51+05:30

--- a/fab/changes/260307-8n60-fix-ios-terminal-touch-scroll/checklist.md
+++ b/fab/changes/260307-8n60-fix-ios-terminal-touch-scroll/checklist.md
@@ -1,0 +1,39 @@
+# Quality Checklist: Fix iOS Terminal Touch Scroll
+
+**Change**: 260307-8n60-fix-ios-terminal-touch-scroll
+**Generated**: 2026-03-07
+**Spec**: `spec.md`
+
+## Functional Completeness
+
+- [x] CHK-001 Terminal touch-action: `touch-none` class present on terminal container div
+- [x] CHK-002 Body overflow prevention: `html.fullbleed` CSS rule sets `overflow: hidden` and `overscroll-behavior: none`
+- [x] CHK-003 Fullbleed class toggle: `useEffect` in ContentSlot adds/removes `fullbleed` class on `<html>` element
+
+## Behavioral Correctness
+
+- [x] CHK-004 Fullbleed class only applied when terminal page is active (fullbleed=true)
+- [x] CHK-005 Fullbleed class removed on cleanup (component unmount / page navigation away)
+
+## Scenario Coverage
+
+- [x] CHK-006 Terminal container has `touch-none` — prevents browser touch scroll on canvas area
+- [x] CHK-007 Non-terminal pages unaffected — no `fullbleed` class on `<html>` when on dashboard/project pages
+- [x] CHK-008 Compose buffer not inside terminal container — touch behavior unblocked for textarea
+- [x] CHK-009 Bottom bar is sibling to content — not affected by terminal touch-action
+
+## Edge Cases & Error Handling
+
+- [x] CHK-010 Class cleanup on unmount: navigating away from terminal removes `fullbleed` class from `<html>`
+
+## Code Quality
+
+- [x] CHK-011 Pattern consistency: CSS approach matches existing project patterns (Tailwind classes, globals.css for global rules)
+- [x] CHK-012 No unnecessary duplication: no redundant overflow handling introduced
+- [x] CHK-013 Server Components unaffected: changes only in Client Components and CSS
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] CHK-008 **N/A**: {reason}`

--- a/fab/changes/260307-8n60-fix-ios-terminal-touch-scroll/intake.md
+++ b/fab/changes/260307-8n60-fix-ios-terminal-touch-scroll/intake.md
@@ -1,0 +1,64 @@
+# Intake: Fix iOS Terminal Touch Scroll
+
+**Change**: 260307-8n60-fix-ios-terminal-touch-scroll
+**Created**: 2026-03-07
+**Status**: Draft
+
+## Origin
+
+> "I am unable to touch scroll the terminal on the phone (iOS) still. the whole page scrolls."
+
+One-shot bug report. The user cannot scroll the terminal output on iOS — touch gestures scroll the entire page instead of scrolling within the xterm terminal.
+
+## Why
+
+On iOS Safari, touching the terminal area and swiping scrolls the entire page instead of scrolling the xterm terminal's scrollback buffer. This makes the terminal unusable on mobile — the user cannot review output history, and the page bounces/shifts unexpectedly.
+
+The terminal page already sets `fullbleed(true)` which applies `overflow-hidden` on the `ContentSlot` (`src/contexts/chrome-context.tsx:85`), but iOS Safari ignores `overflow: hidden` for touch-initiated scrolling on the body/html elements. The outer flex container and `body` have no touch-action or overscroll-behavior constraints, so iOS elastic scrolling kicks in.
+
+xterm.js handles mouse wheel scrolling natively but does not automatically prevent touch event propagation on its canvas element. Without explicit `touch-action: none` on the terminal container, the browser claims the touch gesture for page scrolling before xterm can process it.
+
+## What Changes
+
+### Prevent page scroll on terminal page
+
+The fix needs to stop iOS Safari from scrolling the page when the user touches the terminal area. Two complementary approaches:
+
+1. **CSS `touch-action: none` on the terminal container** — The `terminalRef` div in `terminal-client.tsx` (line 307) needs `touch-action: none` to tell the browser not to handle touch gestures (scroll, zoom) on the terminal area. xterm.js has its own touch handling for scrollback.
+
+2. **CSS `overscroll-behavior: none` on the body** — When the terminal page is active (fullbleed mode), prevent iOS elastic/bounce scrolling from the body element. This can be applied globally or conditionally via the `--app-height` CSS custom property context.
+
+3. **`overflow: hidden` on `html` and `body`** — iOS Safari sometimes ignores overflow on inner containers but respects it on `html`/`body`. The fullbleed terminal page should ensure these elements cannot scroll.
+
+### Key files
+
+- `src/app/globals.css` — global body/html overflow rules for iOS
+- `src/components/terminal-client.tsx` or `src/app/p/[project]/[window]/terminal-client.tsx` — `touch-action: none` on the terminal div
+- `src/contexts/chrome-context.tsx` — potentially tie body overflow to fullbleed state
+
+## Affected Memory
+
+- `run-kit/ui-patterns`: (modify) Document touch-action handling for terminal page on iOS
+- `run-kit/architecture`: (modify) Note iOS touch scroll prevention in Chrome Architecture section
+
+## Impact
+
+- **Terminal page** — primary fix target, touch behavior changes
+- **Other pages** — must NOT be affected; dashboard and project pages need normal touch scrolling
+- **Bottom bar** — already has `touch-none` on individual buttons (arrow-pad), should remain unaffected
+- **Compose buffer** — textarea overlay needs normal touch behavior (scroll within textarea), must not be blocked
+
+## Open Questions
+
+- None — the fix is well-understood CSS/touch-action work.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Use `touch-action: none` on the terminal container div | Standard CSS solution for preventing browser touch handling on canvas-based UIs; xterm.js expects this | S:80 R:90 A:95 D:90 |
+| 2 | Certain | Apply `overscroll-behavior: none` to prevent iOS bounce scroll | Well-known iOS Safari fix; no downside when page doesn't need elastic scrolling | S:80 R:95 A:90 D:90 |
+| 3 | Confident | Scope overflow/touch changes to fullbleed mode only | Non-terminal pages (dashboard, project) need normal scroll behavior; fullbleed flag already distinguishes terminal page | S:70 R:85 A:80 D:75 |
+| 4 | Confident | No JavaScript touch event handlers needed — CSS-only fix | `touch-action: none` + `overscroll-behavior: none` should suffice; JS `preventDefault()` on touchmove is a heavier fallback if CSS alone doesn't work on iOS Safari | S:65 R:90 A:70 D:65 |
+
+4 assumptions (2 certain, 2 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260307-8n60-fix-ios-terminal-touch-scroll/intake.md
+++ b/fab/changes/260307-8n60-fix-ios-terminal-touch-scroll/intake.md
@@ -14,7 +14,7 @@ One-shot bug report. The user cannot scroll the terminal output on iOS — touch
 
 On iOS Safari, touching the terminal area and swiping scrolls the entire page instead of scrolling the xterm terminal's scrollback buffer. This makes the terminal unusable on mobile — the user cannot review output history, and the page bounces/shifts unexpectedly.
 
-The terminal page already sets `fullbleed(true)` which applies `overflow-hidden` on the `ContentSlot` (`src/contexts/chrome-context.tsx:85`), but iOS Safari ignores `overflow: hidden` for touch-initiated scrolling on the body/html elements. The outer flex container and `body` have no touch-action or overscroll-behavior constraints, so iOS elastic scrolling kicks in.
+The terminal page already sets `fullbleed(true)` which applies `overflow-hidden` on the `ContentSlot` (`src/contexts/chrome-context.tsx`), but iOS Safari ignores `overflow: hidden` for touch-initiated scrolling on the body/html elements. The outer flex container and `body` have no touch-action or overscroll-behavior constraints, so iOS elastic scrolling kicks in.
 
 xterm.js handles mouse wheel scrolling natively but does not automatically prevent touch event propagation on its canvas element. Without explicit `touch-action: none` on the terminal container, the browser claims the touch gesture for page scrolling before xterm can process it.
 

--- a/fab/changes/260307-8n60-fix-ios-terminal-touch-scroll/spec.md
+++ b/fab/changes/260307-8n60-fix-ios-terminal-touch-scroll/spec.md
@@ -1,0 +1,94 @@
+# Spec: Fix iOS Terminal Touch Scroll
+
+**Change**: 260307-8n60-fix-ios-terminal-touch-scroll
+**Created**: 2026-03-07
+**Affected memory**: `docs/memory/run-kit/ui-patterns.md`, `docs/memory/run-kit/architecture.md`
+
+## Non-Goals
+
+- JavaScript `touchmove` event handlers with `preventDefault()` — CSS `touch-action` is sufficient and lighter
+- Changing scroll behavior on dashboard or project pages — those need normal touch scrolling
+- Modifying xterm.js internals or its touch handling — the issue is page-level, not terminal-level
+
+## Terminal: Touch Scroll Prevention
+
+### Requirement: Terminal container MUST prevent browser touch scrolling
+
+The terminal container div (`terminalRef` in `terminal-client.tsx`) SHALL have `touch-action: none` applied via CSS class. This tells the browser not to handle any touch gestures (scroll, zoom, pan) on the terminal area, allowing xterm.js to handle touch-based scrollback natively.
+
+#### Scenario: Touch scroll on terminal area on iOS
+
+- **GIVEN** the terminal page is open on iOS Safari
+- **WHEN** the user touches the xterm canvas area and swipes up/down
+- **THEN** the page does NOT scroll
+- **AND** xterm.js scrollback buffer scrolls (if scrollback content exists)
+
+#### Scenario: Pinch-to-zoom prevented on terminal
+
+- **GIVEN** the terminal page is open on iOS Safari
+- **WHEN** the user performs a pinch gesture on the terminal area
+- **THEN** the page does NOT zoom
+- **AND** the terminal layout remains stable
+
+### Requirement: Body/html MUST prevent overflow scrolling in fullbleed mode
+
+When the terminal page is active (fullbleed mode), the `html` and `body` elements SHALL have `overflow: hidden` and `overscroll-behavior: none` applied. This prevents iOS Safari's elastic bounce scrolling on the outermost elements.
+
+These styles MUST only apply when the terminal page is active. Dashboard and project pages MUST retain normal scrolling behavior.
+
+#### Scenario: No page bounce on terminal page
+
+- **GIVEN** the terminal page is open on iOS Safari (fullbleed active)
+- **WHEN** the user swipes at the top or bottom edge of the screen
+- **THEN** there is no elastic bounce or page scroll
+- **AND** the page layout remains fixed
+
+#### Scenario: Normal scrolling on non-terminal pages
+
+- **GIVEN** the dashboard page is open on iOS Safari (fullbleed not active)
+- **WHEN** the user scrolls the page via touch
+- **THEN** the page scrolls normally with standard iOS elastic behavior
+
+### Requirement: Compose buffer MUST retain normal touch behavior
+
+The compose buffer textarea (`ComposeBuffer` component) SHALL NOT be affected by the terminal's `touch-action: none`. The textarea needs normal touch behavior for text selection, scrolling within the textarea, and iOS dictation gestures.
+
+#### Scenario: Touch scroll within compose buffer
+
+- **GIVEN** the compose buffer is open on iOS Safari
+- **WHEN** the user touches the textarea area and swipes
+- **THEN** the textarea content scrolls (if content exceeds visible area)
+- **AND** the page does NOT scroll
+
+### Requirement: Bottom bar MUST retain touch interactivity
+
+The bottom bar buttons SHALL remain tappable on iOS. The `touch-action: none` on the terminal container MUST NOT cascade to the bottom bar (which is a sibling element in the layout, not a child of the terminal container).
+
+#### Scenario: Tap bottom bar button on iOS
+
+- **GIVEN** the terminal page is open on iOS Safari
+- **WHEN** the user taps a bottom bar button (e.g., Ctrl, arrow key)
+- **THEN** the button activates normally
+
+## Design Decisions
+
+1. **CSS-only approach over JavaScript touch handlers**
+   - *Why*: `touch-action: none` is the standard, declarative way to prevent browser touch gesture handling. It's simpler, more performant, and doesn't risk interfering with xterm.js's own touch handling.
+   - *Rejected*: `touchmove` event listener with `preventDefault()` — adds complexity, must be passive-false (performance warning), and can conflict with xterm's own touch listeners.
+
+2. **Fullbleed-conditional body overflow via `useEffect` toggling a class on `document.documentElement`**
+   - *Why*: The `fullbleed` state already correctly identifies the terminal page. Toggling a CSS class on `<html>` when fullbleed activates is the cleanest way to apply body/html overflow rules without affecting other pages. Using a class on `<html>` (rather than inline styles) keeps the styling in CSS where it belongs.
+   - *Rejected*: Global `overflow: hidden` on body in `globals.css` — would break scrolling on all pages.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Use `touch-action: none` on the terminal container div | Confirmed from intake #1 — standard CSS for canvas-based UIs; xterm.js docs recommend it | S:85 R:90 A:95 D:90 |
+| 2 | Certain | Apply `overscroll-behavior: none` on html/body in fullbleed mode | Confirmed from intake #2 — well-known iOS Safari fix | S:85 R:95 A:90 D:90 |
+| 3 | Certain | Scope to fullbleed mode via class toggle on `<html>` element | Upgraded from intake #3 Confident — fullbleed flag is already the terminal page discriminator; `useEffect` in ContentSlot or layout to toggle class | S:80 R:90 A:90 D:85 |
+| 4 | Confident | CSS-only fix, no JS touch handlers needed | Confirmed from intake #4 — `touch-action` + `overscroll-behavior` covers the reported behavior; JS fallback only if CSS proves insufficient on specific iOS versions | S:70 R:90 A:75 D:70 |
+| 5 | Certain | Compose buffer unaffected — it's not a child of the terminal container | Compose buffer renders as a sibling to the terminal div, not inside it; `touch-action: none` doesn't cascade to siblings | S:90 R:95 A:95 D:95 |
+| 6 | Certain | Bottom bar unaffected — sibling in layout, not child of terminal | Bottom bar renders via `BottomSlot` in layout, entirely outside `ContentSlot`; no inheritance of terminal's `touch-action` | S:90 R:95 A:95 D:95 |
+
+6 assumptions (5 certain, 1 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260307-8n60-fix-ios-terminal-touch-scroll/tasks.md
+++ b/fab/changes/260307-8n60-fix-ios-terminal-touch-scroll/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: Fix iOS Terminal Touch Scroll
+
+**Change**: 260307-8n60-fix-ios-terminal-touch-scroll
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+## Phase 1: Core Implementation
+
+- [x] T001 [P] Add `touch-action: none` CSS class to the terminal container div in `src/app/p/[project]/[window]/terminal-client.tsx` — add `touch-none` (Tailwind class) to the `terminalRef` div's className
+- [x] T002 [P] Add fullbleed body/html overflow prevention in `src/app/globals.css` — add a CSS rule for `html.fullbleed` that sets `overflow: hidden` and `overscroll-behavior: none` on both `html` and `body`
+- [x] T003 Toggle `fullbleed` class on `document.documentElement` — in `src/contexts/chrome-context.tsx` `ContentSlot`, add a `useEffect` that adds/removes the `fullbleed` class on the `<html>` element when `fullbleed` state changes
+
+## Phase 2: Verification
+
+- [x] T004 Run `npx tsc --noEmit` to verify no type errors
+- [x] T005 Run `pnpm build` to verify production build succeeds
+
+---
+
+## Execution Order
+
+- T001, T002, T003 are independent ([P]) — can execute in parallel
+- T004, T005 run after all Phase 1 tasks complete

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -45,3 +45,10 @@ summary {
   background: var(--color-border);
   border-radius: 3px;
 }
+
+/* Prevent iOS Safari page scroll/bounce when terminal is fullbleed */
+html.fullbleed,
+html.fullbleed body {
+  overflow: hidden;
+  overscroll-behavior: none;
+}

--- a/src/app/p/[project]/[window]/terminal-client.tsx
+++ b/src/app/p/[project]/[window]/terminal-client.tsx
@@ -358,7 +358,7 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
         ref={terminalRef}
         role="application"
         aria-label={`Terminal: ${projectName}/${windowName}`}
-        className={`flex-1 min-h-0 transition-opacity ${composeOpen ? "opacity-50" : ""}`}
+        className={`flex-1 min-h-0 touch-none transition-opacity ${composeOpen ? "opacity-50" : ""}`}
       />
 
       {composeOpen && (

--- a/src/contexts/chrome-context.tsx
+++ b/src/contexts/chrome-context.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useState, useMemo, useRef } from "react";
+import { createContext, useContext, useState, useMemo, useRef, useEffect } from "react";
 
 export type Breadcrumb = {
   icon?: string;
@@ -81,6 +81,16 @@ export function useChromeDispatch(): ChromeDispatch {
 
 export function ContentSlot({ children }: { children: React.ReactNode }) {
   const { fullbleed } = useChrome();
+
+  useEffect(() => {
+    if (fullbleed) {
+      document.documentElement.classList.add("fullbleed");
+    } else {
+      document.documentElement.classList.remove("fullbleed");
+    }
+    return () => document.documentElement.classList.remove("fullbleed");
+  }, [fullbleed]);
+
   return (
     <main id="main-content" className={`flex-1 min-h-0 overflow-x-hidden ${fullbleed ? "overflow-hidden" : "overflow-y-auto"}`}>
       <div className={`max-w-4xl mx-auto w-full px-6 min-w-0 min-h-full flex flex-col ${fullbleed ? "overflow-hidden" : ""}`}>


### PR DESCRIPTION
## Summary

On iOS Safari, touching the terminal area scrolls the entire page instead of xterm's scrollback buffer. The existing `overflow-hidden` on `ContentSlot` is ignored by iOS for touch-initiated scrolling. This fix adds `touch-action: none` on the terminal container and toggles body-level overflow prevention when the terminal page is active.

## Changes

- CSS `touch-action: none` on the terminal container — yields touch gestures to xterm.js
- CSS `overscroll-behavior: none` on body in fullbleed mode — prevents iOS elastic bounce
- `fullbleed` class toggle on `<html>` via `useEffect` in `ContentSlot` — scoped to terminal page only

## Stats

| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| fix | 4.7 / 5.0 | 13/13 ✓ | 5/5 | Pass (1 iteration) |

[intake](https://github.com/wvrdz/run-kit/blob/260307-8n60-fix-ios-terminal-touch-scroll/fab/changes/260307-8n60-fix-ios-terminal-touch-scroll/intake.md) → [spec](https://github.com/wvrdz/run-kit/blob/260307-8n60-fix-ios-terminal-touch-scroll/fab/changes/260307-8n60-fix-ios-terminal-touch-scroll/spec.md) → tasks → apply → review → hydrate → ship → review-pr