### PR TITLE
Wire file upload into terminal page

### DIFF
--- a/src/app/api/upload/__tests__/route.test.ts
+++ b/src/app/api/upload/__tests__/route.test.ts
@@ -11,7 +11,7 @@ vi.mock("@/lib/tmux", () => ({
 }));
 
 vi.mock("node:fs/promises", async (importOriginal) => {
-  const actual = await importOriginal();
+  const actual = await importOriginal() as Record<string, unknown>;
   return {
     ...actual,
     default: { ...actual, mkdir: mockMkdir, writeFile: mockWriteFile, readFile: mockReadFile },
@@ -55,7 +55,7 @@ describe("POST /api/upload", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(listWindows).mockResolvedValue([
-      { index: 0, name: "main", worktreePath: "/home/user/project", activity: "active" },
+      { index: 0, name: "main", worktreePath: "/home/user/project", activity: "active", isActiveWindow: true },
     ]);
     mockReadFile.mockResolvedValue("");
     mockMkdir.mockResolvedValue(undefined);
@@ -198,8 +198,8 @@ describe("POST /api/upload", () => {
 
   it("uses specified window index for project root", async () => {
     vi.mocked(listWindows).mockResolvedValue([
-      { index: 0, name: "main", worktreePath: "/home/user/project", activity: "active" },
-      { index: 1, name: "worktree", worktreePath: "/home/user/project-wt", activity: "idle" },
+      { index: 0, name: "main", worktreePath: "/home/user/project", activity: "active", isActiveWindow: true },
+      { index: 1, name: "worktree", worktreePath: "/home/user/project-wt", activity: "idle", isActiveWindow: false },
     ]);
     await postUpload({
       session: "my-project",

--- a/src/app/p/[project]/[window]/terminal-client.tsx
+++ b/src/app/p/[project]/[window]/terminal-client.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useRef, useCallback, useState, useMemo } from "react";
 import { useSessions } from "@/hooks/use-sessions";
 import { useVisualViewport } from "@/hooks/use-visual-viewport";
+import { useFileUpload } from "@/hooks/use-file-upload";
 import { useChromeDispatch } from "@/contexts/chrome-context";
 import { BottomBar } from "@/components/bottom-bar";
 import { ComposeBuffer } from "@/components/compose-buffer";
@@ -33,6 +34,10 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
   const [showRenameDialog, setShowRenameDialog] = useState(false);
   const [renameName, setRenameName] = useState("");
   const [composeOpen, setComposeOpen] = useState(false);
+  const [composeInitialText, setComposeInitialText] = useState<string | undefined>();
+  const [dragOver, setDragOver] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const { uploadFiles } = useFileUpload(projectName, windowIndex);
 
   useVisualViewport();
 
@@ -144,16 +149,68 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
     );
   }, [activeWindow, setLine2Right]);
 
+  // Open compose buffer with uploaded file paths
+  const openComposeWithPaths = useCallback((paths: string[]) => {
+    if (paths.length === 0) return;
+    const text = paths.join("\n");
+    setComposeInitialText(text);
+    setComposeOpen(true);
+  }, []);
+
+  // Paste handler — upload files from clipboard
+  useEffect(() => {
+    function handlePaste(e: ClipboardEvent) {
+      const files = e.clipboardData?.files;
+      if (!files || files.length === 0) return;
+      e.preventDefault();
+      uploadFiles(files).then(openComposeWithPaths);
+    }
+    document.addEventListener("paste", handlePaste);
+    return () => document.removeEventListener("paste", handlePaste);
+  }, [uploadFiles, openComposeWithPaths]);
+
+  // Drag-and-drop handlers
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes("Files")) return;
+    e.preventDefault();
+    setDragOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    if (e.currentTarget.contains(e.relatedTarget as Node)) return;
+    setDragOver(false);
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setDragOver(false);
+      const files = e.dataTransfer.files;
+      if (files.length === 0) return;
+      uploadFiles(files).then(openComposeWithPaths);
+    },
+    [uploadFiles, openComposeWithPaths],
+  );
+
+  // Upload button handler (passed to BottomBar)
+  const handleUploadFiles = useCallback(
+    (files: FileList) => {
+      uploadFiles(files).then(openComposeWithPaths);
+    },
+    [uploadFiles, openComposeWithPaths],
+  );
+
   // Bottom bar injection
   useEffect(() => {
     setBottomBar(
       <BottomBar
         wsRef={wsRef}
         onOpenCompose={() => setComposeOpen((v) => !v)}
+        onUploadFiles={handleUploadFiles}
       />,
     );
     return () => setBottomBar(null);
-  }, [setBottomBar]);
+  }, [setBottomBar, handleUploadFiles]);
 
   // Keyboard shortcuts (double-Esc + rename)
   const handleKeyDown = useCallback(
@@ -376,6 +433,11 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
   const paletteActions: PaletteAction[] = useMemo(
     () => [
       {
+        id: "upload-file",
+        label: "Upload file",
+        onSelect: () => fileInputRef.current?.click(),
+      },
+      {
         id: "rename-window",
         label: "Rename window",
         shortcut: "r",
@@ -409,11 +471,32 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
         ref={terminalRef}
         role="application"
         aria-label={`Terminal: ${projectName}/${displayName}`}
-        className={`flex-1 min-h-0 transition-opacity ${composeOpen ? "opacity-50" : ""}`}
+        className={`flex-1 min-h-0 transition-opacity ${composeOpen ? "opacity-50" : ""} ${dragOver ? "ring-2 ring-accent ring-inset" : ""}`}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      />
+
+      {/* Hidden file input for command palette upload action */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        className="hidden"
+        onChange={(e) => {
+          if (e.target.files && e.target.files.length > 0) {
+            handleUploadFiles(e.target.files);
+            e.target.value = "";
+          }
+        }}
       />
 
       {composeOpen && (
-        <ComposeBuffer wsRef={wsRef} onClose={() => { setComposeOpen(false); xtermRef.current?.focus(); }} />
+        <ComposeBuffer
+          wsRef={wsRef}
+          onClose={() => { setComposeOpen(false); setComposeInitialText(undefined); xtermRef.current?.focus(); }}
+          initialText={composeInitialText}
+        />
       )}
 
       {/* Rename dialog */}


### PR DESCRIPTION
## Summary

The original upload PR (#20) merged without the terminal-client wiring due to a rebase conflict resolution that reverted `terminal-client.tsx` to the upstream version. This PR adds the missing integration:

- `useFileUpload` hook wired into terminal page
- Clipboard paste handler (uploads files from `clipboardData.files`, text paste passes through)
- Drag-and-drop with `ring-2 ring-accent` visual highlight
- `onUploadFiles` callback passed to `BottomBar` (enables the 📎 button)
- `composeInitialText` state for pre-populating compose buffer with file paths
- Hidden file input + "Upload file" command palette action
- Upload test fixes for `isActiveWindow` field added in main

## Test plan

- [ ] Verify 📎 button appears in bottom bar between extended keys and compose toggle
- [ ] Click 📎 → select file → verify path appears in compose buffer
- [ ] Paste screenshot (Cmd+V with image in clipboard) → verify upload + compose
- [ ] Drag file onto terminal → verify ring highlight + upload + compose
- [ ] Cmd+K → "Upload file" → verify file picker opens
- [ ] `pnpm test` passes (147 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)