### PR TITLE
test: Playwright E2E tests for UI design spec

### DIFF
--- a/docs/memory/run-kit/architecture.md
+++ b/docs/memory/run-kit/architecture.md
@@ -111,7 +111,23 @@ Test scripts: `pnpm test` (single run), `pnpm test:watch` (watch mode).
 
 Test files co-located with source using `.test.{ts,tsx}` suffix (test-alongside strategy per `code-quality.md`). Path alias `@/` resolves to `src/` in both app and test contexts.
 
-Current coverage: `validate.ts` (input validation + tilde expansion), `config.ts` (CLI arg parsing, port validation, defaults), `command-palette.tsx` (keyboard interaction, filtering, open/close), `tmux.ts` (listSessions parsing + byobu filtering, listWindows activity computation), `use-keyboard-nav.ts` (j/k/Enter navigation, input skip, clamping, custom shortcuts), `api/sessions/route.ts` POST handler (5-action dispatch, validation, error propagation).
+Current unit test coverage: `validate.ts` (input validation + tilde expansion), `config.ts` (CLI arg parsing, port validation, defaults), `command-palette.tsx` (keyboard interaction, filtering, open/close), `tmux.ts` (listSessions parsing + byobu filtering, listWindows activity computation), `use-keyboard-nav.ts` (j/k/Enter navigation, input skip, clamping, custom shortcuts), `api/sessions/route.ts` POST handler (5-action dispatch, validation, error propagation).
+
+### Playwright E2E Tests
+
+Playwright for browser-level integration tests. Config at `playwright.config.ts` (repo root). E2E tests live in `e2e/` (separate from unit tests in `__tests__/`). Two projects: `desktop` (Chromium) and `mobile` (WebKit, iPhone 14 viewport). `mobile.spec.ts` runs only on the mobile project; all other specs run only on desktop.
+
+Test scripts: `pnpm test:e2e` (headless), `pnpm test:e2e:ui` (interactive UI mode). Web server auto-starts via `pnpm dev` if not already running (`reuseExistingServer: true`).
+
+Tests self-manage tmux sessions via `POST /api/sessions` in `beforeAll`/`afterAll` hooks. Shared helpers in `e2e/helpers.ts`.
+
+E2E test suites:
+- `chrome-stability.spec.ts` — top bar bounding box invariance across page navigation, Line 2 min-height, max-width 896px
+- `breadcrumbs.spec.ts` — page-specific breadcrumb segments, link verification, no text prefixes
+- `bottom-bar.spec.ts` — terminal-only visibility, modifier armed state (`aria-pressed`), Fn dropdown lifecycle, special keys
+- `compose-buffer.spec.ts` — open/close flow, terminal dimming, Send button, multiline input
+- `kill-button.spec.ts` — always-visible kill buttons, confirmation dialog flow
+- `mobile.spec.ts` — mobile bottom bar rendering, tap target minimum height (30px), ⌘K badge visibility
 
 ## Security
 
@@ -142,3 +158,4 @@ Current coverage: `validate.ts` (input validation + tilde expansion), `config.ts
 | 2026-03-07 | iOS keyboard viewport overlap fix — visualViewport scroll listener, fixed positioning in fullbleed mode | `260307-f3o9-ios-keyboard-viewport-overlap` |
 | 2026-03-07 | Sync byobu active tab — `isActiveWindow` on `WindowInfo`, breadcrumb/URL/action sync via SSE + `history.replaceState` | `260307-f3li-sync-byobu-active-tab` |
 | 2026-03-07 | Breadcrumb type extended with `dropdownItems` for project/window switching dropdowns | `260307-uzsa-navbar-breadcrumb-dropdowns` |
+| 2026-03-07 | Playwright E2E tests — chrome stability, breadcrumbs, bottom bar, compose buffer, kill button, mobile viewport | `260305-r7zs-playwright-e2e-design-spec` |

--- a/e2e/bottom-bar.spec.ts
+++ b/e2e/bottom-bar.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from "@playwright/test";
+import { createTestSession, killTestSession, TEST_SESSION } from "./helpers";
+
+test.describe("Bottom Bar", () => {
+  test.beforeAll(async () => {
+    await createTestSession(TEST_SESSION);
+  });
+
+  test.afterAll(async () => {
+    await killTestSession(TEST_SESSION);
+  });
+
+  test("visible on terminal page only", async ({ page }) => {
+    const toolbar = page.locator('[role="toolbar"][aria-label="Terminal keys"]');
+
+    // Dashboard — no bottom bar
+    await page.goto("/");
+    await page.waitForSelector("header");
+    await expect(toolbar).toHaveCount(0);
+
+    // Project page — no bottom bar
+    await page.goto(`/p/${TEST_SESSION}`);
+    await page.waitForSelector("header");
+    await expect(toolbar).toHaveCount(0);
+
+    // Terminal page — bottom bar present
+    await page.goto(`/p/${TEST_SESSION}/0?name=main`);
+    await expect(toolbar).toBeVisible();
+  });
+
+  test("modifier key armed state", async ({ page }) => {
+    await page.goto(`/p/${TEST_SESSION}/0?name=main`);
+    const ctrlButton = page.locator('button[aria-label="Control"]');
+    await expect(ctrlButton).toBeVisible();
+
+    // Initially not armed
+    await expect(ctrlButton).toHaveAttribute("aria-pressed", "false");
+
+    // Click to arm
+    await ctrlButton.click();
+    await expect(ctrlButton).toHaveAttribute("aria-pressed", "true");
+  });
+
+  test("Fn dropdown opens and closes on selection", async ({ page }) => {
+    await page.goto(`/p/${TEST_SESSION}/0?name=main`);
+    const fnButton = page.locator('button[aria-label="Function keys"]');
+    await expect(fnButton).toBeVisible();
+
+    // Open dropdown
+    await fnButton.click();
+    const menu = page.locator('[role="menu"][aria-label="Function keys"]');
+    await expect(menu).toBeVisible();
+
+    // Verify F1 through F12 buttons exist
+    for (let i = 1; i <= 12; i++) {
+      await expect(menu.locator(`button[aria-label="F${i}"]`)).toBeVisible();
+    }
+
+    // Click F1 — dropdown should close
+    await menu.locator('button[aria-label="F1"]').click();
+    await expect(menu).not.toBeVisible();
+  });
+
+  test("Esc and Tab buttons present", async ({ page }) => {
+    await page.goto(`/p/${TEST_SESSION}/0?name=main`);
+    const toolbar = page.locator('[role="toolbar"][aria-label="Terminal keys"]');
+
+    await expect(toolbar.locator('button[aria-label="Escape"]')).toBeVisible();
+    await expect(toolbar.locator('button[aria-label="Tab"]')).toBeVisible();
+  });
+
+  test("Compose text button present", async ({ page }) => {
+    await page.goto(`/p/${TEST_SESSION}/0?name=main`);
+    const toolbar = page.locator('[role="toolbar"][aria-label="Terminal keys"]');
+    await expect(toolbar.locator('button[aria-label="Compose text"]')).toBeVisible();
+  });
+});

--- a/e2e/breadcrumbs.spec.ts
+++ b/e2e/breadcrumbs.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from "@playwright/test";
+import { createTestSession, killTestSession, TEST_SESSION } from "./helpers";
+
+test.describe("Breadcrumbs", () => {
+  test.beforeAll(async () => {
+    await createTestSession(TEST_SESSION);
+  });
+
+  test.afterAll(async () => {
+    await killTestSession(TEST_SESSION);
+  });
+
+  test("Dashboard shows only logo, no text breadcrumbs", async ({ page }) => {
+    await page.goto("/");
+    const nav = page.locator('nav[aria-label="Breadcrumb"]');
+    await expect(nav).toBeVisible();
+
+    // Logo image should be present
+    const logo = nav.locator('a[aria-label="RunKit home"] img');
+    await expect(logo).toBeVisible();
+
+    // No breadcrumb text segments (separator + label spans)
+    const separators = nav.locator("text=›");
+    await expect(separators).toHaveCount(0);
+  });
+
+  test("Project page shows logo > session name", async ({ page }) => {
+    await page.goto(`/p/${TEST_SESSION}`);
+    const nav = page.locator('nav[aria-label="Breadcrumb"]');
+    await expect(nav).toBeVisible();
+
+    // Logo present
+    await expect(nav.locator('a[aria-label="RunKit home"]')).toBeVisible();
+
+    // One separator and session name
+    const segments = nav.locator(`text=${TEST_SESSION}`);
+    await expect(segments.first()).toBeVisible();
+
+    // No "project:" prefix
+    await expect(nav.locator("text=project:")).toHaveCount(0);
+  });
+
+  test("Terminal page shows logo > session > window", async ({ page }) => {
+    await page.goto(`/p/${TEST_SESSION}/0?name=main`);
+    const nav = page.locator('nav[aria-label="Breadcrumb"]');
+    await expect(nav).toBeVisible();
+
+    // Session name is a link (non-final segment)
+    const sessionLink = nav.locator(`a:has-text("${TEST_SESSION}")`);
+    await expect(sessionLink).toBeVisible();
+    const href = await sessionLink.getAttribute("href");
+    expect(href).toContain(`/p/${TEST_SESSION}`);
+
+    // Window name visible
+    await expect(nav.locator("text=main")).toBeVisible();
+
+    // No prefixes
+    await expect(nav.locator("text=project:")).toHaveCount(0);
+    await expect(nav.locator("text=window:")).toHaveCount(0);
+  });
+
+  test("non-final segments are links, final segment is not", async ({ page }) => {
+    await page.goto(`/p/${TEST_SESSION}/0?name=main`);
+    const nav = page.locator('nav[aria-label="Breadcrumb"]');
+
+    // Logo is a link to dashboard
+    const logoLink = nav.locator('a[aria-label="RunKit home"]');
+    await expect(logoLink).toHaveAttribute("href", "/");
+
+    // Session name is a link
+    const sessionLink = nav.locator(`a:has-text("${TEST_SESSION}")`);
+    await expect(sessionLink).toBeVisible();
+
+    // Final segment (window name "main") should NOT be a link — it's a <span> with aria-current
+    const currentPage = nav.locator('[aria-current="page"]');
+    await expect(currentPage).toBeVisible();
+    const tagName = await currentPage.evaluate((el) => el.tagName.toLowerCase());
+    expect(tagName).toBe("span");
+  });
+});

--- a/e2e/chrome-stability.spec.ts
+++ b/e2e/chrome-stability.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from "@playwright/test";
+import { createTestSession, killTestSession, TEST_SESSION } from "./helpers";
+
+test.describe("Chrome Stability", () => {
+  test.beforeAll(async () => {
+    await createTestSession(TEST_SESSION);
+  });
+
+  test.afterAll(async () => {
+    await killTestSession(TEST_SESSION);
+  });
+
+  test("top bar bounding box stays constant across all pages", async ({ page }) => {
+    // Dashboard
+    await page.goto("/");
+    await page.waitForSelector("header");
+    const dashboardBox = await page.locator("header").boundingBox();
+    expect(dashboardBox).not.toBeNull();
+
+    // Project page
+    await page.goto(`/p/${TEST_SESSION}`);
+    await page.waitForSelector("header");
+    const projectBox = await page.locator("header").boundingBox();
+    expect(projectBox).not.toBeNull();
+    expect(projectBox!.y).toBeCloseTo(dashboardBox!.y, 0);
+    expect(projectBox!.height).toBeCloseTo(dashboardBox!.height, 0);
+
+    // Terminal page — need a window index, use 0
+    await page.goto(`/p/${TEST_SESSION}/0?name=main`);
+    await page.waitForSelector("header");
+    const terminalBox = await page.locator("header").boundingBox();
+    expect(terminalBox).not.toBeNull();
+    expect(terminalBox!.y).toBeCloseTo(dashboardBox!.y, 0);
+    expect(terminalBox!.height).toBeCloseTo(dashboardBox!.height, 0);
+
+    // Back to dashboard
+    await page.goto("/");
+    await page.waitForSelector("header");
+    const returnBox = await page.locator("header").boundingBox();
+    expect(returnBox).not.toBeNull();
+    expect(returnBox!.y).toBeCloseTo(dashboardBox!.y, 0);
+    expect(returnBox!.height).toBeCloseTo(dashboardBox!.height, 0);
+  });
+
+  test("Line 2 maintains minimum height on all pages", async ({ page }) => {
+    // Line 2 is the last child div of <header>, which has min-h-[36px]
+    const line2 = page.locator("header > div:last-child");
+
+    // Dashboard — Line 2 has content (action buttons + summary)
+    await page.goto("/");
+    await expect(line2).toBeVisible();
+    const dashLine2 = await line2.boundingBox();
+    expect(dashLine2).not.toBeNull();
+    expect(dashLine2!.height).toBeGreaterThanOrEqual(36);
+
+    // Project page
+    await page.goto(`/p/${TEST_SESSION}`);
+    await expect(line2).toBeVisible();
+    const projLine2 = await line2.boundingBox();
+    expect(projLine2).not.toBeNull();
+    expect(projLine2!.height).toBeGreaterThanOrEqual(36);
+
+    // Terminal page
+    await page.goto(`/p/${TEST_SESSION}/0?name=main`);
+    await expect(line2).toBeVisible();
+    const termLine2 = await line2.boundingBox();
+    expect(termLine2).not.toBeNull();
+    expect(termLine2!.height).toBeGreaterThanOrEqual(36);
+  });
+
+  test("chrome container has max-width 896px on all pages", async ({ page }) => {
+    // The chrome wrapper is the first child of .app-shell > .shrink-0, containing TopBarChrome
+    // We verify the computed max-width of the container that wraps the header
+    const chromeWrapper = page.locator("header").locator("..");
+
+    await page.goto("/");
+    await expect(chromeWrapper).toBeVisible();
+    const dashWidth = await chromeWrapper.evaluate(
+      (el) => getComputedStyle(el).maxWidth,
+    );
+    expect(dashWidth).toBe("896px");
+
+    await page.goto(`/p/${TEST_SESSION}`);
+    await expect(chromeWrapper).toBeVisible();
+    const projWidth = await chromeWrapper.evaluate(
+      (el) => getComputedStyle(el).maxWidth,
+    );
+    expect(projWidth).toBe("896px");
+
+    await page.goto(`/p/${TEST_SESSION}/0?name=main`);
+    await expect(chromeWrapper).toBeVisible();
+    const termWidth = await chromeWrapper.evaluate(
+      (el) => getComputedStyle(el).maxWidth,
+    );
+    expect(termWidth).toBe("896px");
+  });
+});

--- a/e2e/compose-buffer.spec.ts
+++ b/e2e/compose-buffer.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from "@playwright/test";
+import { createTestSession, killTestSession, TEST_SESSION } from "./helpers";
+
+test.describe("Compose Buffer", () => {
+  test.beforeAll(async () => {
+    await createTestSession(TEST_SESSION);
+  });
+
+  test.afterAll(async () => {
+    await killTestSession(TEST_SESSION);
+  });
+
+  test("opens when compose button is clicked", async ({ page }) => {
+    await page.goto(`/p/${TEST_SESSION}/0?name=main`);
+    const composeButton = page.locator('button[aria-label="Compose text"]');
+    await expect(composeButton).toBeVisible();
+
+    // Click compose
+    await composeButton.click();
+
+    // Textarea appears
+    const textarea = page.locator('textarea[aria-label="Compose text to send to terminal"]');
+    await expect(textarea).toBeVisible();
+
+    // Terminal dims when compose is open
+    const terminal = page.locator('[role="application"]');
+    const opacity = await terminal.evaluate((el) => getComputedStyle(el).opacity);
+    expect(Number(opacity)).toBeLessThan(1);
+  });
+
+  test("dismisses on Escape", async ({ page }) => {
+    await page.goto(`/p/${TEST_SESSION}/0?name=main`);
+
+    // Open compose
+    await page.locator('button[aria-label="Compose text"]').click();
+    const textarea = page.locator('textarea[aria-label="Compose text to send to terminal"]');
+    await expect(textarea).toBeVisible();
+
+    // Press Escape
+    await textarea.press("Escape");
+
+    // Textarea disappears
+    await expect(textarea).not.toBeVisible();
+
+    // Terminal opacity returns to normal
+    const terminal = page.locator('[role="application"]');
+    const opacity = await terminal.evaluate((el) => getComputedStyle(el).opacity);
+    expect(Number(opacity)).toBe(1);
+  });
+
+  test("Send button is visible when compose is open", async ({ page }) => {
+    await page.goto(`/p/${TEST_SESSION}/0?name=main`);
+    await page.locator('button[aria-label="Compose text"]').click();
+
+    const sendButton = page.locator("button", { hasText: "Send" });
+    await expect(sendButton).toBeVisible();
+  });
+
+  test("accepts multiline text", async ({ page }) => {
+    await page.goto(`/p/${TEST_SESSION}/0?name=main`);
+    await page.locator('button[aria-label="Compose text"]').click();
+
+    const textarea = page.locator('textarea[aria-label="Compose text to send to terminal"]');
+    await textarea.fill("line 1\nline 2\nline 3");
+
+    const value = await textarea.inputValue();
+    expect(value).toContain("\n");
+    expect(value.split("\n")).toHaveLength(3);
+  });
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -4,25 +4,35 @@ const BASE_URL = "http://localhost:3000";
 
 export async function createTestSession(name: string): Promise<void> {
   const ctx = await request.newContext({ baseURL: BASE_URL });
-  const res = await ctx.post("/api/sessions", {
-    data: { action: "createSession", name },
-  });
-  if (!res.ok()) {
-    throw new Error(`Failed to create test session "${name}": ${res.status()} ${await res.text()}`);
+  try {
+    const res = await ctx.post("/api/sessions", {
+      data: { action: "createSession", name },
+    });
+    if (!res.ok()) {
+      throw new Error(`Failed to create test session "${name}": ${res.status()} ${await res.text()}`);
+    }
+  } finally {
+    await ctx.dispose();
   }
-  await ctx.dispose();
 }
 
 export async function killTestSession(name: string): Promise<void> {
   const ctx = await request.newContext({ baseURL: BASE_URL });
-  const res = await ctx.post("/api/sessions", {
-    data: { action: "killSession", session: name },
-  });
-  // Best-effort cleanup — session may already be gone
-  if (!res.ok() && res.status() !== 500) {
-    throw new Error(`Failed to kill test session "${name}": ${res.status()} ${await res.text()}`);
+  try {
+    const res = await ctx.post("/api/sessions", {
+      data: { action: "killSession", session: name },
+    });
+    if (!res.ok()) {
+      const body = await res.text();
+      // Best-effort cleanup — only ignore "not found" errors (session already gone)
+      const isNotFound = res.status() === 500 && body.toLowerCase().includes("not found");
+      if (!isNotFound) {
+        throw new Error(`Failed to kill test session "${name}": ${res.status()} ${body}`);
+      }
+    }
+  } finally {
+    await ctx.dispose();
   }
-  await ctx.dispose();
 }
 
 export const TEST_SESSION = "e2e-test";

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,28 @@
+import { request } from "@playwright/test";
+
+const BASE_URL = "http://localhost:3000";
+
+export async function createTestSession(name: string): Promise<void> {
+  const ctx = await request.newContext({ baseURL: BASE_URL });
+  const res = await ctx.post("/api/sessions", {
+    data: { action: "createSession", name },
+  });
+  if (!res.ok()) {
+    throw new Error(`Failed to create test session "${name}": ${res.status()} ${await res.text()}`);
+  }
+  await ctx.dispose();
+}
+
+export async function killTestSession(name: string): Promise<void> {
+  const ctx = await request.newContext({ baseURL: BASE_URL });
+  const res = await ctx.post("/api/sessions", {
+    data: { action: "killSession", session: name },
+  });
+  // Best-effort cleanup — session may already be gone
+  if (!res.ok() && res.status() !== 500) {
+    throw new Error(`Failed to kill test session "${name}": ${res.status()} ${await res.text()}`);
+  }
+  await ctx.dispose();
+}
+
+export const TEST_SESSION = "e2e-test";

--- a/e2e/kill-button.spec.ts
+++ b/e2e/kill-button.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "@playwright/test";
+import { createTestSession, killTestSession, TEST_SESSION } from "./helpers";
+
+test.describe("Kill Button Visibility", () => {
+  test.beforeAll(async () => {
+    await createTestSession(TEST_SESSION);
+  });
+
+  test.afterAll(async () => {
+    await killTestSession(TEST_SESSION);
+  });
+
+  test("kill button visible on session card without hover", async ({ page }) => {
+    await page.goto("/");
+    // Wait for sessions to load
+    await page.waitForSelector(`text=${TEST_SESSION}`);
+
+    // Kill button on window card — always visible (no hover needed)
+    const killButton = page.locator(`button[aria-label^="Kill window"]`).first();
+    await expect(killButton).toBeVisible();
+  });
+
+  test("kill button visible on session header without hover", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForSelector(`text=${TEST_SESSION}`);
+
+    // Kill button on session header
+    const killSessionButton = page.locator(`button[aria-label="Kill session ${TEST_SESSION}"]`);
+    await expect(killSessionButton).toBeVisible();
+  });
+
+  test("clicking kill button opens confirmation dialog", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForSelector(`text=${TEST_SESSION}`);
+
+    // Click the session kill button
+    const killButton = page.locator(`button[aria-label="Kill session ${TEST_SESSION}"]`);
+    await killButton.click();
+
+    // Confirmation dialog appears
+    const dialog = page.locator("text=Kill session?");
+    await expect(dialog).toBeVisible();
+
+    // Cancel and Kill buttons in dialog
+    await expect(page.locator("button", { hasText: "Cancel" })).toBeVisible();
+    await expect(page.locator("button", { hasText: "Kill" }).last()).toBeVisible();
+
+    // Dismiss dialog without killing
+    await page.locator("button", { hasText: "Cancel" }).click();
+    await expect(dialog).not.toBeVisible();
+  });
+});

--- a/e2e/mobile.spec.ts
+++ b/e2e/mobile.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from "@playwright/test";
+import { createTestSession, killTestSession, TEST_SESSION } from "./helpers";
+
+test.describe("Mobile Viewport", () => {
+  test.beforeAll(async () => {
+    await createTestSession(TEST_SESSION);
+  });
+
+  test.afterAll(async () => {
+    await killTestSession(TEST_SESSION);
+  });
+
+  test("bottom bar renders on mobile terminal page", async ({ page }) => {
+    await page.goto(`/p/${TEST_SESSION}/0?name=main`);
+    const toolbar = page.locator('[role="toolbar"][aria-label="Terminal keys"]');
+    await expect(toolbar).toBeVisible();
+  });
+
+  test("bottom bar buttons meet minimum tap height", async ({ page }) => {
+    await page.goto(`/p/${TEST_SESSION}/0?name=main`);
+    const toolbar = page.locator('[role="toolbar"][aria-label="Terminal keys"]');
+    await expect(toolbar).toBeVisible();
+
+    const buttons = toolbar.locator("button");
+    const count = await buttons.count();
+    expect(count).toBeGreaterThan(0);
+
+    for (let i = 0; i < count; i++) {
+      const box = await buttons.nth(i).boundingBox();
+      expect(box).not.toBeNull();
+      expect(box!.height).toBeGreaterThanOrEqual(30);
+    }
+  });
+
+  test("command-K badge visible on mobile (not yet hidden per design spec)", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForSelector("header");
+
+    // Current implementation: ⌘K badge is always rendered, even on mobile.
+    // The design spec says it should be hidden on mobile and replaced by ⋯,
+    // but that hasn't been implemented yet. This test documents current behavior.
+    // TODO: When mobile Line 2 collapse is implemented, flip to expect not visible.
+    const cmdKBadge = page.locator("kbd", { hasText: "⌘K" });
+    await expect(cmdKBadge).toBeVisible();
+  });
+});

--- a/fab/changes/260305-r7zs-playwright-e2e-design-spec/.history.jsonl
+++ b/fab/changes/260305-r7zs-playwright-e2e-design-spec/.history.jsonl
@@ -1,3 +1,16 @@
 {"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-03-05T23:19:08+05:30"}
 {"args":"Playwright E2E Tests — mobile viewport, fixed chrome stability, compose buffer, modifier keys, touch targets","cmd":"fab-new","event":"command","ts":"2026-03-05T23:19:08+05:30"}
 {"delta":"+4.1","event":"confidence","score":4.1,"trigger":"calc-score","ts":"2026-03-05T23:20:08+05:30"}
+{"cmd":"fab-switch","event":"command","ts":"2026-03-07T03:07:18+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"spec","ts":"2026-03-07T03:08:42+05:30"}
+{"delta":"-0.6","event":"confidence","score":3.5,"trigger":"calc-score","ts":"2026-03-07T03:09:58+05:30"}
+{"delta":"+0.0","event":"confidence","score":3.5,"trigger":"calc-score","ts":"2026-03-07T03:10:02+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"tasks","ts":"2026-03-07T03:10:08+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"apply","ts":"2026-03-07T03:10:51+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"review","ts":"2026-03-07T03:14:05+05:30"}
+{"event":"review","result":"failed","ts":"2026-03-07T03:18:09+05:30"}
+{"action":"re-entry","driver":"fab-ff","event":"stage-transition","stage":"apply","ts":"2026-03-07T03:18:09+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"review","ts":"2026-03-07T03:19:41+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"hydrate","ts":"2026-03-07T03:22:13+05:30"}
+{"event":"review","result":"passed","ts":"2026-03-07T03:22:13+05:30"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"ship","ts":"2026-03-07T03:22:51+05:30"}

--- a/fab/changes/260305-r7zs-playwright-e2e-design-spec/.status.yaml
+++ b/fab/changes/260305-r7zs-playwright-e2e-design-spec/.status.yaml
@@ -4,33 +4,38 @@ created_by: sahil-weaver
 change_type: test
 issues: []
 progress:
-    intake: ready
-    spec: pending
-    tasks: pending
-    apply: pending
-    review: pending
-    hydrate: pending
-    ship: pending
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
     review-pr: pending
 checklist:
-    generated: false
+    generated: true
     path: checklist.md
-    completed: 0
-    total: 0
+    completed: 21
+    total: 21
 confidence:
-    certain: 4
-    confident: 3
+    certain: 5
+    confident: 5
     tentative: 0
     unresolved: 0
-    score: 4.1
-    indicative: true
+    score: 3.5
     fuzzy: true
     dimensions:
-        signal: 72.9
-        reversibility: 90.0
-        competence: 85.0
-        disambiguation: 83.6
+        signal: 75.0
+        reversibility: 90.5
+        competence: 85.5
+        disambiguation: 81.5
 stage_metrics:
-    intake: {started_at: "2026-03-05T23:19:08+05:30", driver: fab-new, iterations: 1}
+    intake: {started_at: "2026-03-05T23:19:08+05:30", driver: fab-new, iterations: 1, completed_at: "2026-03-07T03:08:42+05:30"}
+    spec: {started_at: "2026-03-07T03:08:42+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T03:10:08+05:30"}
+    tasks: {started_at: "2026-03-07T03:10:08+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T03:10:51+05:30"}
+    apply: {started_at: "2026-03-07T03:18:09+05:30", driver: fab-ff, iterations: 2, completed_at: "2026-03-07T03:19:41+05:30"}
+    review: {started_at: "2026-03-07T03:19:41+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T03:22:13+05:30"}
+    hydrate: {started_at: "2026-03-07T03:22:13+05:30", driver: fab-ff, iterations: 1, completed_at: "2026-03-07T03:22:51+05:30"}
+    ship: {started_at: "2026-03-07T03:22:51+05:30", driver: fab-ff, iterations: 1}
 prs: []
-last_updated: 2026-03-05T23:20:08+05:30
+last_updated: 2026-03-07T03:22:51+05:30

--- a/fab/changes/260305-r7zs-playwright-e2e-design-spec/checklist.md
+++ b/fab/changes/260305-r7zs-playwright-e2e-design-spec/checklist.md
@@ -1,0 +1,42 @@
+# Quality Checklist: Playwright E2E Tests for UI Design Spec
+
+**Change**: 260305-r7zs-playwright-e2e-design-spec
+**Generated**: 2026-03-07
+**Spec**: `spec.md`
+
+## Functional Completeness
+- [x] CHK-001 Playwright config: `playwright.config.ts` exists with desktop and mobile projects, webServer config, testDir `e2e/`
+- [x] CHK-002 Test scripts: `package.json` includes `test:e2e` and `test:e2e:ui` scripts
+- [x] CHK-003 Test isolation: `e2e/` excluded from Vitest, `__tests__/` excluded from Playwright
+- [x] CHK-004 Chrome stability tests: `e2e/chrome-stability.spec.ts` covers bounding box invariance, Line 2 height, max-width
+- [x] CHK-005 Breadcrumb tests: `e2e/breadcrumbs.spec.ts` covers all three page depths with correct segments and links
+- [x] CHK-006 Bottom bar tests: `e2e/bottom-bar.spec.ts` covers page scope, modifier armed state, Fn dropdown, special keys
+- [x] CHK-007 Compose buffer tests: `e2e/compose-buffer.spec.ts` covers open/close, send button, multiline
+- [x] CHK-008 Kill button tests: `e2e/kill-button.spec.ts` covers always-visible kill buttons and confirmation dialog
+- [x] CHK-009 Mobile tests: `e2e/mobile.spec.ts` covers mobile viewport bottom bar, tap target sizes
+
+## Behavioral Correctness
+- [x] CHK-010 Session management: All test files create/teardown tmux sessions in beforeAll/afterAll hooks
+- [x] CHK-011 No flaky selectors: Tests use accessible selectors (aria-label, role, semantic elements), not CSS classes
+
+## Scenario Coverage
+- [x] CHK-012 Chrome stability: Navigate Dashboard→Project→Terminal→Dashboard with bounding box assertions
+- [x] CHK-013 Breadcrumbs: Verify logo-only on Dashboard, two-segment on Project, three-segment on Terminal
+- [x] CHK-014 Bottom bar scope: Verify visible on Terminal, absent on Dashboard and Project
+- [x] CHK-015 Compose flow: Open→type→dismiss via Escape
+- [x] CHK-016 Kill flow: Click kill→confirmation dialog appears with Cancel and Kill buttons
+
+## Edge Cases & Error Handling
+- [x] CHK-017 Empty Line 2: Verify Line 2 maintains min-height even when no action buttons are injected
+- [x] CHK-018 Mobile bottom bar: Verify bottom bar renders in mobile viewport on terminal page
+
+## Code Quality
+- [x] CHK-019 Pattern consistency: Test files follow Playwright conventions (test.describe, test.beforeAll/afterAll, expect assertions)
+- [x] CHK-020 No unnecessary duplication: Shared session setup/teardown extracted into helpers or fixtures
+- [x] CHK-021 No `exec` or shell strings: Any subprocess calls in test helpers use `execFile` with argument arrays (per constitution)
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] CHK-008 **N/A**: {reason}`

--- a/fab/changes/260305-r7zs-playwright-e2e-design-spec/spec.md
+++ b/fab/changes/260305-r7zs-playwright-e2e-design-spec/spec.md
@@ -1,0 +1,286 @@
+# Spec: Playwright E2E Tests for UI Design Spec
+
+**Change**: 260305-r7zs-playwright-e2e-design-spec
+**Created**: 2026-03-07
+**Affected memory**: `docs/memory/run-kit/architecture.md`
+
+## Non-Goals
+
+- Firefox browser testing — can be added later, not needed for initial coverage
+- Visual regression / screenshot diffing — tests verify structure and behavior, not pixel-perfect rendering
+- Testing the terminal relay WebSocket protocol directly — E2E tests verify the user-facing result (text appears in terminal), not wire format
+- CI pipeline integration — tests run locally; CI setup is a separate concern
+
+## E2E Infrastructure: Playwright Setup
+
+### Requirement: Playwright Configuration
+
+The project SHALL include a `playwright.config.ts` at the repo root that configures:
+- Test directory: `e2e/`
+- Base URL: `http://localhost:3000`
+- Two browser projects: `desktop` (Desktop Chrome) and `mobile` (iPhone 14 via WebKit)
+- Web server: `pnpm dev` on port 3000 with `reuseExistingServer: true`
+
+#### Scenario: Desktop browser project available
+- **GIVEN** the Playwright config is loaded
+- **WHEN** tests run with `--project=desktop`
+- **THEN** tests execute in a Chromium-based browser with desktop viewport dimensions
+
+#### Scenario: Mobile browser project available
+- **GIVEN** the Playwright config is loaded
+- **WHEN** tests run with `--project=mobile`
+- **THEN** tests execute in WebKit with iPhone 14 viewport (390x844)
+
+### Requirement: Test Scripts
+
+`package.json` SHALL include `test:e2e` and `test:e2e:ui` scripts.
+
+#### Scenario: Run E2E tests
+- **GIVEN** the dev server is running (or auto-started by Playwright)
+- **WHEN** `pnpm test:e2e` is executed
+- **THEN** Playwright runs all tests in `e2e/` and reports results
+
+### Requirement: Test Directory Convention
+
+E2E tests SHALL live in `e2e/` at the repo root, separate from unit tests in `__tests__/` directories.
+
+#### Scenario: E2E and unit tests coexist
+- **GIVEN** both `e2e/` and `src/**/__tests__/` directories exist
+- **WHEN** `pnpm test` (Vitest) runs
+- **THEN** only unit tests in `__tests__/` execute — `e2e/` is excluded from Vitest
+- **AND** `pnpm test:e2e` (Playwright) runs only tests in `e2e/`
+
+### Requirement: Test Session Management
+
+E2E tests that require tmux sessions SHALL create them via `POST /api/sessions` (action: `createSession`) in test setup and kill them via `POST /api/sessions` (action: `killSession`) in teardown. Tests MUST NOT assume pre-existing tmux state.
+
+#### Scenario: Test creates and tears down a session
+- **GIVEN** a test requires a tmux session named `e2e-test`
+- **WHEN** the test's `beforeAll` hook runs
+- **THEN** it sends `POST /api/sessions { action: "createSession", name: "e2e-test" }`
+- **AND** the `afterAll` hook sends `POST /api/sessions { action: "killSession", session: "e2e-test" }`
+
+## E2E Testing: Chrome Stability
+
+### Requirement: Top Bar Position Invariance
+
+The top bar's bounding box (y position and height) MUST NOT change when navigating between Dashboard, Project, and Terminal pages.
+
+#### Scenario: Navigate across all three pages
+- **GIVEN** the app is loaded on the Dashboard page
+- **WHEN** the user captures the top bar's `<header>` bounding box
+- **AND** navigates to a Project page
+- **THEN** the top bar's y position and height are identical to the Dashboard measurement
+- **AND** navigating to a Terminal page yields the same bounding box
+- **AND** navigating back to Dashboard yields the same bounding box
+
+### Requirement: Line 2 Fixed Height
+
+Line 2 of the top bar MUST maintain a minimum height of 36px on all pages, including when its content slots are empty.
+
+#### Scenario: Line 2 height on Dashboard vs empty state
+- **GIVEN** the Dashboard page is loaded with Line 2 content (action buttons, summary)
+- **WHEN** the Line 2 container's bounding box is measured
+- **THEN** its height is >= 36px
+- **AND** the same measurement on any page without Line 2 content yields height >= 36px
+
+### Requirement: Consistent Max Width
+
+All chrome zones (top bar, content, bottom bar) and page content MUST use `max-w-4xl` (896px) on desktop viewports.
+
+#### Scenario: Max width across pages
+- **GIVEN** the viewport is wider than 896px
+- **WHEN** the top bar container width is measured on each page
+- **THEN** the computed max-width is 896px on all three pages
+
+## E2E Testing: Breadcrumbs
+
+### Requirement: Page-Specific Breadcrumb Content
+
+Breadcrumbs MUST reflect the current navigation depth with icon-driven segments.
+
+#### Scenario: Dashboard breadcrumbs
+- **GIVEN** the Dashboard page is loaded
+- **WHEN** the breadcrumb nav is inspected
+- **THEN** only the logo image is visible — no text breadcrumb segments
+
+#### Scenario: Project page breadcrumbs
+- **GIVEN** a Project page is loaded for session `e2e-test`
+- **WHEN** the breadcrumb nav is inspected
+- **THEN** the breadcrumbs show: logo > separator > `e2e-test`
+- **AND** the `e2e-test` segment has no preceding `project:` text prefix
+
+#### Scenario: Terminal page breadcrumbs
+- **GIVEN** a Terminal page is loaded for session `e2e-test`, window `main`
+- **WHEN** the breadcrumb nav is inspected
+- **THEN** the breadcrumbs show: logo > separator > `e2e-test` > separator > `main`
+- **AND** no `project:` or `window:` text prefixes appear
+
+### Requirement: Breadcrumb Segment Links
+
+Each breadcrumb segment except the final one (current page) MUST be a clickable link.
+
+#### Scenario: Non-final segments are links
+- **GIVEN** the Terminal page breadcrumbs show: logo > `e2e-test` > `main`
+- **WHEN** the `e2e-test` segment is inspected
+- **THEN** it is an `<a>` element with an `href` pointing to the project page
+- **AND** the logo is an `<a>` element with `href="/"` pointing to the dashboard
+
+## E2E Testing: Bottom Bar
+
+### Requirement: Bottom Bar Page Scope
+
+The bottom bar MUST be visible only on the Terminal page. It MUST NOT render on Dashboard or Project pages.
+
+#### Scenario: Bottom bar visible on terminal
+- **GIVEN** a Terminal page is loaded
+- **WHEN** the bottom bar toolbar is queried
+- **THEN** a `[role="toolbar"]` element with label "Terminal keys" is visible
+
+#### Scenario: Bottom bar hidden on dashboard
+- **GIVEN** the Dashboard page is loaded
+- **WHEN** the bottom bar toolbar is queried
+- **THEN** no `[role="toolbar"]` element is present in the DOM
+
+#### Scenario: Bottom bar hidden on project page
+- **GIVEN** a Project page is loaded
+- **WHEN** the bottom bar toolbar is queried
+- **THEN** no `[role="toolbar"]` element is present in the DOM
+
+### Requirement: Modifier Key Armed State
+
+Clicking a modifier button (Ctrl, Alt, Cmd) SHALL toggle its armed visual state. The armed modifier auto-clears after the next key action.
+
+#### Scenario: Arm and observe Ctrl
+- **GIVEN** the Terminal page is loaded with the bottom bar visible
+- **WHEN** the user clicks the Control button
+- **THEN** the button's `aria-pressed` attribute becomes `"true"`
+- **AND** the button visually shows the armed state (accent color styling)
+
+### Requirement: Function Key Dropdown
+
+The Fn dropdown SHALL open a grid of F1-F12 keys. Selecting a key SHALL close the dropdown.
+
+#### Scenario: Open Fn dropdown and select F1
+- **GIVEN** the Terminal page is loaded
+- **WHEN** the user clicks the "Function keys" button
+- **THEN** a menu with `role="menu"` appears containing F1 through F12 buttons
+- **AND** clicking F1 closes the dropdown menu
+
+### Requirement: Special Keys
+
+Esc and Tab buttons MUST be present and functional.
+
+#### Scenario: Esc and Tab buttons exist
+- **GIVEN** the Terminal page bottom bar is visible
+- **WHEN** the toolbar buttons are inspected
+- **THEN** buttons with `aria-label="Escape"` and `aria-label="Tab"` are visible
+
+## E2E Testing: Compose Buffer
+
+### Requirement: Compose Buffer Open/Close
+
+Clicking the compose button SHALL open a textarea overlay, and Escape SHALL dismiss it.
+
+#### Scenario: Open compose buffer
+- **GIVEN** the Terminal page is loaded
+- **WHEN** the user clicks the "Compose text" button in the bottom bar
+- **THEN** a textarea with `aria-label="Compose text to send to terminal"` appears
+- **AND** the terminal container has reduced opacity (`opacity-50` class)
+
+#### Scenario: Dismiss compose via Escape
+- **GIVEN** the compose buffer textarea is open
+- **WHEN** the user presses Escape
+- **THEN** the textarea disappears
+- **AND** the terminal opacity returns to normal
+
+### Requirement: Compose Send Button
+
+The Send button SHALL be visible when the compose buffer is open.
+
+#### Scenario: Send button presence
+- **GIVEN** the compose buffer is open
+- **WHEN** the compose area is inspected
+- **THEN** a "Send" button is visible
+
+### Requirement: Compose Multiline
+
+The compose buffer textarea MUST accept multiline input.
+
+#### Scenario: Type multiline text
+- **GIVEN** the compose buffer is open
+- **WHEN** the user types multiline text (using Shift+Enter or paste)
+- **THEN** the textarea value contains newline characters
+
+## E2E Testing: Mobile Viewport
+
+### Requirement: Touch Target Minimum Size
+
+All interactive elements in the bottom bar MUST have a minimum tap height of 30px (the `min-h-[30px]` from `KBD_CLASS`).
+
+#### Scenario: Bottom bar button sizes on mobile
+- **GIVEN** the Terminal page is loaded in the mobile project (iPhone 14 viewport)
+- **WHEN** each button in the bottom bar toolbar is measured
+- **THEN** every button has a bounding box height >= 30px
+
+### Requirement: Command Key Badge Hidden on Mobile
+
+The `⌘K` keyboard badge in Line 1 SHOULD be hidden on narrow mobile viewports where a physical keyboard is not expected.
+
+#### Scenario: Command-K badge on mobile
+- **GIVEN** the Dashboard page is loaded in the mobile viewport
+- **WHEN** the `<kbd>` element containing `⌘K` is queried
+- **THEN** it is either not visible or has `display: none` / zero dimensions
+
+<!-- assumed: ⌘K hiding on mobile — the design spec says ⌘K hint should be hidden on mobile and replaced by ⋯, but the current TopBarChrome always renders it. Test may need to verify current behavior vs intended behavior. -->
+
+### Requirement: Bottom Bar Renders on Mobile
+
+The bottom bar MUST render on the Terminal page in the mobile viewport, providing the only way to send modifier keys without a physical keyboard.
+
+#### Scenario: Bottom bar on mobile terminal
+- **GIVEN** the Terminal page is loaded in the mobile project viewport
+- **WHEN** the bottom bar toolbar is queried
+- **THEN** a `[role="toolbar"]` element is visible with modifier and special key buttons
+
+## E2E Testing: Kill Button Visibility
+
+### Requirement: Always-Visible Kill Button
+
+The kill button (✕) on session cards and session headers MUST be visible without hover — it SHALL NOT be hidden behind a hover-reveal interaction.
+
+#### Scenario: Kill button on session card
+- **GIVEN** the Dashboard page is loaded with at least one session
+- **WHEN** a window card is inspected (without hovering)
+- **THEN** a button with `aria-label` matching "Kill window *" is visible
+
+#### Scenario: Kill button on session header
+- **GIVEN** the Dashboard page is loaded with at least one session
+- **WHEN** the session header is inspected (without hovering)
+- **THEN** a button with `aria-label` matching "Kill session *" is visible
+
+### Requirement: Kill Confirmation Dialog
+
+Clicking the kill button MUST open a confirmation dialog before performing the destructive action.
+
+#### Scenario: Click kill opens confirmation
+- **GIVEN** the Dashboard page is loaded with a session
+- **WHEN** the user clicks the kill button (✕) on a session header
+- **THEN** a dialog appears with title "Kill session?" and Cancel/Kill buttons
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Playwright as E2E framework | Confirmed from intake #1 — user specified Playwright | S:90 R:90 A:90 D:95 |
+| 2 | Certain | Tests depend on all 3 UI design changes being complete | Confirmed from intake #2 — tests verify integrated result | S:90 R:85 A:90 D:90 |
+| 3 | Certain | E2E tests in `e2e/` directory | Confirmed from intake #3 — different runner, different convention | S:80 R:95 A:85 D:85 |
+| 4 | Certain | Chromium + WebKit browsers only | Confirmed from intake #4 — desktop Chrome, mobile WebKit | S:80 R:90 A:85 D:85 |
+| 5 | Confident | iPhone 14 as mobile viewport | Confirmed from intake #5 — common reference device, easily changeable | S:55 R:95 A:80 D:75 |
+| 6 | Confident | Tests self-manage tmux sessions via API | Confirmed from intake #7 — tests create/teardown via POST /api/sessions | S:55 R:85 A:80 D:75 |
+| 7 | Confident | Bottom bar button min-height 30px (not 44px) | Codebase inspection: `KBD_CLASS` uses `min-h-[30px]`. The intake mentions 44px from Apple HIG, but actual implementation uses 30px. Test verifies actual implementation. | S:85 R:90 A:90 D:70 |
+| 8 | Confident | Chrome stability tested via bounding box comparison | Confirmed from intake #6 — Playwright `boundingBox()` API for position comparison | S:60 R:90 A:85 D:80 |
+| 9 | Confident | No WebSocket data verification in E2E tests | E2E tests verify UI state changes (armed state, compose open/close, menu open/close), not raw WebSocket messages. Terminal I/O verification requires a live tmux session which adds fragility. | S:65 R:90 A:80 D:70 |
+| 10 | Certain | Test scripts added to package.json | Confirmed from intake — `test:e2e` and `test:e2e:ui` scripts | S:90 R:95 A:90 D:90 |
+
+10 assumptions (5 certain, 5 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260305-r7zs-playwright-e2e-design-spec/tasks.md
+++ b/fab/changes/260305-r7zs-playwright-e2e-design-spec/tasks.md
@@ -1,0 +1,32 @@
+# Tasks: Playwright E2E Tests for UI Design Spec
+
+**Change**: 260305-r7zs-playwright-e2e-design-spec
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+## Phase 1: Setup
+
+- [x] T001 Install Playwright and configure — `pnpm add -D @playwright/test`, install chromium and webkit browsers, create `playwright.config.ts` at repo root with desktop (Desktop Chrome) and mobile (iPhone 14 WebKit) projects, webServer config for `pnpm dev` on port 3000
+- [x] T002 Add test scripts to `package.json` — add `"test:e2e": "playwright test"` and `"test:e2e:ui": "playwright test --ui"` scripts
+- [x] T003 Exclude `e2e/` from Vitest — update `vitest.config.ts` to exclude `e2e/**` from test discovery so Playwright and Vitest don't interfere
+
+## Phase 2: Core Implementation
+
+- [x] T004 [P] Create `e2e/chrome-stability.spec.ts` — test top bar bounding box invariance across Dashboard/Project/Terminal navigation, Line 2 minimum height (>= 36px) on all pages, max-w-4xl consistency. Requires test session via API setup/teardown.
+- [x] T005 [P] Create `e2e/breadcrumbs.spec.ts` — test Dashboard (logo only), Project (logo > session name), Terminal (logo > session > window) breadcrumbs. Verify no "project:"/"window:" prefixes. Verify non-final segments are `<a>` links. Requires test session via API.
+- [x] T006 [P] Create `e2e/bottom-bar.spec.ts` — test bottom bar visible only on Terminal page (not Dashboard/Project). Test modifier armed state (`aria-pressed`), Fn dropdown open/close/select, Esc and Tab button presence. Requires test session via API.
+- [x] T007 [P] Create `e2e/compose-buffer.spec.ts` — test compose open (textarea appears, terminal dims), Escape dismissal, Send button presence, multiline input. Requires test session via API.
+- [x] T008 [P] Create `e2e/kill-button.spec.ts` — test kill button (✕) always visible on session cards and session headers without hover. Test kill confirmation dialog opens on click. Requires test session via API.
+
+## Phase 3: Integration & Edge Cases
+
+- [x] T009 Create `e2e/mobile.spec.ts` — test in mobile project (iPhone 14 viewport): bottom bar renders on terminal, button tap heights >= 30px, ⌘K badge visibility check. Requires test session via API.
+
+---
+
+## Execution Order
+
+- T001 blocks all Phase 2 and Phase 3 tasks (Playwright must be installed first)
+- T002 and T003 can run in parallel with T001 once package.json is readable
+- T004-T008 are all independent (`[P]`) — different spec files, no dependencies on each other
+- T009 depends on T001 (needs Playwright config with mobile project)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "relay": "tsx src/terminal-relay/server.ts",
     "supervisor": "bash supervisor.sh",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@xterm/addon-fit": "^0.10.0",
@@ -30,6 +32,7 @@
     ]
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4.0.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./e2e",
-  fullyParallel: true,
+  fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   use: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "desktop",
+      use: { ...devices["Desktop Chrome"] },
+      testIgnore: /mobile\.spec\.ts$/,
+    },
+    {
+      name: "mobile",
+      use: { ...devices["iPhone 14"] },
+      testMatch: /mobile\.spec\.ts$/,
+    },
+  ],
+  webServer: {
+    command: "pnpm dev",
+    port: 3000,
+    reuseExistingServer: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 5.5.0
       next:
         specifier: ^15.2.0
-        version: 15.5.12(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 15.5.12(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0
@@ -36,6 +36,9 @@ importers:
         specifier: ^2.7.0
         version: 2.8.2
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
       '@tailwindcss/postcss':
         specifier: ^4.0.0
         version: 4.2.1
@@ -618,6 +621,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
@@ -1125,6 +1133,11 @@ packages:
       picomatch:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1345,6 +1358,16 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -2072,6 +2095,10 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.12':
     optional: true
 
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
+
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
@@ -2520,6 +2547,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -2665,7 +2695,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  next@15.5.12(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@15.5.12(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 15.5.12
       '@swc/helpers': 0.5.15
@@ -2683,6 +2713,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.12
       '@next/swc-win32-arm64-msvc': 15.5.12
       '@next/swc-win32-x64-msvc': 15.5.12
+      '@playwright/test': 1.58.2
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -2707,6 +2738,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
+
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.4.31:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds Playwright E2E test infrastructure with `playwright.config.ts` (desktop Chromium + mobile WebKit/iPhone 14)
- 6 test suites covering core UI design spec guarantees: chrome stability, breadcrumbs, bottom bar, compose buffer, kill button visibility, and mobile viewport behavior
- Tests self-manage tmux sessions via API, using accessible selectors (aria-label, role) throughout

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` — all 149 unit tests pass (no regressions)
- [ ] `pnpm test:e2e` — run with a live dev server + tmux to verify all E2E tests pass

Generated with [Claude Code](https://claude.com/claude-code)