### PR TITLE
feat: Navbar Breadcrumb Dropdowns

### DIFF
--- a/docs/memory/run-kit/architecture.md
+++ b/docs/memory/run-kit/architecture.md
@@ -71,7 +71,7 @@ The root layout (`src/app/layout.tsx`) owns a flex-col skeleton (height: `var(--
 
 All three zones use `max-w-4xl mx-auto w-full px-6` for identical width/padding — pages cannot override this.
 
-**ChromeProvider** (`src/contexts/chrome-context.tsx`) — split into two React contexts: `ChromeStateContext` (read-only state: breadcrumbs, line2Left, line2Right, bottomBar, isConnected, fullbleed) and `ChromeDispatchContext` (stable setter functions). `useChrome()` returns both (backward compat, re-renders on state change). `useChromeDispatch()` returns only setters (stable reference, no re-renders from state changes). Pages that only set chrome slots use `useChromeDispatch()` to avoid cascade re-renders.
+**ChromeProvider** (`src/contexts/chrome-context.tsx`) — split into two React contexts: `ChromeStateContext` (read-only state: breadcrumbs, line2Left, line2Right, bottomBar, isConnected, fullbleed) and `ChromeDispatchContext` (stable setter functions). `useChrome()` returns both (backward compat, re-renders on state change). `useChromeDispatch()` returns only setters (stable reference, no re-renders from state changes). Pages that only set chrome slots use `useChromeDispatch()` to avoid cascade re-renders. `Breadcrumb` type includes optional `dropdownItems: BreadcrumbDropdownItem[]` for breadcrumb dropdown menus (project/window switching).
 
 **SessionProvider** (`src/contexts/session-context.tsx`) — layout-level React Context that owns the single `EventSource` connection to `/api/sessions/stream`. Exposes `{ sessions, isConnected }` to all descendant pages via `useSessions()` hook. Forwards `isConnected` to `ChromeProvider` internally, eliminating per-page connection status forwarding. Mounted inside `ChromeProvider` in `src/app/layout.tsx`.
 
@@ -141,3 +141,4 @@ Current coverage: `validate.ts` (input validation + tilde expansion), `config.ts
 | 2026-03-07 | File upload: `/api/upload` endpoint, clipboard paste/drag-drop/file picker triggers, compose buffer integration, `.uploads/` auto-gitignore | `260307-kqio-image-upload-claude-terminal` |
 | 2026-03-07 | iOS keyboard viewport overlap fix — visualViewport scroll listener, fixed positioning in fullbleed mode | `260307-f3o9-ios-keyboard-viewport-overlap` |
 | 2026-03-07 | Sync byobu active tab — `isActiveWindow` on `WindowInfo`, breadcrumb/URL/action sync via SSE + `history.replaceState` | `260307-f3li-sync-byobu-active-tab` |
+| 2026-03-07 | Breadcrumb type extended with `dropdownItems` for project/window switching dropdowns | `260307-uzsa-navbar-breadcrumb-dropdowns` |

--- a/docs/memory/run-kit/ui-patterns.md
+++ b/docs/memory/run-kit/ui-patterns.md
@@ -19,14 +19,25 @@ The root layout renders `TopBarChrome` (`src/components/top-bar-chrome.tsx`) whi
 | Page | Breadcrumb |
 |------|-----------|
 | Dashboard | `{logo}` (SVG logo only) |
-| Project | `{logo} › ⬡ {name}` |
-| Terminal | `{logo} › ⬡ {name} › ❯ {window}` (syncs with tmux active window via SSE) |
+| Project | `{logo} › ⬡ {name} ▾` |
+| Terminal | `{logo} › ⬡ {name} ▾ › ❯ {window} ▾` (syncs with tmux active window via SSE) |
 
 - Logo SVG (`logo.svg`) — always links to `/`
 - ⬡ — Unicode hexagon (U+2B21), `text-text-secondary`, precedes project name
 - ❯ — Unicode heavy right angle (U+276F), `text-text-secondary`, precedes window name
+- ▾ — Chevron dropdown trigger, opens sibling-switching dropdown menu
 - All segments except the last are clickable links
 - No text prefixes like "project:" or "window:"
+
+### Breadcrumb Dropdowns
+
+Breadcrumb segments with a `dropdownItems` array render a small chevron (`▾`) next to the label. Split click-target pattern: clicking the label navigates (existing behavior), clicking the chevron opens the dropdown.
+
+**Project dropdown** (project page + terminal page): Lists all tmux sessions. Current project highlighted with `text-accent`. Selecting navigates to `/p/{name}`.
+
+**Window dropdown** (terminal page only): Lists all windows in the current session. Current window highlighted. Selecting navigates to `/p/{project}/{index}?name={name}`.
+
+**Dropdown component** (`src/components/breadcrumb-dropdown.tsx`): Reusable dropdown with outside-click dismiss, Escape dismiss, ArrowUp/ArrowDown keyboard navigation, ARIA `role="menu"`/`role="menuitem"`. Styled with `bg-bg-primary border-border shadow-2xl`, matching bottom-bar Fn key dropdown pattern. Chevron has 24px minimum tap target. Long names truncated via `max-w-[240px]`.
 
 Connection indicator: green/gray dot with "live"/"disconnected" label, driven by `isConnected` from ChromeProvider (set by each page from `useSessions`).
 
@@ -181,3 +192,4 @@ Windows are `"active"` (last tmux activity within 10 seconds) or `"idle"`. No "e
 | 2026-03-07 | File upload: clipboard paste, drag-and-drop, file picker button, compose buffer path insertion, command palette action | `260307-kqio-image-upload-claude-terminal` |
 | 2026-03-07 | iOS keyboard viewport overlap fix — scroll+resize listeners on visualViewport, fixed positioning for app-shell in fullbleed | `260307-f3o9-ios-keyboard-viewport-overlap` |
 | 2026-03-07 | Active window sync — breadcrumb, URL, rename/kill targets follow byobu/tmux window switches via SSE + `history.replaceState` | `260307-f3li-sync-byobu-active-tab` |
+| 2026-03-07 | Breadcrumb dropdown menus — chevron triggers for project/window switching, split click-target pattern | `260307-uzsa-navbar-breadcrumb-dropdowns` |

--- a/fab/changes/260307-uzsa-navbar-breadcrumb-dropdowns/.history.jsonl
+++ b/fab/changes/260307-uzsa-navbar-breadcrumb-dropdowns/.history.jsonl
@@ -1,0 +1,24 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-03-07T01:15:56+05:30"}
+{"args":"Clicking on tab name in navbar should show dropdown of tabs in project. Clicking project in navbar should show dropdown of projects.","cmd":"fab-new","event":"command","ts":"2026-03-07T01:15:56+05:30"}
+{"delta":"+2.5","event":"confidence","score":2.5,"trigger":"calc-score","ts":"2026-03-07T01:16:35+05:30"}
+{"delta":"+0.0","event":"confidence","score":2.5,"trigger":"calc-score","ts":"2026-03-07T01:16:42+05:30"}
+{"delta":"+0.0","event":"confidence","score":2.5,"trigger":"calc-score","ts":"2026-03-07T01:20:41+05:30"}
+{"delta":"+0.0","event":"confidence","score":2.5,"trigger":"calc-score","ts":"2026-03-07T01:20:46+05:30"}
+{"delta":"+0.0","event":"confidence","score":2.5,"trigger":"calc-score","ts":"2026-03-07T01:20:55+05:30"}
+{"delta":"+0.0","event":"confidence","score":2.5,"trigger":"calc-score","ts":"2026-03-07T01:21:00+05:30"}
+{"delta":"+0.0","event":"confidence","score":2.5,"trigger":"calc-score","ts":"2026-03-07T01:21:14+05:30"}
+{"delta":"+0.0","event":"confidence","score":2.5,"trigger":"calc-score","ts":"2026-03-07T01:21:18+05:30"}
+{"cmd":"fab-clarify","event":"command","ts":"2026-03-07T01:23:21+05:30"}
+{"delta":"+1.5","event":"confidence","score":4,"trigger":"calc-score","ts":"2026-03-07T01:29:43+05:30"}
+{"delta":"+0.0","event":"confidence","score":4,"trigger":"calc-score","ts":"2026-03-07T01:29:47+05:30"}
+{"delta":"+0.0","event":"confidence","score":4,"trigger":"calc-score","ts":"2026-03-07T01:29:52+05:30"}
+{"delta":"+0.0","event":"confidence","score":4,"trigger":"calc-score","ts":"2026-03-07T01:30:00+05:30"}
+{"cmd":"fab-ff","event":"command","ts":"2026-03-07T01:30:53+05:30"}
+{"delta":"+0.4","event":"confidence","score":4.4,"trigger":"calc-score","ts":"2026-03-07T01:32:41+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"spec","ts":"2026-03-07T01:32:45+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"tasks","ts":"2026-03-07T01:33:19+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"apply","ts":"2026-03-07T01:33:19+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"review","ts":"2026-03-07T01:35:08+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"hydrate","ts":"2026-03-07T01:38:10+05:30"}
+{"event":"review","result":"passed","ts":"2026-03-07T01:38:10+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"ship","ts":"2026-03-07T01:38:54+05:30"}

--- a/fab/changes/260307-uzsa-navbar-breadcrumb-dropdowns/.history.jsonl
+++ b/fab/changes/260307-uzsa-navbar-breadcrumb-dropdowns/.history.jsonl
@@ -22,3 +22,5 @@
 {"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"hydrate","ts":"2026-03-07T01:38:10+05:30"}
 {"event":"review","result":"passed","ts":"2026-03-07T01:38:10+05:30"}
 {"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"ship","ts":"2026-03-07T01:38:54+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"review-pr","ts":"2026-03-07T01:41:03+05:30"}
+{"event":"review","result":"passed","ts":"2026-03-07T01:41:03+05:30"}

--- a/fab/changes/260307-uzsa-navbar-breadcrumb-dropdowns/.status.yaml
+++ b/fab/changes/260307-uzsa-navbar-breadcrumb-dropdowns/.status.yaml
@@ -10,8 +10,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: done
 checklist:
     generated: true
     path: checklist.md
@@ -36,6 +36,8 @@ stage_metrics:
     apply: {started_at: "2026-03-07T01:33:19+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T01:35:08+05:30"}
     review: {started_at: "2026-03-07T01:35:08+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T01:38:10+05:30"}
     hydrate: {started_at: "2026-03-07T01:38:10+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T01:38:54+05:30"}
-    ship: {started_at: "2026-03-07T01:38:54+05:30", driver: fab-ff, iterations: 1}
-prs: []
-last_updated: 2026-03-07T01:38:54+05:30
+    ship: {started_at: "2026-03-07T01:38:54+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T01:41:03+05:30"}
+    review-pr: {started_at: "2026-03-07T01:41:03+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T01:41:03+05:30"}
+prs:
+    - https://github.com/wvrdz/run-kit/pull/23
+last_updated: 2026-03-07T01:41:03+05:30

--- a/fab/changes/260307-uzsa-navbar-breadcrumb-dropdowns/.status.yaml
+++ b/fab/changes/260307-uzsa-navbar-breadcrumb-dropdowns/.status.yaml
@@ -1,7 +1,7 @@
 name: 260307-uzsa-navbar-breadcrumb-dropdowns
 created: 2026-03-07T01:15:56+05:30
 created_by: sahil-weaver
-change_type: refactor
+change_type: feat
 issues: []
 progress:
     intake: done
@@ -40,4 +40,4 @@ stage_metrics:
     review-pr: {started_at: "2026-03-07T01:41:03+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T01:41:03+05:30"}
 prs:
     - https://github.com/wvrdz/run-kit/pull/23
-last_updated: 2026-03-07T01:41:03+05:30
+last_updated: 2026-03-07T01:48:36+05:30

--- a/fab/changes/260307-uzsa-navbar-breadcrumb-dropdowns/.status.yaml
+++ b/fab/changes/260307-uzsa-navbar-breadcrumb-dropdowns/.status.yaml
@@ -1,0 +1,41 @@
+name: 260307-uzsa-navbar-breadcrumb-dropdowns
+created: 2026-03-07T01:15:56+05:30
+created_by: sahil-weaver
+change_type: refactor
+issues: []
+progress:
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+checklist:
+    generated: true
+    path: checklist.md
+    completed: 0
+    total: 0
+confidence:
+    certain: 12
+    confident: 2
+    tentative: 0
+    unresolved: 0
+    score: 4.4
+    fuzzy: true
+    dimensions:
+        signal: 88.9
+        reversibility: 91.1
+        competence: 88.6
+        disambiguation: 86.8
+stage_metrics:
+    intake: {started_at: "2026-03-07T01:15:56+05:30", driver: fab-new, iterations: 1, completed_at: "2026-03-07T01:32:45+05:30"}
+    spec: {started_at: "2026-03-07T01:32:45+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T01:33:19+05:30"}
+    tasks: {started_at: "2026-03-07T01:33:19+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T01:33:19+05:30"}
+    apply: {started_at: "2026-03-07T01:33:19+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T01:35:08+05:30"}
+    review: {started_at: "2026-03-07T01:35:08+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T01:38:10+05:30"}
+    hydrate: {started_at: "2026-03-07T01:38:10+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T01:38:54+05:30"}
+    ship: {started_at: "2026-03-07T01:38:54+05:30", driver: fab-ff, iterations: 1}
+prs: []
+last_updated: 2026-03-07T01:38:54+05:30

--- a/fab/changes/260307-uzsa-navbar-breadcrumb-dropdowns/checklist.md
+++ b/fab/changes/260307-uzsa-navbar-breadcrumb-dropdowns/checklist.md
@@ -1,0 +1,28 @@
+# Quality Checklist: Navbar Breadcrumb Dropdowns
+
+## Functional Completeness
+- [ ] Project dropdown appears on project page with all sessions listed
+- [ ] Project dropdown appears on terminal page with all sessions listed
+- [ ] Window dropdown appears on terminal page with all windows listed
+- [ ] Current item highlighted in both dropdowns
+- [ ] Selecting a project navigates to `/p/{name}`
+- [ ] Selecting a window navigates to `/p/{project}/{index}?name={name}`
+- [ ] Dashboard breadcrumbs unchanged (no dropdown)
+
+## Behavioral Correctness
+- [ ] Clicking label/name navigates (terminal page project link) — does NOT open dropdown
+- [ ] Clicking chevron opens dropdown — does NOT navigate
+- [ ] Outside click dismisses dropdown
+- [ ] Escape key dismisses dropdown
+- [ ] ArrowUp/ArrowDown navigates dropdown items
+- [ ] Enter selects focused dropdown item
+- [ ] Only one dropdown open at a time
+
+## Edge Cases
+- [ ] Single session — dropdown with one item (current, highlighted)
+- [ ] Single window — dropdown with one item
+- [ ] Session/window list updates via SSE while dropdown is open (dropdown reflects latest data)
+- [ ] Long project/window names don't break dropdown layout
+
+## Security
+- [ ] No shell injection vectors (feature is client-side only, navigation via Next.js Link)

--- a/fab/changes/260307-uzsa-navbar-breadcrumb-dropdowns/intake.md
+++ b/fab/changes/260307-uzsa-navbar-breadcrumb-dropdowns/intake.md
@@ -1,0 +1,102 @@
+# Intake: Navbar Breadcrumb Dropdowns
+
+**Change**: 260307-uzsa-navbar-breadcrumb-dropdowns
+**Created**: 2026-03-07
+**Status**: Draft
+
+## Origin
+
+> Clicking on tab name in the navbar should show a dropdown of tabs in the project. And when we are in the project page, clicking on the project in the navbar should show a dropdown of projects.
+
+Conversational refinement. Initial request for breadcrumb dropdowns, then discussed preserving back-navigation on the terminal page's project link. Settled on a split click-target: name clicks retain existing behavior, a chevron icon next to the name opens the dropdown. Chevron applied to both project and window segments for consistency.
+
+## Why
+
+The breadcrumb currently shows context (project name, window name) but doesn't let users switch between siblings without navigating back. Clicking the project name on a project page does nothing (it's the current page). Clicking the window name on a terminal page also does nothing (it's the last breadcrumb, rendered as static text).
+
+Adding dropdowns to these segments turns the breadcrumb into a fast navigation switcher — users can jump between projects or between windows within a project without leaving their current context. This is a standard pattern in tools like Linear and VS Code. The split click-target (name = navigate, chevron = dropdown) preserves existing back-navigation while adding the new switching capability.
+
+## What Changes
+
+### Split Click-Target Pattern
+
+Each breadcrumb segment that has a dropdown gets a small chevron icon (e.g., `▾`) next to the label. The two click zones behave differently:
+
+- **Click the name/label** — existing behavior: navigates (e.g., project name on terminal page links back to `/p/:project`). On the current page's segment (e.g., project name on project page, window name on terminal page), clicking the name does nothing (already there).
+- **Click the chevron** — opens the dropdown menu below the segment.
+
+This preserves back-navigation on the terminal page while adding dropdown switching.
+
+### Breadcrumb Project Dropdown
+
+A chevron appears next to the project name on both the **project page** and the **terminal page**. Clicking the chevron opens a dropdown listing all projects (tmux sessions). Selecting a project navigates to `/p/:selected`. The current project is visually marked.
+
+### Breadcrumb Window Dropdown
+
+A chevron appears next to the window name on the **terminal page**. Clicking the chevron opens a dropdown listing all windows in the current project. Selecting a window navigates to `/p/:project/:window?name=:name`. The current window is visually marked.
+
+### Data Requirements
+
+- **Projects list**: Already available from `useSessions()` — the `sessions` array contains all `ProjectSession` objects with their names.
+- **Windows list**: Already available from `useSessions()` — each `ProjectSession` has a `windows` array with `{ index, name, activity }`.
+- No new API endpoints needed.
+
+### Interaction
+
+- Click chevron → dropdown opens below/aligned to the segment
+- Click name/label → navigates (existing behavior) or no-op if current page
+- Click outside or press Escape → dropdown closes
+- Click item → navigate + close
+- Keyboard: arrow keys to navigate items, Enter to select, Escape to close
+
+### Visual Design
+
+- Same dark theme dropdown style as the Fn key dropdown in the bottom bar (dark background, border, shadow)
+- Items show name, current item has accent highlight or checkmark
+- Dropdown opens downward from the breadcrumb segment
+
+## Affected Memory
+
+- `run-kit/ui-patterns`: (modify) Document breadcrumb dropdown behavior and keyboard shortcuts
+- `run-kit/architecture`: (modify) Note ChromeProvider changes if breadcrumb type is extended
+
+## Impact
+
+- **`src/components/top-bar-chrome.tsx`** — Breadcrumb rendering changes from links/text to dropdown triggers
+- **`src/contexts/chrome-context.tsx`** — `Breadcrumb` type may need extension (e.g., `items` array for dropdown content, or an `onDropdown` callback)
+- **Page client components** — Need to pass dropdown data (sessions list, windows list) when setting breadcrumbs
+- **New component** — A `BreadcrumbDropdown` or reusable `Popover` component for the dropdown UI
+
+## Open Questions
+
+- None — the scope is clear from context.
+
+## Clarifications
+
+### Session 2026-03-07 (bulk confirm)
+
+| # | Action | Detail |
+|---|--------|--------|
+| 5 | Confirmed | — |
+| 6 | Confirmed | — |
+| 7 | Confirmed | — |
+| 8 | Confirmed | — |
+| 9 | Confirmed | — |
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Use existing `useSessions()` data for dropdown items | Sessions and windows are already available in the session context — no new API needed | S:90 R:95 A:95 D:95 |
+| 2 | Certain | Follow existing dropdown pattern from bottom bar Fn keys | Codebase has an established custom dropdown pattern with outside-click, Escape, ARIA roles — reuse it | S:85 R:90 A:95 D:90 |
+| 3 | Certain | Split click-target: name navigates, chevron opens dropdown | Discussed — user chose chevron approach to preserve back-navigation on terminal page project link | S:95 R:90 A:95 D:95 |
+| 4 | Certain | Chevron on both project and window segments for consistency | Discussed — user explicitly requested consistency across both segments | S:95 R:90 A:95 D:95 |
+| 5 | Certain | Extend `Breadcrumb` type to support dropdown data | Clarified — user confirmed | S:95 R:85 A:80 D:75 |
+| 6 | Certain | Project dropdown available on both project and terminal pages | Clarified — user confirmed | S:95 R:90 A:80 D:80 |
+| 7 | Certain | Window dropdown only on terminal page | Clarified — user confirmed | S:95 R:95 A:90 D:95 |
+| 8 | Certain | Dropdown opens downward from breadcrumb segment | Clarified — user confirmed | S:95 R:90 A:85 D:80 |
+| 9 | Certain | Current item highlighted in dropdown | Clarified — user confirmed | S:95 R:95 A:85 D:90 |
+| 10 | Tentative | Dashboard page: no dropdown (no project breadcrumb to click) | Dashboard has empty breadcrumbs — no segment to attach a dropdown to. User didn't mention dashboard. | S:60 R:85 A:70 D:60 |
+<!-- assumed: No dashboard dropdown — dashboard has no project breadcrumb segment, and user request scoped to project/terminal pages -->
+
+10 assumptions (9 certain, 0 confident, 1 tentative, 0 unresolved).

--- a/fab/changes/260307-uzsa-navbar-breadcrumb-dropdowns/spec.md
+++ b/fab/changes/260307-uzsa-navbar-breadcrumb-dropdowns/spec.md
@@ -1,0 +1,194 @@
+# Spec: Navbar Breadcrumb Dropdowns
+
+**Change**: 260307-uzsa-navbar-breadcrumb-dropdowns
+**Created**: 2026-03-07
+**Affected memory**: `docs/memory/run-kit/ui-patterns.md`, `docs/memory/run-kit/architecture.md`
+
+## Non-Goals
+
+- Dashboard breadcrumb dropdowns — dashboard renders no breadcrumb segments, so there is nothing to attach a dropdown to
+- Command palette integration for breadcrumb dropdowns — this is a mouse/touch interaction; keyboard navigation within dropdowns is sufficient
+- Search/filtering within dropdowns — project and window lists are small enough that filtering is unnecessary
+
+## Chrome: Breadcrumb Type Extension
+
+### Requirement: Breadcrumb Type MUST Support Dropdown Items
+
+The `Breadcrumb` type in `src/contexts/chrome-context.tsx` SHALL be extended with an optional `dropdownItems` property. When present, the breadcrumb segment renders a chevron toggle that opens a dropdown menu.
+
+```typescript
+export type BreadcrumbDropdownItem = {
+  label: string;
+  href: string;
+  current?: boolean;
+};
+
+export type Breadcrumb = {
+  icon?: string;
+  label: string;
+  href?: string;
+  dropdownItems?: BreadcrumbDropdownItem[];
+};
+```
+
+#### Scenario: Breadcrumb with no dropdown items
+- **GIVEN** a breadcrumb with `dropdownItems` undefined or empty
+- **WHEN** `TopBarChrome` renders the breadcrumb
+- **THEN** no chevron is rendered
+- **AND** behavior is identical to current implementation (link if `href`, static text otherwise)
+
+#### Scenario: Breadcrumb with dropdown items
+- **GIVEN** a breadcrumb with `dropdownItems` containing 2+ items
+- **WHEN** `TopBarChrome` renders the breadcrumb
+- **THEN** a chevron icon (`▾`) appears immediately after the label text
+- **AND** the chevron is a separate click target from the label
+
+## Chrome: Breadcrumb Dropdown Component
+
+### Requirement: Chevron MUST Open a Dropdown Menu
+
+A new `BreadcrumbDropdown` component (`src/components/breadcrumb-dropdown.tsx`) SHALL render the chevron button and its associated dropdown menu. The component receives `dropdownItems` and renders them as a list.
+
+#### Scenario: Opening the dropdown
+- **GIVEN** a breadcrumb segment with dropdown items and the dropdown is closed
+- **WHEN** the user clicks the chevron icon
+- **THEN** a dropdown menu appears below the breadcrumb segment
+- **AND** the dropdown is visually aligned to the chevron/segment
+
+#### Scenario: Selecting a dropdown item
+- **GIVEN** the dropdown is open
+- **WHEN** the user clicks an item
+- **THEN** the browser navigates to the item's `href`
+- **AND** the dropdown closes
+
+#### Scenario: Current item highlighting
+- **GIVEN** the dropdown is open and one item has `current: true`
+- **WHEN** the dropdown renders
+- **THEN** the current item has `text-accent` color
+- **AND** all other items have `text-text-secondary` with `hover:text-text-primary`
+
+#### Scenario: Dismiss on outside click
+- **GIVEN** the dropdown is open
+- **WHEN** the user clicks outside the dropdown
+- **THEN** the dropdown closes
+
+#### Scenario: Dismiss on Escape
+- **GIVEN** the dropdown is open
+- **WHEN** the user presses Escape
+- **THEN** the dropdown closes
+
+#### Scenario: Keyboard navigation
+- **GIVEN** the dropdown is open
+- **WHEN** the user presses ArrowDown/ArrowUp
+- **THEN** focus moves between dropdown items
+- **AND** pressing Enter on a focused item navigates to its `href`
+
+### Requirement: Split Click-Target MUST Preserve Navigation
+
+The label/name portion of a breadcrumb segment SHALL retain its existing click behavior (navigation via `href` or no-op if no `href`). The chevron SHALL be the sole trigger for the dropdown.
+
+#### Scenario: Terminal page project breadcrumb — click name
+- **GIVEN** the user is on the terminal page `/p/myproject/1`
+- **WHEN** the user clicks the project name text "myproject"
+- **THEN** the browser navigates to `/p/myproject` (existing back-navigation)
+- **AND** the dropdown does NOT open
+
+#### Scenario: Terminal page project breadcrumb — click chevron
+- **GIVEN** the user is on the terminal page `/p/myproject/1`
+- **WHEN** the user clicks the chevron next to the project name
+- **THEN** the dropdown opens showing all projects
+- **AND** "myproject" is highlighted as the current project
+
+#### Scenario: Project page project breadcrumb — click name
+- **GIVEN** the user is on the project page `/p/myproject`
+- **WHEN** the user clicks the project name text "myproject"
+- **THEN** nothing happens (no `href` — already on this page)
+
+#### Scenario: Project page project breadcrumb — click chevron
+- **GIVEN** the user is on the project page `/p/myproject`
+- **WHEN** the user clicks the chevron next to the project name
+- **THEN** the dropdown opens showing all projects
+- **AND** "myproject" is highlighted as the current project
+
+## Pages: Dropdown Data Population
+
+### Requirement: Project Page MUST Provide Project Dropdown Items
+
+The project page client component (`src/app/p/[project]/project-client.tsx`) SHALL populate `dropdownItems` on the project breadcrumb with all sessions from `useSessions()`, marking the current project as `current: true`.
+
+#### Scenario: Project breadcrumb with session list
+- **GIVEN** the user is on project page `/p/myproject` and there are 3 sessions
+- **WHEN** the page sets breadcrumbs via `useChromeDispatch()`
+- **THEN** the breadcrumb has `dropdownItems` with 3 entries
+- **AND** each entry has `label` = session name, `href` = `/p/{name}`
+- **AND** the entry matching `projectName` has `current: true`
+
+### Requirement: Terminal Page MUST Provide Both Dropdowns
+
+The terminal page client component (`src/app/p/[project]/[window]/terminal-client.tsx`) SHALL populate `dropdownItems` on both the project breadcrumb and the window breadcrumb.
+
+#### Scenario: Terminal breadcrumbs with dropdown data
+- **GIVEN** the user is on terminal page `/p/myproject/1?name=agent` with 3 sessions, and the current session has 4 windows
+- **WHEN** the page sets breadcrumbs via `useChromeDispatch()`
+- **THEN** the project breadcrumb has `dropdownItems` with 3 project entries (current project marked)
+- **AND** the window breadcrumb has `dropdownItems` with 4 window entries
+- **AND** each window entry has `href` = `/p/myproject/{index}?name={name}` and `current: true` on the matching window
+
+### Requirement: Dashboard MUST NOT Have Dropdowns
+
+The dashboard page (`src/app/dashboard-client.tsx`) SHALL continue to set empty breadcrumbs. No dropdown functionality on the dashboard.
+
+#### Scenario: Dashboard breadcrumbs unchanged
+- **GIVEN** the user is on the dashboard
+- **WHEN** the page sets breadcrumbs
+- **THEN** `setBreadcrumbs([])` is called (no change from current behavior)
+
+## Visual: Dropdown Styling
+
+### Requirement: Dropdown MUST Follow Existing Visual Patterns
+
+The dropdown menu SHALL use the same dark theme styling as the Fn key dropdown in `bottom-bar.tsx`:
+
+- Background: `bg-bg-card` with `border border-border` and `shadow-lg`
+- Items: `px-3 py-2` padding, `text-sm`, `text-text-secondary` default, `hover:text-text-primary hover:bg-bg-primary` on hover
+- Current item: `text-accent` color
+- Z-index: `z-50`
+- Min-width: `min-w-[160px]`
+- ARIA: `role="menu"` on container, `role="menuitem"` on items
+
+#### Scenario: Dropdown visual consistency
+- **GIVEN** the dropdown is open
+- **WHEN** the user views the dropdown
+- **THEN** it has dark background, border, and shadow consistent with other dropdowns in the app
+- **AND** items are legible in the dark theme with appropriate hover states
+
+### Requirement: Chevron MUST Be Visually Subtle
+
+The chevron icon (`▾`) SHALL be styled with `text-text-secondary` at a smaller font size, with `hover:text-text-primary` transition. It SHOULD have sufficient click target size (at least 24px tap area via padding).
+
+#### Scenario: Chevron appearance
+- **GIVEN** a breadcrumb with dropdown items
+- **WHEN** the page renders
+- **THEN** a `▾` character appears after the label in secondary color
+- **AND** hovering the chevron changes it to primary color
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Use existing `useSessions()` data for dropdown items | Sessions and windows already available in session context — no new API needed | S:90 R:95 A:95 D:95 |
+| 2 | Certain | Follow existing dropdown pattern from bottom bar Fn keys | Codebase has established custom dropdown pattern with outside-click, Escape, ARIA roles | S:85 R:90 A:95 D:90 |
+| 3 | Certain | Split click-target: name navigates, chevron opens dropdown | Discussed — user chose chevron approach to preserve back-navigation | S:95 R:90 A:95 D:95 |
+| 4 | Certain | Chevron on both project and window segments for consistency | Discussed — user explicitly requested | S:95 R:90 A:95 D:95 |
+| 5 | Certain | Extend `Breadcrumb` type with optional `dropdownItems` array | Confirmed — natural extension point, pages opt in by providing items | S:95 R:85 A:80 D:75 |
+| 6 | Certain | Project dropdown on both project and terminal pages | Confirmed — applies wherever project segment appears | S:95 R:90 A:80 D:80 |
+| 7 | Certain | Window dropdown only on terminal page | Confirmed — window breadcrumb only exists there | S:95 R:95 A:90 D:95 |
+| 8 | Certain | Dropdown opens downward from breadcrumb | Confirmed — standard pattern | S:95 R:90 A:85 D:80 |
+| 9 | Certain | Current item highlighted with accent color | Confirmed — standard switcher pattern | S:95 R:95 A:85 D:90 |
+| 10 | Certain | No dashboard dropdown | Dashboard has empty breadcrumbs — no segment to attach to | S:95 R:85 A:90 D:90 |
+| 11 | Certain | New `BreadcrumbDropdown` component for dropdown UI | Separation of concerns — keeps `TopBarChrome` clean, dropdown logic encapsulated | S:80 R:90 A:90 D:85 |
+| 12 | Certain | Use Next.js `Link` for dropdown items (client-side navigation) | Consistent with existing breadcrumb link usage in `top-bar-chrome.tsx` | S:85 R:95 A:95 D:95 |
+| 13 | Confident | `BreadcrumbDropdownItem` uses `href` string (not `onClick` callback) | Dropdown items are navigational — `href` + `Link` is the right pattern for Next.js routing | S:75 R:90 A:85 D:80 |
+| 14 | Confident | Chevron character is `▾` (U+25BE BLACK DOWN-POINTING SMALL TRIANGLE) | Simple, universally supported, visually consistent with existing Unicode icons (⬡, ❯) | S:70 R:95 A:80 D:70 |
+
+14 assumptions (12 certain, 2 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260307-uzsa-navbar-breadcrumb-dropdowns/tasks.md
+++ b/fab/changes/260307-uzsa-navbar-breadcrumb-dropdowns/tasks.md
@@ -1,0 +1,32 @@
+# Tasks: Navbar Breadcrumb Dropdowns
+
+**Change**: 260307-uzsa-navbar-breadcrumb-dropdowns
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+## Phase 1: Type Extension
+
+- [x] T001 Extend `Breadcrumb` type in `src/contexts/chrome-context.tsx` — add `BreadcrumbDropdownItem` type (`{ label: string; href: string; current?: boolean }`) and optional `dropdownItems?: BreadcrumbDropdownItem[]` to `Breadcrumb`
+
+## Phase 2: Dropdown Component
+
+- [x] T002 Create `src/components/breadcrumb-dropdown.tsx` — new Client Component that receives `dropdownItems: BreadcrumbDropdownItem[]` and renders a chevron (`▾`) button + dropdown menu. Implement: open/close state, outside-click dismiss (document listener), Escape key dismiss, ArrowUp/ArrowDown keyboard navigation, Enter to select. Style: `bg-bg-card border border-border shadow-lg z-50 min-w-[160px]`, items with `role="menuitem"`, container with `role="menu"`. Current item highlighted with `text-accent`. Use Next.js `Link` for items.
+
+## Phase 3: Integration
+
+- [x] T003 Update `src/components/top-bar-chrome.tsx` — modify breadcrumb rendering loop to render `BreadcrumbDropdown` chevron next to crumbs that have `dropdownItems`. Keep existing label rendering (Link with `href` or static span) unchanged. Import `BreadcrumbDropdown` and render it inline after the label.
+- [x] T004 [P] Update `src/app/p/[project]/project-client.tsx` — populate `dropdownItems` on the project breadcrumb. Map `sessions` from `useSessions()` to `BreadcrumbDropdownItem[]` with `label: s.name`, `href: /p/${s.name}`, `current: s.name === projectName`.
+- [x] T005 [P] Update `src/app/p/[project]/[window]/terminal-client.tsx` — populate `dropdownItems` on both breadcrumbs. Project breadcrumb: same mapping as T004. Window breadcrumb: map current session's `windows` to items with `label: w.name`, `href: /p/${projectName}/${w.index}?name=${encodeURIComponent(w.name)}`, `current: w.index === windowIndex`.
+
+## Phase 4: Polish
+
+- [x] T006 Verify build — run `npx tsc --noEmit` and `pnpm build` to confirm no type errors or build issues
+
+---
+
+## Execution Order
+
+- T001 blocks T002, T003, T004, T005
+- T002 blocks T003
+- T004 and T005 are independent (different files)
+- T006 runs after all other tasks

--- a/src/app/p/[project]/[window]/terminal-client.tsx
+++ b/src/app/p/[project]/[window]/terminal-client.tsx
@@ -71,14 +71,32 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
 
   // Update breadcrumb and URL when active window changes
   useEffect(() => {
+    const currentSession = sessions.find((s) => s.name === projectName);
     setBreadcrumbs([
-      { icon: "⬡", label: projectName, href: `/p/${projectName}` },
-      { icon: "❯", label: displayName },
+      {
+        icon: "⬡",
+        label: projectName,
+        href: `/p/${encodeURIComponent(projectName)}`,
+        dropdownItems: sessions.map((s) => ({
+          label: s.name,
+          href: `/p/${encodeURIComponent(s.name)}`,
+          current: s.name === projectName,
+        })),
+      },
+      {
+        icon: "❯",
+        label: displayName,
+        dropdownItems: currentSession?.windows.map((w) => ({
+          label: w.name,
+          href: `/p/${encodeURIComponent(projectName)}/${w.index}?name=${encodeURIComponent(w.name)}`,
+          current: String(w.index) === displayIndex,
+        })) ?? [],
+      },
     ]);
     // Sync URL without triggering Next.js routing
     const newUrl = `/p/${encodeURIComponent(projectName)}/${displayIndex}?name=${encodeURIComponent(displayName)}`;
     window.history.replaceState(window.history.state, "", newUrl);
-  }, [projectName, displayName, displayIndex, setBreadcrumbs]);
+  }, [projectName, displayName, displayIndex, sessions, setBreadcrumbs]);
 
   useEffect(() => {
     setLine2Left(

--- a/src/app/p/[project]/project-client.tsx
+++ b/src/app/p/[project]/project-client.tsx
@@ -85,13 +85,21 @@ export function ProjectClient({ projectName, initialWindows }: Props) {
 
   // Set chrome slots
   useEffect(() => {
-    setBreadcrumbs([{ icon: "⬡", label: projectName }]);
+    setBreadcrumbs([{
+      icon: "⬡",
+      label: projectName,
+      dropdownItems: sessions.map((s) => ({
+        label: s.name,
+        href: `/p/${s.name}`,
+        current: s.name === projectName,
+      })),
+    }]);
     return () => {
       setBreadcrumbs([]);
       setLine2Left(null);
       setLine2Right(null);
     };
-  }, [projectName, setBreadcrumbs, setLine2Left, setLine2Right]);
+  }, [projectName, sessions, setBreadcrumbs, setLine2Left, setLine2Right]);
 
   useEffect(() => {
     setLine2Left(

--- a/src/app/p/[project]/project-client.tsx
+++ b/src/app/p/[project]/project-client.tsx
@@ -90,7 +90,7 @@ export function ProjectClient({ projectName, initialWindows }: Props) {
       label: projectName,
       dropdownItems: sessions.map((s) => ({
         label: s.name,
-        href: `/p/${s.name}`,
+        href: `/p/${encodeURIComponent(s.name)}`,
         current: s.name === projectName,
       })),
     }]);

--- a/src/components/__tests__/breadcrumb-dropdown.test.tsx
+++ b/src/components/__tests__/breadcrumb-dropdown.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
 import { BreadcrumbDropdown } from "@/components/breadcrumb-dropdown";
 import type { BreadcrumbDropdownItem } from "@/contexts/chrome-context";
 
@@ -94,26 +94,33 @@ describe("BreadcrumbDropdown", () => {
     expect(links[2]).toHaveAttribute("href", "/p/project-c");
   });
 
+  it("auto-focuses current item on open", async () => {
+    render(<BreadcrumbDropdown items={items} />);
+    clickChevron();
+    // item 0 has current: true, should be auto-focused (via rAF)
+    const currentItem = screen.getAllByRole("menuitem")[0];
+    await waitFor(() => expect(document.activeElement).toBe(currentItem));
+  });
+
   it("navigates items with ArrowDown", () => {
     render(<BreadcrumbDropdown items={items} />);
     clickChevron();
-    fireEvent.keyDown(document, { key: "ArrowDown" });
-    const firstItem = screen.getAllByRole("menuitem")[0];
-    expect(document.activeElement).toBe(firstItem);
-
+    // Auto-focused on item 0 (current). ArrowDown → item 1
     fireEvent.keyDown(document, { key: "ArrowDown" });
     const secondItem = screen.getAllByRole("menuitem")[1];
     expect(document.activeElement).toBe(secondItem);
+
+    fireEvent.keyDown(document, { key: "ArrowDown" });
+    const thirdItem = screen.getAllByRole("menuitem")[2];
+    expect(document.activeElement).toBe(thirdItem);
   });
 
   it("navigates items with ArrowUp", () => {
     render(<BreadcrumbDropdown items={items} />);
     clickChevron();
-    // Go to first item
+    // Auto-focused on item 0. ArrowDown → item 1
     fireEvent.keyDown(document, { key: "ArrowDown" });
-    // Go to second
-    fireEvent.keyDown(document, { key: "ArrowDown" });
-    // Back to first
+    // ArrowUp → back to item 0
     fireEvent.keyDown(document, { key: "ArrowUp" });
     const firstItem = screen.getAllByRole("menuitem")[0];
     expect(document.activeElement).toBe(firstItem);
@@ -122,8 +129,7 @@ describe("BreadcrumbDropdown", () => {
   it("ArrowDown wraps from last to first", () => {
     render(<BreadcrumbDropdown items={items} />);
     clickChevron();
-    // Navigate to last item
-    fireEvent.keyDown(document, { key: "ArrowDown" });
+    // Auto-focused on item 0. Navigate to last item (2 ArrowDowns)
     fireEvent.keyDown(document, { key: "ArrowDown" });
     fireEvent.keyDown(document, { key: "ArrowDown" });
     // Wrap to first
@@ -135,9 +141,7 @@ describe("BreadcrumbDropdown", () => {
   it("ArrowUp wraps from first to last", () => {
     render(<BreadcrumbDropdown items={items} />);
     clickChevron();
-    // Navigate to first item
-    fireEvent.keyDown(document, { key: "ArrowDown" });
-    // Wrap to last
+    // Auto-focused on item 0. ArrowUp → wrap to last
     fireEvent.keyDown(document, { key: "ArrowUp" });
     const lastItem = screen.getAllByRole("menuitem")[2];
     expect(document.activeElement).toBe(lastItem);

--- a/src/components/__tests__/breadcrumb-dropdown.test.tsx
+++ b/src/components/__tests__/breadcrumb-dropdown.test.tsx
@@ -1,0 +1,178 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { BreadcrumbDropdown } from "@/components/breadcrumb-dropdown";
+import type { BreadcrumbDropdownItem } from "@/contexts/chrome-context";
+
+// Mock next/link to render a plain <a> in jsdom
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+const items: BreadcrumbDropdownItem[] = [
+  { label: "project-a", href: "/p/project-a", current: true },
+  { label: "project-b", href: "/p/project-b" },
+  { label: "project-c", href: "/p/project-c" },
+];
+
+function clickChevron() {
+  fireEvent.click(screen.getByRole("button", { name: /switch/i }));
+}
+
+describe("BreadcrumbDropdown", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders a chevron button", () => {
+    render(<BreadcrumbDropdown items={items} />);
+    expect(screen.getByRole("button", { name: /switch/i })).toBeInTheDocument();
+  });
+
+  it("dropdown is hidden by default", () => {
+    render(<BreadcrumbDropdown items={items} />);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("opens dropdown on chevron click", () => {
+    render(<BreadcrumbDropdown items={items} />);
+    clickChevron();
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(screen.getAllByRole("menuitem")).toHaveLength(3);
+  });
+
+  it("closes dropdown on second chevron click", () => {
+    render(<BreadcrumbDropdown items={items} />);
+    clickChevron();
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    clickChevron();
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("closes dropdown on Escape", () => {
+    render(<BreadcrumbDropdown items={items} />);
+    clickChevron();
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("closes dropdown on outside click", () => {
+    const { container } = render(
+      <div>
+        <span data-testid="outside">outside</span>
+        <BreadcrumbDropdown items={items} />
+      </div>,
+    );
+    clickChevron();
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    fireEvent.mouseDown(screen.getByTestId("outside"));
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("highlights current item with accent color", () => {
+    render(<BreadcrumbDropdown items={items} />);
+    clickChevron();
+    const currentItem = screen.getByText("project-a");
+    expect(currentItem.className).toContain("text-accent");
+  });
+
+  it("non-current items have secondary color", () => {
+    render(<BreadcrumbDropdown items={items} />);
+    clickChevron();
+    const otherItem = screen.getByText("project-b");
+    expect(otherItem.className).toContain("text-text-secondary");
+  });
+
+  it("renders correct hrefs on menu items", () => {
+    render(<BreadcrumbDropdown items={items} />);
+    clickChevron();
+    const links = screen.getAllByRole("menuitem");
+    expect(links[0]).toHaveAttribute("href", "/p/project-a");
+    expect(links[1]).toHaveAttribute("href", "/p/project-b");
+    expect(links[2]).toHaveAttribute("href", "/p/project-c");
+  });
+
+  it("navigates items with ArrowDown", () => {
+    render(<BreadcrumbDropdown items={items} />);
+    clickChevron();
+    fireEvent.keyDown(document, { key: "ArrowDown" });
+    const firstItem = screen.getAllByRole("menuitem")[0];
+    expect(document.activeElement).toBe(firstItem);
+
+    fireEvent.keyDown(document, { key: "ArrowDown" });
+    const secondItem = screen.getAllByRole("menuitem")[1];
+    expect(document.activeElement).toBe(secondItem);
+  });
+
+  it("navigates items with ArrowUp", () => {
+    render(<BreadcrumbDropdown items={items} />);
+    clickChevron();
+    // Go to first item
+    fireEvent.keyDown(document, { key: "ArrowDown" });
+    // Go to second
+    fireEvent.keyDown(document, { key: "ArrowDown" });
+    // Back to first
+    fireEvent.keyDown(document, { key: "ArrowUp" });
+    const firstItem = screen.getAllByRole("menuitem")[0];
+    expect(document.activeElement).toBe(firstItem);
+  });
+
+  it("ArrowDown wraps from last to first", () => {
+    render(<BreadcrumbDropdown items={items} />);
+    clickChevron();
+    // Navigate to last item
+    fireEvent.keyDown(document, { key: "ArrowDown" });
+    fireEvent.keyDown(document, { key: "ArrowDown" });
+    fireEvent.keyDown(document, { key: "ArrowDown" });
+    // Wrap to first
+    fireEvent.keyDown(document, { key: "ArrowDown" });
+    const firstItem = screen.getAllByRole("menuitem")[0];
+    expect(document.activeElement).toBe(firstItem);
+  });
+
+  it("ArrowUp wraps from first to last", () => {
+    render(<BreadcrumbDropdown items={items} />);
+    clickChevron();
+    // Navigate to first item
+    fireEvent.keyDown(document, { key: "ArrowDown" });
+    // Wrap to last
+    fireEvent.keyDown(document, { key: "ArrowUp" });
+    const lastItem = screen.getAllByRole("menuitem")[2];
+    expect(document.activeElement).toBe(lastItem);
+  });
+
+  it("uses contextual aria-label when label prop provided", () => {
+    render(<BreadcrumbDropdown items={items} label="project" />);
+    expect(screen.getByRole("button", { name: "Switch project" })).toBeInTheDocument();
+  });
+
+  it("uses generic aria-label when no label prop", () => {
+    render(<BreadcrumbDropdown items={items} />);
+    expect(screen.getByRole("button", { name: "Switch" })).toBeInTheDocument();
+  });
+
+  it("sets aria-expanded correctly", () => {
+    render(<BreadcrumbDropdown items={items} />);
+    const button = screen.getByRole("button", { name: /switch/i });
+    expect(button).toHaveAttribute("aria-expanded", "false");
+    clickChevron();
+    expect(button).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("closes dropdown when item is clicked", () => {
+    render(<BreadcrumbDropdown items={items} />);
+    clickChevron();
+    fireEvent.click(screen.getByText("project-b"));
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("handles single item list", () => {
+    const singleItem = [{ label: "only-project", href: "/p/only-project", current: true }];
+    render(<BreadcrumbDropdown items={singleItem} />);
+    clickChevron();
+    expect(screen.getAllByRole("menuitem")).toHaveLength(1);
+    expect(screen.getByText("only-project").className).toContain("text-accent");
+  });
+});

--- a/src/components/breadcrumb-dropdown.tsx
+++ b/src/components/breadcrumb-dropdown.tsx
@@ -13,6 +13,7 @@ export function BreadcrumbDropdown({ items, label }: Props) {
   const [open, setOpen] = useState(false);
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
   const itemRefs = useRef<(HTMLAnchorElement | null)[]>([]);
 
   // Close on outside click
@@ -27,16 +28,20 @@ export function BreadcrumbDropdown({ items, label }: Props) {
     return () => document.removeEventListener("mousedown", handleClick);
   }, [open]);
 
-  // Close on Escape, arrow key navigation
+  // Keyboard: Escape closes, ArrowDown/Up navigates. Capture phase + stopPropagation
+  // prevents terminal page handlers (double-Esc nav) from firing while menu is open.
   useEffect(() => {
     if (!open) return;
     function handleKey(e: KeyboardEvent) {
       if (e.key === "Escape") {
+        e.stopPropagation();
         setOpen(false);
+        buttonRef.current?.focus();
         return;
       }
       if (e.key === "ArrowDown") {
         e.preventDefault();
+        e.stopPropagation();
         setFocusedIndex((prev) => {
           const next = prev < items.length - 1 ? prev + 1 : 0;
           itemRefs.current[next]?.focus();
@@ -45,6 +50,7 @@ export function BreadcrumbDropdown({ items, label }: Props) {
       }
       if (e.key === "ArrowUp") {
         e.preventDefault();
+        e.stopPropagation();
         setFocusedIndex((prev) => {
           const next = prev > 0 ? prev - 1 : items.length - 1;
           itemRefs.current[next]?.focus();
@@ -52,20 +58,29 @@ export function BreadcrumbDropdown({ items, label }: Props) {
         });
       }
     }
-    document.addEventListener("keydown", handleKey);
-    return () => document.removeEventListener("keydown", handleKey);
+    document.addEventListener("keydown", handleKey, { capture: true });
+    return () => document.removeEventListener("keydown", handleKey, { capture: true });
   }, [open, items.length]);
 
-  const toggle = useCallback(() => {
-    setOpen((v) => {
-      if (!v) setFocusedIndex(-1);
-      return !v;
+  // Auto-focus current item (or first) when opening
+  useEffect(() => {
+    if (!open) return;
+    const currentIdx = items.findIndex((item) => item.current);
+    const targetIdx = currentIdx >= 0 ? currentIdx : 0;
+    setFocusedIndex(targetIdx);
+    requestAnimationFrame(() => {
+      itemRefs.current[targetIdx]?.focus();
     });
+  }, [open, items]);
+
+  const toggle = useCallback(() => {
+    setOpen((v) => !v);
   }, []);
 
   return (
     <div ref={containerRef} className="relative inline-flex items-center">
       <button
+        ref={buttonRef}
         aria-haspopup="true"
         aria-expanded={open}
         aria-label={label ? `Switch ${label}` : "Switch"}

--- a/src/components/breadcrumb-dropdown.tsx
+++ b/src/components/breadcrumb-dropdown.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import Link from "next/link";
+import type { BreadcrumbDropdownItem } from "@/contexts/chrome-context";
+
+type Props = {
+  items: BreadcrumbDropdownItem[];
+  label?: string;
+};
+
+export function BreadcrumbDropdown({ items, label }: Props) {
+  const [open, setOpen] = useState(false);
+  const [focusedIndex, setFocusedIndex] = useState(-1);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef<(HTMLAnchorElement | null)[]>([]);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  // Close on Escape, arrow key navigation
+  useEffect(() => {
+    if (!open) return;
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        setOpen(false);
+        return;
+      }
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setFocusedIndex((prev) => {
+          const next = prev < items.length - 1 ? prev + 1 : 0;
+          itemRefs.current[next]?.focus();
+          return next;
+        });
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setFocusedIndex((prev) => {
+          const next = prev > 0 ? prev - 1 : items.length - 1;
+          itemRefs.current[next]?.focus();
+          return next;
+        });
+      }
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, items.length]);
+
+  const toggle = useCallback(() => {
+    setOpen((v) => {
+      if (!v) setFocusedIndex(-1);
+      return !v;
+    });
+  }, []);
+
+  return (
+    <div ref={containerRef} className="relative inline-flex items-center">
+      <button
+        aria-haspopup="true"
+        aria-expanded={open}
+        aria-label={label ? `Switch ${label}` : "Switch"}
+        onClick={toggle}
+        className="text-text-secondary hover:text-text-primary transition-colors min-w-[24px] min-h-[24px] flex items-center justify-center text-[10px]"
+      >
+        ▾
+      </button>
+      {open && (
+        <div
+          role="menu"
+          aria-label={label ? `Switch ${label}` : "Switch"}
+          className="absolute top-full left-0 mt-1 bg-bg-primary border border-border rounded-lg shadow-2xl py-1 min-w-[160px] max-w-[240px] z-50"
+        >
+          {items.map((item, i) => (
+            <Link
+              key={item.href}
+              ref={(el) => { itemRefs.current[i] = el; }}
+              href={item.href}
+              role="menuitem"
+              tabIndex={focusedIndex === i ? 0 : -1}
+              onClick={() => setOpen(false)}
+              className={`block px-3 py-2 text-sm truncate transition-colors ${
+                item.current
+                  ? "text-accent"
+                  : "text-text-secondary hover:text-text-primary hover:bg-bg-card"
+              }`}
+            >
+              {item.label}
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/top-bar-chrome.tsx
+++ b/src/components/top-bar-chrome.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useChrome } from "@/contexts/chrome-context";
+import { BreadcrumbDropdown } from "@/components/breadcrumb-dropdown";
 
 export function TopBarChrome() {
   const { breadcrumbs, line2Left, line2Right, isConnected } = useChrome();
@@ -36,6 +37,9 @@ export function TopBarChrome() {
                 <span className="text-text-primary font-medium" aria-current="page">
                   {crumb.label}
                 </span>
+              )}
+              {crumb.dropdownItems && crumb.dropdownItems.length > 0 && (
+                <BreadcrumbDropdown items={crumb.dropdownItems} label={crumb.label} />
               )}
             </span>
           ))}

--- a/src/contexts/chrome-context.tsx
+++ b/src/contexts/chrome-context.tsx
@@ -2,10 +2,17 @@
 
 import { createContext, useContext, useState, useMemo, useRef, useEffect } from "react";
 
+export type BreadcrumbDropdownItem = {
+  label: string;
+  href: string;
+  current?: boolean;
+};
+
 export type Breadcrumb = {
   icon?: string;
   label: string;
   href?: string;
+  dropdownItems?: BreadcrumbDropdownItem[];
 };
 
 type ChromeState = {


### PR DESCRIPTION
## Summary

The breadcrumb bar shows context (project name, window name) but doesn't let users switch between siblings without navigating back. This adds dropdown menus to breadcrumb segments so users can jump between projects or between windows within a project directly from the navbar — a standard switcher pattern. A split click-target (name = navigate, chevron = dropdown) preserves existing back-navigation.

## Changes

- Split click-target pattern: label navigates, chevron (`▾`) opens dropdown
- Project dropdown on both project and terminal pages (lists all sessions)
- Window dropdown on the terminal page (lists all windows in the current project)
- Data populated from existing `useSessions()` — no new API endpoints

## Stats
| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| feat | 4.4 / 5.0 | — | 6/6 | Pass (1 iteration) |

[intake](https://github.com/wvrdz/run-kit/blob/260307-uzsa-navbar-breadcrumb-dropdowns/fab/changes/260307-uzsa-navbar-breadcrumb-dropdowns/intake.md) → [spec](https://github.com/wvrdz/run-kit/blob/260307-uzsa-navbar-breadcrumb-dropdowns/fab/changes/260307-uzsa-navbar-breadcrumb-dropdowns/spec.md) → tasks → apply → review → hydrate → ship