### PR TITLE
refactor: Go Backend API

### DIFF
--- a/app/backend/api/directories.go
+++ b/app/backend/api/directories.go
@@ -1,1 +1,75 @@
 package api
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"run-kit/internal/validate"
+)
+
+func (s *Server) handleDirectories(w http.ResponseWriter, r *http.Request) {
+	prefix := r.URL.Query().Get("prefix")
+	if prefix == "" {
+		writeJSON(w, http.StatusOK, map[string][]string{"directories": {}})
+		return
+	}
+
+	expanded, expandErr := validate.ExpandTilde(prefix)
+	if expandErr != "" {
+		writeError(w, http.StatusBadRequest, expandErr)
+		return
+	}
+
+	home, _ := os.UserHomeDir()
+
+	var parentDir, filter string
+	if strings.HasSuffix(prefix, "/") {
+		parentDir = expanded
+		filter = ""
+	} else {
+		parentDir = filepath.Dir(expanded)
+		filter = strings.ToLower(filepath.Base(expanded))
+	}
+
+	entries, err := os.ReadDir(parentDir)
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string][]string{"directories": {}})
+		return
+	}
+
+	var directories []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if filter != "" && !strings.HasPrefix(strings.ToLower(entry.Name()), filter) {
+			continue
+		}
+		// Skip hidden directories
+		if strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+
+		absPath := filepath.Join(parentDir, entry.Name())
+		display := tildePrefix(absPath, home) + "/"
+		directories = append(directories, display)
+	}
+
+	if directories == nil {
+		directories = []string{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string][]string{"directories": directories})
+}
+
+func tildePrefix(absPath, home string) string {
+	if absPath == home {
+		return "~"
+	}
+	if strings.HasPrefix(absPath, home+"/") {
+		return "~/" + absPath[len(home)+1:]
+	}
+	return absPath
+}

--- a/app/backend/api/directories.go
+++ b/app/backend/api/directories.go
@@ -18,7 +18,7 @@ func (s *Server) handleDirectories(w http.ResponseWriter, r *http.Request) {
 
 	expanded, expandErr := validate.ExpandTilde(prefix)
 	if expandErr != "" {
-		writeError(w, http.StatusBadRequest, expandErr)
+		writeJSON(w, http.StatusOK, map[string][]string{"directories": {}})
 		return
 	}
 

--- a/app/backend/api/directories_test.go
+++ b/app/backend/api/directories_test.go
@@ -1,0 +1,179 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDirectoriesEmptyPrefix(t *testing.T) {
+	router := newTestRouter(&mockSessionFetcher{}, &mockTmuxOps{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/directories", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var result struct {
+		Directories []string `json:"directories"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(result.Directories) != 0 {
+		t.Errorf("directories = %v, want empty", result.Directories)
+	}
+}
+
+func TestDirectoriesListChildren(t *testing.T) {
+	// Create temp dirs under $HOME to test listing
+	home, _ := os.UserHomeDir()
+	testDir := filepath.Join(home, ".run-kit-test-dirs")
+	if err := os.MkdirAll(filepath.Join(testDir, "alpha"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(testDir, "beta"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(testDir, ".hidden"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(testDir)
+
+	router := newTestRouter(&mockSessionFetcher{}, &mockTmuxOps{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/directories?prefix=~/.run-kit-test-dirs/", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var result struct {
+		Directories []string `json:"directories"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	if len(result.Directories) != 2 {
+		t.Fatalf("directories count = %d, want 2, got %v", len(result.Directories), result.Directories)
+	}
+
+	// Should contain alpha and beta but not .hidden
+	foundAlpha := false
+	foundBeta := false
+	for _, d := range result.Directories {
+		if strings.Contains(d, "alpha") {
+			foundAlpha = true
+		}
+		if strings.Contains(d, "beta") {
+			foundBeta = true
+		}
+		if strings.Contains(d, ".hidden") {
+			t.Error("hidden directory should be excluded")
+		}
+	}
+	if !foundAlpha {
+		t.Error("alpha not found in results")
+	}
+	if !foundBeta {
+		t.Error("beta not found in results")
+	}
+}
+
+func TestDirectoriesPrefixFilter(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	testDir := filepath.Join(home, ".run-kit-test-filter")
+	if err := os.MkdirAll(filepath.Join(testDir, "abc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(testDir, "abd"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(testDir, "xyz"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(testDir)
+
+	router := newTestRouter(&mockSessionFetcher{}, &mockTmuxOps{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/directories?prefix=~/.run-kit-test-filter/ab", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var result struct {
+		Directories []string `json:"directories"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	if len(result.Directories) != 2 {
+		t.Fatalf("directories count = %d, want 2, got %v", len(result.Directories), result.Directories)
+	}
+
+	for _, d := range result.Directories {
+		if strings.Contains(d, "xyz") {
+			t.Error("xyz should be filtered out")
+		}
+	}
+}
+
+func TestDirectoriesInvalidPath(t *testing.T) {
+	router := newTestRouter(&mockSessionFetcher{}, &mockTmuxOps{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/directories?prefix=~/nonexistent-dir-12345/", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var result struct {
+		Directories []string `json:"directories"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(result.Directories) != 0 {
+		t.Errorf("directories = %v, want empty", result.Directories)
+	}
+}
+
+func TestTildePrefix(t *testing.T) {
+	home, _ := os.UserHomeDir()
+
+	tests := []struct {
+		name    string
+		absPath string
+		home    string
+		want    string
+	}{
+		{"home itself", home, home, "~"},
+		{"under home", home + "/code/project", home, "~/code/project"},
+		{"outside home", "/etc/other", home, "/etc/other"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tildePrefix(tt.absPath, tt.home)
+			if got != tt.want {
+				t.Errorf("tildePrefix(%q, %q) = %q, want %q", tt.absPath, tt.home, got, tt.want)
+			}
+		})
+	}
+}

--- a/app/backend/api/directories_test.go
+++ b/app/backend/api/directories_test.go
@@ -33,9 +33,11 @@ func TestDirectoriesEmptyPrefix(t *testing.T) {
 }
 
 func TestDirectoriesListChildren(t *testing.T) {
-	// Create temp dirs under $HOME to test listing
-	home, _ := os.UserHomeDir()
-	testDir := filepath.Join(home, ".run-kit-test-dirs")
+	// Use a temp HOME so the test is hermetic and doesn't touch the real home dir
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	testDir := filepath.Join(tmpHome, ".run-kit-test-dirs")
 	if err := os.MkdirAll(filepath.Join(testDir, "alpha"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -45,7 +47,6 @@ func TestDirectoriesListChildren(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(testDir, ".hidden"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(testDir)
 
 	router := newTestRouter(&mockSessionFetcher{}, &mockTmuxOps{})
 
@@ -91,8 +92,11 @@ func TestDirectoriesListChildren(t *testing.T) {
 }
 
 func TestDirectoriesPrefixFilter(t *testing.T) {
-	home, _ := os.UserHomeDir()
-	testDir := filepath.Join(home, ".run-kit-test-filter")
+	// Use a temp HOME so the test is hermetic and doesn't touch the real home dir
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	testDir := filepath.Join(tmpHome, ".run-kit-test-filter")
 	if err := os.MkdirAll(filepath.Join(testDir, "abc"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -102,7 +106,6 @@ func TestDirectoriesPrefixFilter(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(testDir, "xyz"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(testDir)
 
 	router := newTestRouter(&mockSessionFetcher{}, &mockTmuxOps{})
 

--- a/app/backend/api/health.go
+++ b/app/backend/api/health.go
@@ -1,1 +1,9 @@
 package api
+
+import (
+	"net/http"
+)
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}

--- a/app/backend/api/health_test.go
+++ b/app/backend/api/health_test.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestHealthEndpoint(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	router := NewTestRouter(logger, nil, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	ct := rec.Header().Get("Content-Type")
+	if ct != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", ct, "application/json")
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if body["status"] != "ok" {
+		t.Errorf("body.status = %q, want %q", body["status"], "ok")
+	}
+}

--- a/app/backend/api/relay.go
+++ b/app/backend/api/relay.go
@@ -1,1 +1,142 @@
 package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/exec"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/creack/pty"
+	"github.com/go-chi/chi/v5"
+	"github.com/gorilla/websocket"
+
+	"run-kit/internal/validate"
+)
+
+// No timeout for the attach command — it's a long-lived process that stays alive
+// for the duration of the WebSocket connection. Cancellation happens via the
+// cancel() call in the cleanup function on disconnect.
+
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool { return true },
+}
+
+type resizeMsg struct {
+	Type string `json:"type"`
+	Cols uint16 `json:"cols"`
+	Rows uint16 `json:"rows"`
+}
+
+func (s *Server) handleRelay(w http.ResponseWriter, r *http.Request) {
+	session := chi.URLParam(r, "session")
+	windowIndex := chi.URLParam(r, "window")
+
+	// Validate inputs
+	if errMsg := validate.ValidateName(session, "Session name"); errMsg != "" {
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+	// Window index must be a non-negative integer
+	winIdx, err := strconv.Atoi(windowIndex)
+	if err != nil || winIdx < 0 {
+		http.Error(w, "Window index must be a non-negative integer", http.StatusBadRequest)
+		return
+	}
+
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		slog.Error("websocket upgrade failed", "err", err)
+		return
+	}
+	defer conn.Close()
+
+	// Create independent pane via split-window (agent pane 0 untouched)
+	paneID, err := s.tmux.SplitWindow(session, winIdx)
+	if err != nil {
+		slog.Error("split-window failed", "err", err, "session", session, "window", windowIndex)
+		conn.WriteMessage(websocket.CloseMessage,
+			websocket.FormatCloseMessage(4001, "Failed to create tmux pane"))
+		return
+	}
+
+	// Attach to the NEW pane via pty. attach-session -t accepts a pane target
+	// (e.g., %5) which resolves to that pane's session. We combine it with
+	// select-pane to ensure the correct pane is active on attach.
+	ctx, cancel := context.WithCancel(context.Background())
+	// First, select the target pane so attach-session focuses on it
+	selectCtx, selectCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	if err := exec.CommandContext(selectCtx, "tmux", "select-pane", "-t", paneID).Run(); err != nil {
+		slog.Debug("select-pane failed", "err", err, "paneID", paneID)
+	}
+	selectCancel()
+	cmd := exec.CommandContext(ctx, "tmux", "attach-session", "-t", session)
+	cmd.Env = os.Environ()
+
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		cancel()
+		s.tmux.KillPane(paneID)
+		slog.Error("pty start failed", "err", err, "paneID", paneID)
+		conn.WriteMessage(websocket.CloseMessage,
+			websocket.FormatCloseMessage(4001, "Failed to attach to tmux pane"))
+		return
+	}
+
+	var once sync.Once
+	cleanup := func() {
+		once.Do(func() {
+			cancel()
+			ptmx.Close()
+			if cmd.Process != nil {
+				cmd.Process.Kill()
+			}
+			s.tmux.KillPane(paneID)
+			slog.Debug("relay cleanup", "paneID", paneID)
+		})
+	}
+	defer cleanup()
+
+	// Relay pty output -> WebSocket
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, err := ptmx.Read(buf)
+			if err != nil {
+				if err != io.EOF {
+					slog.Debug("pty read error", "err", err)
+				}
+				conn.Close()
+				return
+			}
+			if err := conn.WriteMessage(websocket.TextMessage, buf[:n]); err != nil {
+				return
+			}
+		}
+	}()
+
+	// Relay WebSocket input -> pty
+	for {
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			break
+		}
+
+		// Check for resize messages
+		var resize resizeMsg
+		if json.Unmarshal(msg, &resize) == nil && resize.Type == "resize" && resize.Cols > 0 && resize.Rows > 0 {
+			pty.Setsize(ptmx, &pty.Winsize{Cols: resize.Cols, Rows: resize.Rows})
+			continue
+		}
+
+		// Send raw input to pty
+		if _, err := ptmx.Write(msg); err != nil {
+			break
+		}
+	}
+}

--- a/app/backend/api/router.go
+++ b/app/backend/api/router.go
@@ -1,1 +1,156 @@
 package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"sync"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/go-chi/cors"
+
+	"run-kit/internal/sessions"
+	"run-kit/internal/tmux"
+)
+
+// SessionFetcher fetches enriched session data.
+type SessionFetcher interface {
+	FetchSessions() ([]sessions.ProjectSession, error)
+}
+
+// TmuxOps defines tmux operations used by handlers.
+type TmuxOps interface {
+	CreateSession(name, cwd string) error
+	KillSession(session string) error
+	CreateWindow(session, name, cwd string) error
+	KillWindow(session string, index int) error
+	RenameWindow(session string, index int, name string) error
+	SendKeys(session string, window int, keys string) error
+	ListWindows(session string) ([]tmux.WindowInfo, error)
+	SplitWindow(session string, window int) (string, error)
+	KillPane(paneID string) error
+}
+
+// Server holds handler dependencies.
+type Server struct {
+	logger   *slog.Logger
+	sessions SessionFetcher
+	tmux     TmuxOps
+	sseHub   *sseHub
+	sseOnce  sync.Once
+}
+
+// initSSEHub lazily creates the SSE hub on first use.
+func (s *Server) initSSEHub() {
+	s.sseOnce.Do(func() {
+		s.sseHub = newSSEHub(s.sessions)
+	})
+}
+
+// prodSessionFetcher wraps the sessions package for production use.
+type prodSessionFetcher struct{}
+
+func (p *prodSessionFetcher) FetchSessions() ([]sessions.ProjectSession, error) {
+	return sessions.FetchSessions()
+}
+
+// prodTmuxOps wraps the tmux package for production use.
+type prodTmuxOps struct{}
+
+func (p *prodTmuxOps) CreateSession(name, cwd string) error {
+	return tmux.CreateSession(name, cwd)
+}
+func (p *prodTmuxOps) KillSession(session string) error {
+	return tmux.KillSession(session)
+}
+func (p *prodTmuxOps) CreateWindow(session, name, cwd string) error {
+	return tmux.CreateWindow(session, name, cwd)
+}
+func (p *prodTmuxOps) KillWindow(session string, index int) error {
+	return tmux.KillWindow(session, index)
+}
+func (p *prodTmuxOps) RenameWindow(session string, index int, name string) error {
+	return tmux.RenameWindow(session, index, name)
+}
+func (p *prodTmuxOps) SendKeys(session string, window int, keys string) error {
+	return tmux.SendKeys(session, window, keys)
+}
+func (p *prodTmuxOps) ListWindows(session string) ([]tmux.WindowInfo, error) {
+	return tmux.ListWindows(session)
+}
+func (p *prodTmuxOps) SplitWindow(session string, window int) (string, error) {
+	return tmux.SplitWindow(session, window)
+}
+func (p *prodTmuxOps) KillPane(paneID string) error {
+	return tmux.KillPane(paneID)
+}
+
+// NewRouter creates the chi router with all middleware and routes.
+// Uses production dependencies (live tmux, real session fetcher).
+func NewRouter(logger *slog.Logger) chi.Router {
+	s := &Server{
+		logger:   logger,
+		sessions: &prodSessionFetcher{},
+		tmux:     &prodTmuxOps{},
+	}
+	return s.buildRouter()
+}
+
+// NewTestRouter creates a chi router with injectable dependencies for testing.
+func NewTestRouter(logger *slog.Logger, sf SessionFetcher, ops TmuxOps) chi.Router {
+	s := &Server{
+		logger:   logger,
+		sessions: sf,
+		tmux:     ops,
+	}
+	return s.buildRouter()
+}
+
+func (s *Server) buildRouter() chi.Router {
+	r := chi.NewRouter()
+
+	// Middleware stack
+	r.Use(cors.Handler(cors.Options{
+		AllowedOrigins:   []string{"*"},
+		AllowedMethods:   []string{"GET", "POST", "OPTIONS"},
+		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type"},
+		AllowCredentials: false,
+		MaxAge:           300,
+	}))
+	r.Use(middleware.Logger)
+	r.Use(middleware.Recoverer)
+
+	// API routes
+	r.Get("/api/health", s.handleHealth)
+	r.Get("/api/sessions", s.handleSessionsList)
+	r.Post("/api/sessions", s.handleSessionCreate)
+	r.Post("/api/sessions/{session}/kill", s.handleSessionKill)
+	r.Post("/api/sessions/{session}/windows", s.handleWindowCreate)
+	r.Post("/api/sessions/{session}/windows/{index}/kill", s.handleWindowKill)
+	r.Post("/api/sessions/{session}/windows/{index}/rename", s.handleWindowRename)
+	r.Post("/api/sessions/{session}/windows/{index}/keys", s.handleWindowKeys)
+	r.Get("/api/directories", s.handleDirectories)
+	r.Post("/api/sessions/{session}/upload", s.handleUpload)
+	r.Get("/api/sessions/stream", s.handleSSE)
+
+	// WebSocket relay
+	r.Get("/relay/{session}/{window}", s.handleRelay)
+
+	// SPA static serving — catch-all, must be last
+	s.mountSPA(r)
+
+	return r
+}
+
+// writeJSON writes a JSON response with the given status code.
+func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}
+
+// writeError writes a JSON error response.
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}

--- a/app/backend/api/sessions.go
+++ b/app/backend/api/sessions.go
@@ -1,1 +1,71 @@
 package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"run-kit/internal/validate"
+)
+
+func (s *Server) handleSessionsList(w http.ResponseWriter, r *http.Request) {
+	result, err := s.sessions.FetchSessions()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
+func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Name string `json:"name"`
+		CWD  string `json:"cwd"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid JSON body")
+		return
+	}
+
+	if errMsg := validate.ValidateName(body.Name, "Session name"); errMsg != "" {
+		writeError(w, http.StatusBadRequest, errMsg)
+		return
+	}
+
+	var resolvedCwd string
+	if body.CWD != "" {
+		if errMsg := validate.ValidatePath(body.CWD, "Working directory"); errMsg != "" {
+			writeError(w, http.StatusBadRequest, errMsg)
+			return
+		}
+		expanded, expandErr := validate.ExpandTilde(body.CWD)
+		if expandErr != "" {
+			writeError(w, http.StatusBadRequest, expandErr)
+			return
+		}
+		resolvedCwd = expanded
+	}
+
+	if err := s.tmux.CreateSession(body.Name, resolvedCwd); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]bool{"ok": true})
+}
+
+func (s *Server) handleSessionKill(w http.ResponseWriter, r *http.Request) {
+	session := chi.URLParam(r, "session")
+	if errMsg := validate.ValidateName(session, "Session name"); errMsg != "" {
+		writeError(w, http.StatusBadRequest, errMsg)
+		return
+	}
+
+	if err := s.tmux.KillSession(session); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}

--- a/app/backend/api/sessions_test.go
+++ b/app/backend/api/sessions_test.go
@@ -1,0 +1,286 @@
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"run-kit/internal/sessions"
+	"run-kit/internal/tmux"
+)
+
+// mockSessionFetcher returns canned session data.
+type mockSessionFetcher struct {
+	result []sessions.ProjectSession
+	err    error
+}
+
+func (m *mockSessionFetcher) FetchSessions() ([]sessions.ProjectSession, error) {
+	return m.result, m.err
+}
+
+// mockTmuxOps records calls for verification.
+type mockTmuxOps struct {
+	createSessionCalled bool
+	createSessionName   string
+	createSessionCwd    string
+	killSessionCalled   bool
+	killSessionName     string
+
+	createWindowCalled  bool
+	createWindowSession string
+	createWindowName    string
+	createWindowCwd     string
+	killWindowCalled    bool
+	killWindowSession   string
+	killWindowIndex     int
+	renameWindowCalled  bool
+	renameWindowSession string
+	renameWindowIndex   int
+	renameWindowName    string
+	sendKeysCalled      bool
+	sendKeysSession     string
+	sendKeysWindow      int
+	sendKeysKeys        string
+
+	listWindowsResult []tmux.WindowInfo
+	listWindowsErr    error
+
+	splitWindowResult string
+	splitWindowErr    error
+
+	err error
+}
+
+func (m *mockTmuxOps) CreateSession(name, cwd string) error {
+	m.createSessionCalled = true
+	m.createSessionName = name
+	m.createSessionCwd = cwd
+	return m.err
+}
+func (m *mockTmuxOps) KillSession(session string) error {
+	m.killSessionCalled = true
+	m.killSessionName = session
+	return m.err
+}
+func (m *mockTmuxOps) CreateWindow(session, name, cwd string) error {
+	m.createWindowCalled = true
+	m.createWindowSession = session
+	m.createWindowName = name
+	m.createWindowCwd = cwd
+	return m.err
+}
+func (m *mockTmuxOps) KillWindow(session string, index int) error {
+	m.killWindowCalled = true
+	m.killWindowSession = session
+	m.killWindowIndex = index
+	return m.err
+}
+func (m *mockTmuxOps) RenameWindow(session string, index int, name string) error {
+	m.renameWindowCalled = true
+	m.renameWindowSession = session
+	m.renameWindowIndex = index
+	m.renameWindowName = name
+	return m.err
+}
+func (m *mockTmuxOps) SendKeys(session string, window int, keys string) error {
+	m.sendKeysCalled = true
+	m.sendKeysSession = session
+	m.sendKeysWindow = window
+	m.sendKeysKeys = keys
+	return m.err
+}
+func (m *mockTmuxOps) ListWindows(session string) ([]tmux.WindowInfo, error) {
+	return m.listWindowsResult, m.listWindowsErr
+}
+func (m *mockTmuxOps) SplitWindow(session string, window int) (string, error) {
+	return m.splitWindowResult, m.splitWindowErr
+}
+func (m *mockTmuxOps) KillPane(paneID string) error {
+	return nil
+}
+
+func newTestRouter(sf SessionFetcher, ops TmuxOps) http.Handler {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	return NewTestRouter(logger, sf, ops)
+}
+
+func TestSessionsList(t *testing.T) {
+	sf := &mockSessionFetcher{
+		result: []sessions.ProjectSession{
+			{
+				Name: "run-kit",
+				Windows: []tmux.WindowInfo{
+					{Index: 0, Name: "main", WorktreePath: "/home/user/code", Activity: "active", IsActiveWindow: true, FabChange: "260312-abc", FabStage: "apply"},
+					{Index: 1, Name: "build", WorktreePath: "/tmp/build", Activity: "idle", IsActiveWindow: false, FabChange: "260312-abc", FabStage: "apply"},
+				},
+			},
+		},
+	}
+
+	router := newTestRouter(sf, &mockTmuxOps{})
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	ct := rec.Header().Get("Content-Type")
+	if ct != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", ct, "application/json")
+	}
+
+	var result []sessions.ProjectSession
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+	if result[0].Name != "run-kit" {
+		t.Errorf("result[0].Name = %q, want %q", result[0].Name, "run-kit")
+	}
+	if len(result[0].Windows) != 2 {
+		t.Fatalf("len(windows) = %d, want 2", len(result[0].Windows))
+	}
+	if result[0].Windows[0].FabChange != "260312-abc" {
+		t.Errorf("FabChange = %q, want %q", result[0].Windows[0].FabChange, "260312-abc")
+	}
+	if result[0].Windows[0].FabStage != "apply" {
+		t.Errorf("FabStage = %q, want %q", result[0].Windows[0].FabStage, "apply")
+	}
+}
+
+func TestSessionCreate(t *testing.T) {
+	ops := &mockTmuxOps{}
+	router := newTestRouter(&mockSessionFetcher{}, ops)
+
+	body := `{"name":"my-project","cwd":"~/code/my-project"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusCreated)
+	}
+
+	if !ops.createSessionCalled {
+		t.Error("CreateSession was not called")
+	}
+	if ops.createSessionName != "my-project" {
+		t.Errorf("createSessionName = %q, want %q", ops.createSessionName, "my-project")
+	}
+
+	var result map[string]bool
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if !result["ok"] {
+		t.Error("expected ok: true")
+	}
+}
+
+func TestSessionCreateEmptyName(t *testing.T) {
+	router := newTestRouter(&mockSessionFetcher{}, &mockTmuxOps{})
+
+	body := `{"name":""}`
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+
+	var result map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if !strings.Contains(result["error"], "cannot be empty") {
+		t.Errorf("error = %q, want containing %q", result["error"], "cannot be empty")
+	}
+}
+
+func TestSessionCreateForbiddenChars(t *testing.T) {
+	router := newTestRouter(&mockSessionFetcher{}, &mockTmuxOps{})
+
+	body := `{"name":"test;hack"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+
+	var result map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if !strings.Contains(result["error"], "forbidden characters") {
+		t.Errorf("error = %q, want containing %q", result["error"], "forbidden characters")
+	}
+}
+
+func TestSessionCreateInvalidJSON(t *testing.T) {
+	router := newTestRouter(&mockSessionFetcher{}, &mockTmuxOps{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions", strings.NewReader("{invalid"))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestSessionKill(t *testing.T) {
+	ops := &mockTmuxOps{}
+	router := newTestRouter(&mockSessionFetcher{}, ops)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/test-session/kill", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	if !ops.killSessionCalled {
+		t.Error("KillSession was not called")
+	}
+	if ops.killSessionName != "test-session" {
+		t.Errorf("killSessionName = %q, want %q", ops.killSessionName, "test-session")
+	}
+}
+
+func TestSessionKillInvalidName(t *testing.T) {
+	router := newTestRouter(&mockSessionFetcher{}, &mockTmuxOps{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/test;rm/kill", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+
+	var result map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if !strings.Contains(result["error"], "forbidden characters") {
+		t.Errorf("error = %q, want containing %q", result["error"], "forbidden characters")
+	}
+}

--- a/app/backend/api/spa.go
+++ b/app/backend/api/spa.go
@@ -1,1 +1,53 @@
 package api
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// spaDir is the directory containing the built SPA assets.
+var spaDir = "app/frontend/dist"
+
+func (s *Server) mountSPA(r chi.Router) {
+	r.Get("/*", func(w http.ResponseWriter, req *http.Request) {
+		// Clean the URL path and strip the leading slash so filepath.Join
+		// resolves relative to spaDir instead of discarding it.
+		urlPath := strings.TrimPrefix(req.URL.Path, "/")
+
+		// Skip API and relay routes (should never reach here due to route ordering,
+		// but guard defensively)
+		if strings.HasPrefix(req.URL.Path, "/api/") || strings.HasPrefix(req.URL.Path, "/relay/") {
+			http.NotFound(w, req)
+			return
+		}
+
+		// Try to serve the static file directly
+		filePath := filepath.Join(spaDir, filepath.Clean(urlPath))
+
+		// Ensure the resolved path stays within spaDir to prevent path traversal
+		absFilePath, _ := filepath.Abs(filePath)
+		absSpaDir, _ := filepath.Abs(spaDir)
+		if !strings.HasPrefix(absFilePath, absSpaDir+string(filepath.Separator)) && absFilePath != absSpaDir {
+			http.NotFound(w, req)
+			return
+		}
+		if info, err := os.Stat(filePath); err == nil && !info.IsDir() {
+			http.ServeFile(w, req, filePath)
+			return
+		}
+
+		// SPA fallback: serve index.html for client-side routing
+		indexPath := filepath.Join(spaDir, "index.html")
+		if _, err := os.Stat(indexPath); err != nil {
+			// SPA not built yet — return 404
+			http.NotFound(w, req)
+			return
+		}
+
+		http.ServeFile(w, req, indexPath)
+	})
+}

--- a/app/backend/api/spa_test.go
+++ b/app/backend/api/spa_test.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func setupSPADir(t *testing.T) (string, func()) {
+	t.Helper()
+	dir := t.TempDir()
+
+	// Save original spaDir and restore after test
+	orig := spaDir
+	spaDir = dir
+
+	// Create index.html
+	indexPath := filepath.Join(dir, "index.html")
+	if err := os.WriteFile(indexPath, []byte("<html>SPA</html>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a static asset
+	assetsDir := filepath.Join(dir, "assets")
+	if err := os.MkdirAll(assetsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(assetsDir, "main.js"), []byte("console.log('app')"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	return dir, func() {
+		spaDir = orig
+	}
+}
+
+func TestSPAStaticAsset(t *testing.T) {
+	_, cleanup := setupSPADir(t)
+	defer cleanup()
+
+	router := newTestRouter(&mockSessionFetcher{}, &mockTmuxOps{})
+
+	req := httptest.NewRequest(http.MethodGet, "/assets/main.js", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	body := rec.Body.String()
+	if body != "console.log('app')" {
+		t.Errorf("body = %q, want %q", body, "console.log('app')")
+	}
+}
+
+func TestSPAFallback(t *testing.T) {
+	_, cleanup := setupSPADir(t)
+	defer cleanup()
+
+	router := newTestRouter(&mockSessionFetcher{}, &mockTmuxOps{})
+
+	req := httptest.NewRequest(http.MethodGet, "/p/run-kit/0", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	body := rec.Body.String()
+	if body != "<html>SPA</html>" {
+		t.Errorf("body = %q, want SPA index.html content", body)
+	}
+}
+
+func TestSPAPathTraversal(t *testing.T) {
+	_, cleanup := setupSPADir(t)
+	defer cleanup()
+
+	router := newTestRouter(&mockSessionFetcher{}, &mockTmuxOps{})
+
+	req := httptest.NewRequest(http.MethodGet, "/../../etc/passwd", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	// Should not serve /etc/passwd — path traversal blocked
+	if rec.Code == http.StatusOK {
+		body := rec.Body.String()
+		if body != "<html>SPA</html>" {
+			t.Errorf("expected SPA fallback or 404, got different content: %q", body[:min(len(body), 100)])
+		}
+	}
+}
+
+func TestSPANotBuilt(t *testing.T) {
+	// Point spaDir to a nonexistent directory
+	orig := spaDir
+	spaDir = "/tmp/nonexistent-spa-dir-12345"
+	defer func() { spaDir = orig }()
+
+	router := newTestRouter(&mockSessionFetcher{}, &mockTmuxOps{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/app/backend/api/spa_test.go
+++ b/app/backend/api/spa_test.go
@@ -86,12 +86,9 @@ func TestSPAPathTraversal(t *testing.T) {
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 
-	// Should not serve /etc/passwd — path traversal blocked
-	if rec.Code == http.StatusOK {
-		body := rec.Body.String()
-		if body != "<html>SPA</html>" {
-			t.Errorf("expected SPA fallback or 404, got different content: %q", body[:min(len(body), 100)])
-		}
+	// Should not serve /etc/passwd — path traversal must be blocked with 404
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotFound)
 	}
 }
 
@@ -110,11 +107,4 @@ func TestSPANotBuilt(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotFound)
 	}
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
 }

--- a/app/backend/api/sse.go
+++ b/app/backend/api/sse.go
@@ -1,1 +1,146 @@
 package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	ssePollInterval = 2500 * time.Millisecond
+	maxLifetime     = 30 * time.Minute
+)
+
+type sseClient struct {
+	ch chan []byte
+}
+
+type sseHub struct {
+	mu           sync.RWMutex
+	clients      map[*sseClient]struct{}
+	previousJSON string
+	polling      bool
+	fetcher      SessionFetcher
+}
+
+func newSSEHub(fetcher SessionFetcher) *sseHub {
+	return &sseHub{
+		clients: make(map[*sseClient]struct{}),
+		fetcher: fetcher,
+	}
+}
+
+func (h *sseHub) addClient(c *sseClient) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.clients[c] = struct{}{}
+
+	// Send cached snapshot immediately
+	if h.previousJSON != "" {
+		select {
+		case c.ch <- []byte(fmt.Sprintf("event: sessions\ndata: %s\n\n", h.previousJSON)):
+		default:
+		}
+	}
+
+	if !h.polling {
+		h.polling = true
+		go h.poll()
+	}
+}
+
+func (h *sseHub) removeClient(c *sseClient) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	delete(h.clients, c)
+}
+
+func (h *sseHub) poll() {
+	for {
+		h.mu.Lock()
+		if len(h.clients) == 0 {
+			h.polling = false
+			h.mu.Unlock()
+			return
+		}
+		h.mu.Unlock()
+
+		result, err := h.fetcher.FetchSessions()
+		if err != nil {
+			slog.Warn("SSE poll error", "err", err)
+			time.Sleep(ssePollInterval)
+			continue
+		}
+
+		jsonBytes, err := json.Marshal(result)
+		if err != nil {
+			time.Sleep(ssePollInterval)
+			continue
+		}
+		jsonStr := string(jsonBytes)
+
+		h.mu.Lock()
+		if jsonStr != h.previousJSON {
+			h.previousJSON = jsonStr
+			event := []byte(fmt.Sprintf("event: sessions\ndata: %s\n\n", jsonStr))
+
+			for c := range h.clients {
+				select {
+				case c.ch <- event:
+				default:
+					// Client buffer full — skip
+				}
+			}
+		}
+		h.mu.Unlock()
+
+		time.Sleep(ssePollInterval)
+	}
+}
+
+func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	client := &sseClient{
+		ch: make(chan []byte, 8),
+	}
+
+	// Lazy-init the hub on first SSE connection
+	s.initSSEHub()
+	s.sseHub.addClient(client)
+	defer s.sseHub.removeClient(client)
+
+	// Lifetime cap
+	lifetime := time.NewTimer(maxLifetime)
+	defer lifetime.Stop()
+
+	ctx := r.Context()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-lifetime.C:
+			return
+		case data := <-client.ch:
+			_, err := w.Write(data)
+			if err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}

--- a/app/backend/api/sse_test.go
+++ b/app/backend/api/sse_test.go
@@ -1,0 +1,169 @@
+package api
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"run-kit/internal/sessions"
+	"run-kit/internal/tmux"
+)
+
+// slowSessionFetcher returns canned data with a small delay.
+type slowSessionFetcher struct {
+	result []sessions.ProjectSession
+}
+
+func (s *slowSessionFetcher) FetchSessions() ([]sessions.ProjectSession, error) {
+	return s.result, nil
+}
+
+func TestSSEInitialSnapshot(t *testing.T) {
+	sf := &slowSessionFetcher{
+		result: []sessions.ProjectSession{
+			{
+				Name: "test-session",
+				Windows: []tmux.WindowInfo{
+					{Index: 0, Name: "main", WorktreePath: "/home/user", Activity: "active", IsActiveWindow: true},
+				},
+			},
+		},
+	}
+
+	router := newTestRouter(sf, &mockTmuxOps{})
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	// Create a context with timeout to avoid hanging
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/api/sessions/stream", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	if ct != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want %q", ct, "text/event-stream")
+	}
+
+	// Read the first SSE event
+	scanner := bufio.NewScanner(resp.Body)
+	var eventLines []string
+	for scanner.Scan() {
+		line := scanner.Text()
+		eventLines = append(eventLines, line)
+		// SSE events end with an empty line
+		if line == "" && len(eventLines) > 1 {
+			break
+		}
+	}
+
+	// Verify we got a sessions event
+	foundEvent := false
+	foundData := false
+	for _, line := range eventLines {
+		if strings.HasPrefix(line, "event: sessions") {
+			foundEvent = true
+		}
+		if strings.HasPrefix(line, "data: ") {
+			foundData = true
+			if !strings.Contains(line, "test-session") {
+				t.Errorf("data does not contain session name: %s", line)
+			}
+		}
+	}
+	if !foundEvent {
+		t.Error("did not receive 'event: sessions' line")
+	}
+	if !foundData {
+		t.Error("did not receive 'data:' line")
+	}
+}
+
+func TestSSEHubDeduplication(t *testing.T) {
+	sf := &slowSessionFetcher{
+		result: []sessions.ProjectSession{
+			{Name: "static", Windows: []tmux.WindowInfo{}},
+		},
+	}
+
+	hub := newSSEHub(sf)
+	client := &sseClient{ch: make(chan []byte, 16)}
+
+	hub.addClient(client)
+	defer hub.removeClient(client)
+
+	// Wait for initial snapshot delivery
+	select {
+	case <-client.ch:
+		// Got initial snapshot (may be empty or from first poll)
+	case <-time.After(4 * time.Second):
+		// First poll may take up to ssePollInterval
+	}
+
+	// Drain any pending events from the first poll cycle
+	time.Sleep(100 * time.Millisecond)
+drainLoop:
+	for {
+		select {
+		case <-client.ch:
+		default:
+			break drainLoop
+		}
+	}
+
+	// Wait for another poll cycle — since data hasn't changed, no event should be sent
+	time.Sleep(ssePollInterval + 500*time.Millisecond)
+
+	select {
+	case <-client.ch:
+		t.Error("received duplicate event when data didn't change")
+	default:
+		// Expected: no event
+	}
+}
+
+func TestSSEHubStopsPollingWhenNoClients(t *testing.T) {
+	sf := &slowSessionFetcher{
+		result: []sessions.ProjectSession{},
+	}
+
+	hub := newSSEHub(sf)
+	client := &sseClient{ch: make(chan []byte, 8)}
+
+	hub.addClient(client)
+
+	// Wait a bit for polling to start
+	time.Sleep(100 * time.Millisecond)
+
+	hub.mu.RLock()
+	isPolling := hub.polling
+	hub.mu.RUnlock()
+	if !isPolling {
+		t.Error("hub should be polling with a client connected")
+	}
+
+	hub.removeClient(client)
+
+	// Wait for poll loop to detect no clients
+	time.Sleep(ssePollInterval + 500*time.Millisecond)
+
+	hub.mu.RLock()
+	isPolling = hub.polling
+	hub.mu.RUnlock()
+	if isPolling {
+		t.Error("hub should stop polling when no clients")
+	}
+}

--- a/app/backend/api/upload.go
+++ b/app/backend/api/upload.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -29,7 +30,8 @@ func (s *Server) handleUpload(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, uploadMaxBytes)
 
 	if err := r.ParseMultipartForm(uploadMaxBytes); err != nil {
-		if err.Error() == "http: request body too large" {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
 			writeError(w, 413, "File exceeds 50MB limit")
 			return
 		}

--- a/app/backend/api/upload.go
+++ b/app/backend/api/upload.go
@@ -1,1 +1,145 @@
 package api
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"run-kit/internal/tmux"
+	"run-kit/internal/validate"
+)
+
+const uploadMaxBytes = 50 * 1024 * 1024 // 50MB
+
+func (s *Server) handleUpload(w http.ResponseWriter, r *http.Request) {
+	session := chi.URLParam(r, "session")
+	if errMsg := validate.ValidateName(session, "Session name"); errMsg != "" {
+		writeError(w, http.StatusBadRequest, errMsg)
+		return
+	}
+
+	// Enforce size limit
+	r.Body = http.MaxBytesReader(w, r.Body, uploadMaxBytes)
+
+	if err := r.ParseMultipartForm(uploadMaxBytes); err != nil {
+		if err.Error() == "http: request body too large" {
+			writeError(w, 413, "File exceeds 50MB limit")
+			return
+		}
+		writeError(w, http.StatusBadRequest, "Invalid multipart form")
+		return
+	}
+
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "Missing file field")
+		return
+	}
+	defer file.Close()
+
+	if header.Size > uploadMaxBytes {
+		writeError(w, 413, "File exceeds 50MB limit")
+		return
+	}
+
+	// Parse optional window index
+	windowIndex := 0
+	if wf := r.FormValue("window"); wf != "" {
+		parsed, err := strconv.Atoi(wf)
+		if err != nil || parsed < 0 {
+			writeError(w, http.StatusBadRequest, "Invalid window index")
+			return
+		}
+		windowIndex = parsed
+	}
+
+	// Get project root via tmux windows
+	windows, err := s.tmux.ListWindows(session)
+	if err != nil || len(windows) == 0 {
+		writeError(w, http.StatusBadRequest, "Session not found or has no windows")
+		return
+	}
+
+	var targetWindow tmux.WindowInfo
+	found := false
+	for _, win := range windows {
+		if win.Index == windowIndex {
+			targetWindow = win
+			found = true
+			break
+		}
+	}
+	if !found {
+		targetWindow = windows[0]
+	}
+
+	projectRoot := targetWindow.WorktreePath
+	if projectRoot == "" {
+		writeError(w, http.StatusInternalServerError, "Could not determine project root from tmux window")
+		return
+	}
+
+	// Ensure .uploads/ directory exists
+	uploadsDir := filepath.Join(projectRoot, ".uploads")
+	if err := os.MkdirAll(uploadsDir, 0o755); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// Ensure .uploads/ is in .gitignore
+	gitignorePath := filepath.Join(projectRoot, ".gitignore")
+	gitignoreContent, _ := os.ReadFile(gitignorePath)
+	lines := strings.Split(string(gitignoreContent), "\n")
+	hasUploadEntry := false
+	for _, line := range lines {
+		if strings.TrimSpace(line) == ".uploads/" {
+			hasUploadEntry = true
+			break
+		}
+	}
+	if !hasUploadEntry {
+		separator := ""
+		if len(gitignoreContent) > 0 && !strings.HasSuffix(string(gitignoreContent), "\n") {
+			separator = "\n"
+		}
+		newContent := string(gitignoreContent) + separator + ".uploads/\n"
+		if err := os.WriteFile(gitignorePath, []byte(newContent), 0o644); err != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to update .gitignore: %v", err))
+			return
+		}
+	}
+
+	// Build timestamped filename
+	now := time.Now()
+	timestamp := fmt.Sprintf("%02d%02d%02d%02d%02d%02d",
+		now.Year()%100, now.Month(), now.Day(),
+		now.Hour(), now.Minute(), now.Second())
+	safeName := validate.SanitizeFilename(header.Filename)
+	finalName := fmt.Sprintf("%s-%s", timestamp, safeName)
+
+	// Write file to disk
+	filePath := filepath.Join(uploadsDir, finalName)
+	out, err := os.Create(filePath)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, file); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"ok":   true,
+		"path": filePath,
+	})
+}

--- a/app/backend/api/upload_test.go
+++ b/app/backend/api/upload_test.go
@@ -1,0 +1,213 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"run-kit/internal/tmux"
+)
+
+func createMultipartRequest(t *testing.T, url string, fields map[string]string, fileName, fileContent string) *http.Request {
+	t.Helper()
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+
+	for k, v := range fields {
+		if err := writer.WriteField(k, v); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if fileName != "" {
+		part, err := writer.CreateFormFile("file", fileName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := io.WriteString(part, fileContent); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, url, &buf)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	return req
+}
+
+func TestUploadFile(t *testing.T) {
+	projectDir := t.TempDir()
+
+	ops := &mockTmuxOps{
+		listWindowsResult: []tmux.WindowInfo{
+			{Index: 0, Name: "main", WorktreePath: projectDir},
+		},
+	}
+	router := newTestRouter(&mockSessionFetcher{}, ops)
+
+	req := createMultipartRequest(t, "/api/sessions/run-kit/upload", nil, "screenshot.png", "fake-image-data")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d, body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if result["ok"] != true {
+		t.Error("expected ok: true")
+	}
+	path, ok := result["path"].(string)
+	if !ok || path == "" {
+		t.Error("expected non-empty path in response")
+	}
+
+	// Verify file exists on disk
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("uploaded file does not exist: %v", err)
+	}
+
+	// Verify .uploads/ directory was created
+	uploadsDir := filepath.Join(projectDir, ".uploads")
+	if _, err := os.Stat(uploadsDir); err != nil {
+		t.Errorf(".uploads/ directory does not exist: %v", err)
+	}
+
+	// Verify .gitignore was updated
+	gitignore, err := os.ReadFile(filepath.Join(projectDir, ".gitignore"))
+	if err != nil {
+		t.Fatalf("failed to read .gitignore: %v", err)
+	}
+	if !strings.Contains(string(gitignore), ".uploads/") {
+		t.Error(".gitignore does not contain .uploads/")
+	}
+}
+
+func TestUploadFilenameSanitization(t *testing.T) {
+	projectDir := t.TempDir()
+
+	ops := &mockTmuxOps{
+		listWindowsResult: []tmux.WindowInfo{
+			{Index: 0, Name: "main", WorktreePath: projectDir},
+		},
+	}
+	router := newTestRouter(&mockSessionFetcher{}, ops)
+
+	req := createMultipartRequest(t, "/api/sessions/run-kit/upload", nil, "../../../etc/passwd", "evil")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d, body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	path := result["path"].(string)
+	// File should be in .uploads/, not in /etc/
+	if !strings.HasPrefix(path, filepath.Join(projectDir, ".uploads")) {
+		t.Errorf("file path escaped .uploads/: %s", path)
+	}
+}
+
+func TestUploadMissingFile(t *testing.T) {
+	ops := &mockTmuxOps{
+		listWindowsResult: []tmux.WindowInfo{
+			{Index: 0, Name: "main", WorktreePath: t.TempDir()},
+		},
+	}
+	router := newTestRouter(&mockSessionFetcher{}, ops)
+
+	// Send multipart without a file field
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	writer.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/run-kit/upload", &buf)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestUploadInvalidSession(t *testing.T) {
+	router := newTestRouter(&mockSessionFetcher{}, &mockTmuxOps{})
+
+	req := createMultipartRequest(t, "/api/sessions/bad;name/upload", nil, "file.txt", "data")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestUploadSessionFromURL(t *testing.T) {
+	// Verify session comes from URL param, not form field
+	projectDir := t.TempDir()
+
+	ops := &mockTmuxOps{
+		listWindowsResult: []tmux.WindowInfo{
+			{Index: 0, Name: "main", WorktreePath: projectDir},
+		},
+	}
+	router := newTestRouter(&mockSessionFetcher{}, ops)
+
+	req := createMultipartRequest(t, "/api/sessions/my-session/upload", nil, "test.txt", "data")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	// Should succeed (session from URL)
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d, body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+}
+
+func TestUploadGitignoreNotDuplicated(t *testing.T) {
+	projectDir := t.TempDir()
+
+	// Pre-create .gitignore with .uploads/
+	gitignorePath := filepath.Join(projectDir, ".gitignore")
+	os.WriteFile(gitignorePath, []byte("node_modules/\n.uploads/\n"), 0o644)
+
+	ops := &mockTmuxOps{
+		listWindowsResult: []tmux.WindowInfo{
+			{Index: 0, Name: "main", WorktreePath: projectDir},
+		},
+	}
+	router := newTestRouter(&mockSessionFetcher{}, ops)
+
+	req := createMultipartRequest(t, "/api/sessions/run-kit/upload", nil, "test.txt", "data")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	// Verify .uploads/ not duplicated in .gitignore
+	content, _ := os.ReadFile(gitignorePath)
+	count := strings.Count(string(content), ".uploads/")
+	if count != 1 {
+		t.Errorf(".uploads/ appears %d times in .gitignore, want 1", count)
+	}
+}

--- a/app/backend/api/windows.go
+++ b/app/backend/api/windows.go
@@ -1,1 +1,154 @@
 package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"run-kit/internal/validate"
+)
+
+func (s *Server) handleWindowCreate(w http.ResponseWriter, r *http.Request) {
+	session := chi.URLParam(r, "session")
+	if errMsg := validate.ValidateName(session, "Session name"); errMsg != "" {
+		writeError(w, http.StatusBadRequest, errMsg)
+		return
+	}
+
+	var body struct {
+		Name string `json:"name"`
+		CWD  string `json:"cwd"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid JSON body")
+		return
+	}
+
+	if errMsg := validate.ValidateName(body.Name, "Window name"); errMsg != "" {
+		writeError(w, http.StatusBadRequest, errMsg)
+		return
+	}
+
+	var resolvedCwd string
+	if body.CWD != "" {
+		if errMsg := validate.ValidatePath(body.CWD, "Working directory"); errMsg != "" {
+			writeError(w, http.StatusBadRequest, errMsg)
+			return
+		}
+		expanded, expandErr := validate.ExpandTilde(body.CWD)
+		if expandErr != "" {
+			writeError(w, http.StatusBadRequest, expandErr)
+			return
+		}
+		resolvedCwd = expanded
+	}
+
+	if err := s.tmux.CreateWindow(session, body.Name, resolvedCwd); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]bool{"ok": true})
+}
+
+// parseWindowIndex extracts and validates the window index from the URL.
+func parseWindowIndex(r *http.Request) (int, bool) {
+	indexStr := chi.URLParam(r, "index")
+	index, err := strconv.Atoi(indexStr)
+	if err != nil || index < 0 {
+		return 0, false
+	}
+	return index, true
+}
+
+func (s *Server) handleWindowKill(w http.ResponseWriter, r *http.Request) {
+	session := chi.URLParam(r, "session")
+	if errMsg := validate.ValidateName(session, "Session name"); errMsg != "" {
+		writeError(w, http.StatusBadRequest, errMsg)
+		return
+	}
+
+	index, ok := parseWindowIndex(r)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "Invalid window index")
+		return
+	}
+
+	if err := s.tmux.KillWindow(session, index); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+func (s *Server) handleWindowRename(w http.ResponseWriter, r *http.Request) {
+	session := chi.URLParam(r, "session")
+	if errMsg := validate.ValidateName(session, "Session name"); errMsg != "" {
+		writeError(w, http.StatusBadRequest, errMsg)
+		return
+	}
+
+	index, ok := parseWindowIndex(r)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "Invalid window index")
+		return
+	}
+
+	var body struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid JSON body")
+		return
+	}
+
+	if errMsg := validate.ValidateName(body.Name, "Window name"); errMsg != "" {
+		writeError(w, http.StatusBadRequest, errMsg)
+		return
+	}
+
+	if err := s.tmux.RenameWindow(session, index, body.Name); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+func (s *Server) handleWindowKeys(w http.ResponseWriter, r *http.Request) {
+	session := chi.URLParam(r, "session")
+	if errMsg := validate.ValidateName(session, "Session name"); errMsg != "" {
+		writeError(w, http.StatusBadRequest, errMsg)
+		return
+	}
+
+	index, ok := parseWindowIndex(r)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "Invalid window index")
+		return
+	}
+
+	var body struct {
+		Keys string `json:"keys"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid JSON body")
+		return
+	}
+
+	if strings.TrimSpace(body.Keys) == "" {
+		writeError(w, http.StatusBadRequest, "Keys cannot be empty")
+		return
+	}
+
+	if err := s.tmux.SendKeys(session, index, body.Keys); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}

--- a/app/backend/api/windows_test.go
+++ b/app/backend/api/windows_test.go
@@ -1,0 +1,209 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestWindowCreate(t *testing.T) {
+	ops := &mockTmuxOps{}
+	router := newTestRouter(&mockSessionFetcher{}, ops)
+
+	body := `{"name":"feature","cwd":"~/code/run-kit"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/run-kit/windows", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusCreated)
+	}
+
+	if !ops.createWindowCalled {
+		t.Error("CreateWindow was not called")
+	}
+	if ops.createWindowSession != "run-kit" {
+		t.Errorf("session = %q, want %q", ops.createWindowSession, "run-kit")
+	}
+	if ops.createWindowName != "feature" {
+		t.Errorf("name = %q, want %q", ops.createWindowName, "feature")
+	}
+}
+
+func TestWindowCreateInvalidSession(t *testing.T) {
+	router := newTestRouter(&mockSessionFetcher{}, &mockTmuxOps{})
+
+	body := `{"name":"win"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/bad;session/windows", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestWindowCreateInvalidWindowName(t *testing.T) {
+	router := newTestRouter(&mockSessionFetcher{}, &mockTmuxOps{})
+
+	body := `{"name":""}`
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/run-kit/windows", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestWindowKill(t *testing.T) {
+	ops := &mockTmuxOps{}
+	router := newTestRouter(&mockSessionFetcher{}, ops)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/run-kit/windows/1/kill", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	if !ops.killWindowCalled {
+		t.Error("KillWindow was not called")
+	}
+	if ops.killWindowSession != "run-kit" {
+		t.Errorf("session = %q, want %q", ops.killWindowSession, "run-kit")
+	}
+	if ops.killWindowIndex != 1 {
+		t.Errorf("index = %d, want %d", ops.killWindowIndex, 1)
+	}
+}
+
+func TestWindowKillInvalidIndex(t *testing.T) {
+	router := newTestRouter(&mockSessionFetcher{}, &mockTmuxOps{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/run-kit/windows/abc/kill", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+
+	var result map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if result["error"] != "Invalid window index" {
+		t.Errorf("error = %q, want %q", result["error"], "Invalid window index")
+	}
+}
+
+func TestWindowKillNegativeIndex(t *testing.T) {
+	router := newTestRouter(&mockSessionFetcher{}, &mockTmuxOps{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/run-kit/windows/-1/kill", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestWindowRename(t *testing.T) {
+	ops := &mockTmuxOps{}
+	router := newTestRouter(&mockSessionFetcher{}, ops)
+
+	body := `{"name":"new-name"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/run-kit/windows/1/rename", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	if !ops.renameWindowCalled {
+		t.Error("RenameWindow was not called")
+	}
+	if ops.renameWindowSession != "run-kit" {
+		t.Errorf("session = %q, want %q", ops.renameWindowSession, "run-kit")
+	}
+	if ops.renameWindowIndex != 1 {
+		t.Errorf("index = %d, want %d", ops.renameWindowIndex, 1)
+	}
+	if ops.renameWindowName != "new-name" {
+		t.Errorf("name = %q, want %q", ops.renameWindowName, "new-name")
+	}
+}
+
+func TestWindowRenameEmptyName(t *testing.T) {
+	router := newTestRouter(&mockSessionFetcher{}, &mockTmuxOps{})
+
+	body := `{"name":""}`
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/run-kit/windows/0/rename", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestWindowKeys(t *testing.T) {
+	ops := &mockTmuxOps{}
+	router := newTestRouter(&mockSessionFetcher{}, ops)
+
+	body := `{"keys":"echo hello"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/run-kit/windows/0/keys", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	if !ops.sendKeysCalled {
+		t.Error("SendKeys was not called")
+	}
+	if ops.sendKeysSession != "run-kit" {
+		t.Errorf("session = %q, want %q", ops.sendKeysSession, "run-kit")
+	}
+	if ops.sendKeysWindow != 0 {
+		t.Errorf("window = %d, want %d", ops.sendKeysWindow, 0)
+	}
+	if ops.sendKeysKeys != "echo hello" {
+		t.Errorf("keys = %q, want %q", ops.sendKeysKeys, "echo hello")
+	}
+}
+
+func TestWindowKeysEmpty(t *testing.T) {
+	router := newTestRouter(&mockSessionFetcher{}, &mockTmuxOps{})
+
+	body := `{"keys":"  "}`
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/run-kit/windows/0/keys", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+
+	var result map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if result["error"] != "Keys cannot be empty" {
+		t.Errorf("error = %q, want %q", result["error"], "Keys cannot be empty")
+	}
+}

--- a/app/backend/cmd/run-kit/main.go
+++ b/app/backend/cmd/run-kit/main.go
@@ -1,17 +1,52 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"run-kit/api"
+	"run-kit/internal/config"
 )
 
 func main() {
-	fmt.Println("run-kit")
+	cfg := config.Load()
 
-	http.HandleFunc("/api/health", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"status":"ok"}`))
-	})
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	slog.SetDefault(logger)
 
-	http.ListenAndServe(":3000", nil)
+	router := api.NewRouter(logger)
+
+	addr := fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
+	server := &http.Server{
+		Addr:    addr,
+		Handler: router,
+	}
+
+	// Graceful shutdown via SIGINT/SIGTERM
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	go func() {
+		slog.Info("server starting", "addr", addr)
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("server error", "err", err)
+			os.Exit(1)
+		}
+	}()
+
+	<-ctx.Done()
+	slog.Info("shutting down...")
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		slog.Error("shutdown error", "err", err)
+	}
 }

--- a/app/backend/go.sum
+++ b/app/backend/go.sum
@@ -1,6 +1,12 @@
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
 github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/go-chi/cors v1.2.2 h1:Jmey33TE+b+rB7fT8MUy1u0I4L+NARQlK6LhzKPSyQE=
 github.com/go-chi/cors v1.2.2/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/app/backend/internal/config/config.go
+++ b/app/backend/internal/config/config.go
@@ -1,4 +1,86 @@
 package config
 
-// Placeholder is a TODO marker for the config package scaffold.
-const Placeholder = "TODO"
+import (
+	"flag"
+	"log/slog"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config holds server configuration.
+type Config struct {
+	Port int    `yaml:"port"`
+	Host string `yaml:"host"`
+}
+
+var defaults = Config{
+	Port: 3000,
+	Host: "127.0.0.1",
+}
+
+// validPort returns true if the port is in the valid range 1-65535.
+func validPort(p int) bool {
+	return p >= 1 && p <= 65535
+}
+
+// readYAML reads config from run-kit.yaml. Returns zero-value fields for missing/invalid values.
+func readYAML() Config {
+	data, err := os.ReadFile("run-kit.yaml")
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Warn("error reading run-kit.yaml", "err", err)
+		}
+		return Config{}
+	}
+
+	var doc struct {
+		Server struct {
+			Port *int   `yaml:"port"`
+			Host string `yaml:"host"`
+		} `yaml:"server"`
+	}
+
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		slog.Warn("error parsing run-kit.yaml", "err", err)
+		return Config{}
+	}
+
+	var cfg Config
+	if doc.Server.Port != nil && validPort(*doc.Server.Port) {
+		cfg.Port = *doc.Server.Port
+	}
+	if doc.Server.Host != "" {
+		cfg.Host = doc.Server.Host
+	}
+	return cfg
+}
+
+// Load reads configuration with resolution order: CLI flags > run-kit.yaml > defaults.
+func Load() Config {
+	portFlag := flag.Int("port", 0, "server port")
+	hostFlag := flag.String("host", "", "bind address")
+	flag.Parse()
+
+	yamlCfg := readYAML()
+
+	cfg := defaults
+
+	// YAML overrides defaults
+	if yamlCfg.Port != 0 {
+		cfg.Port = yamlCfg.Port
+	}
+	if yamlCfg.Host != "" {
+		cfg.Host = yamlCfg.Host
+	}
+
+	// CLI overrides YAML
+	if *portFlag != 0 && validPort(*portFlag) {
+		cfg.Port = *portFlag
+	}
+	if *hostFlag != "" {
+		cfg.Host = *hostFlag
+	}
+
+	return cfg
+}

--- a/app/backend/internal/config/config_test.go
+++ b/app/backend/internal/config/config_test.go
@@ -1,1 +1,39 @@
 package config
+
+import (
+	"testing"
+)
+
+func TestValidPort(t *testing.T) {
+	tests := []struct {
+		name string
+		port int
+		want bool
+	}{
+		{"valid lower bound", 1, true},
+		{"valid upper bound", 65535, true},
+		{"valid common port", 3000, true},
+		{"zero", 0, false},
+		{"negative", -1, false},
+		{"above upper bound", 65536, false},
+		{"way above", 99999, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := validPort(tt.port)
+			if got != tt.want {
+				t.Errorf("validPort(%d) = %v, want %v", tt.port, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaults(t *testing.T) {
+	if defaults.Port != 3000 {
+		t.Errorf("default port = %d, want 3000", defaults.Port)
+	}
+	if defaults.Host != "127.0.0.1" {
+		t.Errorf("default host = %q, want 127.0.0.1", defaults.Host)
+	}
+}

--- a/app/backend/internal/fab/fab.go
+++ b/app/backend/internal/fab/fab.go
@@ -1,4 +1,58 @@
 package fab
 
-// Placeholder is a TODO marker for the fab package scaffold.
-const Placeholder = "TODO"
+import (
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// stageOrder defines the canonical order of fab pipeline stages.
+var stageOrder = []string{
+	"intake", "spec", "tasks", "apply", "review", "hydrate", "ship", "review-pr",
+}
+
+// State holds the active fab change name and current stage.
+type State struct {
+	Change string // active change folder name
+	Stage  string // first stage with "active" progress, empty if none
+}
+
+// statusFile is the YAML structure of .fab-status.yaml.
+type statusFile struct {
+	Name     string            `yaml:"name"`
+	Progress map[string]string `yaml:"progress"`
+}
+
+// ReadState reads .fab-status.yaml from projectRoot and returns the active
+// change name and current stage. Returns nil if the file does not exist,
+// is a dangling symlink, or cannot be parsed.
+func ReadState(projectRoot string) *State {
+	data, err := os.ReadFile(filepath.Join(projectRoot, ".fab-status.yaml"))
+	if err != nil {
+		return nil
+	}
+
+	var status statusFile
+	if err := yaml.Unmarshal(data, &status); err != nil {
+		return nil
+	}
+
+	if status.Name == "" {
+		return nil
+	}
+
+	// Find the first active stage in canonical order.
+	stage := ""
+	for _, s := range stageOrder {
+		if status.Progress[s] == "active" {
+			stage = s
+			break
+		}
+	}
+
+	return &State{
+		Change: status.Name,
+		Stage:  stage,
+	}
+}

--- a/app/backend/internal/fab/fab_test.go
+++ b/app/backend/internal/fab/fab_test.go
@@ -1,1 +1,212 @@
 package fab
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadState(t *testing.T) {
+	tests := []struct {
+		name       string
+		setup      func(t *testing.T) string
+		wantNil    bool
+		wantChange string
+		wantStage  string
+	}{
+		{
+			name: "active change with active stage",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				yaml := `name: 260312-r4t9-go-backend-api
+progress:
+  intake: done
+  spec: done
+  tasks: done
+  apply: active
+  review: pending
+  hydrate: pending
+  ship: pending
+  review-pr: pending
+`
+				writeFile(t, dir, ".fab-status.yaml", yaml)
+				return dir
+			},
+			wantNil:    false,
+			wantChange: "260312-r4t9-go-backend-api",
+			wantStage:  "apply",
+		},
+		{
+			name: "no file returns nil",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				return t.TempDir()
+			},
+			wantNil: true,
+		},
+		{
+			name: "dangling symlink returns nil",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				// Create a symlink to a nonexistent target
+				target := filepath.Join(dir, "nonexistent-target.yaml")
+				link := filepath.Join(dir, ".fab-status.yaml")
+				if err := os.Symlink(target, link); err != nil {
+					t.Fatal(err)
+				}
+				return dir
+			},
+			wantNil: true,
+		},
+		{
+			name: "all stages done returns change with empty stage",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				yaml := `name: 260312-abc-feature
+progress:
+  intake: done
+  spec: done
+  tasks: done
+  apply: done
+  review: done
+  hydrate: done
+  ship: done
+  review-pr: done
+`
+				writeFile(t, dir, ".fab-status.yaml", yaml)
+				return dir
+			},
+			wantNil:    false,
+			wantChange: "260312-abc-feature",
+			wantStage:  "",
+		},
+		{
+			name: "all stages pending returns change with empty stage",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				yaml := `name: 260312-xyz-other
+progress:
+  intake: pending
+  spec: pending
+  tasks: pending
+  apply: pending
+  review: pending
+  hydrate: pending
+  ship: pending
+  review-pr: pending
+`
+				writeFile(t, dir, ".fab-status.yaml", yaml)
+				return dir
+			},
+			wantNil:    false,
+			wantChange: "260312-xyz-other",
+			wantStage:  "",
+		},
+		{
+			name: "invalid YAML returns nil",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				writeFile(t, dir, ".fab-status.yaml", "{{invalid yaml")
+				return dir
+			},
+			wantNil: true,
+		},
+		{
+			name: "empty name returns nil",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				yaml := `name: ""
+progress:
+  apply: active
+`
+				writeFile(t, dir, ".fab-status.yaml", yaml)
+				return dir
+			},
+			wantNil: true,
+		},
+		{
+			name: "first active stage in canonical order wins",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				yaml := `name: 260312-multi-active
+progress:
+  intake: done
+  spec: active
+  tasks: active
+  apply: pending
+`
+				writeFile(t, dir, ".fab-status.yaml", yaml)
+				return dir
+			},
+			wantNil:    false,
+			wantChange: "260312-multi-active",
+			wantStage:  "spec",
+		},
+		{
+			name: "symlink to real file works",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				yaml := `name: 260312-linked-change
+progress:
+  intake: active
+`
+				// Write the real file in a subdirectory
+				subDir := filepath.Join(dir, "changes")
+				if err := os.MkdirAll(subDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				realFile := filepath.Join(subDir, "status.yaml")
+				if err := os.WriteFile(realFile, []byte(yaml), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				// Symlink .fab-status.yaml -> changes/status.yaml
+				if err := os.Symlink(realFile, filepath.Join(dir, ".fab-status.yaml")); err != nil {
+					t.Fatal(err)
+				}
+				return dir
+			},
+			wantNil:    false,
+			wantChange: "260312-linked-change",
+			wantStage:  "intake",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := tt.setup(t)
+			got := ReadState(dir)
+
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("ReadState() = %+v, want nil", got)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Fatal("ReadState() = nil, want non-nil")
+			}
+			if got.Change != tt.wantChange {
+				t.Errorf("Change = %q, want %q", got.Change, tt.wantChange)
+			}
+			if got.Stage != tt.wantStage {
+				t.Errorf("Stage = %q, want %q", got.Stage, tt.wantStage)
+			}
+		})
+	}
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/app/backend/internal/sessions/sessions.go
+++ b/app/backend/internal/sessions/sessions.go
@@ -1,4 +1,113 @@
 package sessions
 
-// Placeholder is a TODO marker for the sessions package scaffold.
-const Placeholder = "TODO"
+import (
+	"os"
+	"path/filepath"
+	"sync"
+
+	"run-kit/internal/fab"
+	"run-kit/internal/tmux"
+)
+
+// ProjectSession is a tmux session with its windows and optional fab enrichment.
+type ProjectSession struct {
+	Name    string            `json:"name"`
+	Windows []tmux.WindowInfo `json:"windows"`
+}
+
+// hasFabKit checks if a project root contains a fab-kit project.
+func hasFabKit(projectRoot string) bool {
+	_, err := os.Stat(filepath.Join(projectRoot, "fab/project/config.yaml"))
+	return err == nil
+}
+
+// enrichSession reads .fab-status.yaml once from the project root (window 0's
+// WorktreePath) and applies the fab state to ALL windows in the session.
+func enrichSession(windows []tmux.WindowInfo, projectRoot string) {
+	state := fab.ReadState(projectRoot)
+	if state == nil {
+		return
+	}
+	for i := range windows {
+		windows[i].FabChange = state.Change
+		windows[i].FabStage = state.Stage
+	}
+}
+
+// FetchSessions fetches all sessions, derives project roots from tmux, and enriches with fab state.
+func FetchSessions() ([]ProjectSession, error) {
+	sessionNames, err := tmux.ListSessions()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(sessionNames) == 0 {
+		return []ProjectSession{}, nil
+	}
+
+	// Fetch windows for all sessions in parallel
+	type sessionData struct {
+		name    string
+		windows []tmux.WindowInfo
+	}
+
+	data := make([]sessionData, len(sessionNames))
+	var wg sync.WaitGroup
+
+	for i, name := range sessionNames {
+		wg.Add(1)
+		go func(idx int, sName string) {
+			defer wg.Done()
+			windows, _ := tmux.ListWindows(sName)
+			if windows == nil {
+				windows = []tmux.WindowInfo{}
+			}
+			data[idx] = sessionData{name: sName, windows: windows}
+		}(i, name)
+	}
+	wg.Wait()
+
+	// Enrich all sessions in parallel, preserve tmux ordering via indexed assignment
+	result := make([]ProjectSession, len(data))
+	var enrichWg sync.WaitGroup
+
+	for i, sd := range data {
+		enrichWg.Add(1)
+		go func(idx int, sd sessionData) {
+			defer enrichWg.Done()
+
+			projectRoot := ""
+			if len(sd.windows) > 0 {
+				projectRoot = sd.windows[0].WorktreePath
+			}
+
+			if projectRoot != "" && hasFabKit(projectRoot) {
+				enrichSession(sd.windows, projectRoot)
+			}
+
+			result[idx] = ProjectSession{Name: sd.name, Windows: sd.windows}
+		}(i, sd)
+	}
+	enrichWg.Wait()
+
+	return result, nil
+}
+
+// ProjectRoot derives the project root from a session's target window.
+func ProjectRoot(session string, windowIndex int) (string, error) {
+	windows, err := tmux.ListWindows(session)
+	if err != nil {
+		return "", err
+	}
+	if len(windows) == 0 {
+		return "", nil
+	}
+
+	for _, w := range windows {
+		if w.Index == windowIndex {
+			return w.WorktreePath, nil
+		}
+	}
+	// Fall back to first window
+	return windows[0].WorktreePath, nil
+}

--- a/app/backend/internal/sessions/sessions_test.go
+++ b/app/backend/internal/sessions/sessions_test.go
@@ -1,1 +1,206 @@
 package sessions
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"run-kit/internal/tmux"
+)
+
+func TestHasFabKit(t *testing.T) {
+	tests := []struct {
+		name       string
+		setupDir   func(t *testing.T) string
+		wantResult bool
+	}{
+		{
+			name: "returns true when fab/project/config.yaml exists",
+			setupDir: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				configDir := filepath.Join(dir, "fab", "project")
+				if err := os.MkdirAll(configDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte("name: test"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return dir
+			},
+			wantResult: true,
+		},
+		{
+			name: "returns false when fab/project/config.yaml does not exist",
+			setupDir: func(t *testing.T) string {
+				t.Helper()
+				return t.TempDir()
+			},
+			wantResult: false,
+		},
+		{
+			name: "returns false when fab dir exists but config.yaml is missing",
+			setupDir: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				if err := os.MkdirAll(filepath.Join(dir, "fab", "project"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				return dir
+			},
+			wantResult: false,
+		},
+		{
+			name: "returns false for empty string",
+			setupDir: func(t *testing.T) string {
+				t.Helper()
+				return ""
+			},
+			wantResult: false,
+		},
+		{
+			name: "returns false for nonexistent directory",
+			setupDir: func(t *testing.T) string {
+				t.Helper()
+				return "/nonexistent/path/that/does/not/exist"
+			},
+			wantResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := tt.setupDir(t)
+			got := hasFabKit(dir)
+			if got != tt.wantResult {
+				t.Errorf("hasFabKit(%q) = %v, want %v", dir, got, tt.wantResult)
+			}
+		})
+	}
+}
+
+func TestProjectRootDerivation(t *testing.T) {
+	tests := []struct {
+		name     string
+		windows  []tmux.WindowInfo
+		wantRoot string
+	}{
+		{
+			name: "project root from first window",
+			windows: []tmux.WindowInfo{
+				{Index: 0, Name: "main", WorktreePath: "/home/user/project"},
+				{Index: 1, Name: "build", WorktreePath: "/tmp/build"},
+			},
+			wantRoot: "/home/user/project",
+		},
+		{
+			name:     "empty windows returns empty root",
+			windows:  []tmux.WindowInfo{},
+			wantRoot: "",
+		},
+		{
+			name: "single window",
+			windows: []tmux.WindowInfo{
+				{Index: 0, Name: "dev", WorktreePath: "/home/user/code"},
+			},
+			wantRoot: "/home/user/code",
+		},
+		{
+			name: "first window has empty path",
+			windows: []tmux.WindowInfo{
+				{Index: 0, Name: "main", WorktreePath: ""},
+				{Index: 1, Name: "sub", WorktreePath: "/home/user/other"},
+			},
+			wantRoot: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			projectRoot := ""
+			if len(tt.windows) > 0 {
+				projectRoot = tt.windows[0].WorktreePath
+			}
+			if projectRoot != tt.wantRoot {
+				t.Errorf("projectRoot = %q, want %q", projectRoot, tt.wantRoot)
+			}
+		})
+	}
+}
+
+func TestEnrichSessionWithFabState(t *testing.T) {
+	// Create a project root with .fab-status.yaml
+	dir := t.TempDir()
+	yaml := `name: 260312-abc-feature
+progress:
+  intake: done
+  spec: done
+  tasks: done
+  apply: active
+  review: pending
+`
+	if err := os.WriteFile(filepath.Join(dir, ".fab-status.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	windows := []tmux.WindowInfo{
+		{Index: 0, Name: "main", WorktreePath: dir},
+		{Index: 1, Name: "build", WorktreePath: "/tmp/build"},
+		{Index: 2, Name: "test", WorktreePath: "/tmp/test"},
+	}
+
+	enrichSession(windows, dir)
+
+	// All windows should share the same fab state
+	for i, win := range windows {
+		if win.FabChange != "260312-abc-feature" {
+			t.Errorf("window[%d].FabChange = %q, want %q", i, win.FabChange, "260312-abc-feature")
+		}
+		if win.FabStage != "apply" {
+			t.Errorf("window[%d].FabStage = %q, want %q", i, win.FabStage, "apply")
+		}
+	}
+}
+
+func TestEnrichSessionNoFabFile(t *testing.T) {
+	dir := t.TempDir()
+
+	windows := []tmux.WindowInfo{
+		{Index: 0, Name: "test", WorktreePath: dir},
+		{Index: 1, Name: "other", WorktreePath: dir},
+	}
+
+	enrichSession(windows, dir)
+
+	for i, win := range windows {
+		if win.FabChange != "" {
+			t.Errorf("window[%d].FabChange = %q, want empty", i, win.FabChange)
+		}
+		if win.FabStage != "" {
+			t.Errorf("window[%d].FabStage = %q, want empty", i, win.FabStage)
+		}
+	}
+}
+
+func TestProjectSessionStruct(t *testing.T) {
+	ps := ProjectSession{
+		Name: "my-project",
+		Windows: []tmux.WindowInfo{
+			{Index: 0, Name: "main", WorktreePath: "/home/user/project", Activity: "active", IsActiveWindow: true},
+			{Index: 1, Name: "build", WorktreePath: "/tmp/build", Activity: "idle", IsActiveWindow: false},
+		},
+	}
+
+	if ps.Name != "my-project" {
+		t.Errorf("Name = %q, want %q", ps.Name, "my-project")
+	}
+	if len(ps.Windows) != 2 {
+		t.Fatalf("Windows count = %d, want 2", len(ps.Windows))
+	}
+	if ps.Windows[0].IsActiveWindow != true {
+		t.Error("Windows[0].IsActiveWindow should be true")
+	}
+	if ps.Windows[1].IsActiveWindow != false {
+		t.Error("Windows[1].IsActiveWindow should be false")
+	}
+}

--- a/app/backend/internal/tmux/tmux.go
+++ b/app/backend/internal/tmux/tmux.go
@@ -1,4 +1,249 @@
 package tmux
 
-// Placeholder is a TODO marker for the tmux package scaffold.
-const Placeholder = "TODO"
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// TmuxTimeout is the default timeout for tmux commands.
+	TmuxTimeout = 10 * time.Second
+	// ActivityThresholdSeconds is how recently a window must have had activity to be "active".
+	ActivityThresholdSeconds = 10
+	// listDelim is the tab delimiter used in tmux format strings.
+	listDelim = "\t"
+)
+
+// WindowInfo describes a single tmux window within a session.
+type WindowInfo struct {
+	Index          int    `json:"index"`
+	Name           string `json:"name"`
+	WorktreePath   string `json:"worktreePath"`
+	Activity       string `json:"activity"` // "active" or "idle"
+	IsActiveWindow bool   `json:"isActiveWindow"`
+	FabChange      string `json:"fabChange,omitempty"`
+	FabStage       string `json:"fabStage,omitempty"`
+}
+
+// tmuxExec runs a tmux command with a timeout and returns stdout lines (empty lines filtered).
+func tmuxExec(ctx context.Context, args ...string) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "tmux", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	raw := strings.TrimSpace(string(out))
+	if raw == "" {
+		return nil, nil
+	}
+	lines := strings.Split(raw, "\n")
+	var result []string
+	for _, l := range lines {
+		if l != "" {
+			result = append(result, l)
+		}
+	}
+	return result, nil
+}
+
+// tmuxExecRaw runs a tmux command and returns raw stdout.
+func tmuxExecRaw(ctx context.Context, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "tmux", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// withTimeout creates a context with the default tmux timeout.
+func withTimeout() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), TmuxTimeout)
+}
+
+// parseSessions parses tmux list-sessions output lines into session names,
+// filtering out byobu session-group copies. Exported for testing.
+func parseSessions(lines []string) []string {
+	var sessions []string
+	for _, line := range lines {
+		parts := strings.Split(line, listDelim)
+		if len(parts) < 3 {
+			continue
+		}
+		name, grouped, group := parts[0], parts[1], parts[2]
+		// Filter out session-group copies: keep if ungrouped or if name matches group
+		if grouped == "0" || name == group {
+			sessions = append(sessions, name)
+		}
+	}
+	return sessions
+}
+
+// ListSessions returns all tmux session names, filtering out byobu session-group copies.
+// Returns nil if tmux server is not running.
+func ListSessions() ([]string, error) {
+	ctx, cancel := withTimeout()
+	defer cancel()
+
+	format := fmt.Sprintf("#{session_name}%s#{session_grouped}%s#{session_group}", listDelim, listDelim)
+	lines, err := tmuxExec(ctx, "list-sessions", "-F", format)
+	if err != nil {
+		// tmux not running or no sessions
+		return nil, nil
+	}
+
+	return parseSessions(lines), nil
+}
+
+// parseWindows parses tmux list-windows output lines into WindowInfo structs.
+// nowUnix is the current Unix timestamp for activity threshold computation.
+// Exported for testing.
+func parseWindows(lines []string, nowUnix int64) []WindowInfo {
+	var windows []WindowInfo
+	for _, line := range lines {
+		parts := strings.Split(line, listDelim)
+		if len(parts) < 5 {
+			continue
+		}
+
+		index, _ := strconv.Atoi(parts[0])
+		activityTs, _ := strconv.ParseInt(parts[3], 10, 64)
+
+		activity := "idle"
+		if nowUnix-activityTs <= ActivityThresholdSeconds {
+			activity = "active"
+		}
+		isActive := strings.TrimSpace(parts[4]) == "1"
+
+		windows = append(windows, WindowInfo{
+			Index:          index,
+			Name:           parts[1],
+			WorktreePath:   parts[2],
+			Activity:       activity,
+			IsActiveWindow: isActive,
+		})
+	}
+	return windows
+}
+
+// ListWindows returns windows for a given session. Returns nil if session does not exist.
+func ListWindows(session string) ([]WindowInfo, error) {
+	ctx, cancel := withTimeout()
+	defer cancel()
+
+	format := strings.Join([]string{
+		"#{window_index}",
+		"#{window_name}",
+		"#{pane_current_path}",
+		"#{window_activity}",
+		"#{window_active}",
+	}, listDelim)
+
+	lines, err := tmuxExec(ctx, "list-windows", "-t", session, "-F", format)
+	if err != nil {
+		return nil, nil
+	}
+
+	return parseWindows(lines, time.Now().Unix()), nil
+}
+
+// CreateSession creates a new detached tmux session, optionally in a specific directory.
+func CreateSession(name string, cwd string) error {
+	ctx, cancel := withTimeout()
+	defer cancel()
+
+	args := []string{"new-session", "-d", "-s", name}
+	if cwd != "" {
+		args = append(args, "-c", cwd)
+	}
+	_, err := tmuxExec(ctx, args...)
+	return err
+}
+
+// CreateWindow creates a new window in an existing session.
+func CreateWindow(session, name, cwd string) error {
+	ctx, cancel := withTimeout()
+	defer cancel()
+
+	_, err := tmuxExec(ctx, "new-window", "-t", session, "-n", name, "-c", cwd)
+	return err
+}
+
+// KillSession kills an entire tmux session.
+func KillSession(session string) error {
+	ctx, cancel := withTimeout()
+	defer cancel()
+
+	_, err := tmuxExec(ctx, "kill-session", "-t", session)
+	return err
+}
+
+// KillWindow kills a window by session and index.
+func KillWindow(session string, index int) error {
+	ctx, cancel := withTimeout()
+	defer cancel()
+
+	target := fmt.Sprintf("%s:%d", session, index)
+	_, err := tmuxExec(ctx, "kill-window", "-t", target)
+	return err
+}
+
+// RenameWindow renames a window by session and index.
+func RenameWindow(session string, index int, name string) error {
+	ctx, cancel := withTimeout()
+	defer cancel()
+
+	target := fmt.Sprintf("%s:%d", session, index)
+	_, err := tmuxExec(ctx, "rename-window", "-t", target, name)
+	return err
+}
+
+// SendKeys sends keystrokes to a tmux window.
+func SendKeys(session string, window int, keys string) error {
+	ctx, cancel := withTimeout()
+	defer cancel()
+
+	target := fmt.Sprintf("%s:%d", session, window)
+	_, err := tmuxExec(ctx, "send-keys", "-t", target, keys, "Enter")
+	return err
+}
+
+// SplitWindow splits a window to create an independent pane. Returns the new pane ID.
+func SplitWindow(session string, window int) (string, error) {
+	ctx, cancel := withTimeout()
+	defer cancel()
+
+	target := fmt.Sprintf("%s:%d", session, window)
+	lines, err := tmuxExec(ctx, "split-window", "-t", target, "-d", "-P", "-F", "#{pane_id}")
+	if err != nil {
+		return "", err
+	}
+	if len(lines) == 0 {
+		return "", fmt.Errorf("split-window returned no pane ID")
+	}
+	return lines[0], nil
+}
+
+// KillPane kills a specific pane by ID.
+func KillPane(paneID string) error {
+	ctx, cancel := withTimeout()
+	defer cancel()
+
+	_, err := tmuxExec(ctx, "kill-pane", "-t", paneID)
+	// Pane may already be dead — ignore errors
+	_ = err
+	return nil
+}
+
+// CapturePane captures pane content (last N lines). Preserves blank lines.
+func CapturePane(paneID string, lines int) (string, error) {
+	ctx, cancel := withTimeout()
+	defer cancel()
+
+	start := -lines
+	return tmuxExecRaw(ctx, "capture-pane", "-t", paneID, "-p", "-S", strconv.Itoa(start))
+}

--- a/app/backend/internal/tmux/tmux_test.go
+++ b/app/backend/internal/tmux/tmux_test.go
@@ -1,1 +1,234 @@
 package tmux
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// Helper to build a tab-delimited tmux line.
+func sessionLine(name, grouped, group string) string {
+	return strings.Join([]string{name, grouped, group}, listDelim)
+}
+
+func windowLine(index int, name, path string, activityTs int64, active int) string {
+	return fmt.Sprintf("%d%s%s%s%s%s%d%s%d",
+		index, listDelim, name, listDelim, path, listDelim, activityTs, listDelim, active)
+}
+
+func TestParseSessions(t *testing.T) {
+	tests := []struct {
+		name  string
+		lines []string
+		want  []string
+	}{
+		{
+			name: "standard sessions with session_grouped=0",
+			lines: []string{
+				sessionLine("alpha", "0", "alpha"),
+				sessionLine("beta", "0", "beta"),
+			},
+			want: []string{"alpha", "beta"},
+		},
+		{
+			name: "filters out session-group copies (grouped=1, name != group)",
+			lines: []string{
+				sessionLine("devshell", "0", "devshell"),
+				sessionLine("devshell-82", "1", "devshell"),
+			},
+			want: []string{"devshell"},
+		},
+		{
+			name: "keeps group-named session (grouped=1, name == group)",
+			lines: []string{
+				sessionLine("mygroup", "1", "mygroup"),
+			},
+			want: []string{"mygroup"},
+		},
+		{
+			name:  "empty input returns nil",
+			lines: nil,
+			want:  nil,
+		},
+		{
+			name:  "empty slice returns nil",
+			lines: []string{},
+			want:  nil,
+		},
+		{
+			name: "malformed line with fewer than 3 fields is skipped",
+			lines: []string{
+				"onlyname",
+				sessionLine("good", "0", "good"),
+			},
+			want: []string{"good"},
+		},
+		{
+			name: "multiple session-group copies filtered, original kept",
+			lines: []string{
+				sessionLine("proj", "0", "proj"),
+				sessionLine("proj-1", "1", "proj"),
+				sessionLine("proj-2", "1", "proj"),
+			},
+			want: []string{"proj"},
+		},
+		{
+			name: "mixed grouped and ungrouped sessions",
+			lines: []string{
+				sessionLine("alpha", "0", "alpha"),
+				sessionLine("beta", "1", "beta"),
+				sessionLine("beta-N", "1", "beta"),
+				sessionLine("gamma", "0", "gamma"),
+			},
+			want: []string{"alpha", "beta", "gamma"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseSessions(tt.lines)
+			if !stringSliceEqual(got, tt.want) {
+				t.Errorf("parseSessions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseWindows(t *testing.T) {
+	const fakeNow int64 = 1700000000
+
+	tests := []struct {
+		name  string
+		lines []string
+		now   int64
+		want  []WindowInfo
+	}{
+		{
+			name: "marks window as active when within threshold",
+			lines: []string{
+				windowLine(0, "dev", "/home/user/project", fakeNow-1, 1),
+			},
+			now: fakeNow,
+			want: []WindowInfo{
+				{Index: 0, Name: "dev", WorktreePath: "/home/user/project", Activity: "active", IsActiveWindow: true},
+			},
+		},
+		{
+			name: "marks window as idle when beyond threshold",
+			lines: []string{
+				windowLine(0, "dev", "/home/user/project", fakeNow-ActivityThresholdSeconds-100, 0),
+			},
+			now: fakeNow,
+			want: []WindowInfo{
+				{Index: 0, Name: "dev", WorktreePath: "/home/user/project", Activity: "idle", IsActiveWindow: false},
+			},
+		},
+		{
+			name: "parses all fields correctly including isActiveWindow",
+			lines: []string{
+				windowLine(0, "dev", "/home/user/project", fakeNow, 1),
+				windowLine(2, "build", "/tmp/build", fakeNow, 0),
+			},
+			now: fakeNow,
+			want: []WindowInfo{
+				{Index: 0, Name: "dev", WorktreePath: "/home/user/project", Activity: "active", IsActiveWindow: true},
+				{Index: 2, Name: "build", WorktreePath: "/tmp/build", Activity: "active", IsActiveWindow: false},
+			},
+		},
+		{
+			name:  "empty input returns nil",
+			lines: nil,
+			now:   fakeNow,
+			want:  nil,
+		},
+		{
+			name: "malformed line with fewer than 5 fields is skipped",
+			lines: []string{
+				"0\tdev\t/path",
+				windowLine(1, "good", "/home/user", fakeNow, 1),
+			},
+			now: fakeNow,
+			want: []WindowInfo{
+				{Index: 1, Name: "good", WorktreePath: "/home/user", Activity: "active", IsActiveWindow: true},
+			},
+		},
+		{
+			name: "activity exactly at threshold boundary is active",
+			lines: []string{
+				windowLine(0, "edge", "/path", fakeNow-ActivityThresholdSeconds, 0),
+			},
+			now: fakeNow,
+			want: []WindowInfo{
+				{Index: 0, Name: "edge", WorktreePath: "/path", Activity: "active", IsActiveWindow: false},
+			},
+		},
+		{
+			name: "activity one second past threshold is idle",
+			lines: []string{
+				windowLine(0, "past", "/path", fakeNow-ActivityThresholdSeconds-1, 0),
+			},
+			now: fakeNow,
+			want: []WindowInfo{
+				{Index: 0, Name: "past", WorktreePath: "/path", Activity: "idle", IsActiveWindow: false},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseWindows(tt.lines, tt.now)
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("parseWindows() = %v, want nil", got)
+				}
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseWindows() returned %d windows, want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i].Index != tt.want[i].Index {
+					t.Errorf("window[%d].Index = %d, want %d", i, got[i].Index, tt.want[i].Index)
+				}
+				if got[i].Name != tt.want[i].Name {
+					t.Errorf("window[%d].Name = %q, want %q", i, got[i].Name, tt.want[i].Name)
+				}
+				if got[i].WorktreePath != tt.want[i].WorktreePath {
+					t.Errorf("window[%d].WorktreePath = %q, want %q", i, got[i].WorktreePath, tt.want[i].WorktreePath)
+				}
+				if got[i].Activity != tt.want[i].Activity {
+					t.Errorf("window[%d].Activity = %q, want %q", i, got[i].Activity, tt.want[i].Activity)
+				}
+				if got[i].IsActiveWindow != tt.want[i].IsActiveWindow {
+					t.Errorf("window[%d].IsActiveWindow = %v, want %v", i, got[i].IsActiveWindow, tt.want[i].IsActiveWindow)
+				}
+			}
+		})
+	}
+}
+
+// stringSliceEqual compares two string slices, treating nil and empty as equivalent.
+func stringSliceEqual(a, b []string) bool {
+	if len(a) == 0 && len(b) == 0 {
+		// Both nil or empty
+		if a == nil && b == nil {
+			return true
+		}
+		if a == nil && len(b) == 0 {
+			return true
+		}
+		if b == nil && len(a) == 0 {
+			return true
+		}
+		return len(a) == len(b)
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/app/backend/internal/validate/validate.go
+++ b/app/backend/internal/validate/validate.go
@@ -1,4 +1,106 @@
 package validate
 
-// Placeholder is a TODO marker for the validate package scaffold.
-const Placeholder = "TODO"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Characters that are never valid in tmux session/window names.
+var forbiddenChars = regexp.MustCompile(`[;&|` + "`" + `$(){}[\]<>!#*?\n\r\t]`)
+
+// MaxNameLength is the maximum allowed length for names.
+const MaxNameLength = 128
+
+// ValidateName validates a tmux session or window name.
+// Returns empty string if valid, error message if invalid.
+func ValidateName(name, label string) string {
+	if strings.TrimSpace(name) == "" {
+		return fmt.Sprintf("%s cannot be empty", label)
+	}
+	if len(name) > MaxNameLength {
+		return fmt.Sprintf("%s exceeds maximum length of %d characters", label, MaxNameLength)
+	}
+	if forbiddenChars.MatchString(name) {
+		return fmt.Sprintf("%s contains forbidden characters", label)
+	}
+	if strings.Contains(name, ":") || strings.Contains(name, ".") {
+		return fmt.Sprintf("%s cannot contain colons or periods", label)
+	}
+	return ""
+}
+
+// ExpandTilde expands a leading ~ to $HOME and resolves the path.
+// Returns the expanded path and an empty error string on success,
+// or an empty path and error message on failure.
+func ExpandTilde(raw string) (string, string) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", "cannot determine home directory"
+	}
+
+	var expanded string
+
+	if raw == "~" || strings.HasPrefix(raw, "~/") {
+		expanded = filepath.Join(home, raw[1:])
+		if raw == "~" {
+			expanded = home
+		}
+	} else if strings.HasPrefix(raw, "~") {
+		// Reject ~username syntax
+		return "", "~user expansion is not supported; use ~/path"
+	} else if filepath.IsAbs(raw) {
+		expanded = filepath.Clean(raw)
+	} else {
+		// Bare relative path — resolve relative to $HOME
+		expanded = filepath.Join(home, raw)
+	}
+
+	expanded = filepath.Clean(expanded)
+
+	// Reject paths that escape $HOME
+	if expanded != home && !strings.HasPrefix(expanded, home+"/") {
+		return "", "Path must be under home directory"
+	}
+
+	return expanded, ""
+}
+
+// ValidatePath validates a file path.
+// Returns empty string if valid, error message if invalid.
+func ValidatePath(path, label string) string {
+	if strings.TrimSpace(path) == "" {
+		return fmt.Sprintf("%s cannot be empty", label)
+	}
+	if len(path) > 1024 {
+		return fmt.Sprintf("%s exceeds maximum length", label)
+	}
+	if strings.ContainsAny(path, "\x00\n\r") {
+		return fmt.Sprintf("%s contains invalid characters", label)
+	}
+	return ""
+}
+
+// SanitizeFilename sanitizes a user-provided filename for safe disk storage.
+func SanitizeFilename(name string) string {
+	// Strip null bytes
+	sanitized := strings.ReplaceAll(name, "\x00", "")
+	// Replace path separators with dash
+	sanitized = strings.NewReplacer("/", "-", "\\", "-").Replace(sanitized)
+	// Strip leading dots
+	sanitized = strings.TrimLeft(sanitized, ".")
+	// Strip sequences of 2+ dots (traversal remnants)
+	sanitized = regexp.MustCompile(`\.{2,}`).ReplaceAllString(sanitized, "")
+	// Collapse multiple dashes
+	sanitized = regexp.MustCompile(`-{2,}`).ReplaceAllString(sanitized, "-")
+	// Strip leading/trailing dashes
+	sanitized = strings.Trim(sanitized, "-")
+	sanitized = strings.TrimSpace(sanitized)
+
+	if sanitized == "" {
+		return "upload"
+	}
+	return sanitized
+}

--- a/app/backend/internal/validate/validate_test.go
+++ b/app/backend/internal/validate/validate_test.go
@@ -1,1 +1,198 @@
 package validate
+
+import (
+	"os"
+	"testing"
+)
+
+func TestValidateName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		label    string
+		wantErr  bool
+		contains string
+	}{
+		{"valid name", "my-session", "Session name", false, ""},
+		{"alphanumeric with hyphens/underscores", "test_session-123", "Name", false, ""},
+		{"empty string", "", "Session name", true, "cannot be empty"},
+		{"whitespace only", "   ", "Session name", true, "cannot be empty"},
+		{"forbidden semicolon", "my;session", "Name", true, "forbidden characters"},
+		{"forbidden ampersand", "my&session", "Name", true, "forbidden characters"},
+		{"forbidden pipe", "my|session", "Name", true, "forbidden characters"},
+		{"forbidden backtick", "my`session", "Name", true, "forbidden characters"},
+		{"forbidden dollar", "my$session", "Name", true, "forbidden characters"},
+		{"exceeds max length", string(make([]byte, 129)), "Name", true, "maximum length"},
+		{"at max length", string(make([]byte, 128)), "Name", false, ""},
+		{"contains colon", "my:session", "Name", true, "colons or periods"},
+		{"contains period", "my.session", "Name", true, "colons or periods"},
+		{"label in error", "", "Window name", true, "Window name"},
+	}
+
+	// Fill the max/over-max names with 'a'
+	for i := range tests {
+		if tests[i].name == "exceeds max length" {
+			b := make([]byte, 129)
+			for j := range b {
+				b[j] = 'a'
+			}
+			tests[i].input = string(b)
+		}
+		if tests[i].name == "at max length" {
+			b := make([]byte, 128)
+			for j := range b {
+				b[j] = 'a'
+			}
+			tests[i].input = string(b)
+		}
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ValidateName(tt.input, tt.label)
+			if tt.wantErr && result == "" {
+				t.Error("expected error but got none")
+			}
+			if !tt.wantErr && result != "" {
+				t.Errorf("expected no error but got: %s", result)
+			}
+			if tt.contains != "" && result == "" {
+				t.Errorf("expected error containing %q but got none", tt.contains)
+			}
+			if tt.contains != "" && result != "" {
+				if !contains(result, tt.contains) {
+					t.Errorf("expected error containing %q but got: %s", tt.contains, result)
+				}
+			}
+		})
+	}
+}
+
+func TestValidatePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		label    string
+		wantErr  bool
+		contains string
+	}{
+		{"valid path", "/home/user/project", "Path", false, ""},
+		{"empty string", "", "Path", true, "cannot be empty"},
+		{"null bytes", "/home/\x00evil", "Path", true, "invalid characters"},
+		{"newlines", "/home/\nevil", "Path", true, "invalid characters"},
+		{"exceeds max length", "/" + string(make([]byte, 1024)), "Path", true, "maximum length"},
+	}
+
+	// Fill the over-max path with 'a'
+	for i := range tests {
+		if tests[i].name == "exceeds max length" {
+			b := make([]byte, 1024)
+			for j := range b {
+				b[j] = 'a'
+			}
+			tests[i].input = "/" + string(b)
+		}
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ValidatePath(tt.input, tt.label)
+			if tt.wantErr && result == "" {
+				t.Error("expected error but got none")
+			}
+			if !tt.wantErr && result != "" {
+				t.Errorf("expected no error but got: %s", result)
+			}
+		})
+	}
+}
+
+func TestExpandTilde(t *testing.T) {
+	home, _ := os.UserHomeDir()
+
+	tests := []struct {
+		name        string
+		input       string
+		wantPath    string
+		wantErr     bool
+		errContains string
+	}{
+		{"tilde alone", "~", home, false, ""},
+		{"tilde path", "~/code/project", home + "/code/project", false, ""},
+		{"bare relative", "code/project", home + "/code/project", false, ""},
+		{"absolute under home", home + "/code/project", home + "/code/project", false, ""},
+		{"dot-dot escape", "~/../../etc", "", true, "under home directory"},
+		{"absolute outside home", "/etc/passwd", "", true, "under home directory"},
+		{"tilde username", "~root", "", true, "~user expansion is not supported"},
+		{"tilde other user path", "~otheruser/secret", "", true, "~user expansion is not supported"},
+		{"home itself", home, home, false, ""},
+		{"dot-dot within home", "~/code/../code/project", home + "/code/project", false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, errMsg := ExpandTilde(tt.input)
+			if tt.wantErr {
+				if errMsg == "" {
+					t.Error("expected error but got none")
+				}
+				if tt.errContains != "" && !contains(errMsg, tt.errContains) {
+					t.Errorf("expected error containing %q but got: %s", tt.errContains, errMsg)
+				}
+			} else {
+				if errMsg != "" {
+					t.Errorf("expected no error but got: %s", errMsg)
+				}
+				if path != tt.wantPath {
+					t.Errorf("expected path %q but got %q", tt.wantPath, path)
+				}
+			}
+		})
+	}
+}
+
+func TestSanitizeFilename(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"simple filename", "screenshot.png", "screenshot.png"},
+		{"forward slashes", "path/to/file.txt", "path-to-file.txt"},
+		{"backslashes", "path\\to\\file.txt", "path-to-file.txt"},
+		{"null bytes", "file\x00name.txt", "filename.txt"},
+		{"leading dots", ".hidden", "hidden"},
+		{"triple dots", "...triple", "triple"},
+		{"path traversal", "../../../etc/passwd", "etc-passwd"},
+		{"backslash traversal", "..\\..\\..\\etc\\passwd", "etc-passwd"},
+		{"collapse dashes", "a---b", "a-b"},
+		{"strip edges", "-file-", "file"},
+		{"empty string", "", "upload"},
+		{"dots only", "...", "upload"},
+		{"slashes only", "///", "upload"},
+		{"preserves extension", "my-document.pdf", "my-document.pdf"},
+		{"spaces in name", "my file name.png", "my file name.png"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeFilename(tt.input)
+			if got != tt.want {
+				t.Errorf("SanitizeFilename(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
+}
+
+func containsStr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/docs/memory/run-kit/architecture.md
+++ b/docs/memory/run-kit/architecture.md
@@ -4,61 +4,43 @@
 
 run-kit is a web-based agent orchestration dashboard. Two independent processes in production, three in development:
 
-1. **Bash supervisor** (`supervisor.sh`) — builds Go binary from `app/backend/` + frontend from `app/frontend/`, manages the server as a single deployment unit
-2. **Go backend** (default port 3000) — single binary serving REST API, SSE, WebSocket terminal relay, and SPA static files on one port
+1. **Bash supervisor** (`supervisor.sh`) — builds Go binary + frontend, manages the server as a single deployment unit
+2. **Go backend** (`app/backend/`, default port 3000) — single binary serving REST API, SSE, WebSocket terminal relay, and SPA static files on one port
 
-In development, `just dev` runs two concurrent processes (replaces the removed `dev.sh`):
-- Go backend (`:3000`) via `go run ./cmd/run-kit` from `app/backend/` — API, WebSocket relay, SPA static serving
-- Vite dev server (`:5173`) via `pnpm dev` from `app/frontend/` — HMR, proxies `/api/*` and `/relay/*` to Go via `vite.config.ts`
+> **Legacy note**: `packages/api/` contains the prior implementation, pending removal in Phase 4. The canonical backend is now `app/backend/`.
 
-Ports and bind host are configurable via CLI args > `run-kit.yaml` > hardcoded defaults. See `packages/api/internal/config/config.go` (old) / `app/backend/internal/config/` (new scaffold).
+In development, `dev.sh` runs two concurrent processes:
+- Go backend (`:3000`) — API, WebSocket relay, SPA static serving
+- Vite dev server (`:5173`) — HMR, proxies `/api/*` and `/relay/*` to Go via `vite.config.ts`
+
+Ports and bind host are configurable via CLI args > `run-kit.yaml` > hardcoded defaults. See `app/backend/internal/config/config.go`.
 
 The tmux server is an external dependency — never started or stopped by run-kit.
 
 ## Repository Structure
 
-pnpm workspaces monorepo. Two codebases coexist during the reimplementation: `packages/` (legacy, untouched until Phase 4 cleanup) and `app/` (new scaffold, Phases 1-3).
-
-### New: `app/` (scaffold — Phase 1)
+pnpm workspaces monorepo:
 
 ```
 app/
-  backend/            # Go module — new scaffold
-    cmd/run-kit/      # Entry point (main.go — prints "run-kit" and exits)
-    api/              # HTTP handler placeholders (router.go, sessions.go, windows.go,
-                      #   directories.go, upload.go, sse.go, relay.go, health.go, spa.go)
-    internal/         # tmux/, sessions/, fab/, config/, validate/ — each with
-                      #   placeholder .go + empty _test.go (no internal/worktree/ — dead code)
+  backend/            # Go module — canonical backend (Phase 2+)
+    cmd/run-kit/      # Entry point (main.go)
+    internal/         # validate, config, tmux, fab, sessions
+    api/              # HTTP handlers — one file per resource domain
+      router.go       # chi router, CORS/logger/recovery middleware, route registration
+      health.go       # GET /api/health
+      sessions.go     # GET /api/sessions, POST /api/sessions, POST .../kill
+      windows.go      # POST .../windows (create, kill, rename, keys)
+      directories.go  # GET /api/directories
+      upload.go       # POST /api/sessions/:session/upload
+      sse.go          # GET /api/sessions/stream (hub singleton)
+      relay.go        # WS /relay/:session/:window
+      spa.go          # SPA static serving from app/frontend/dist/
     go.mod, go.sum
-  frontend/           # Vite + React SPA — new scaffold
-    src/
-      api/            # Type stubs (client.ts — all functions throw "not implemented")
-      main.tsx        # Minimal React entry
-      app.tsx         # Single-view layout skeleton (top bar, sidebar, terminal, bottom bar)
-      router.tsx      # TanStack Router — one route: /:session/:window
-      types.ts        # ProjectSession, WindowInfo types matching API spec
-      test-setup.ts   # @testing-library/jest-dom/vitest
-    tests/
-      msw/            # MSW handler stubs (handlers.ts)
-      e2e/            # Playwright smoke test (smoke.spec.ts — test.skip)
-    index.html
-    vite.config.ts    # React plugin, @/ alias, proxy /api/* and /relay/* to :3000
-    vitest.config.ts  # jsdom environment
-    tsconfig.json
-    playwright.config.ts  # Chromium desktop project, tests/e2e/
-    package.json
-```
-
-### Legacy: `packages/` (functional code — until Phase 4)
-
-```
+  frontend/           # (Phase 3 — planned) Vite + React SPA
 packages/
-  api/              # Go module — stable backend (fully functional)
-    cmd/run-kit/    # Entry point (main.go)
-    internal/       # tmux, config, fab, worktree, sessions, validate, relay
-    api/            # HTTP handlers (routes.go, sse.go, relay.go, upload.go, spa.go)
-    go.mod, go.sum
-  web/              # Vite + React SPA — disposable frontend (fully functional)
+  api/                # Legacy Go backend — pending removal in Phase 4
+  web/                # Vite + React SPA — disposable frontend
     src/
       api/          # Typed fetch wrappers (client.ts)
       components/   # React components
@@ -69,38 +51,34 @@ packages/
       types.ts      # Shared TypeScript types
     vite.config.ts
     vitest.config.ts
-```
-
-### Root files
-
-```
-e2e/                # Playwright E2E tests (legacy, for packages/web)
+e2e/                # Playwright E2E tests
 fab/                # Fab-kit project config + changes
 docs/               # Memory files
-justfile            # Task runner — all recipes target app/ paths (replaced dev.sh)
-supervisor.sh       # Production process manager (updated to app/ paths)
+supervisor.sh       # Production process manager
+dev.sh              # Development launcher (Go + Vite concurrent)
 Caddyfile.example   # HTTPS reverse proxy (TLS termination only)
-pnpm-workspace.yaml # ["app/frontend"] — updated from ["packages/web"]
+pnpm-workspace.yaml # ["packages/web"] — Go is independent
 ```
 
 ## Data Model
 
 **No database.** State derived at request time from:
 - **tmux server** — `tmux list-sessions`, `tmux list-windows` via `internal/tmux/tmux.go`. Project roots derived from window 0's `pane_current_path`
-- **Filesystem** — `fab/current`, `.status.yaml` via `internal/fab/fab.go`. Fab-kit projects auto-detected via `os.Stat()` on `fab/project/config.yaml` at the derived project root
+- **Filesystem** — `.fab-status.yaml` via `internal/fab/fab.go` (reads change name + active stage). Fab-kit projects auto-detected via `os.Stat()` on `fab/project/config.yaml` at the derived project root
 
 ## Backend Libraries (Go Modules)
 
-Functional code lives in `packages/api/` until Phase 2+ ports it to `app/backend/`. The `app/backend/internal/` packages are empty placeholders (package declaration + exported placeholder + empty `_test.go`). No `internal/worktree/` in `app/backend/` — removed as dead code not exposed via API.
+Packages in `app/backend/internal/`:
 
 | Package | Responsibility |
 |---------|---------------|
-| `internal/tmux` | All tmux operations via `os/exec.CommandContext` with argument slices + `context.WithTimeout` (10s). `ListWindows()` includes `isActiveWindow` flag from `#{window_active}` |
-| `internal/worktree` | Wraps fab-kit `wt-*` scripts (never reimplements) — `packages/api/` only, not in `app/backend/` |
-| `internal/fab` | Reads fab state (progress-line, current change, change list) |
-| `internal/sessions` | Derives project roots from tmux, auto-detects fab-kit, enriches with fab state. Session enrichment runs in parallel via goroutines with `sync.WaitGroup` and indexed assignment to preserve tmux ordering |
+| `internal/tmux` | All tmux operations via `os/exec.CommandContext` with argument slices + `context.WithTimeout` (10s). `ListWindows()` includes `isActiveWindow` flag from `#{window_active}`. `WindowInfo` struct uses `FabChange`/`FabStage` fields (replaced legacy `FabStage`/`FabProgress`) |
+| `internal/fab` | Reads `.fab-status.yaml` from project root via `os.ReadFile` + `yaml.Unmarshal`. Returns `*State{Change, Stage}` (active change name + first active stage in canonical order). Returns nil if file missing, dangling symlink, or parse error. No subprocess calls |
+| `internal/sessions` | Derives project roots from tmux, auto-detects fab-kit via `os.Stat("fab/project/config.yaml")`, enriches with fab state. Per-session enrichment model: reads `.fab-status.yaml` once from window 0's project root, applies `FabChange`/`FabStage` to all windows in the session. Session enrichment runs in parallel via goroutines with `sync.WaitGroup` and indexed assignment to preserve tmux ordering |
 | `internal/validate` | Input validation for names/paths + tilde expansion with `$HOME` security boundary + filename sanitization for uploads |
 | `internal/config` | Server config (port, host) — reads CLI args > `run-kit.yaml` > defaults. YAML parsing via `gopkg.in/yaml.v3` |
+
+> `internal/worktree` was present in `packages/api/` but is not ported to `app/backend/` (dead code, not API-exposed).
 
 ### External Go Dependencies
 
@@ -114,26 +92,29 @@ Functional code lives in `packages/api/` until Phase 2+ ports it to `app/backend
 
 ## API Layer
 
-All endpoints served by the single Go binary on one port.
+All endpoints served by the single Go binary on one port. POST-only mutations with path-based intent (no multiplexed action field).
 
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
-| `/api/health` | GET | Returns `200 { "status": "ok" }` for supervisor health checks |
-| `/api/sessions` | GET | Returns `ProjectSession[]` — one per tmux session, with auto-detected fab enrichment |
-| `/api/sessions` | POST | Actions: `createSession` (with optional `cwd`), `createWindow`, `killSession`, `killWindow`, `renameWindow`, `sendKeys` |
+| `/api/health` | GET | Returns `200 {"status":"ok"}` for supervisor health checks |
+| `/api/sessions` | GET | Returns `ProjectSession[]` — one per tmux session, with auto-detected fab enrichment (`fabChange`/`fabStage` on windows) |
+| `/api/sessions` | POST | Create session — JSON body `{"name":"...","cwd":"..."}`. Returns `201 {"ok":true}` |
+| `/api/sessions/:session/kill` | POST | Kill session — `:session` validated via `validate.ValidateName()`. Returns `200 {"ok":true}` |
+| `/api/sessions/:session/windows` | POST | Create window — JSON body `{"name":"...","cwd":"..."}`. Returns `201 {"ok":true}` |
+| `/api/sessions/:session/windows/:index/kill` | POST | Kill window — `:index` must be non-negative integer. Returns `200 {"ok":true}` |
+| `/api/sessions/:session/windows/:index/rename` | POST | Rename window — JSON body `{"name":"..."}`. Returns `200 {"ok":true}` |
+| `/api/sessions/:session/windows/:index/keys` | POST | Send keys — JSON body `{"keys":"..."}` (non-empty after trim). Returns `200 {"ok":true}` |
 | `/api/directories` | GET | Server-side directory listing for autocomplete — `?prefix=~/code/wvr` returns matching dirs under `$HOME` |
-| `/api/sessions/stream` | GET | SSE — module-level goroutine polls tmux every 2.5s, fans out full snapshots to all connected clients on change. Deduplicates polling across browser tabs. 30-minute lifetime cap per connection. |
-| `/api/upload` | POST | File upload — accepts `multipart/form-data` with `file` and `session` fields. Resolves project root via `ListWindows`, writes to `.uploads/{timestamp}-{name}`, auto-manages `.gitignore`. 50MB limit. |
+| `/api/sessions/:session/upload` | POST | File upload — session from URL path (not form field). Multipart with `file` field, optional `window` field (defaults to `"0"`). Resolves project root via `ListWindows`, writes to `.uploads/{timestamp}-{name}`, auto-manages `.gitignore`. 50MB limit. Returns `200 {"ok":true,"path":"..."}` |
+| `/api/sessions/stream` | GET | SSE — hub singleton polls tmux every 2.5s, fans out full snapshots to all connected clients on change. Deduplicates polling across browser tabs. 30-minute lifetime cap per connection |
 
 ### Frontend API Client
 
-`packages/web/src/api/client.ts` — typed fetch wrappers for all endpoints (functional, legacy). Uses relative URLs (e.g., `/api/sessions`) — works with both Vite proxy in dev and same-origin in production. Exports `getSessions()`, `postSessionAction()`, `getDirectories()`, `uploadFile()` with TypeScript types.
-
-`app/frontend/src/api/client.ts` — type stubs matching the new POST-only API spec. All functions throw "not implemented". Uses individual POST routes (e.g., `/api/sessions/:session/kill`) rather than the legacy multiplexed POST. Will be implemented in Phase 3.
+`packages/web/src/api/client.ts` — typed fetch wrappers for all endpoints. Uses relative URLs (e.g., `/api/sessions`) — works with both Vite proxy in dev and same-origin in production. Exports `getSessions()`, `postSessionAction()`, `getDirectories()`, `uploadFile()` with TypeScript types.
 
 ## Terminal Relay
 
-WebSocket endpoint at `/relay/{session}/{window}` on the same port as the API — no separate relay port. Uses `gorilla/websocket` for WebSocket handling and `creack/pty` for PTY allocation. Implementation in `packages/api/api/relay.go`.
+WebSocket endpoint at `/relay/{session}/{window}` on the same port as the API — no separate relay port. Uses `gorilla/websocket` for WebSocket handling and `creack/pty` for PTY allocation. Implementation in `app/backend/api/relay.go`.
 
 Per connection:
 1. Creates independent pane via `tmux split-window` (agent pane 0 untouched)
@@ -148,7 +129,7 @@ Client-side WebSocket reconnection: exponential backoff (1s, 2s, 4s, 8s, 16s, ma
 
 ~140-line bash script. Reads `run-kit.yaml` at startup via grep-based parsing (no `yq` dependency) for port/host config. Polling loop checks for `.restart-requested` file.
 
-Build cycle: `cd app/backend && go build -o ../../bin/run-kit ./cmd/run-kit` (Go binary) + `cd app/frontend && pnpm build` (frontend to `app/frontend/dist/`).
+Build cycle: `go build -o bin/run-kit ./cmd/run-kit` (Go binary) + `pnpm build` (frontend to `app/frontend/dist/`).
 On detection: build all → kill server → start Go server → `GET /api/health` (10s timeout).
 On failure: `git revert HEAD` → rebuild → restart prior version.
 Signal trapping: SIGINT/SIGTERM → `stop_services` → clean exit.
@@ -156,7 +137,7 @@ Auto-restart: detects if server process died and restarts automatically.
 
 ## SPA Static Serving
 
-The Go server serves static files from the built SPA directory (`app/frontend/dist/`, previously `packages/web/dist/`). Any request not matching `/api/*` or `/relay/*` serves `index.html` for client-side routing (SPA fallback). Requests matching actual static file paths serve the file directly. Implementation in `packages/api/api/spa.go` (legacy) / `app/backend/api/spa.go` (scaffold placeholder).
+The Go server serves static files from the built SPA directory (`app/frontend/dist/`). Any request not matching `/api/*` or `/relay/*` serves `index.html` for client-side routing (SPA fallback). Requests matching actual static file paths serve the file directly. Path traversal is prevented (resolved path must stay within SPA directory). Implementation in `app/backend/api/spa.go`.
 
 In development, Vite handles SPA fallback natively. In production, Go's catch-all handles it. Caddy is optional — used only for TLS termination, not routing.
 
@@ -206,65 +187,47 @@ Pages do NOT render their own top bar or outer containers — they set chrome sl
 - **Sticky modifier state via useRef + forceUpdate** — `useModifierState` uses a ref for the authoritative state and a counter state to trigger re-renders. Ensures `consume()` reads the latest value atomically without stale closure issues.
 - **Compose buffer as native textarea (not xterm input)** — xterm renders to `<canvas>`, blocking OS-level input features. The compose buffer provides a real `<textarea>` where dictation, autocorrect, paste, and IME all work. Text sent as a single WebSocket message.
 - **Armed modifiers bridge to physical keyboard** — When bottom-bar modifiers (Ctrl/Alt/Cmd) are armed, a capture-phase `keydown` listener intercepts physical keypresses, translates them to terminal escape sequences (Ctrl+letter → control characters, Alt/Cmd → ESC prefix), and sends via WebSocket. Prevents xterm from receiving the unmodified key. Ignores real Cmd/Ctrl/Alt held by the OS.
-- **File upload via server filesystem (not terminal binary injection)** — Browser uploads file to `POST /api/upload`, server writes to `.uploads/` in project root, path auto-inserted into compose buffer. Works because run-kit server and tmux are always co-located; the browser is the remote part. Separate `/api/upload` route (not extending `/api/sessions`) because FormData and JSON body parsing are incompatible.
+- **File upload via server filesystem (not terminal binary injection)** — Browser uploads file to `POST /api/sessions/:session/upload`, server writes to `.uploads/` in project root, path auto-inserted into compose buffer. Works because run-kit server and tmux are always co-located; the browser is the remote part. Session identified by URL param (consistent with other session-scoped endpoints, replaces legacy form field approach)
+- **Handler files split by resource domain (not monolithic routes.go)** — Each handler file owns one resource: `sessions.go`, `windows.go`, `directories.go`, `upload.go`, `sse.go`, `relay.go`, `spa.go`, `health.go`. `router.go` owns middleware, dependency interfaces, and route registration only. (`260312-r4t9-go-backend-api`)
+- **Dependency injection via interfaces for handler testability** — `Server` struct holds `SessionFetcher` and `TmuxOps` interfaces. `NewRouter()` wires production implementations; `NewTestRouter()` accepts mocks. Enables `httptest.NewRecorder` tests without live tmux. (`260312-r4t9-go-backend-api`)
+- **Per-session fab enrichment (not per-window)** — `internal/sessions` reads `.fab-status.yaml` once from window 0's project root and applies `FabChange`/`FabStage` to all windows in the session. Eliminates redundant filesystem reads and subprocess calls per window. (`260312-r4t9-go-backend-api`)
+- **`internal/fab` reads `.fab-status.yaml` directly (not subprocess)** — Pure `os.ReadFile` + `yaml.Unmarshal`, no calls to `statusman.sh` or `changeman.sh`, no reading `fab/current`. Simpler, faster, no shell dependency. (`260312-r4t9-go-backend-api`)
 
 ## Testing
 
-### Task Runner
-
-The `justfile` is the single task runner for all test/build/dev commands (replaces `dev.sh` which was removed):
-
-| Recipe | Command |
-|--------|---------|
-| `just dev` | Go backend (`app/backend/`) + Vite dev server (`app/frontend/`) concurrently |
-| `just build` | `go build` from `app/backend/` + `pnpm build` from `app/frontend/` |
-| `just test` | `test-backend` + `test-frontend` + `test-e2e` |
-| `just test-backend` | `go test ./...` from `app/backend/` |
-| `just test-frontend` | `pnpm test` from `app/frontend/` (Vitest) |
-| `just test-e2e` | `pnpm exec playwright test` from `app/frontend/` |
-| `just check` | `pnpm exec tsc --noEmit` from `app/frontend/` |
-| `just verify` | `check` + `test` + `build` |
-| `just up` | `./supervisor.sh` |
-| `just bg` / `just logs` / `just down` | Supervisor in detached tmux session |
-| `just https` / `just trust` | Caddy HTTPS proxy |
-
 ### Go Unit Tests
 
-Go `testing` package with table-driven tests. Test files co-located with source using `_test.go` suffix. Test scripts: `just test-backend` (runs `go test ./...` from `app/backend/`).
+Go `testing` package with table-driven tests. Test files co-located with source using `_test.go` suffix. Test scripts: `go test ./...` from `app/backend/`.
 
-Legacy tests in `packages/api/` remain functional. New `app/backend/internal/` packages have empty `_test.go` files (package declaration only, zero tests).
-
-Current Go test coverage (legacy `packages/api/`): `internal/validate` (input validation + tilde expansion + filename sanitization), `internal/config` (CLI arg parsing, port validation, YAML parsing, defaults), `internal/tmux` (listSessions parsing + byobu filtering, listWindows activity computation), `internal/sessions` (fab-kit detection, project root derivation, session enrichment).
+Current Go test coverage (`app/backend/`):
+- **Internal packages**: `internal/validate` (input validation + tilde expansion + filename sanitization), `internal/config` (CLI arg parsing, port validation, YAML parsing, defaults), `internal/tmux` (listSessions parsing + byobu filtering, listWindows activity computation), `internal/sessions` (fab-kit detection, project root derivation, per-session enrichment), `internal/fab` (`.fab-status.yaml` parsing, missing file, dangling symlink, all-done stages)
+- **Handler integration tests**: `api/health_test.go`, `api/sessions_test.go`, `api/windows_test.go`, `api/directories_test.go`, `api/upload_test.go`, `api/sse_test.go`, `api/spa_test.go` — all use `httptest.NewRecorder` with the chi router and mock `SessionFetcher`/`TmuxOps` interfaces for tmux isolation. Cover response shapes, validation errors, URL param parsing, content-type enforcement. `api/relay.go` has no unit test (requires live tmux + PTY)
 
 ### Frontend Unit Tests
 
-Vitest with jsdom environment. New scaffold config at `app/frontend/vitest.config.ts`. Setup file at `app/frontend/src/test-setup.ts` imports `@testing-library/jest-dom/vitest`. Legacy config remains at `packages/web/vitest.config.ts`.
+Vitest with jsdom environment. Config at `packages/web/vitest.config.ts`. Setup file at `packages/web/src/test-setup.ts` imports `@testing-library/jest-dom/vitest` for extended DOM matchers.
 
-Test scripts: `just test-frontend` (runs `pnpm test` from `app/frontend/`).
+Test scripts: `pnpm test` (single run, in `packages/web/`), `pnpm test:watch` (watch mode).
 
 Test files co-located with source using `.test.{ts,tsx}` suffix (test-alongside strategy per `code-quality.md`). Path alias `@/` resolves to `src/` in both app and test contexts.
 
-Current frontend test coverage (legacy `packages/web/`): `command-palette.tsx` (keyboard interaction, filtering, open/close), `use-keyboard-nav.ts` (j/k/Enter navigation, input skip, clamping, custom shortcuts).
+Current frontend test coverage: `command-palette.tsx` (keyboard interaction, filtering, open/close), `use-keyboard-nav.ts` (j/k/Enter navigation, input skip, clamping, custom shortcuts).
 
 ### Playwright E2E Tests
 
-Two Playwright setups coexist:
+Playwright for browser-level integration tests. Config at `playwright.config.ts` (repo root). E2E tests live in `e2e/` (separate from unit tests). Two projects: `desktop` (Chromium) and `mobile` (WebKit, iPhone 14 viewport). `mobile.spec.ts` runs only on the mobile project; all other specs run only on desktop.
 
-**Legacy** (`e2e/` at repo root): Config at `playwright.config.ts` (repo root). Two projects: `desktop` (Chromium) and `mobile` (WebKit, iPhone 14 viewport). `mobile.spec.ts` runs only on the mobile project; all other specs run only on desktop.
-
-Test scripts (legacy): `pnpm test:e2e` (headless), `pnpm test:e2e:ui` (interactive UI mode). Web server auto-starts via `just dev` if not already running (`reuseExistingServer: true`).
+Test scripts: `pnpm test:e2e` (headless), `pnpm test:e2e:ui` (interactive UI mode). Web server auto-starts via `bash dev.sh` (Go + Vite) if not already running (`reuseExistingServer: true`).
 
 Tests self-manage tmux sessions via `POST /api/sessions` in `beforeAll`/`afterAll` hooks. Shared helpers in `e2e/helpers.ts`.
 
-E2E test suites (legacy):
+E2E test suites:
 - `chrome-stability.spec.ts` — top bar bounding box invariance across page navigation, Line 2 min-height, max-width 896px
 - `breadcrumbs.spec.ts` — page-specific breadcrumb segments, link verification, no text prefixes
 - `bottom-bar.spec.ts` — terminal-only visibility, modifier armed state (`aria-pressed`), Fn dropdown lifecycle, special keys
 - `compose-buffer.spec.ts` — open/close flow, terminal dimming, Send button, multiline input
 - `kill-button.spec.ts` — always-visible kill buttons, confirmation dialog flow
 - `mobile.spec.ts` — mobile bottom bar rendering, tap target minimum height (30px), Cmd+K badge visibility
-
-**New scaffold** (`app/frontend/tests/e2e/`): Config at `app/frontend/playwright.config.ts`. One project: `desktop` (Chromium). One placeholder test (`smoke.spec.ts` — `test.skip`). Run via `just test-e2e`.
 
 ## Security
 
@@ -298,4 +261,4 @@ E2E test suites (legacy):
 | 2026-03-07 | Breadcrumb type extended with `dropdownItems` for project/window switching dropdowns | `260307-uzsa-navbar-breadcrumb-dropdowns` |
 | 2026-03-07 | Playwright E2E tests — chrome stability, breadcrumbs, bottom bar, compose buffer, kill button, mobile viewport | `260305-r7zs-playwright-e2e-design-spec` |
 | 2026-03-10 | **Go backend + Vite SPA split** — replaced Next.js monolith with Go backend (`packages/api/`) + Vite React SPA (`packages/web/`). Single-port architecture (API, SSE, WebSocket relay, SPA static serving on one Go binary). chi router, gorilla/websocket, creack/pty. TanStack Router for client-side routing. Typed API client module. Go table-driven tests ported from Vitest. E2E tests updated for Go + Vite dev servers. | `260310-8xaq-go-backend-vite-spa-split` |
-| 2026-03-12 | **Scaffold `app/` folder structure** (Phase 1 of reimplementation) — created `app/backend/` Go module (placeholder packages, no `internal/worktree/`) and `app/frontend/` Vite project (type stubs, MSW handlers, Playwright config). Replaced `justfile` recipes to target `app/` paths. Updated `supervisor.sh` build paths to `app/backend/` and `app/frontend/`. Updated `pnpm-workspace.yaml` from `["packages/web"]` to `["app/frontend"]`. Removed `dev.sh` (replaced by `just dev`). Legacy `packages/` untouched until Phase 4. | `260312-jz77-scaffold-app-structure` |
+| 2026-03-12 | **Go backend API at `app/backend/`** — new canonical backend alongside legacy `packages/api/`. Handler files split by resource domain (sessions.go, windows.go, etc.). POST-only mutations with path-based intent. `internal/fab` rewritten to read `.fab-status.yaml` directly (no subprocess). Per-session fab enrichment model. `WindowInfo` fields changed: `FabChange`/`FabStage` replace `FabStage`/`FabProgress`. Upload endpoint session from URL path. Handler integration tests via `httptest.NewRecorder` + mock interfaces. SPA serves from `app/frontend/dist/`. | `260312-r4t9-go-backend-api` |

--- a/fab/changes/260312-r4t9-go-backend-api/.history.jsonl
+++ b/fab/changes/260312-r4t9-go-backend-api/.history.jsonl
@@ -16,3 +16,4 @@
 {"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"hydrate","ts":"2026-03-12T09:28:11Z"}
 {"event":"review","result":"passed","ts":"2026-03-12T09:28:11Z"}
 {"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"ship","ts":"2026-03-12T09:31:29Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-03-12T09:33:14Z"}

--- a/fab/changes/260312-r4t9-go-backend-api/.history.jsonl
+++ b/fab/changes/260312-r4t9-go-backend-api/.history.jsonl
@@ -5,3 +5,14 @@
 {"cmd":"fab-new","event":"command","ts":"2026-03-12T07:23:17Z"}
 {"delta":"+0.0","event":"confidence","score":4.1,"trigger":"calc-score","ts":"2026-03-12T07:45:13Z"}
 {"delta":"+0.0","event":"confidence","score":4.1,"trigger":"calc-score","ts":"2026-03-12T07:45:20Z"}
+{"cmd":"fab-switch","event":"command","ts":"2026-03-12T09:00:36Z"}
+{"cmd":"fab-ff","event":"command","ts":"2026-03-12T09:00:51Z"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"spec","ts":"2026-03-12T09:05:38Z"}
+{"delta":"-0.3","event":"confidence","score":3.8,"trigger":"calc-score","ts":"2026-03-12T09:07:46Z"}
+{"cmd":"fab-clarify","event":"command","ts":"2026-03-12T09:08:33Z"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"tasks","ts":"2026-03-12T09:09:34Z"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"apply","ts":"2026-03-12T09:12:31Z"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"review","ts":"2026-03-12T09:24:21Z"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"hydrate","ts":"2026-03-12T09:28:11Z"}
+{"event":"review","result":"passed","ts":"2026-03-12T09:28:11Z"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"ship","ts":"2026-03-12T09:31:29Z"}

--- a/fab/changes/260312-r4t9-go-backend-api/.status.yaml
+++ b/fab/changes/260312-r4t9-go-backend-api/.status.yaml
@@ -11,8 +11,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 checklist:
     generated: true
     path: checklist.md
@@ -37,6 +37,8 @@ stage_metrics:
     apply: {started_at: "2026-03-12T09:12:31Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-12T09:24:21Z"}
     review: {started_at: "2026-03-12T09:24:21Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-12T09:28:11Z"}
     hydrate: {started_at: "2026-03-12T09:28:11Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-12T09:31:29Z"}
-    ship: {started_at: "2026-03-12T09:31:29Z", driver: fab-ff, iterations: 1}
-prs: []
-last_updated: 2026-03-12T09:31:29Z
+    ship: {started_at: "2026-03-12T09:31:29Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-12T09:33:14Z"}
+    review-pr: {started_at: "2026-03-12T09:33:14Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/wvrdz/run-kit/pull/33
+last_updated: 2026-03-12T09:33:14Z

--- a/fab/changes/260312-r4t9-go-backend-api/.status.yaml
+++ b/fab/changes/260312-r4t9-go-backend-api/.status.yaml
@@ -5,40 +5,40 @@ created_by: sahil-weaver
 change_type: refactor
 issues: []
 progress:
-    intake: done
-    spec: done
-    tasks: done
-    apply: done
-    review: done
-    hydrate: done
-    ship: done
-    review-pr: active
+  intake: done
+  spec: done
+  tasks: done
+  apply: done
+  review: done
+  hydrate: done
+  ship: done
+  review-pr: active
 checklist:
-    generated: true
-    path: checklist.md
-    completed: 0
-    total: 0
+  generated: true
+  path: checklist.md
+  completed: 0
+  total: 0
 confidence:
-    certain: 8
-    confident: 4
-    tentative: 0
-    unresolved: 0
-    score: 3.8
-    fuzzy: true
-    dimensions:
-        signal: 86.3
-        reversibility: 86.3
-        competence: 89.6
-        disambiguation: 90.8
+  certain: 8
+  confident: 4
+  tentative: 0
+  unresolved: 0
+  score: 3.8
+  fuzzy: true
+  dimensions:
+    signal: 86.3
+    reversibility: 86.3
+    competence: 89.6
+    disambiguation: 90.8
 stage_metrics:
-    intake: {started_at: "2026-03-12T07:22:36Z", driver: fab-new, iterations: 1, completed_at: "2026-03-12T09:05:38Z"}
-    spec: {started_at: "2026-03-12T09:05:38Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-12T09:09:34Z"}
-    tasks: {started_at: "2026-03-12T09:09:34Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-12T09:12:31Z"}
-    apply: {started_at: "2026-03-12T09:12:31Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-12T09:24:21Z"}
-    review: {started_at: "2026-03-12T09:24:21Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-12T09:28:11Z"}
-    hydrate: {started_at: "2026-03-12T09:28:11Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-12T09:31:29Z"}
-    ship: {started_at: "2026-03-12T09:31:29Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-12T09:33:14Z"}
-    review-pr: {started_at: "2026-03-12T09:33:14Z", driver: git-pr, iterations: 1}
+  intake: {started_at: "2026-03-12T07:22:36Z", driver: fab-new, iterations: 1, completed_at: "2026-03-12T09:05:38Z"}
+  spec: {started_at: "2026-03-12T09:05:38Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-12T09:09:34Z"}
+  tasks: {started_at: "2026-03-12T09:09:34Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-12T09:12:31Z"}
+  apply: {started_at: "2026-03-12T09:12:31Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-12T09:24:21Z"}
+  review: {started_at: "2026-03-12T09:24:21Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-12T09:28:11Z"}
+  hydrate: {started_at: "2026-03-12T09:28:11Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-12T09:31:29Z"}
+  ship: {started_at: "2026-03-12T09:31:29Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-12T09:33:14Z"}
+  review-pr: {started_at: "2026-03-12T09:33:14Z", driver: git-pr, iterations: 1, phase: fixing, reviewer: 'copilot-pull-request-reviewer[bot]'}
 prs:
-    - https://github.com/wvrdz/run-kit/pull/33
+  - https://github.com/wvrdz/run-kit/pull/33
 last_updated: 2026-03-12T09:33:14Z

--- a/fab/changes/260312-r4t9-go-backend-api/.status.yaml
+++ b/fab/changes/260312-r4t9-go-backend-api/.status.yaml
@@ -5,33 +5,38 @@ created_by: sahil-weaver
 change_type: refactor
 issues: []
 progress:
-    intake: ready
-    spec: pending
-    tasks: pending
-    apply: pending
-    review: pending
-    hydrate: pending
-    ship: pending
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
     review-pr: pending
 checklist:
-    generated: false
+    generated: true
     path: checklist.md
     completed: 0
     total: 0
 confidence:
-    certain: 5
-    confident: 3
+    certain: 8
+    confident: 4
     tentative: 0
     unresolved: 0
-    score: 4.1
-    indicative: true
+    score: 3.8
     fuzzy: true
     dimensions:
-        signal: 85.6
-        reversibility: 83.8
-        competence: 88.8
-        disambiguation: 90.6
+        signal: 86.3
+        reversibility: 86.3
+        competence: 89.6
+        disambiguation: 90.8
 stage_metrics:
-    intake: {started_at: "2026-03-12T07:22:36Z", driver: fab-new, iterations: 1}
+    intake: {started_at: "2026-03-12T07:22:36Z", driver: fab-new, iterations: 1, completed_at: "2026-03-12T09:05:38Z"}
+    spec: {started_at: "2026-03-12T09:05:38Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-12T09:09:34Z"}
+    tasks: {started_at: "2026-03-12T09:09:34Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-12T09:12:31Z"}
+    apply: {started_at: "2026-03-12T09:12:31Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-12T09:24:21Z"}
+    review: {started_at: "2026-03-12T09:24:21Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-12T09:28:11Z"}
+    hydrate: {started_at: "2026-03-12T09:28:11Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-12T09:31:29Z"}
+    ship: {started_at: "2026-03-12T09:31:29Z", driver: fab-ff, iterations: 1}
 prs: []
-last_updated: 2026-03-12T07:45:20Z
+last_updated: 2026-03-12T09:31:29Z

--- a/fab/changes/260312-r4t9-go-backend-api/checklist.md
+++ b/fab/changes/260312-r4t9-go-backend-api/checklist.md
@@ -1,0 +1,87 @@
+# Quality Checklist: Go Backend API
+
+**Change**: 260312-r4t9-go-backend-api
+**Generated**: 2026-03-12
+**Spec**: `spec.md`
+
+## Functional Completeness
+
+- [ ] CHK-001 Module structure: `app/backend/` exists with `go.mod` (module `run-kit`, go 1.22+), correct directory layout per architecture spec
+- [ ] CHK-002 validate port: All functions (`ValidateName`, `ValidatePath`, `ExpandTilde`, `SanitizeFilename`) present and unchanged in `app/backend/internal/validate/`
+- [ ] CHK-003 config port: `Config` struct + `Load()` with CLI > YAML > defaults resolution present in `app/backend/internal/config/`
+- [ ] CHK-004 tmux port: All functions (`ListSessions`, `ListWindows`, `CreateSession`, `CreateWindow`, `KillSession`, `KillWindow`, `RenameWindow`, `SendKeys`, `SplitWindow`, `KillPane`) present in `app/backend/internal/tmux/`
+- [ ] CHK-005 fab rewrite: `internal/fab` reads `.fab-status.yaml` via `os.ReadFile` + YAML parse. No subprocess calls. Returns change name + active stage
+- [ ] CHK-006 sessions enrichment: Per-session fab enrichment — reads `.fab-status.yaml` once from window 0's project root, applies to all windows
+- [ ] CHK-007 WindowInfo fields: `FabChange` and `FabStage` fields with `omitempty` JSON tags replace old `FabStage`/`FabProgress`
+- [ ] CHK-008 Router: chi router with CORS (`*` origin, `GET POST OPTIONS`), logger, recovery middleware
+- [ ] CHK-009 Health endpoint: `GET /api/health` returns `200 {"status":"ok"}`
+- [ ] CHK-010 Sessions list: `GET /api/sessions` returns JSON array with fab-enriched windows
+- [ ] CHK-011 Session create: `POST /api/sessions` with `{"name","cwd"}`, returns `201 {"ok":true}`
+- [ ] CHK-012 Session kill: `POST /api/sessions/:session/kill` returns `200 {"ok":true}`
+- [ ] CHK-013 Window create: `POST /api/sessions/:session/windows` with `{"name","cwd"}`, returns `201 {"ok":true}`
+- [ ] CHK-014 Window kill: `POST /api/sessions/:session/windows/:index/kill` returns `200 {"ok":true}`
+- [ ] CHK-015 Window rename: `POST /api/sessions/:session/windows/:index/rename` with `{"name"}`, returns `200 {"ok":true}`
+- [ ] CHK-016 Window keys: `POST /api/sessions/:session/windows/:index/keys` with `{"keys"}`, returns `200 {"ok":true}`
+- [ ] CHK-017 Directories: `GET /api/directories?prefix=...` with tilde expansion, child listing, hidden dir skip
+- [ ] CHK-018 Upload: `POST /api/sessions/:session/upload` — session from URL param, multipart, 50MB limit, `.uploads/` + gitignore management
+- [ ] CHK-019 SSE: `GET /api/sessions/stream` — hub singleton, 2.5s poll, dedup, cached snapshot, 30min cap
+- [ ] CHK-020 Relay: `WS /relay/:session/:window` — split-window, PTY attach, bidirectional, sync.Once cleanup
+- [ ] CHK-021 SPA: `GET /*` serves from `app/frontend/dist/`, SPA fallback to `index.html`, path traversal prevention
+- [ ] CHK-022 Main: `cmd/run-kit/main.go` — config load, router create, HTTP server, graceful shutdown (5s)
+
+## Behavioral Correctness
+
+- [ ] CHK-023 POST-only mutations: All mutating endpoints use POST (not PUT/DELETE/PATCH). Intent in URL path, not action field
+- [ ] CHK-024 Resource-based routes: Each endpoint uses path-based intent (e.g., `/api/sessions/:session/kill` not `POST { action: "killSession" }`)
+- [ ] CHK-025 Per-session (not per-window) fab: `.fab-status.yaml` read once per session, not per window. All windows share same fab state
+- [ ] CHK-026 Upload session from URL: `:session` comes from URL param, not form field (changed from old implementation)
+- [ ] CHK-027 SPA directory updated: `spaDir` points to `app/frontend/dist/` not `packages/web/dist/`
+
+## Removal Verification
+
+- [ ] CHK-028 No `internal/worktree/`: Package not present in `app/backend/internal/`
+- [ ] CHK-029 No subprocess fab calls: `internal/fab` has no `exec.Command`, no `statusman.sh`, no `changeman.sh`, no `fab/current` reads
+- [ ] CHK-030 No multiplexed POST: No `action` field dispatch pattern in any handler
+
+## Scenario Coverage
+
+- [ ] CHK-031 Name validation: Tests verify forbidden chars, empty name, max length for session/window names
+- [ ] CHK-032 Path validation: Tests verify tilde expansion, `~user` rejection, home directory boundary
+- [ ] CHK-033 Fab state scenarios: Tests cover active change, no file, dangling symlink, all stages done
+- [ ] CHK-034 Session enrichment: Tests verify per-session model — all windows get same fab state from window 0
+- [ ] CHK-035 Handler response shapes: Each handler test verifies JSON structure, status codes, content-type
+- [ ] CHK-036 Validation error paths: Handler tests verify 400 responses with `{"error":"..."}` for invalid input
+
+## Edge Cases & Error Handling
+
+- [ ] CHK-037 Invalid window index: Non-integer `:index` params return 400
+- [ ] CHK-038 Upload size limit: Files > 50MB return 413
+- [ ] CHK-039 Empty prefix: `GET /api/directories` with no prefix returns `{"directories":[]}`
+- [ ] CHK-040 SPA not built: Requests when `app/frontend/dist/` doesn't exist return 404
+- [ ] CHK-041 SSE client disconnect: Handled gracefully (no panics, client removed from hub)
+- [ ] CHK-042 Relay cleanup: PTY + pane killed on WebSocket disconnect via sync.Once
+
+## Code Quality
+
+- [ ] CHK-043 Pattern consistency: New code follows naming and structural patterns of existing `packages/api/` code
+- [ ] CHK-044 No unnecessary duplication: Existing utilities (`validate`, `tmux`, `config`) reused — not reimplemented
+- [ ] CHK-045 execFile with argument arrays: All subprocess calls use `os/exec.CommandContext` with argument slices, never `sh -c` or shell strings
+- [ ] CHK-046 No exec/execSync: No `exec()` or string shell commands anywhere in `app/backend/`
+- [ ] CHK-047 Timeouts on tmux operations: All `exec.CommandContext` calls include timeout via `context.WithTimeout`
+- [ ] CHK-048 No database imports: No ORM, migration, or database packages imported
+- [ ] CHK-049 Handler test isolation: Tests use mock interfaces, not live tmux
+- [ ] CHK-050 Type narrowing: Prefer `if` guards over `.(type)` assertions where applicable
+
+## Security
+
+- [ ] CHK-051 No shell injection: All tmux calls via argument slices, user input validated before subprocess
+- [ ] CHK-052 Path traversal: SPA serving prevents path escape via `filepath.Abs` boundary check
+- [ ] CHK-053 Upload filename sanitization: `SanitizeFilename` strips null bytes, path separators, leading dots, dot sequences
+- [ ] CHK-054 Home directory boundary: All path operations restricted to `$HOME` via `ExpandTilde` checks
+- [ ] CHK-055 Upload size enforcement: `http.MaxBytesReader` applied before multipart parsing
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] CHK-008 **N/A**: {reason}`

--- a/fab/changes/260312-r4t9-go-backend-api/spec.md
+++ b/fab/changes/260312-r4t9-go-backend-api/spec.md
@@ -1,0 +1,491 @@
+# Spec: Go Backend API
+
+**Change**: 260312-r4t9-go-backend-api
+**Created**: 2026-03-12
+**Affected memory**: `docs/memory/run-kit/architecture.md`
+
+## Non-Goals
+
+- Frontend implementation (Phase 3) — backend API only
+- Old code removal from `packages/` (Phase 4) — old code stays as reference
+- Frontend E2E tests — backend has handler-level integration tests only
+- `internal/worktree/` — dead code, not API-exposed, explicitly excluded by architecture spec
+
+## Module Structure
+
+### Requirement: Go module at `app/backend/`
+
+The Go module SHALL be located at `app/backend/` with module name `run-kit` and Go version 1.22+. The directory structure SHALL match `docs/specs/architecture.md`:
+
+```
+app/backend/
+  cmd/run-kit/main.go
+  api/
+    router.go, health.go, sessions.go, windows.go,
+    directories.go, upload.go, sse.go, relay.go, spa.go
+  internal/
+    validate/, config/, tmux/, fab/, sessions/
+  go.mod, go.sum
+```
+
+Each `api/` handler file SHALL contain only HTTP concerns (parse request, call internal package, write response). Business logic MUST live in `internal/` packages.
+
+#### Scenario: Module compiles
+- **GIVEN** the `app/backend/` directory exists with `go.mod` and all source files
+- **WHEN** `go build ./...` is run from `app/backend/`
+- **THEN** the build succeeds with zero errors
+
+#### Scenario: All tests pass
+- **GIVEN** all handler and internal package tests are written
+- **WHEN** `go test ./...` is run from `app/backend/`
+- **THEN** all tests pass with zero failures
+
+## Internal Packages: Verbatim Ports
+
+### Requirement: Port `internal/validate`
+
+The validate package SHALL be copied verbatim from `packages/api/internal/validate/` to `app/backend/internal/validate/`. All functions (`ValidateName`, `ValidatePath`, `ExpandTilde`, `SanitizeFilename`) and their existing tests MUST be preserved unchanged.
+
+#### Scenario: Name validation rejects forbidden characters
+- **GIVEN** the validate package is ported
+- **WHEN** `ValidateName("test;cmd", "Session name")` is called
+- **THEN** a non-empty error string is returned containing "forbidden characters"
+
+#### Scenario: Tilde expansion security boundary
+- **GIVEN** the validate package is ported
+- **WHEN** `ExpandTilde("~user/path")` is called
+- **THEN** an error is returned rejecting `~user` syntax
+
+### Requirement: Port `internal/config`
+
+The config package SHALL be copied verbatim from `packages/api/internal/config/` to `app/backend/internal/config/`. The `Config` struct, `Load()` function, and resolution order (CLI > YAML > defaults) MUST be preserved. Existing tests MUST be preserved.
+
+#### Scenario: CLI overrides YAML
+- **GIVEN** `run-kit.yaml` has `server.port: 8080` and CLI has `-port 9090`
+- **WHEN** `config.Load()` is called
+- **THEN** `cfg.Port` is `9090`
+
+### Requirement: Port `internal/tmux`
+
+The tmux package SHALL be copied verbatim from `packages/api/internal/tmux/` to `app/backend/internal/tmux/`. All functions (`ListSessions`, `ListWindows`, `CreateSession`, `CreateWindow`, `KillSession`, `KillWindow`, `RenameWindow`, `SendKeys`, `SplitWindow`, `KillPane`, `CapturePane`) and their parse/filter helpers MUST be preserved. Existing tests MUST be preserved.
+
+#### Scenario: Byobu session-group filtering
+- **GIVEN** tmux output includes sessions with `session_grouped=1` where `name != group`
+- **WHEN** `parseSessions(lines)` is called
+- **THEN** only primary sessions are returned (where `name == group` or `grouped == 0`)
+
+#### Scenario: Window activity threshold
+- **GIVEN** a window with `window_activity` timestamp 5 seconds ago
+- **WHEN** `parseWindows(lines, nowUnix)` is called
+- **THEN** the window's `Activity` field is `"active"` (within 10-second threshold)
+
+## Internal Packages: Fab Rewrite
+
+### Requirement: Read `.fab-status.yaml` for fab state
+
+The `internal/fab` package SHALL be completely rewritten (not ported). It MUST read `.fab-status.yaml` from the project root via `os.ReadFile` (which follows symlinks). It SHALL NOT call subprocess scripts (`statusman.sh`, `changeman.sh`). It SHALL NOT read `fab/current`.
+
+The package MUST export a function that accepts a project root path and returns:
+- The active change name (`name` field from the parsed YAML)
+- The current active stage (first stage in the `progress` map with value `active`)
+- A nil/zero result if `.fab-status.yaml` does not exist or cannot be parsed
+
+#### Scenario: Active change with active stage
+- **GIVEN** `.fab-status.yaml` exists at `{projectRoot}/.fab-status.yaml` with `name: 260312-r4t9-go-backend-api` and `progress.apply: active`
+- **WHEN** the state reader is called with `projectRoot`
+- **THEN** it returns change name `"260312-r4t9-go-backend-api"` and stage `"apply"`
+
+#### Scenario: No active change
+- **GIVEN** `.fab-status.yaml` does not exist at the project root
+- **WHEN** the state reader is called
+- **THEN** it returns nil (no fab state available)
+
+#### Scenario: Dangling symlink
+- **GIVEN** `.fab-status.yaml` is a symlink whose target has been deleted
+- **WHEN** the state reader is called
+- **THEN** it returns nil gracefully (no panic, no error logged to user)
+
+#### Scenario: All stages done
+- **GIVEN** `.fab-status.yaml` exists but all progress stages are `done` or `pending` (none `active`)
+- **WHEN** the state reader is called
+- **THEN** it returns the change name with an empty stage string
+
+## Internal Packages: Sessions Enrichment
+
+### Requirement: Per-session fab enrichment via `.fab-status.yaml`
+
+The `internal/sessions` package SHALL read `.fab-status.yaml` once per session from window 0's `WorktreePath` (the project root). The resulting fab state (change name and active stage) SHALL be applied to ALL windows in that session. The previous per-window enrichment model (calling `fab.GetCurrentChange` and `fab.GetStatus` per window) is removed.
+
+The `WindowInfo` struct in `internal/tmux` SHALL replace `FabStage`/`FabProgress` fields with:
+- `FabChange string` — JSON tag: `"fabChange,omitempty"` — the active change folder name
+- `FabStage string` — JSON tag: `"fabStage,omitempty"` — the current active pipeline stage
+
+#### Scenario: All windows share session-level fab state
+- **GIVEN** a tmux session "run-kit" with 3 windows, window 0 at `/home/user/code/run-kit` which has `.fab-status.yaml` with change `"260312-abc-feature"` and stage `"apply"`
+- **WHEN** `FetchSessions()` is called
+- **THEN** all 3 windows have `fabChange: "260312-abc-feature"` and `fabStage: "apply"`
+
+#### Scenario: Session without fab-kit project
+- **GIVEN** a tmux session "other" with window 0 at `/home/user/other-project` which has no `fab/project/config.yaml`
+- **WHEN** `FetchSessions()` is called
+- **THEN** all windows have empty `fabChange` and `fabStage` (omitted from JSON output)
+
+#### Scenario: Parallel enrichment preserves order
+- **GIVEN** 5 tmux sessions exist
+- **WHEN** `FetchSessions()` is called
+- **THEN** sessions are enriched in parallel (goroutines with `sync.WaitGroup`, indexed assignment) and the result preserves tmux session ordering
+
+## API Router
+
+### Requirement: Route registration and middleware stack
+
+`api/router.go` SHALL create a chi router with middleware applied to all `/api/*` routes:
+1. **CORS** — allow all origins (`*`), methods `GET POST OPTIONS`, headers `Accept Authorization Content-Type`, no credentials, max-age 300s
+2. **Request logger** — chi `middleware.Logger`
+3. **Panic recovery** — chi `middleware.Recoverer`
+
+Routes SHALL be registered per the route table in `docs/specs/api.md`. The router creation function SHALL accept dependencies (session fetcher, tmux operations) to enable handler test isolation.
+
+#### Scenario: CORS preflight response
+- **GIVEN** the router is configured
+- **WHEN** an `OPTIONS /api/sessions` request is sent with `Origin: http://localhost:5173`
+- **THEN** the response includes `Access-Control-Allow-Origin: *` and status 200
+
+### Requirement: Consistent JSON response helpers
+
+The router module SHALL export helper functions used by all handler files:
+- `writeJSON(w, status, v)` — sets `Content-Type: application/json`, writes status code, JSON-encodes `v`
+- `writeError(w, status, msg)` — writes `{"error":"<msg>"}` with given status
+
+#### Scenario: All error responses have consistent shape
+- **GIVEN** any handler encounters a validation error
+- **WHEN** the error response is sent
+- **THEN** it has `Content-Type: application/json` and body matching `{"error":"<message>"}`
+
+## API Handlers: Health
+
+### Requirement: Health check endpoint
+
+`api/health.go` SHALL handle `GET /api/health` returning `200 {"status":"ok"}`. No authentication, no dependencies.
+
+#### Scenario: Health check succeeds
+- **GIVEN** the server is running
+- **WHEN** `GET /api/health` is requested
+- **THEN** response status is `200` with body `{"status":"ok"}`
+
+## API Handlers: Sessions
+
+### Requirement: List sessions
+
+`api/sessions.go` SHALL handle `GET /api/sessions` by calling the session fetcher and returning the result as a JSON array of `ProjectSession` objects.
+
+#### Scenario: Sessions with fab enrichment
+- **GIVEN** tmux has sessions, some with fab-kit projects
+- **WHEN** `GET /api/sessions` is requested
+- **THEN** response is `200` with a JSON array where fab-enriched sessions include `fabChange` and `fabStage` on each window
+
+### Requirement: Create session
+
+`api/sessions.go` SHALL handle `POST /api/sessions` with JSON body `{"name":"...","cwd":"..."}`.
+- `name` is required — validated via `validate.ValidateName()`
+- `cwd` is optional — validated via `validate.ValidatePath()` then `validate.ExpandTilde()`
+- On success: response `201 {"ok":true}`
+
+#### Scenario: Create session with CWD
+- **GIVEN** the server is running
+- **WHEN** `POST /api/sessions` with body `{"name":"my-project","cwd":"~/code/my-project"}` is sent
+- **THEN** `tmux.CreateSession("my-project", expandedCwd)` is called and response is `201 {"ok":true}`
+
+#### Scenario: Create session validation failure
+- **GIVEN** the server is running
+- **WHEN** `POST /api/sessions` with body `{"name":""}` is sent
+- **THEN** response is `400` with `{"error":"Session name cannot be empty"}`
+
+### Requirement: Kill session
+
+`api/sessions.go` SHALL handle `POST /api/sessions/:session/kill`.
+- `:session` URL param validated via `validate.ValidateName()`
+- On success: response `200 {"ok":true}`
+
+#### Scenario: Kill session
+- **GIVEN** tmux session "test" exists
+- **WHEN** `POST /api/sessions/test/kill` is requested
+- **THEN** `tmux.KillSession("test")` is called and response is `200 {"ok":true}`
+
+#### Scenario: Kill session with invalid name
+- **GIVEN** the server is running
+- **WHEN** `POST /api/sessions/test;rm/kill` is requested
+- **THEN** response is `400` with validation error (forbidden characters)
+
+## API Handlers: Windows
+
+### Requirement: Create window
+
+`api/windows.go` SHALL handle `POST /api/sessions/:session/windows` with JSON body `{"name":"...","cwd":"..."}`.
+- `:session` URL param validated
+- `name` required, validated via `validate.ValidateName()`
+- `cwd` optional, validated via `validate.ValidatePath()` + `validate.ExpandTilde()`
+- On success: response `201 {"ok":true}`
+
+#### Scenario: Create window
+- **GIVEN** tmux session "run-kit" exists
+- **WHEN** `POST /api/sessions/run-kit/windows` with body `{"name":"feature","cwd":"~/code/run-kit"}` is sent
+- **THEN** a new window is created and response is `201 {"ok":true}`
+
+### Requirement: Kill window
+
+`api/windows.go` SHALL handle `POST /api/sessions/:session/windows/:index/kill`.
+- `:session` validated, `:index` MUST be a non-negative integer
+- On success: response `200 {"ok":true}`
+
+#### Scenario: Kill window
+- **GIVEN** session "run-kit" with window at index 1
+- **WHEN** `POST /api/sessions/run-kit/windows/1/kill` is requested
+- **THEN** `tmux.KillWindow("run-kit", 1)` is called and response is `200 {"ok":true}`
+
+#### Scenario: Invalid window index
+- **GIVEN** the server is running
+- **WHEN** `POST /api/sessions/run-kit/windows/abc/kill` is requested
+- **THEN** response is `400` with `{"error":"Invalid window index"}`
+
+### Requirement: Rename window
+
+`api/windows.go` SHALL handle `POST /api/sessions/:session/windows/:index/rename` with JSON body `{"name":"..."}`.
+- `name` required, validated
+- On success: response `200 {"ok":true}`
+
+#### Scenario: Rename window
+- **GIVEN** session "run-kit" with window at index 1
+- **WHEN** `POST /api/sessions/run-kit/windows/1/rename` with body `{"name":"new-name"}` is sent
+- **THEN** `tmux.RenameWindow("run-kit", 1, "new-name")` is called and response is `200 {"ok":true}`
+
+### Requirement: Send keys
+
+`api/windows.go` SHALL handle `POST /api/sessions/:session/windows/:index/keys` with JSON body `{"keys":"..."}`.
+- `keys` MUST be non-empty after trim
+- Sends via `tmux.SendKeys(session, index, keys)`
+- On success: response `200 {"ok":true}`
+
+#### Scenario: Send keys
+- **GIVEN** session "run-kit" with window at index 0
+- **WHEN** `POST /api/sessions/run-kit/windows/0/keys` with body `{"keys":"echo hello"}` is sent
+- **THEN** `tmux.SendKeys("run-kit", 0, "echo hello")` is called and response is `200 {"ok":true}`
+
+#### Scenario: Empty keys rejected
+- **GIVEN** the server is running
+- **WHEN** `POST /api/sessions/run-kit/windows/0/keys` with body `{"keys":"  "}` is sent
+- **THEN** response is `400` with `{"error":"Keys cannot be empty"}`
+
+## API Handlers: Directories
+
+### Requirement: Directory autocomplete
+
+`api/directories.go` SHALL handle `GET /api/directories?prefix=:path` per `docs/specs/api.md`:
+- Tilde expansion via `validate.ExpandTilde()`
+- If prefix ends with `/`, list child directories
+- Otherwise, match directory names against the basename prefix (case-insensitive)
+- Skip hidden directories (`.`-prefixed)
+- Return paths with `~/` prefix when under home directory
+- Return empty array on invalid path or no matches
+
+#### Scenario: List child directories
+- **GIVEN** `~/code/` contains directories `wvrdz/` and `other/` and hidden `.cache/`
+- **WHEN** `GET /api/directories?prefix=~/code/` is requested
+- **THEN** response includes `["~/code/other/","~/code/wvrdz/"]` and excludes `.cache/`
+
+#### Scenario: Empty prefix
+- **GIVEN** the server is running
+- **WHEN** `GET /api/directories` is requested (no prefix param)
+- **THEN** response is `200` with `{"directories":[]}`
+
+## API Handlers: Upload
+
+### Requirement: Session-scoped file upload
+
+`api/upload.go` SHALL handle `POST /api/sessions/:session/upload` with multipart form data.
+
+Key change from current implementation: session is identified by the `:session` URL parameter, not a `session` form field.
+
+- `:session` URL param validated via `validate.ValidateName()`
+- `file` form field required, max 50 MB via `http.MaxBytesReader`
+- `window` form field optional, integer string, defaults to `"0"`
+- Resolves project root from target window's `WorktreePath` via `tmux.ListWindows()`
+- Creates `.uploads/` in project root, auto-adds `.uploads/` to `.gitignore`
+- Filename format: `{YYMMDDHHmmss}-{sanitized_name}` where sanitization uses `validate.SanitizeFilename()`
+- On success: response `200 {"ok":true,"path":"<absolute-path>"}`
+
+#### Scenario: Upload file to session
+- **GIVEN** session "run-kit" exists with window 0 at `/home/user/code/run-kit`
+- **WHEN** `POST /api/sessions/run-kit/upload` with multipart file `screenshot.png` is sent
+- **THEN** file is saved to `/home/user/code/run-kit/.uploads/{timestamp}-screenshot.png` and response includes the absolute path
+
+#### Scenario: Upload size limit exceeded
+- **GIVEN** the server is running
+- **WHEN** a file exceeding 50 MB is uploaded to `/api/sessions/run-kit/upload`
+- **THEN** response is `413` with `{"error":"File exceeds 50MB limit"}`
+
+#### Scenario: Gitignore auto-management
+- **GIVEN** project root has no `.uploads/` entry in `.gitignore`
+- **WHEN** a file is uploaded successfully
+- **THEN** `.uploads/` is appended to `.gitignore`
+
+## API Handlers: SSE
+
+### Requirement: Session state stream
+
+`api/sse.go` SHALL handle `GET /api/sessions/stream` using a module-level hub singleton. The architecture SHALL be ported from the current `packages/api/api/sse.go`:
+
+- Hub manages a set of connected SSE clients
+- Polls `FetchSessions()` every 2500ms, only when clients are connected
+- Deduplicates by JSON string comparison — only fans out on change
+- New clients receive the cached snapshot immediately on connect
+- 30-minute lifetime cap per connection
+- Non-blocking fan-out (skip if client buffer full)
+- Event format: `event: sessions\ndata: <json>\n\n`
+
+#### Scenario: Client receives initial snapshot
+- **GIVEN** the hub has a cached session snapshot
+- **WHEN** a new client connects to `/api/sessions/stream`
+- **THEN** the client receives the cached snapshot immediately as an `event: sessions` message
+
+#### Scenario: Deduplication prevents redundant events
+- **GIVEN** a client is connected and the hub polls twice with identical tmux state
+- **WHEN** the second poll returns the same JSON as the first
+- **THEN** no duplicate event is sent to the client
+
+#### Scenario: Polling stops when no clients
+- **GIVEN** the hub is polling with one connected client
+- **WHEN** the client disconnects
+- **THEN** the polling goroutine exits (checks `len(clients) == 0` and stops)
+
+## API Handlers: Relay
+
+### Requirement: WebSocket terminal relay
+
+`api/relay.go` SHALL handle `WS /relay/:session/:window` with the same lifecycle as the current `packages/api/api/relay.go`:
+
+1. Validate `:session` via `validate.ValidateName()` and `:window` as non-negative integer
+2. Upgrade HTTP → WebSocket via `gorilla/websocket.Upgrader` (accept all origins)
+3. Create independent pane: `tmux.SplitWindow(session, windowIndex)` — agent pane 0 untouched
+4. Select target pane, attach via PTY: `exec.CommandContext(ctx, "tmux", "attach-session", "-t", session)` with `creack/pty`
+5. Bidirectional relay: goroutine for PTY→WS reads, main loop for WS→PTY writes
+6. Handle resize: JSON `{"type":"resize","cols":N,"rows":N}` → `pty.Setsize()`
+7. On disconnect: kill PTY, kill process, kill pane via `sync.Once` cleanup
+
+Error close code `4001` for pane creation or attach failure.
+
+#### Scenario: Relay connection lifecycle
+- **GIVEN** session "run-kit" with window at index 0
+- **WHEN** a WebSocket connection is established to `/relay/run-kit/0`
+- **THEN** a new tmux pane is created, PTY is started, and terminal I/O flows bidirectionally
+
+#### Scenario: Resize message handling
+- **GIVEN** an active relay connection
+- **WHEN** the client sends `{"type":"resize","cols":120,"rows":40}`
+- **THEN** the PTY size is updated to 120 columns × 40 rows
+
+#### Scenario: Cleanup on disconnect
+- **GIVEN** an active relay connection with spawned pane `%5`
+- **WHEN** the WebSocket connection closes
+- **THEN** the PTY fd is closed, the attach process is killed, and pane `%5` is killed — all via `sync.Once` (idempotent)
+
+## API Handlers: SPA Fallback
+
+### Requirement: Static file serving with SPA fallback
+
+`api/spa.go` SHALL serve static files from `app/frontend/dist/` (changed from `packages/web/dist/`) with SPA fallback to `index.html`.
+
+- Requests matching actual files in the SPA directory → serve file directly
+- All other requests (not `/api/*` or `/relay/*`) → serve `index.html` for client-side routing
+- Path traversal MUST be prevented (resolved path must stay within SPA directory)
+- Returns 404 if SPA is not built (no `index.html`)
+
+#### Scenario: Static asset served
+- **GIVEN** `app/frontend/dist/assets/main.js` exists
+- **WHEN** `GET /assets/main.js` is requested
+- **THEN** the file is served with appropriate content type
+
+#### Scenario: SPA fallback for client routes
+- **GIVEN** no file matches the path `/p/run-kit/0`
+- **WHEN** `GET /p/run-kit/0` is requested
+- **THEN** `index.html` is served (enabling client-side routing)
+
+#### Scenario: Path traversal blocked
+- **GIVEN** the server is running
+- **WHEN** `GET /../../etc/passwd` is requested
+- **THEN** the request returns 404 (resolved path escapes SPA directory)
+
+## Handler Integration Tests
+
+### Requirement: Test coverage for every handler file
+
+Each handler file in `api/` SHALL have a corresponding `_test.go` file using `httptest.NewRecorder` with the chi router.
+
+Handler tests MUST cover:
+- Request/response shape validation (correct JSON structure, status codes)
+- Validation error messages (400 responses for invalid input)
+- URL parameter parsing (`:session`, `:index`)
+- Content-type enforcement (`application/json`)
+- Success and error paths
+
+Handler tests SHALL mock `internal/` dependencies (tmux operations, session fetching) via interfaces to run without a live tmux server. The `api/` package SHALL define interfaces for its dependencies and accept them during router construction.
+
+#### Scenario: Handler test with mock dependencies
+- **GIVEN** a handler test for `sessions.go` with a mock session fetcher returning canned data
+- **WHEN** `GET /api/sessions` is tested via `httptest.NewRecorder`
+- **THEN** the response has status `200`, `Content-Type: application/json`, and body matching the canned session data
+
+#### Scenario: Validation error test
+- **GIVEN** a handler test for `POST /api/sessions`
+- **WHEN** the request body has `{"name":"test;hack"}`
+- **THEN** the response has status `400` and body `{"error":"Session name contains forbidden characters"}`
+
+## Server Entry Point
+
+### Requirement: Server binary with graceful shutdown
+
+`cmd/run-kit/main.go` SHALL:
+1. Load config via `config.Load()` (CLI > YAML > defaults)
+2. Create slog logger writing to stderr
+3. Create router via `api.NewRouter(logger)` (or equivalent, with production dependencies)
+4. Start HTTP server on `{host}:{port}` from config
+5. Handle graceful shutdown on SIGINT/SIGTERM with 5-second timeout via `signal.NotifyContext`
+
+#### Scenario: Server starts and serves
+- **GIVEN** `run-kit.yaml` has `server.port: 8080`
+- **WHEN** the binary is started
+- **THEN** the server listens on `127.0.0.1:8080` and responds to `GET /api/health`
+
+#### Scenario: Graceful shutdown
+- **GIVEN** the server is running with active connections
+- **WHEN** SIGTERM is received
+- **THEN** the server drains in-flight requests and exits within 5 seconds
+
+## Design Decisions
+
+1. **Dependency injection via interfaces for handler testability**: Handlers receive dependencies (session fetcher, tmux operations) as interfaces on a server/router struct, rather than calling package-level functions directly. This enables mock injection in `_test.go` files without requiring a live tmux server.
+   - *Why*: Handler tests need isolation from tmux. Package-level functions can't be swapped in tests without build tags.
+   - *Rejected*: Build-tag test doubles — fragile, splits code across files, easy to forget.
+
+2. **Session URL param (not form field) for upload**: Upload endpoint uses `:session` in the URL path (`POST /api/sessions/:session/upload`) rather than a `session` form field. All session-scoped operations use the same URL pattern.
+   - *Why*: Consistency with all other session-scoped endpoints; URL routing is declarative.
+   - *Rejected*: Form field approach (current implementation) — inconsistent with other endpoints.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | POST-only mutations | Confirmed from intake #1 — routes enumerated in api.md | S:95 R:80 A:95 D:95 |
+| 2 | Certain | Port internal packages verbatim (except fab) | Confirmed from intake #2 — code review confirms stable, well-tested packages | S:90 R:90 A:95 D:95 |
+| 3 | Certain | No internal/worktree | Confirmed from intake #3 — architecture spec excludes it | S:90 R:90 A:90 D:95 |
+| 4 | Certain | Handler files split by resource domain | Confirmed from intake #4 — architecture spec maps each resource to a file | S:90 R:85 A:90 D:90 |
+| 5 | Certain | chi router with CORS, logger, recovery middleware | Confirmed from intake #5 — same stack as current, proven | S:90 R:85 A:90 D:95 |
+| 6 | Certain | SSE hub architecture unchanged | Upgraded from intake #7 — code review confirms sse.go is clean, portable as-is | S:90 R:85 A:90 D:95 |
+| 7 | Certain | WebSocket relay architecture unchanged | Upgraded from intake #8 — code review confirms relay.go is clean, portable as-is | S:90 R:80 A:90 D:95 |
+| 8 | Certain | Go module name `run-kit`, version 1.22+ | Same as current go.mod, no reason to change | S:95 R:90 A:95 D:95 |
+| 9 | Confident | Handler tests use httptest.NewRecorder + chi router | Confirmed from intake #6 — standard Go HTTP testing pattern, mock internal interfaces | S:80 R:85 A:85 D:85 |
+| 10 | Confident | `app/backend/` directory created as part of this change | Phase 1 scaffold not done; creating directories is trivial and easily reversed | S:70 R:90 A:80 D:80 |
+| 11 | Confident | Server struct with interfaces for handler testability | Standard Go DI pattern; handlers need mockable dependencies for test isolation | S:75 R:85 A:85 D:80 |
+| 12 | Confident | FabState reads via `os.ReadFile` following symlink | Go's os.ReadFile follows symlinks by default; simplest correct approach | S:80 R:90 A:90 D:90 |
+
+12 assumptions (8 certain, 4 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260312-r4t9-go-backend-api/tasks.md
+++ b/fab/changes/260312-r4t9-go-backend-api/tasks.md
@@ -1,0 +1,47 @@
+# Tasks: Go Backend API
+
+**Change**: 260312-r4t9-go-backend-api
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+## Phase 1: Setup
+
+- [x] T001 Create `app/backend/` Go module — `go.mod` (module `run-kit`, go 1.22), `go.sum`, directory skeleton for `cmd/run-kit/`, `api/`, `internal/{validate,config,tmux,fab,sessions}/`
+
+## Phase 2: Core Implementation — Internal Packages
+
+- [x] T002 [P] Port `internal/validate/` verbatim — copy `validate.go` and `validate_test.go` from `packages/api/internal/validate/` to `app/backend/internal/validate/`
+- [x] T003 [P] Port `internal/config/` verbatim — copy `config.go` and `config_test.go` from `packages/api/internal/config/` to `app/backend/internal/config/`
+- [x] T004 [P] Port `internal/tmux/` verbatim — copy `tmux.go` and `tmux_test.go` from `packages/api/internal/tmux/` to `app/backend/internal/tmux/`. Update `WindowInfo` struct: replace `FabStage`/`FabProgress` fields with `FabChange string` (`json:"fabChange,omitempty"`) and `FabStage string` (`json:"fabStage,omitempty"`)
+- [x] T005 Rewrite `internal/fab/` — new `fab.go` that reads `.fab-status.yaml` via `os.ReadFile` + `yaml.Unmarshal`. Export function returning change name + active stage. Write `fab_test.go` with table-driven tests (active change, no file, dangling symlink, all stages done)
+- [x] T006 Update `internal/sessions/` — copy from `packages/api/internal/sessions/`, rewrite enrichment to per-session model: read fab state once from window 0's project root, apply `FabChange`/`FabStage` to all windows. Update `sessions_test.go`
+
+## Phase 3: Core Implementation — API Layer
+
+- [x] T007 Create `api/router.go` — define dependency interfaces (`SessionFetcher`, `TmuxOps`), server struct, `NewRouter()` with chi, CORS, logger, recovery middleware, route registration. Export `writeJSON`/`writeError` helpers
+- [x] T008 Create `api/health.go` + `api/health_test.go` — `GET /api/health` handler and httptest integration test
+- [x] T009 Create `api/sessions.go` + `api/sessions_test.go` — `GET /api/sessions`, `POST /api/sessions` (create), `POST /api/sessions/:session/kill`. Tests cover response shapes, validation errors, 201 vs 200 status codes
+- [x] T010 Create `api/windows.go` + `api/windows_test.go` — `POST .../windows` (create), `POST .../windows/:index/kill`, `POST .../windows/:index/rename`, `POST .../windows/:index/keys`. Tests cover URL param parsing, validation, all four actions
+- [x] T011 Create `api/directories.go` + `api/directories_test.go` — `GET /api/directories?prefix=...`. Tests cover prefix filtering, empty prefix, hidden dir exclusion
+- [x] T012 Create `api/upload.go` + `api/upload_test.go` — `POST /api/sessions/:session/upload`. Session from URL param (not form field). Tests cover multipart parsing, size limit, filename sanitization, gitignore management
+- [x] T013 Create `api/sse.go` + `api/sse_test.go` — `GET /api/sessions/stream`. Port hub singleton from `packages/api/api/sse.go`. Tests cover initial snapshot delivery, deduplication, client lifecycle
+- [x] T014 Create `api/relay.go` — `WS /relay/:session/:window`. Port from `packages/api/api/relay.go`. Split-window, PTY attach, bidirectional relay, sync.Once cleanup. No unit test (requires live tmux + PTY)
+- [x] T015 Create `api/spa.go` + `api/spa_test.go` — `GET /*` catch-all. Port from `packages/api/api/spa.go`, update `spaDir` to `app/frontend/dist`. Tests cover static file serving, SPA fallback, path traversal prevention
+
+## Phase 4: Integration
+
+- [x] T016 Create `cmd/run-kit/main.go` — config loading, router creation with production deps, HTTP server, graceful shutdown on SIGINT/SIGTERM (5s timeout)
+- [x] T017 Verify full build and test suite — `go build ./...` and `go test ./...` from `app/backend/` both pass cleanly. Fix any compilation or test failures
+
+---
+
+## Execution Order
+
+- T001 blocks all subsequent tasks (module must exist)
+- T002, T003, T004, T005 are parallel (independent packages — fab rewrite reads `.fab-status.yaml` via os.ReadFile, no tmux dependency) <!-- clarified: removed false T005→T004 dependency — internal/fab does not import internal/tmux -->
+- T006 depends on T004 and T005 (sessions uses tmux.WindowInfo and fab.ReadState)
+- T007 depends on T006 (router uses sessions interfaces)
+- T008 through T015 depend on T007 (handlers register on the router)
+- T008 through T015 are mostly parallel (independent handler files), except T009 should come before T012 (upload uses session resolution pattern from sessions)
+- T016 depends on T007 (main.go creates the router)
+- T017 depends on all previous tasks


### PR DESCRIPTION
## Summary

Phase 2 of the run-kit reimplementation: creates the Go backend API under `app/backend/`. The current multiplexed `POST /api/sessions { action: "..." }` pattern is replaced with path-based intent and POST-only mutations, making the API self-documenting. Handler-level integration tests are added for every endpoint using httptest.NewRecorder with mock interfaces.

## Changes

- Port internal packages (validate, config, tmux, sessions) from `packages/api/internal/`
- Rewrite `internal/fab` to read `.fab-status.yaml` directly (no subprocess calls)
- API handler layer split by resource domain (health, sessions, windows, directories, upload, sse, relay, spa)
- Handler integration tests using httptest.NewRecorder with mock interfaces
- Server entry point with graceful shutdown (SIGINT/SIGTERM, 5s timeout)

## Stats
| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| refactor | 3.8 / 5.0 | — | 17/17 | Pass (1 iterations) |

[intake](https://github.com/wvrdz/run-kit/blob/r4t9/fab/changes/260312-r4t9-go-backend-api/intake.md) → [spec](https://github.com/wvrdz/run-kit/blob/r4t9/fab/changes/260312-r4t9-go-backend-api/spec.md) → tasks → apply → review → hydrate