### PR TITLE
feat: enable xterm clipboard, web-links, and WebGL addons

### DIFF
--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -13,8 +13,10 @@
   },
   "dependencies": {
     "@tanstack/react-router": "^1.114.0",
+    "@xterm/addon-clipboard": "^0.2.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-web-links": "^0.11.0",
+    "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^5.5.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/app/frontend/src/components/terminal-client.tsx
+++ b/app/frontend/src/components/terminal-client.tsx
@@ -115,10 +115,43 @@ export function TerminalClient({
       xtermRef.current = terminal;
       fitAddonRef.current = fitAddon;
 
+      // Clipboard addon — enriched clipboard support
+      const { ClipboardAddon } = await import("@xterm/addon-clipboard");
+      terminal.loadAddon(new ClipboardAddon());
+
+      // Clickable URLs
+      const { WebLinksAddon } = await import("@xterm/addon-web-links");
+      terminal.loadAddon(new WebLinksAddon());
+
+      // GPU-accelerated rendering (silent fallback to canvas)
+      try {
+        const { WebglAddon } = await import("@xterm/addon-webgl");
+        terminal.loadAddon(new WebglAddon());
+      } catch {
+        // canvas renderer continues working
+      }
+
       // Keyboard input → current WebSocket (wsRef always points to latest)
       terminal.onData((data) => {
         if (wsRef.current?.readyState === WebSocket.OPEN)
           wsRef.current.send(data);
+      });
+
+      // Cmd+C / Ctrl+C: copy selection instead of sending SIGINT
+      // Local const narrows the type for the closure (outer `terminal` is T | null).
+      const term = terminal;
+      term.attachCustomKeyEventHandler((event) => {
+        if (
+          (event.metaKey || event.ctrlKey) &&
+          event.key === "c" &&
+          event.type === "keydown"
+        ) {
+          if (term.hasSelection()) {
+            navigator.clipboard.writeText(term.getSelection());
+            return false;
+          }
+        }
+        return true;
       });
 
       resizeObserver = new ResizeObserver(() => {

--- a/app/frontend/src/components/terminal-client.tsx
+++ b/app/frontend/src/components/terminal-client.tsx
@@ -117,19 +117,22 @@ export function TerminalClient({
 
       // Clipboard addon — enriched clipboard support
       const { ClipboardAddon } = await import("@xterm/addon-clipboard");
+      if (cancelled) return void terminal.dispose();
       terminal.loadAddon(new ClipboardAddon());
 
       // Clickable URLs
       const { WebLinksAddon } = await import("@xterm/addon-web-links");
+      if (cancelled) return void terminal.dispose();
       terminal.loadAddon(new WebLinksAddon());
 
       // GPU-accelerated rendering (silent fallback to canvas)
       try {
         const { WebglAddon } = await import("@xterm/addon-webgl");
-        terminal.loadAddon(new WebglAddon());
+        if (!cancelled) terminal.loadAddon(new WebglAddon());
       } catch {
         // canvas renderer continues working
       }
+      if (cancelled) return void terminal.dispose();
 
       // Keyboard input → current WebSocket (wsRef always points to latest)
       terminal.onData((data) => {
@@ -147,7 +150,7 @@ export function TerminalClient({
           event.type === "keydown"
         ) {
           if (term.hasSelection()) {
-            navigator.clipboard.writeText(term.getSelection());
+            void navigator.clipboard.writeText(term.getSelection()).catch(() => {});
             return false;
           }
         }

--- a/docs/memory/run-kit/ui-patterns.md
+++ b/docs/memory/run-kit/ui-patterns.md
@@ -144,6 +144,17 @@ A custom Tailwind variant `coarse:` is defined in `globals.css` via `@custom-var
 
 Bottom bar buttons use `min-h-[44px]` unconditionally (not `coarse:` gated) since the bottom bar is touch-primary.
 
+### Terminal Addons
+
+Addons loaded in `init()` via dynamic import, after `terminal.open()`, before `ResizeObserver` setup. Order: FitAddon (existing) → fit() → ClipboardAddon → WebLinksAddon → WebglAddon.
+
+| Addon | Purpose | Notes |
+|-------|---------|-------|
+| `@xterm/addon-fit` | Auto-resize columns/rows | Existing — loaded first, `fit()` called immediately |
+| `@xterm/addon-clipboard` | OSC 52 clipboard sequences | Programs (tmux, vim, SSH) can write to system clipboard |
+| `@xterm/addon-web-links` | Clickable URLs in terminal output | |
+| `@xterm/addon-webgl` | GPU-accelerated rendering | Wrapped in try/catch — silently falls back to canvas renderer on failure |
+
 ### Terminal Font Scaling
 
 Terminal font size adapts at initialization: 13px on viewports >= 640px, 11px below. Determined via `window.matchMedia('(min-width: 640px)')` at xterm Terminal construction time. FitAddon recalculates columns automatically.
@@ -158,6 +169,7 @@ The `CommandPalette` component listens for a `palette:open` CustomEvent on `docu
 | Key | Action | Context |
 |-----|--------|---------|
 | `Cmd+K` | Open command palette | Always |
+| `Cmd+C` / `Ctrl+C` | Copy selection to clipboard (with selection) or send SIGINT (without selection) | Terminal focused — via `attachCustomKeyEventHandler`, `keydown` only |
 | `Esc Esc` | Navigate back (close drawer if open, else no-op) | 300ms double-tap window |
 
 ### Sidebar
@@ -236,3 +248,4 @@ Windows are `"active"` (last tmux activity within 10 seconds) or `"idle"`. No "e
 | 2026-03-12 | Single-view UI model — sidebar + terminal replaces three-page navigation, POST-only API client with path-based intent, ChromeProvider derives from selection (no slot injection), fullbleed always on, no max-width constraint, sidebar with session/window tree and mobile drawer | `260312-ux92-vite-react-frontend` |
 | 2026-03-12 | UI chrome refinements — simplified breadcrumbs (`☰ {logo} ❯ session ❯ window`, removed `⬡` and `›`), drag-resizable sidebar (default 220px, min 160, max 400, localStorage persist), bottom bar moved inside terminal column (`border-t border-border`, `py-1.5`), top bar `border-b border-border`, `[+ Session]` button in top bar line 2, sidebar footer removed, padding consistency (`px-3 sm:px-6` sidebar, `py-0.5 px-1` terminal container) | `260312-y4ci-ui-chrome-layout-refinements` |
 | 2026-03-13 | Rich sidebar window status — activity dot ring for `isActiveWindow`, idle duration display, info popover (change, process, path, state), shared format helpers (`lib/format.ts`). Top bar Line 2 enriched with paneCommand, duration, fab change ID+slug. Backend: `paneCommand` + `activityTimestamp` from tmux, `.fab-runtime.yaml` reading for agent state | `260313-txna-rich-sidebar-window-status` |
+| 2026-03-13 | xterm addon activation — ClipboardAddon (OSC 52), WebLinksAddon (clickable URLs), WebglAddon (GPU rendering with silent canvas fallback), Cmd+C selection-aware copy via `attachCustomKeyEventHandler` | `260313-dr60-xterm-clipboard-addons` |

--- a/fab/changes/260313-dr60-xterm-clipboard-addons/.history.jsonl
+++ b/fab/changes/260313-dr60-xterm-clipboard-addons/.history.jsonl
@@ -8,3 +8,13 @@
 {"delta":"+0.0","event":"confidence","score":4.1,"trigger":"calc-score","ts":"2026-03-13T11:46:23Z"}
 {"delta":"+0.0","event":"confidence","score":4.1,"trigger":"calc-score","ts":"2026-03-13T11:46:30Z"}
 {"delta":"+0.0","event":"confidence","score":4.1,"trigger":"calc-score","ts":"2026-03-13T11:46:35Z"}
+{"cmd":"fab-switch","event":"command","ts":"2026-03-13T14:55:08Z"}
+{"cmd":"fab-ff","event":"command","ts":"2026-03-13T14:55:23Z"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"spec","ts":"2026-03-13T14:56:11Z"}
+{"delta":"+0.0","event":"confidence","score":4.1,"trigger":"calc-score","ts":"2026-03-13T14:56:52Z"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"tasks","ts":"2026-03-13T14:57:01Z"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"apply","ts":"2026-03-13T14:57:36Z"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"review","ts":"2026-03-13T14:59:22Z"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"hydrate","ts":"2026-03-13T15:00:36Z"}
+{"event":"review","result":"passed","ts":"2026-03-13T15:00:36Z"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"ship","ts":"2026-03-13T15:01:26Z"}

--- a/fab/changes/260313-dr60-xterm-clipboard-addons/.status.yaml
+++ b/fab/changes/260313-dr60-xterm-clipboard-addons/.status.yaml
@@ -2,36 +2,41 @@ id: dr60
 name: 260313-dr60-xterm-clipboard-addons
 created: 2026-03-13T11:43:21Z
 created_by: sahil-weaver
-change_type: docs
+change_type: feat
 issues: []
 progress:
-    intake: ready
-    spec: pending
-    tasks: pending
-    apply: pending
-    review: pending
-    hydrate: pending
-    ship: pending
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
     review-pr: pending
 checklist:
-    generated: false
+    generated: true
     path: checklist.md
     completed: 0
-    total: 0
+    total: 17
 confidence:
-    certain: 4
+    certain: 5
     confident: 3
     tentative: 0
     unresolved: 0
     score: 4.1
-    indicative: true
     fuzzy: true
     dimensions:
-        signal: 82.9
-        reversibility: 92.1
-        competence: 87.9
+        signal: 83.1
+        reversibility: 91.3
+        competence: 88.8
         disambiguation: 90.0
 stage_metrics:
-    intake: {started_at: "2026-03-13T11:43:21Z", driver: fab-new, iterations: 1}
+    intake: {started_at: "2026-03-13T11:43:21Z", driver: fab-new, iterations: 1, completed_at: "2026-03-13T14:56:11Z"}
+    spec: {started_at: "2026-03-13T14:56:11Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-13T14:57:01Z"}
+    tasks: {started_at: "2026-03-13T14:57:01Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-13T14:57:36Z"}
+    apply: {started_at: "2026-03-13T14:57:36Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-13T14:59:22Z"}
+    review: {started_at: "2026-03-13T14:59:22Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-13T15:00:36Z"}
+    hydrate: {started_at: "2026-03-13T15:00:36Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-13T15:01:26Z"}
+    ship: {started_at: "2026-03-13T15:01:26Z", driver: fab-ff, iterations: 1}
 prs: []
-last_updated: 2026-03-13T11:46:35Z
+last_updated: 2026-03-13T15:01:26Z

--- a/fab/changes/260313-dr60-xterm-clipboard-addons/checklist.md
+++ b/fab/changes/260313-dr60-xterm-clipboard-addons/checklist.md
@@ -1,0 +1,38 @@
+# Quality Checklist: xterm Clipboard & Addons
+
+**Change**: 260313-dr60-xterm-clipboard-addons
+**Generated**: 2026-03-13
+**Spec**: `spec.md`
+
+## Functional Completeness
+- [x] CHK-001 Clipboard copy: `attachCustomKeyEventHandler` intercepts Cmd+C/Ctrl+C and copies when text selected
+- [x] CHK-002 SIGINT passthrough: Cmd+C/Ctrl+C without selection sends SIGINT normally
+- [x] CHK-003 ClipboardAddon: `@xterm/addon-clipboard` loaded via dynamic import in init()
+- [x] CHK-004 WebLinksAddon: `@xterm/addon-web-links` loaded via dynamic import in init()
+- [x] CHK-005 WebglAddon: `@xterm/addon-webgl` loaded with try/catch silent fallback
+
+## Behavioral Correctness
+- [x] CHK-006 Key handler only intercepts keydown events — keyup passes through
+- [x] CHK-007 All other key combinations pass through unchanged (return true)
+- [x] CHK-008 WebGL failure does not log errors or show user-visible messages
+
+## Scenario Coverage
+- [x] CHK-009 Copy selected text scenario: selected text → clipboard write → no SIGINT
+- [x] CHK-010 SIGINT scenario: no selection → normal SIGINT behavior
+- [x] CHK-011 WebGL fallback scenario: canvas renderer continues on WebGL failure
+
+## Edge Cases & Error Handling
+- [x] CHK-012 WebGL context creation failure caught silently
+- [x] CHK-013 navigator.clipboard.writeText works in secure context (localhost)
+
+## Code Quality
+- [x] CHK-014 Pattern consistency: dynamic imports match existing FitAddon pattern
+- [x] CHK-015 No unnecessary duplication: addons loaded in single init() function
+- [x] CHK-016 Addon loading order: FitAddon → fit() → ClipboardAddon → WebLinksAddon → WebglAddon (last)
+- [x] CHK-017 No shell string construction or exec calls (constitution: security-first)
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] CHK-008 **N/A**: {reason}`

--- a/fab/changes/260313-dr60-xterm-clipboard-addons/spec.md
+++ b/fab/changes/260313-dr60-xterm-clipboard-addons/spec.md
@@ -1,0 +1,107 @@
+# Spec: xterm Clipboard & Addons
+
+**Change**: 260313-dr60-xterm-clipboard-addons
+**Created**: 2026-03-13
+**Affected memory**: `docs/memory/run-kit/ui-patterns.md`
+
+## Terminal: Clipboard Copy via Key Handler
+
+### Requirement: Cmd+C / Ctrl+C Selection-Aware Copy
+
+The terminal component SHALL intercept `Cmd+C` (macOS) and `Ctrl+C` (Linux/Windows) via `attachCustomKeyEventHandler`. When text is selected in the terminal, the handler SHALL copy the selection to the system clipboard using `navigator.clipboard.writeText()` and prevent xterm from sending the keystroke to the backend (return `false`). When no text is selected, the handler SHALL allow the event to pass through (return `true`) so xterm sends SIGINT as normal.
+
+The handler SHALL only intercept `keydown` events — `keyup` events MUST pass through unchanged.
+
+#### Scenario: Copy selected text
+- **GIVEN** the terminal has text selected via mouse or keyboard
+- **WHEN** the user presses `Cmd+C` (macOS) or `Ctrl+C` (Linux)
+- **THEN** the selected text is written to the system clipboard
+- **AND** xterm does not send `\x03` (SIGINT) to the backend
+- **AND** the selection remains visible
+
+#### Scenario: SIGINT with no selection
+- **GIVEN** the terminal has no text selected
+- **WHEN** the user presses `Cmd+C` or `Ctrl+C`
+- **THEN** xterm sends `\x03` (SIGINT) to the running process as normal
+
+#### Scenario: Other key combinations pass through
+- **GIVEN** any key combination that is not `Cmd+C` / `Ctrl+C`
+- **WHEN** the user presses the key combination
+- **THEN** the handler returns `true` and xterm processes the key normally
+
+## Terminal: Addon Loading
+
+### Requirement: Load ClipboardAddon for OSC 52 Support
+
+The terminal component SHALL install `@xterm/addon-clipboard` as a new dependency and load it via dynamic import in the `init()` function, following the existing FitAddon pattern. This enables OSC 52 clipboard sequences — programs like tmux, vim, and SSH sessions can write to the system clipboard.
+
+#### Scenario: ClipboardAddon loaded on init
+- **GIVEN** the terminal component mounts
+- **WHEN** the async `init()` function runs
+- **THEN** `ClipboardAddon` is dynamically imported and loaded onto the terminal instance
+- **AND** OSC 52 clipboard write sequences from backend programs reach the system clipboard
+
+### Requirement: Activate WebLinksAddon
+
+The terminal component SHALL activate `@xterm/addon-web-links` (already in `package.json`) by dynamically importing and loading it in the `init()` function. This makes URLs in terminal output clickable.
+
+#### Scenario: WebLinksAddon loaded on init
+- **GIVEN** the terminal component mounts
+- **WHEN** the async `init()` function runs
+- **THEN** `WebLinksAddon` is dynamically imported and loaded onto the terminal instance
+- **AND** URLs appearing in terminal output become clickable links
+
+### Requirement: Enable WebglAddon with Silent Fallback
+
+The terminal component SHALL install `@xterm/addon-webgl` as a new dependency and attempt to load it via dynamic import in the `init()` function. Loading MUST be wrapped in a try/catch — WebGL2 context creation can fail on some hardware or when too many contexts are active. On failure, the canvas renderer continues working silently.
+
+#### Scenario: WebGL rendering enabled
+- **GIVEN** the browser supports WebGL2 and a context is available
+- **WHEN** the terminal initializes
+- **THEN** `WebglAddon` is loaded and GPU-accelerated rendering is active
+
+#### Scenario: WebGL fallback to canvas
+- **GIVEN** the browser does not support WebGL2 or context creation fails
+- **WHEN** the terminal initializes
+- **THEN** the `WebglAddon` load error is caught silently
+- **AND** the terminal continues rendering via the default canvas renderer
+- **AND** no error is logged or shown to the user
+
+### Requirement: Addon Loading Order
+
+All addons SHALL be loaded after `terminal.open()` and before the `ResizeObserver` is set up. The loading order SHALL be: FitAddon (existing), ClipboardAddon, WebLinksAddon, WebglAddon. FitAddon MUST be loaded first because `fitAddon.fit()` is called immediately after `terminal.open()`. WebglAddon MUST be loaded last because it replaces the renderer and should operate on a fully configured terminal.
+
+#### Scenario: Addon loading sequence
+- **GIVEN** the terminal is being initialized
+- **WHEN** `terminal.open()` completes
+- **THEN** addons are loaded in order: FitAddon → fit() → ClipboardAddon → WebLinksAddon → WebglAddon
+- **AND** the terminal is fully functional before the ResizeObserver begins observing
+
+## Design Decisions
+
+1. **Cmd+C intercept via `attachCustomKeyEventHandler`**: Selected over auto-copy-on-select (option 2) because it matches native terminal behavior (iTerm2, Terminal.app) — users expect Cmd+C to copy and Ctrl+C to SIGINT.
+   - *Why*: Preserves muscle memory and matches macOS/Linux conventions.
+   - *Rejected*: Auto-copy-on-select — diverges from terminal conventions, could be surprising.
+
+2. **Dynamic imports for all addons**: Follows existing FitAddon pattern in the codebase — all xterm addon imports are dynamic in the async `init()` function.
+   - *Why*: Consistent with existing code, enables tree-shaking.
+   - *Rejected*: Static imports — would diverge from established pattern.
+
+3. **Silent WebGL fallback**: No error logging or user notification on WebGL failure.
+   - *Why*: Canvas renderer is perfectly functional — the user never needs to know. Logging would create noise for devices that simply don't support WebGL2.
+   - *Rejected*: Console.warn on failure — adds noise without actionable information.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Use `attachCustomKeyEventHandler` for Cmd+C copy | Confirmed from intake #1 — user chose option 3 (Cmd+C intercept) | S:95 R:90 A:90 D:95 |
+| 2 | Certain | Load `@xterm/addon-web-links` | Confirmed from intake #2 — already installed, user confirmed | S:90 R:95 A:95 D:95 |
+| 3 | Certain | Install `@xterm/addon-clipboard` | Confirmed from intake #3 — user explicitly requested | S:95 R:90 A:85 D:90 |
+| 4 | Certain | Enable `@xterm/addon-webgl` with try/catch fallback | Confirmed from intake #7 — user confirmed, silent fallback | S:90 R:95 A:90 D:95 |
+| 5 | Confident | Use `navigator.clipboard.writeText` for copy | Confirmed from intake #4 — standard web API, secure context required (run-kit uses localhost) | S:70 R:90 A:85 D:80 |
+| 6 | Confident | Dynamic import pattern for all new addons | Confirmed from intake #5 — matches existing FitAddon pattern in codebase | S:75 R:95 A:90 D:90 |
+| 7 | Confident | Handle both `metaKey` (macOS) and `ctrlKey` (Linux) | Confirmed from intake #6 — standard cross-platform terminal behavior | S:65 R:90 A:80 D:85 |
+| 8 | Certain | Load addons after `terminal.open()`, WebglAddon last | xterm.js requires terminal to be open before loading renderer addons; FitAddon must be first for immediate fit() | S:85 R:85 A:95 D:90 |
+
+8 assumptions (5 certain, 3 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260313-dr60-xterm-clipboard-addons/tasks.md
+++ b/fab/changes/260313-dr60-xterm-clipboard-addons/tasks.md
@@ -1,0 +1,33 @@
+# Tasks: xterm Clipboard & Addons
+
+**Change**: 260313-dr60-xterm-clipboard-addons
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+## Phase 1: Setup
+
+- [x] T001 [P] Install `@xterm/addon-clipboard` — `cd app/frontend && pnpm add @xterm/addon-clipboard`
+- [x] T002 [P] Install `@xterm/addon-webgl` — `cd app/frontend && pnpm add @xterm/addon-webgl`
+
+## Phase 2: Core Implementation
+
+- [x] T003 Add `attachCustomKeyEventHandler` for Cmd+C/Ctrl+C selection-aware copy in `app/frontend/src/components/terminal-client.tsx` — intercept `keydown` events where `(metaKey || ctrlKey) && key === 'c'`, check `terminal.hasSelection()`, copy via `navigator.clipboard.writeText(terminal.getSelection())`, return `false` to suppress SIGINT. Return `true` for all other cases.
+- [x] T004 Load `ClipboardAddon` via dynamic import in `init()` after `fitAddon.fit()` in `app/frontend/src/components/terminal-client.tsx` — `const { ClipboardAddon } = await import("@xterm/addon-clipboard"); terminal.loadAddon(new ClipboardAddon());`
+- [x] T005 [P] Activate `WebLinksAddon` via dynamic import in `init()` after ClipboardAddon in `app/frontend/src/components/terminal-client.tsx` — `const { WebLinksAddon } = await import("@xterm/addon-web-links"); terminal.loadAddon(new WebLinksAddon());`
+- [x] T006 [P] Enable `WebglAddon` via dynamic import in `init()` as last addon in `app/frontend/src/components/terminal-client.tsx` — wrap in try/catch, silent fallback on failure
+
+## Phase 3: Verification
+
+- [x] T007 Run type check — `cd app/frontend && npx tsc --noEmit`
+- [x] T008 Run frontend tests — `cd app/frontend && npx vitest run`
+- [x] T009 Run production build — `cd app/frontend && npx vite build`
+
+---
+
+## Execution Order
+
+- T001 and T002 are parallel (independent package installs)
+- T003, T004 depend on T001 (ClipboardAddon import needs the package)
+- T005 has no install dependency (web-links already in package.json)
+- T006 depends on T002 (WebglAddon import needs the package)
+- T007-T009 depend on all prior tasks

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,12 +17,18 @@ importers:
       '@tanstack/react-router':
         specifier: ^1.114.0
         version: 1.166.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@xterm/addon-clipboard':
+        specifier: ^0.2.0
+        version: 0.2.0
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
       '@xterm/addon-web-links':
         specifier: ^0.11.0
         version: 0.11.0(@xterm/xterm@5.5.0)
+      '@xterm/addon-webgl':
+        specifier: ^0.19.0
+        version: 0.19.0
       '@xterm/xterm':
         specifier: ^5.5.0
         version: 5.5.0
@@ -816,6 +822,9 @@ packages:
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
+  '@xterm/addon-clipboard@0.2.0':
+    resolution: {integrity: sha512-Dl31BCtBhLaUEECUbEiVcCLvLBbaeGYdT7NofB8OJkGTD3MWgBsaLjXvfGAD4tQNHhm6mbKyYkR7XD8kiZsdNg==}
+
   '@xterm/addon-fit@0.10.0':
     resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
     peerDependencies:
@@ -825,6 +834,9 @@ packages:
     resolution: {integrity: sha512-nIHQ38pQI+a5kXnRaTgwqSHnX7KE6+4SVoceompgHL26unAxdfP6IPqUTSYPQgSwM56hsElfoNrrW5V7BUED/Q==}
     peerDependencies:
       '@xterm/xterm': ^5.0.0
+
+  '@xterm/addon-webgl@0.19.0':
+    resolution: {integrity: sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==}
 
   '@xterm/xterm@5.5.0':
     resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
@@ -1051,6 +1063,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  js-base64@3.7.8:
+    resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2176,6 +2191,10 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
+  '@xterm/addon-clipboard@0.2.0':
+    dependencies:
+      js-base64: 3.7.8
+
   '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
     dependencies:
       '@xterm/xterm': 5.5.0
@@ -2183,6 +2202,8 @@ snapshots:
   '@xterm/addon-web-links@0.11.0(@xterm/xterm@5.5.0)':
     dependencies:
       '@xterm/xterm': 5.5.0
+
+  '@xterm/addon-webgl@0.19.0': {}
 
   '@xterm/xterm@5.5.0': {}
 
@@ -2385,6 +2406,8 @@ snapshots:
   isbot@5.1.35: {}
 
   jiti@2.6.1: {}
+
+  js-base64@3.7.8: {}
 
   js-tokens@4.0.0: {}
 
@@ -2815,8 +2838,7 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yaml@2.8.2:
-    optional: true
+  yaml@2.8.2: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
## Summary
- **ClipboardAddon** for OSC 52 clipboard integration
- **Custom Cmd+C / Ctrl+C handler** copies terminal selection instead of sending SIGINT
- **WebLinksAddon** makes URLs in terminal output clickable
- **WebglAddon** for GPU-accelerated rendering with silent fallback to canvas

## Test plan
- [ ] Verify Cmd+C copies selected text in terminal (macOS)
- [ ] Verify Ctrl+C still sends SIGINT when nothing is selected
- [ ] Verify URLs in terminal output are clickable and open in new tab
- [ ] Verify WebGL rendering activates (check for smooth scrolling / no flickering)
- [ ] Verify fallback to canvas renderer on devices without WebGL support