### PR TITLE
fix: Sync focused index on card hover to fix rename targeting

### DIFF
--- a/src/app/p/[project]/project-client.tsx
+++ b/src/app/p/[project]/project-client.tsx
@@ -76,7 +76,7 @@ export function ProjectClient({ projectName, initialWindows }: Props) {
     [],
   );
 
-  const { focusedIndex } = useKeyboardNav({
+  const { focusedIndex, setFocusedIndex } = useKeyboardNav({
     itemCount: windows.length,
     onSelect: navigateToTerminal,
     shortcuts,
@@ -294,6 +294,7 @@ export function ProjectClient({ projectName, initialWindows }: Props) {
               window={win}
               projectName={projectName}
               focused={i === focusedIndex}
+              onMouseEnter={() => setFocusedIndex(i)}
               onClick={() => navigateToTerminal(i)}
               onKill={() => {
                 setKillWindowTarget(win);

--- a/src/components/session-card.tsx
+++ b/src/components/session-card.tsx
@@ -6,6 +6,7 @@ type SessionCardProps = {
   window: WindowInfo;
   projectName: string;
   focused: boolean;
+  onMouseEnter?: () => void;
   onClick: () => void;
   onKill?: (e: React.MouseEvent) => void;
 };
@@ -14,11 +15,13 @@ export function SessionCard({
   window: win,
   projectName,
   focused,
+  onMouseEnter,
   onClick,
   onKill,
 }: SessionCardProps) {
   return (
     <button
+      onMouseEnter={onMouseEnter}
       onClick={onClick}
       aria-label={`${win.name} — ${projectName}, ${win.activity}`}
       className={`group w-full text-left p-3 rounded border transition-colors focus-visible:outline-2 focus-visible:outline-accent ${


### PR DESCRIPTION
## Summary
- Rename/Kill/Send actions on the project page always targeted window index 0 unless the user navigated with j/k keyboard shortcuts
- Root cause: `focusedIndex` from `useKeyboardNav` only tracked keyboard navigation, not mouse interaction
- Fix: `SessionCard` now accepts `onMouseEnter` to update `focusedIndex` on hover, matching the Linear/Raycast pattern where mouse and keyboard focus stay synced

## Test plan
- [ ] Navigate to project page with 2+ windows
- [ ] Hover over the second window card — verify it highlights (border-accent)
- [ ] Click "Rename" in the action bar — verify the dialog pre-fills the **second** window's name (not the first)
- [ ] Use j/k to move focus, then hover a different card — verify focus follows mouse

🤖 Generated with [Claude Code](https://claude.com/claude-code)