### PR TITLE
fix: Sync byobu active tab with run-kit UI

### DIFF
--- a/docs/memory/run-kit/architecture.md
+++ b/docs/memory/run-kit/architecture.md
@@ -22,7 +22,7 @@ The tmux server is an external dependency — never started or stopped by run-ki
 
 | Module | Responsibility |
 |--------|---------------|
-| `src/lib/tmux.ts` | All tmux operations via `execFile` with argument arrays + timeouts |
+| `src/lib/tmux.ts` | All tmux operations via `execFile` with argument arrays + timeouts. `listWindows()` includes `isActiveWindow` flag from `#{window_active}` |
 | `src/lib/worktree.ts` | Wraps fab-kit `wt-*` scripts (never reimplements) |
 | `src/lib/fab.ts` | Reads fab state (progress-line, current change, change list) |
 | `src/lib/sessions.ts` | Derives project roots from tmux, auto-detects fab-kit, enriches with fab state. Session enrichment runs in parallel via `Promise.all` with indexed assignment to preserve tmux ordering |
@@ -89,14 +89,15 @@ Pages do NOT render their own top bar or outer containers — they set chrome sl
 
 ## Design Decisions
 
-- **SSE (not WebSocket) for session state** — simpler, server-push only, naturally resilient. Module-level singleton deduplicates polling across tabs (one `fetchSessions()` per interval regardless of client count)
+- **SSE (not WebSocket) for session state** — simpler, server-push only, naturally resilient. Module-level singleton deduplicates polling across tabs (one `fetchSessions()` per interval regardless of client count). SSE data includes `isActiveWindow` per window, enabling UI sync when users switch tmux/byobu windows via terminal shortcuts
 - **Full snapshots (not diffs)** — small payload (<100 sessions), simple client logic
-- **Independent panes per browser client** — no cursor fights, agent pane untouched
+- **Independent panes per browser client** — no cursor fights, agent pane untouched. The relay pty follows byobu window switches natively (runs `tmux attach-session`)
 - **Every tmux session is a project** — no config, no "Other" bucket. Project root derived from window 0's `pane_current_path`
 - **Config resolution: CLI > YAML > defaults** — `src/lib/config.ts` reads `run-kit.yaml` (optional, gitignored) and CLI args. Relay port delivered to client via server component prop (runtime, not build-time)
 - **Byobu session-group filtering** — `listSessions()` filters out derived session-group copies to avoid duplicate projects. See `docs/memory/run-kit/tmux-sessions.md`
 - **Layout-owned chrome (not per-page TopBar)** — Split React Context for slot injection: state context (re-renders readers) and dispatch context (stable setters, no re-renders). Pages inject content via `useChromeDispatch()` setters in `useEffect`; layout renders it in fixed positions. Prevents both layout shift and cascade re-renders.
 - **Layout-level SessionProvider (not per-page SSE)** — Single `EventSource` connection at layout level, shared across all pages. Eliminates redundant connections and per-page `isConnected` forwarding boilerplate.
+- **Active window sync via `history.replaceState` (not `router.replace()`)** — When byobu switches windows, the terminal relay pty already shows the correct content. The UI syncs breadcrumb, URL, and action targets via SSE polling (2.5s). URL updates use `window.history.replaceState()` which is invisible to Next.js — no server component re-render, no terminal reinitialization. `router.replace()` would change the `[window]` dynamic segment, causing a full remount and xterm flash.
 - **Sticky modifier state via useRef + forceUpdate** — `useModifierState` uses a ref for the authoritative state and a counter state to trigger re-renders. Ensures `consume()` reads the latest value atomically without stale closure issues.
 - **Compose buffer as native textarea (not xterm input)** — xterm renders to `<canvas>`, blocking OS-level input features. The compose buffer provides a real `<textarea>` where dictation, autocorrect, paste, and IME all work. Text sent as a single WebSocket message.
 - **Armed modifiers bridge to physical keyboard** — When bottom-bar modifiers (Ctrl/Alt/Cmd) are armed, a capture-phase `keydown` listener intercepts physical keypresses, translates them to terminal escape sequences (Ctrl+letter → control characters, Alt/Cmd → ESC prefix), and sends via WebSocket. Prevents xterm from receiving the unmodified key. Ignores real Cmd/Ctrl/Alt held by the OS.
@@ -139,3 +140,4 @@ Current coverage: `validate.ts` (input validation + tilde expansion), `config.ts
 | 2026-03-07 | iOS touch scroll prevention — fullbleed class toggle on html, touch-none on terminal container | `260307-8n60-fix-ios-terminal-touch-scroll` |
 | 2026-03-07 | File upload: `/api/upload` endpoint, clipboard paste/drag-drop/file picker triggers, compose buffer integration, `.uploads/` auto-gitignore | `260307-kqio-image-upload-claude-terminal` |
 | 2026-03-07 | iOS keyboard viewport overlap fix — visualViewport scroll listener, fixed positioning in fullbleed mode | `260307-f3o9-ios-keyboard-viewport-overlap` |
+| 2026-03-07 | Sync byobu active tab — `isActiveWindow` on `WindowInfo`, breadcrumb/URL/action sync via SSE + `history.replaceState` | `260307-f3li-sync-byobu-active-tab` |

--- a/docs/memory/run-kit/ui-patterns.md
+++ b/docs/memory/run-kit/ui-patterns.md
@@ -20,7 +20,7 @@ The root layout renders `TopBarChrome` (`src/components/top-bar-chrome.tsx`) whi
 |------|-----------|
 | Dashboard | `{logo}` (SVG logo only) |
 | Project | `{logo} › ⬡ {name}` |
-| Terminal | `{logo} › ⬡ {name} › ❯ {window}` |
+| Terminal | `{logo} › ⬡ {name} › ❯ {window}` (syncs with tmux active window via SSE) |
 
 - Logo SVG (`logo.svg`) — always links to `/`
 - ⬡ — Unicode hexagon (U+2B21), `text-text-secondary`, precedes project name
@@ -117,7 +117,7 @@ The terminal container div has `touch-none` (CSS `touch-action: none`) to preven
 ### Terminal View
 | Key | Action |
 |-----|--------|
-| `r` | Rename window |
+| `r` | Rename active window (follows byobu switches) |
 
 All keyboard shortcuts are registered in the command palette.
 
@@ -180,3 +180,4 @@ Windows are `"active"` (last tmux activity within 10 seconds) or `"idle"`. No "e
 | 2026-03-07 | iOS touch scroll fix — `touch-none` on terminal container, fullbleed class toggle for body overflow/overscroll prevention | `260307-8n60-fix-ios-terminal-touch-scroll` |
 | 2026-03-07 | File upload: clipboard paste, drag-and-drop, file picker button, compose buffer path insertion, command palette action | `260307-kqio-image-upload-claude-terminal` |
 | 2026-03-07 | iOS keyboard viewport overlap fix — scroll+resize listeners on visualViewport, fixed positioning for app-shell in fullbleed | `260307-f3o9-ios-keyboard-viewport-overlap` |
+| 2026-03-07 | Active window sync — breadcrumb, URL, rename/kill targets follow byobu/tmux window switches via SSE + `history.replaceState` | `260307-f3li-sync-byobu-active-tab` |

--- a/src/app/p/[project]/[window]/terminal-client.tsx
+++ b/src/app/p/[project]/[window]/terminal-client.tsx
@@ -36,33 +36,56 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
 
   useVisualViewport();
 
-  // Look up current window's status from session data
-  const currentWindow = useMemo(() => {
+  // Look up active window from session data (follows byobu/tmux switches)
+  const activeWindow = useMemo(() => {
     const session = sessions.find((s) => s.name === projectName);
-    return session?.windows.find((w) => String(w.index) === windowIndex);
+    if (!session) return undefined;
+    // Prefer the tmux-active window; fall back to URL-based lookup
+    return session.windows.find((w) => w.isActiveWindow)
+      ?? session.windows.find((w) => String(w.index) === windowIndex);
   }, [sessions, projectName, windowIndex]);
 
-  // Set chrome slots
+  // Track active window index and name (initialized from URL params, updated by SSE)
+  const activeIndexRef = useRef(windowIndex);
+  const activeNameRef = useRef(windowName);
+  useEffect(() => {
+    if (activeWindow) {
+      activeIndexRef.current = String(activeWindow.index);
+      activeNameRef.current = activeWindow.name;
+    }
+  }, [activeWindow]);
+
+  // Set chrome slots + sync breadcrumb/URL with active window
+  const displayName = activeWindow?.name ?? windowName;
+  const displayIndex = activeWindow ? String(activeWindow.index) : windowIndex;
+
   useEffect(() => {
     setFullbleed(true);
-    setBreadcrumbs([
-      { icon: "⬡", label: projectName, href: `/p/${projectName}` },
-      { icon: "❯", label: windowName },
-    ]);
     return () => {
       setFullbleed(false);
       setBreadcrumbs([]);
       setLine2Left(null);
       setLine2Right(null);
     };
-  }, [projectName, windowName, setBreadcrumbs, setLine2Left, setLine2Right, setFullbleed]);
+  }, [setBreadcrumbs, setLine2Left, setLine2Right, setFullbleed]);
+
+  // Update breadcrumb and URL when active window changes
+  useEffect(() => {
+    setBreadcrumbs([
+      { icon: "⬡", label: projectName, href: `/p/${projectName}` },
+      { icon: "❯", label: displayName },
+    ]);
+    // Sync URL without triggering Next.js routing
+    const newUrl = `/p/${encodeURIComponent(projectName)}/${displayIndex}?name=${encodeURIComponent(displayName)}`;
+    window.history.replaceState(null, "", newUrl);
+  }, [projectName, displayName, displayIndex, setBreadcrumbs]);
 
   useEffect(() => {
     setLine2Left(
       <div className="flex items-center gap-3">
         <button
           onClick={() => {
-            setRenameName(windowName);
+            setRenameName(activeNameRef.current);
             setShowRenameDialog(true);
           }}
           className="text-sm px-3 py-1 border border-border rounded hover:border-text-secondary"
@@ -77,31 +100,31 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
         </button>
       </div>,
     );
-  }, [setLine2Left, windowName]);
+  }, [setLine2Left]);
 
   useEffect(() => {
     setLine2Right(
       <div className="flex items-center gap-2 text-xs text-text-secondary">
-        {currentWindow && (
+        {activeWindow && (
           <>
             <span
               className={`w-2 h-2 rounded-full ${
-                currentWindow.activity === "active"
+                activeWindow.activity === "active"
                   ? "bg-accent-green"
                   : "bg-text-secondary"
               }`}
             />
-            <span>{currentWindow.activity}</span>
-            {currentWindow.fabProgress && (
+            <span>{activeWindow.activity}</span>
+            {activeWindow.fabProgress && (
               <span className="text-accent px-1.5 py-0.5 rounded bg-accent/10">
-                fab: {currentWindow.fabProgress}
+                fab: {activeWindow.fabProgress}
               </span>
             )}
           </>
         )}
       </div>,
     );
-  }, [currentWindow, setLine2Right]);
+  }, [activeWindow, setLine2Right]);
 
   // Bottom bar injection
   useEffect(() => {
@@ -148,11 +171,11 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
       if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
 
       if (e.key === "r") {
-        setRenameName(windowName);
+        setRenameName(activeNameRef.current);
         setShowRenameDialog(true);
       }
     },
-    [projectName, windowName, router],
+    [projectName, router],
   );
 
   useEffect(() => {
@@ -303,7 +326,7 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
         body: JSON.stringify({
           action: "renameWindow",
           session: projectName,
-          index: parseInt(windowIndex, 10),
+          index: parseInt(activeIndexRef.current, 10),
           name: renameName.trim(),
         }),
       });
@@ -322,7 +345,7 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
         body: JSON.stringify({
           action: "killWindow",
           session: projectName,
-          index: parseInt(windowIndex, 10),
+          index: parseInt(activeIndexRef.current, 10),
         }),
       });
     } catch {
@@ -339,7 +362,7 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
         label: "Rename window",
         shortcut: "r",
         onSelect: () => {
-          setRenameName(windowName);
+          setRenameName(activeNameRef.current);
           setShowRenameDialog(true);
         },
       },
@@ -359,7 +382,7 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
         onSelect: () => router.push("/"),
       },
     ],
-    [projectName, windowName, router],
+    [projectName, router],
   );
 
   return (
@@ -367,7 +390,7 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
       <div
         ref={terminalRef}
         role="application"
-        aria-label={`Terminal: ${projectName}/${windowName}`}
+        aria-label={`Terminal: ${projectName}/${displayName}`}
         className={`flex-1 min-h-0 transition-opacity ${composeOpen ? "opacity-50" : ""}`}
       />
 
@@ -402,7 +425,7 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
       {showKillConfirm && (
         <Dialog title="Kill window?" onClose={() => setShowKillConfirm(false)}>
           <p className="text-sm text-text-secondary mb-3">
-            Kill window <strong>{windowName}</strong>? This cannot be undone.
+            Kill window <strong>{displayName}</strong>? This cannot be undone.
           </p>
           <div className="flex gap-2">
             <button

--- a/src/app/p/[project]/[window]/terminal-client.tsx
+++ b/src/app/p/[project]/[window]/terminal-client.tsx
@@ -77,7 +77,7 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
     ]);
     // Sync URL without triggering Next.js routing
     const newUrl = `/p/${encodeURIComponent(projectName)}/${displayIndex}?name=${encodeURIComponent(displayName)}`;
-    window.history.replaceState(null, "", newUrl);
+    window.history.replaceState(window.history.state, "", newUrl);
   }, [projectName, displayName, displayIndex, setBreadcrumbs]);
 
   useEffect(() => {

--- a/src/lib/__tests__/tmux.test.ts
+++ b/src/lib/__tests__/tmux.test.ts
@@ -84,7 +84,7 @@ describe("listWindows", () => {
   it("marks window as active when within threshold", async () => {
     const recentTs = FAKE_NOW_SECS - 1;
     mockExecFile.mockResolvedValueOnce({
-      stdout: `0\tdev\t/home/user/project\t${recentTs}\n`,
+      stdout: `0\tdev\t/home/user/project\t${recentTs}\t1\n`,
       stderr: "",
     });
 
@@ -96,7 +96,7 @@ describe("listWindows", () => {
   it("marks window as idle when beyond threshold", async () => {
     const oldTs = FAKE_NOW_SECS - ACTIVITY_THRESHOLD_SECONDS - 100;
     mockExecFile.mockResolvedValueOnce({
-      stdout: `0\tdev\t/home/user/project\t${oldTs}\n`,
+      stdout: `0\tdev\t/home/user/project\t${oldTs}\t0\n`,
       stderr: "",
     });
 
@@ -105,9 +105,9 @@ describe("listWindows", () => {
     expect(result[0].activity).toBe("idle");
   });
 
-  it("parses all fields correctly", async () => {
+  it("parses all fields correctly including isActiveWindow", async () => {
     mockExecFile.mockResolvedValueOnce({
-      stdout: `0\tdev\t/home/user/project\t${FAKE_NOW_SECS}\n2\tbuild\t/tmp/build\t${FAKE_NOW_SECS}\n`,
+      stdout: `0\tdev\t/home/user/project\t${FAKE_NOW_SECS}\t1\n2\tbuild\t/tmp/build\t${FAKE_NOW_SECS}\t0\n`,
       stderr: "",
     });
 
@@ -117,11 +117,13 @@ describe("listWindows", () => {
       index: 0,
       name: "dev",
       worktreePath: "/home/user/project",
+      isActiveWindow: true,
     });
     expect(result[1]).toMatchObject({
       index: 2,
       name: "build",
       worktreePath: "/tmp/build",
+      isActiveWindow: false,
     });
   });
 

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -59,6 +59,7 @@ export async function listWindows(session: string): Promise<WindowInfo[]> {
     "#{window_name}",
     "#{pane_current_path}",
     "#{window_activity}",
+    "#{window_active}",
   ].join(LIST_WINDOWS_DELIM);
 
   let lines: string[];
@@ -71,15 +72,16 @@ export async function listWindows(session: string): Promise<WindowInfo[]> {
   const now = Math.floor(Date.now() / 1000);
 
   return lines.map((line) => {
-    const [indexStr, name, worktreePath, activityStr] =
+    const [indexStr, name, worktreePath, activityStr, activeStr] =
       line.split(LIST_WINDOWS_DELIM);
     const index = parseInt(indexStr, 10);
     const activityTs = parseInt(activityStr, 10);
 
     const activity: WindowInfo["activity"] =
       now - activityTs <= ACTIVITY_THRESHOLD_SECONDS ? "active" : "idle";
+    const isActiveWindow = activeStr === "1";
 
-    return { index, name, worktreePath, activity };
+    return { index, name, worktreePath, activity, isActiveWindow };
   });
 }
 

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -79,7 +79,7 @@ export async function listWindows(session: string): Promise<WindowInfo[]> {
 
     const activity: WindowInfo["activity"] =
       now - activityTs <= ACTIVITY_THRESHOLD_SECONDS ? "active" : "idle";
-    const isActiveWindow = activeStr === "1";
+    const isActiveWindow = activeStr.trim() === "1";
 
     return { index, name, worktreePath, activity, isActiveWindow };
   });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,6 +10,7 @@ export type WindowInfo = {
   name: string;
   worktreePath: string;
   activity: "active" | "idle";
+  isActiveWindow: boolean;
   fabStage?: string;
   fabProgress?: string;
 };


### PR DESCRIPTION
## Summary

- Added `isActiveWindow: boolean` to `WindowInfo` type, parsed from `#{window_active}` in `listWindows()`
- Terminal client now tracks the tmux-active window via SSE and syncs breadcrumb, URL (via `history.replaceState`), and rename/kill targets
- Fixes bug where rename/kill targeted the URL's window instead of the byobu-switched-to window
- Updated existing tmux tests for the new field
- Hydrated architecture and UI patterns memory docs

## Files changed

- `src/lib/types.ts`
- `src/lib/tmux.ts`
- `src/app/p/[project]/[window]/terminal-client.tsx`
- `src/lib/__tests__/tmux.test.ts`
- `docs/memory/run-kit/architecture.md`
- `docs/memory/run-kit/ui-patterns.md`

## Test plan

- [ ] Switch windows in byobu; verify breadcrumb updates to the active window
- [ ] Switch windows in byobu; verify URL updates via `history.replaceState` (no full navigation)
- [ ] Rename a window after switching in byobu; confirm it targets the byobu-active window, not the URL's window
- [ ] Kill a window after switching in byobu; confirm it targets the byobu-active window
- [ ] Run tmux unit tests: `pnpm test src/lib/__tests__/tmux.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)