### PR TITLE
fix: Terminal overlap and inconsistent bottom bar icon sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,25 @@ Run `just doctor` to verify all dependencies are installed.
 
 ## Getting Started
 
-1. **Start in development mode**
+1. **Install dependencies and browsers**
 
    ```sh
-   pnpm install && pnpm dev
+   pnpm install
+   pnpm exec playwright install --with-deps chromium
+   ```
+
+   > **Note:** Use `chromium`, not `chrome` — Chrome doesn't ship ARM64 Linux binaries.
+   > The `--with-deps` flag installs required system libraries (will prompt for sudo).
+
+2. **Start in development mode**
+
+   ```sh
+   pnpm dev
    ```
 
    This starts both the Next.js dev server ([http://localhost:3000](http://localhost:3000)) and the terminal relay (port 3001). Ctrl+C stops both.
 
-2. **Start in production mode**
+3. **Start in production mode**
 
    Build and run both services with the supervisor:
 

--- a/src/app/p/[project]/[window]/terminal-client.tsx
+++ b/src/app/p/[project]/[window]/terminal-client.tsx
@@ -471,7 +471,7 @@ export function TerminalClient({ projectName, windowIndex, windowName, relayPort
         ref={terminalRef}
         role="application"
         aria-label={`Terminal: ${projectName}/${displayName}`}
-        className={`flex-1 min-h-0 transition-opacity ${composeOpen ? "opacity-50" : ""} ${dragOver ? "ring-2 ring-accent ring-inset" : ""}`}
+        className={`flex-1 min-h-0 overflow-hidden transition-opacity ${composeOpen ? "opacity-50" : ""} ${dragOver ? "ring-2 ring-accent ring-inset" : ""}`}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}

--- a/src/components/arrow-pad.tsx
+++ b/src/components/arrow-pad.tsx
@@ -102,7 +102,7 @@ export function ArrowPad({ onArrow, className }: ArrowPadProps) {
         aria-label="Arrow keys"
         aria-haspopup="true"
         aria-expanded={open}
-        className="min-h-[30px] px-2 py-0.5 text-sm border border-border rounded select-none transition-colors hover:border-text-secondary active:bg-bg-card focus-visible:outline-2 focus-visible:outline-accent text-text-secondary touch-none"
+        className="min-h-[44px] min-w-[44px] flex items-center justify-center px-2 py-0.5 text-sm border border-border rounded select-none transition-colors hover:border-text-secondary active:bg-bg-card focus-visible:outline-2 focus-visible:outline-accent text-text-secondary touch-none"
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
         onMouseDown={handleMouseDown}

--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -47,7 +47,7 @@ const EXT_KEYS = [
 ] as const;
 
 const KBD_CLASS =
-  "min-h-[44px] px-2 py-0.5 text-sm border border-border rounded select-none transition-colors hover:border-text-secondary active:bg-bg-card focus-visible:outline-2 focus-visible:outline-accent";
+  "min-h-[44px] min-w-[44px] flex items-center justify-center px-2 py-0.5 text-sm border border-border rounded select-none transition-colors hover:border-text-secondary active:bg-bg-card focus-visible:outline-2 focus-visible:outline-accent";
 
 const MODIFIER_LABELS: Record<string, string> = {
   ctrl: "Control",


### PR DESCRIPTION
## Summary

- **Terminal behind bottom bar**: Added `overflow-hidden` to the terminal container div to prevent xterm canvas from visually bleeding past its flex bounds during layout transitions (e.g., bottom bar appearing, viewport changes)
- **Inconsistent icon sizes**: Added `min-w-[44px]` with flex centering to all bottom bar buttons (`KBD_CLASS` and arrow-pad trigger) so all icons render as uniform 44×44px tap targets
- **README**: Added Playwright browser install step with note about using `chromium` (not `chrome`) on ARM64 Linux

## Test plan
- [ ] Open terminal page on mobile viewport — bottom bar should not overlap terminal content
- [ ] Verify all bottom bar icons (⎋ ⇥ ^ ⌥ ⌘ ↑ F▴ ⌄ >_) have consistent button widths
- [ ] Verify arrow-pad trigger button matches other toolbar button sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)