### PR TITLE
fix: Improve iOS keyboard viewport handling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -65,8 +65,8 @@ html.fullbleed .app-shell {
   inset: 0;
   width: 100%;
   height: var(--app-height, 100vh);
-  transform: translateY(var(--app-offset-top, 0px));
-  will-change: transform, height;
+  top: var(--app-offset-top, 0px);
+  will-change: top, height;
 }
 
 /* Prevent xterm scroll from chaining to the page on iOS */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -46,19 +46,27 @@ summary {
   border-radius: 3px;
 }
 
-/* Prevent iOS Safari page scroll/bounce when terminal is fullbleed */
+/* Prevent iOS Safari page scroll/bounce when terminal is fullbleed.
+   position: fixed on body is critical — without it iOS scrolls the body
+   behind the keyboard ("ghost scroll"). */
 html.fullbleed,
 html.fullbleed body {
+  position: fixed;
+  width: 100%;
+  height: 100%;
   overflow: hidden;
   overscroll-behavior: none;
 }
 
-/* Pin app shell to viewport when keyboard opens on iOS (fullbleed only) */
+/* Pin app shell to visual viewport when keyboard opens on iOS.
+   --app-height and --app-offset-top are set by useVisualViewport. */
 html.fullbleed .app-shell {
   position: fixed;
   inset: 0;
   width: 100%;
   height: var(--app-height, 100vh);
+  transform: translateY(var(--app-offset-top, 0px));
+  will-change: transform, height;
 }
 
 /* Prevent xterm scroll from chaining to the page on iOS */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,14 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import { ChromeProvider, ContentSlot, BottomSlot } from "@/contexts/chrome-context";
 import { SessionProvider } from "@/contexts/session-context";
 import { TopBarChrome } from "@/components/top-bar-chrome";
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  interactiveWidget: "resizes-content",
+};
 
 export const metadata: Metadata = {
   title: "RunKit",

--- a/src/app/p/[project]/[window]/terminal-client.tsx
+++ b/src/app/p/[project]/[window]/terminal-client.tsx
@@ -357,6 +357,7 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
         resizeRafId = requestAnimationFrame(() => {
           resizeRafId = null;
           fitAddon?.fit();
+          terminal?.scrollToBottom();
           if (wsRef.current?.readyState === WebSocket.OPEN && terminal) {
             wsRef.current.send(
               JSON.stringify({

--- a/src/hooks/__tests__/use-visual-viewport.test.ts
+++ b/src/hooks/__tests__/use-visual-viewport.test.ts
@@ -2,15 +2,20 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { useVisualViewport } from "@/hooks/use-visual-viewport";
 
-// Mock visualViewport as an EventTarget with a height property
-function createMockViewport(height = 800) {
+// Mock visualViewport as an EventTarget with height and offsetTop properties
+function createMockViewport(height = 800, offsetTop = 0) {
   const target = new EventTarget();
   let _height = height;
+  let _offsetTop = offsetTop;
   Object.defineProperty(target, "height", {
     get: () => _height,
     set: (v: number) => { _height = v; },
   });
-  return target as EventTarget & { height: number };
+  Object.defineProperty(target, "offsetTop", {
+    get: () => _offsetTop,
+    set: (v: number) => { _offsetTop = v; },
+  });
+  return target as EventTarget & { height: number; offsetTop: number };
 }
 
 describe("useVisualViewport", () => {
@@ -38,6 +43,7 @@ describe("useVisualViewport", () => {
 
   afterEach(() => {
     document.documentElement.style.removeProperty("--app-height");
+    document.documentElement.style.removeProperty("--app-offset-top");
     vi.restoreAllMocks();
   });
 
@@ -47,12 +53,15 @@ describe("useVisualViewport", () => {
     cbs.forEach((cb) => cb(performance.now()));
   }
 
-  it("sets --app-height on mount", () => {
+  it("sets --app-height and --app-offset-top on mount", () => {
     renderHook(() => useVisualViewport());
 
     expect(
       document.documentElement.style.getPropertyValue("--app-height"),
     ).toBe("800px");
+    expect(
+      document.documentElement.style.getPropertyValue("--app-offset-top"),
+    ).toBe("0px");
   });
 
   it("updates --app-height on resize event", () => {
@@ -79,17 +88,44 @@ describe("useVisualViewport", () => {
     ).toBe("600px");
   });
 
-  it("skips update when height has not changed", () => {
+  it("updates --app-offset-top when viewport scrolls", () => {
+    renderHook(() => useVisualViewport());
+
+    mockVV.offsetTop = 42;
+    mockVV.dispatchEvent(new Event("scroll"));
+    flushRaf();
+
+    expect(
+      document.documentElement.style.getPropertyValue("--app-offset-top"),
+    ).toBe("42px");
+  });
+
+  it("skips update when neither height nor offsetTop changed", () => {
     renderHook(() => useVisualViewport());
 
     const spy = vi.spyOn(document.documentElement.style, "setProperty");
     spy.mockClear();
 
-    // Height unchanged — dispatch scroll
+    // Nothing changed — dispatch scroll
     mockVV.dispatchEvent(new Event("scroll"));
     flushRaf();
 
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("updates when only offsetTop changes (height unchanged)", () => {
+    renderHook(() => useVisualViewport());
+
+    mockVV.offsetTop = 10;
+    mockVV.dispatchEvent(new Event("scroll"));
+    flushRaf();
+
+    expect(
+      document.documentElement.style.getPropertyValue("--app-height"),
+    ).toBe("800px");
+    expect(
+      document.documentElement.style.getPropertyValue("--app-offset-top"),
+    ).toBe("10px");
   });
 
   it("coalesces rapid events into one rAF callback", () => {
@@ -109,7 +145,7 @@ describe("useVisualViewport", () => {
     ).toBe("700px");
   });
 
-  it("removes --app-height and listeners on unmount", () => {
+  it("removes --app-height, --app-offset-top and listeners on unmount", () => {
     const removeSpy = vi.spyOn(mockVV, "removeEventListener");
     const { unmount } = renderHook(() => useVisualViewport());
 
@@ -117,6 +153,9 @@ describe("useVisualViewport", () => {
 
     expect(
       document.documentElement.style.getPropertyValue("--app-height"),
+    ).toBe("");
+    expect(
+      document.documentElement.style.getPropertyValue("--app-offset-top"),
     ).toBe("");
     expect(removeSpy).toHaveBeenCalledWith("resize", expect.any(Function));
     expect(removeSpy).toHaveBeenCalledWith("scroll", expect.any(Function));

--- a/src/hooks/use-visual-viewport.ts
+++ b/src/hooks/use-visual-viewport.ts
@@ -9,14 +9,19 @@ export function useVisualViewport() {
 
     let rafId: number | null = null;
     let lastHeight = 0;
+    let lastOffsetTop = 0;
 
     function apply() {
       rafId = null;
       if (!vv) return;
       const h = vv.height;
-      if (h === lastHeight) return;
+      const ot = vv.offsetTop;
+      const changed = h !== lastHeight || ot !== lastOffsetTop;
+      if (!changed) return;
       lastHeight = h;
+      lastOffsetTop = ot;
       document.documentElement.style.setProperty("--app-height", `${h}px`);
+      document.documentElement.style.setProperty("--app-offset-top", `${ot}px`);
     }
 
     function onViewportChange() {
@@ -26,7 +31,9 @@ export function useVisualViewport() {
 
     // Initial sync (no rAF — run immediately)
     lastHeight = vv.height;
+    lastOffsetTop = vv.offsetTop;
     document.documentElement.style.setProperty("--app-height", `${vv.height}px`);
+    document.documentElement.style.setProperty("--app-offset-top", `${vv.offsetTop}px`);
 
     vv.addEventListener("resize", onViewportChange);
     vv.addEventListener("scroll", onViewportChange);
@@ -36,6 +43,7 @@ export function useVisualViewport() {
       vv.removeEventListener("scroll", onViewportChange);
       if (rafId) cancelAnimationFrame(rafId);
       document.documentElement.style.removeProperty("--app-height");
+      document.documentElement.style.removeProperty("--app-offset-top");
     };
   }, []);
 }


### PR DESCRIPTION
## Summary
Improves the iOS Safari keyboard viewport handling that was introduced in #21. The previous implementation didn't fully prevent ghost scrolling and missed visual viewport offset compensation, causing content to shift behind the keyboard.

## Changes
- Lock `html` and `body` with `position: fixed` when fullbleed to prevent iOS ghost scroll
- Track `visualViewport.offsetTop` and apply `translateY` compensation on the app shell
- Add `scrollToBottom()` after `fitAddon.fit()` so the terminal cursor stays visible on resize
- Add `interactive-widget=resizes-content` viewport meta tag for native Android Chrome support
- Add `will-change: transform, height` hint for smoother animations

## Stats
| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| fix | — | — | — | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)