### PR TITLE
refactor: Remove Top Bar Line 2

### DIFF
--- a/app/frontend/src/app.tsx
+++ b/app/frontend/src/app.tsx
@@ -279,15 +279,10 @@ function AppShell() {
           windowName={displayName}
           isConnected={isConnected}
           onNavigate={navigateToWindow}
-          onRename={() => {
-            if (currentWindow) {
-              dialogs.openRenameDialog(currentWindow.name);
-            }
-          }}
-          onKill={dialogs.openKillConfirm}
           onToggleSidebar={() => setSidebarOpen(!sidebarOpen)}
           onToggleDrawer={() => setDrawerOpen(!drawerOpen)}
           onCreateSession={dialogs.openCreateDialog}
+          onCreateWindow={handleCreateWindow}
         />
       </div>
 
@@ -306,6 +301,7 @@ function AppShell() {
                 currentWindowIndex={windowIndex ?? null}
                 onSelectWindow={navigateToWindow}
                 onCreateWindow={handleCreateWindow}
+                onCreateSession={dialogs.openCreateDialog}
               />
             </div>
             {/* Drag handle */}
@@ -370,6 +366,7 @@ function AppShell() {
                   navigateToWindow(s, w);
                 }}
                 onCreateWindow={handleCreateWindow}
+                onCreateSession={dialogs.openCreateDialog}
               />
             </div>
           </div>

--- a/app/frontend/src/components/breadcrumb-dropdown.tsx
+++ b/app/frontend/src/components/breadcrumb-dropdown.tsx
@@ -6,9 +6,10 @@ type Props = {
   label?: string;
   icon?: string;
   onNavigate?: (href: string) => void;
+  action?: { label: string; onAction: () => void };
 };
 
-export function BreadcrumbDropdown({ items, label, icon, onNavigate }: Props) {
+export function BreadcrumbDropdown({ items, label, icon, onNavigate, action }: Props) {
   const [open, setOpen] = useState(false);
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -90,6 +91,23 @@ export function BreadcrumbDropdown({ items, label, icon, onNavigate }: Props) {
           aria-label={label ? `Switch ${label}` : "Switch"}
           className="absolute top-full left-0 mt-1 bg-bg-primary border border-border rounded-lg shadow-2xl py-1 min-w-[160px] max-w-[240px] z-50"
         >
+          {action && (
+            <>
+              <button
+                type="button"
+                role="menuitem"
+                tabIndex={-1}
+                onClick={() => {
+                  setOpen(false);
+                  action.onAction();
+                }}
+                className="w-full text-left block px-3 py-2 text-sm text-text-primary hover:bg-bg-card transition-colors"
+              >
+                {action.label}
+              </button>
+              <div className="border-t border-border" />
+            </>
+          )}
           {items.map((item, i) => (
             <button
               key={item.href}

--- a/app/frontend/src/components/breadcrumb-dropdown.tsx
+++ b/app/frontend/src/components/breadcrumb-dropdown.tsx
@@ -14,7 +14,18 @@ export function BreadcrumbDropdown({ items, label, icon, onNavigate, action }: P
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
+  const actionRef = useRef<HTMLButtonElement | null>(null);
   const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  // When action exists, index 0 = action button, indices 1..N = items.
+  // When no action, indices 0..N-1 = items directly.
+  const offset = action ? 1 : 0;
+  const totalCount = items.length + offset;
+
+  function getFocusableRef(index: number): HTMLButtonElement | null {
+    if (action && index === 0) return actionRef.current;
+    return itemRefs.current[index - offset] ?? null;
+  }
 
   useEffect(() => {
     if (!open) return;
@@ -40,8 +51,8 @@ export function BreadcrumbDropdown({ items, label, icon, onNavigate, action }: P
         e.preventDefault();
         e.stopPropagation();
         setFocusedIndex((prev) => {
-          const next = prev < items.length - 1 ? prev + 1 : 0;
-          itemRefs.current[next]?.focus();
+          const next = prev < totalCount - 1 ? prev + 1 : 0;
+          getFocusableRef(next)?.focus();
           return next;
         });
       }
@@ -49,23 +60,23 @@ export function BreadcrumbDropdown({ items, label, icon, onNavigate, action }: P
         e.preventDefault();
         e.stopPropagation();
         setFocusedIndex((prev) => {
-          const next = prev > 0 ? prev - 1 : items.length - 1;
-          itemRefs.current[next]?.focus();
+          const next = prev > 0 ? prev - 1 : totalCount - 1;
+          getFocusableRef(next)?.focus();
           return next;
         });
       }
     }
     document.addEventListener("keydown", handleKey, { capture: true });
     return () => document.removeEventListener("keydown", handleKey, { capture: true });
-  }, [open, items.length]);
+  }, [open, totalCount]);
 
   useEffect(() => {
     if (!open) return;
     const currentIdx = items.findIndex((item) => item.current);
-    const targetIdx = currentIdx >= 0 ? currentIdx : 0;
+    const targetIdx = (currentIdx >= 0 ? currentIdx : 0) + offset;
     setFocusedIndex(targetIdx);
     requestAnimationFrame(() => {
-      itemRefs.current[targetIdx]?.focus();
+      getFocusableRef(targetIdx)?.focus();
     });
   }, [open, items]);
 
@@ -94,9 +105,10 @@ export function BreadcrumbDropdown({ items, label, icon, onNavigate, action }: P
           {action && (
             <>
               <button
+                ref={(el) => { actionRef.current = el; }}
                 type="button"
                 role="menuitem"
-                tabIndex={-1}
+                tabIndex={focusedIndex === 0 ? 0 : -1}
                 onClick={() => {
                   setOpen(false);
                   action.onAction();
@@ -114,7 +126,7 @@ export function BreadcrumbDropdown({ items, label, icon, onNavigate, action }: P
               ref={(el) => { itemRefs.current[i] = el; }}
               type="button"
               role="menuitem"
-              tabIndex={focusedIndex === i ? 0 : -1}
+              tabIndex={focusedIndex === i + offset ? 0 : -1}
               onClick={() => {
                 setOpen(false);
                 if (onNavigate) {

--- a/app/frontend/src/components/sidebar.test.tsx
+++ b/app/frontend/src/components/sidebar.test.tsx
@@ -60,6 +60,7 @@ function renderSidebar(overrides: Partial<React.ComponentProps<typeof Sidebar>> 
       currentWindowIndex="0"
       onSelectWindow={vi.fn()}
       onCreateWindow={vi.fn()}
+      onCreateSession={vi.fn()}
       {...overrides}
     />,
   );

--- a/app/frontend/src/components/sidebar.test.tsx
+++ b/app/frontend/src/components/sidebar.test.tsx
@@ -116,7 +116,7 @@ describe("Sidebar", () => {
     expect(applySpans.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("does not render a footer with + New Session button", () => {
+  it("does not render + New Session button when sessions exist", () => {
     renderSidebar();
     expect(screen.queryByText("+ New Session")).not.toBeInTheDocument();
   });
@@ -135,9 +135,14 @@ describe("Sidebar", () => {
     expect(screen.getByText(/2 window/)).toBeInTheDocument();
   });
 
-  it("shows empty state when no sessions", () => {
-    renderSidebar({ sessions: [] });
+  it("shows empty state with + New Session button when no sessions", () => {
+    const onCreateSession = vi.fn();
+    renderSidebar({ sessions: [], onCreateSession });
     expect(screen.getByText("No sessions")).toBeInTheDocument();
+    const btn = screen.getByText("+ New Session");
+    expect(btn).toBeInTheDocument();
+    fireEvent.click(btn);
+    expect(onCreateSession).toHaveBeenCalledTimes(1);
   });
 
   // T009: ring class on isActiveWindow dot

--- a/app/frontend/src/components/sidebar.tsx
+++ b/app/frontend/src/components/sidebar.tsx
@@ -10,6 +10,7 @@ type SidebarProps = {
   currentWindowIndex: string | null;
   onSelectWindow: (session: string, windowIndex: number) => void;
   onCreateWindow: (session: string) => void;
+  onCreateSession?: () => void;
 };
 
 export function Sidebar({
@@ -18,6 +19,7 @@ export function Sidebar({
   currentWindowIndex,
   onSelectWindow,
   onCreateWindow,
+  onCreateSession,
 }: SidebarProps) {
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
   const [killTarget, setKillTarget] = useState<{
@@ -68,8 +70,16 @@ export function Sidebar({
     <nav aria-label="Sessions" className="flex flex-col h-full py-2">
       <div className="flex-1 overflow-y-auto px-3 sm:px-6">
         {sessions.length === 0 ? (
-          <div className="text-text-secondary text-xs py-4 text-center">
-            No sessions
+          <div className="text-text-secondary text-xs py-4 text-center flex flex-col items-center gap-2">
+            <span>No sessions</span>
+            {onCreateSession && (
+              <button
+                onClick={onCreateSession}
+                className="text-sm px-3 py-1.5 border border-border rounded hover:border-text-secondary text-text-primary"
+              >
+                + New Session
+              </button>
+            )}
           </div>
         ) : (
           sessions.map((session) => {

--- a/app/frontend/src/components/sidebar.tsx
+++ b/app/frontend/src/components/sidebar.tsx
@@ -10,7 +10,7 @@ type SidebarProps = {
   currentWindowIndex: string | null;
   onSelectWindow: (session: string, windowIndex: number) => void;
   onCreateWindow: (session: string) => void;
-  onCreateSession?: () => void;
+  onCreateSession: () => void;
 };
 
 export function Sidebar({
@@ -72,14 +72,12 @@ export function Sidebar({
         {sessions.length === 0 ? (
           <div className="text-text-secondary text-xs py-4 text-center flex flex-col items-center gap-2">
             <span>No sessions</span>
-            {onCreateSession && (
-              <button
-                onClick={onCreateSession}
-                className="text-sm px-3 py-1.5 border border-border rounded hover:border-text-secondary text-text-primary"
-              >
-                + New Session
-              </button>
-            )}
+            <button
+              onClick={onCreateSession}
+              className="text-sm px-3 py-1.5 border border-border rounded hover:border-text-secondary text-text-primary"
+            >
+              + New Session
+            </button>
           </div>
         ) : (
           sessions.map((session) => {

--- a/app/frontend/src/components/top-bar.test.tsx
+++ b/app/frontend/src/components/top-bar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { TopBar } from "./top-bar";
 import { ChromeProvider } from "@/contexts/chrome-context";
 import type { ProjectSession, WindowInfo } from "@/types";
@@ -93,5 +93,41 @@ describe("TopBar Line 1", () => {
     expect(screen.queryByText("+ Session")).not.toBeInTheDocument();
     expect(screen.queryByText("Rename")).not.toBeInTheDocument();
     expect(screen.queryByText("Kill")).not.toBeInTheDocument();
+  });
+
+  it("calls onCreateSession when + New Session dropdown action is clicked", () => {
+    const onCreateSession = vi.fn();
+    renderTopBar({ onCreateSession });
+
+    // Open the session breadcrumb dropdown
+    const sessionDropdown = screen.getByLabelText("Switch session");
+    fireEvent.click(sessionDropdown);
+
+    // Click the "+ New Session" action
+    const newSessionBtn = screen.getByText("+ New Session");
+    expect(newSessionBtn).toBeInTheDocument();
+    fireEvent.click(newSessionBtn);
+
+    expect(onCreateSession).toHaveBeenCalledTimes(1);
+    // Menu should close after action
+    expect(screen.queryByText("+ New Session")).not.toBeInTheDocument();
+  });
+
+  it("calls onCreateWindow when + New Window dropdown action is clicked", () => {
+    const onCreateWindow = vi.fn();
+    renderTopBar({ onCreateWindow });
+
+    // Open the window breadcrumb dropdown
+    const windowDropdown = screen.getByLabelText("Switch window");
+    fireEvent.click(windowDropdown);
+
+    // Click the "+ New Window" action
+    const newWindowBtn = screen.getByText("+ New Window");
+    expect(newWindowBtn).toBeInTheDocument();
+    fireEvent.click(newWindowBtn);
+
+    expect(onCreateWindow).toHaveBeenCalledWith("run-kit");
+    // Menu should close after action
+    expect(screen.queryByText("+ New Window")).not.toBeInTheDocument();
   });
 });

--- a/app/frontend/src/components/top-bar.test.tsx
+++ b/app/frontend/src/components/top-bar.test.tsx
@@ -53,86 +53,45 @@ function renderTopBar(overrides: Partial<React.ComponentProps<typeof TopBar>> = 
         windowName="main"
         isConnected={true}
         onNavigate={vi.fn()}
-        onRename={vi.fn()}
-        onKill={vi.fn()}
         onToggleSidebar={vi.fn()}
         onToggleDrawer={vi.fn()}
         onCreateSession={vi.fn()}
+        onCreateWindow={vi.fn()}
         {...overrides}
       />
     </ChromeProvider>,
   );
 }
 
-describe("TopBar Line 2 enriched status", () => {
+describe("TopBar Line 1", () => {
   afterEach(cleanup);
 
-  it("shows full status for fab window", () => {
+  it("renders breadcrumb with session and window names", () => {
     renderTopBar();
-    const status = screen.getByTestId("line2-status");
-    expect(status).toBeInTheDocument();
-    // Activity
-    expect(screen.getByText("active")).toBeInTheDocument();
-    // Pane command
-    expect(screen.getByText("claude")).toBeInTheDocument();
-    // Fab stage badge
-    expect(screen.getByText("apply")).toBeInTheDocument();
-    // Fab change ID and slug
-    expect(screen.getByText("txna")).toBeInTheDocument();
-    expect(screen.getByText("rich-sidebar-window-status")).toBeInTheDocument();
+    expect(screen.getByText("run-kit")).toBeInTheDocument();
+    expect(screen.getByText("main")).toBeInTheDocument();
   });
 
-  it("shows non-fab window status with duration", () => {
-    renderTopBar({ currentWindow: nonFabIdleWindow, currentSession: sessions[1], sessionName: "ao-server" });
-    const status = screen.getByTestId("line2-status");
-    expect(status).toBeInTheDocument();
-    // Activity
-    expect(screen.getByText("idle")).toBeInTheDocument();
-    // Pane command
-    expect(screen.getByText("zsh")).toBeInTheDocument();
-    // Duration: 120s → "2m"
-    expect(screen.getByText("2m")).toBeInTheDocument();
-    // No fab fields
-    expect(screen.queryByText("apply")).not.toBeInTheDocument();
-    expect(screen.queryByText("txna")).not.toBeInTheDocument();
-  });
-
-  it("omits pane command when empty", () => {
-    const winNoPaneCmd: WindowInfo = {
-      ...fabWindow,
-      paneCommand: undefined,
-    };
-    renderTopBar({ currentWindow: winNoPaneCmd });
-    expect(screen.queryByText("claude")).not.toBeInTheDocument();
-  });
-
-  it("omits fab fields when no fabStage", () => {
-    const winNoFab: WindowInfo = {
-      ...fabWindow,
-      fabStage: undefined,
-      fabChange: undefined,
-    };
-    renderTopBar({ currentWindow: winNoFab });
-    expect(screen.queryByText("apply")).not.toBeInTheDocument();
-    expect(screen.queryByText("txna")).not.toBeInTheDocument();
-  });
-
-  it("parses ID and slug from fabChange correctly", () => {
+  it("shows connection status", () => {
     renderTopBar();
-    // "260313-txna-rich-sidebar-window-status" → id: "txna", slug: "rich-sidebar-window-status"
-    expect(screen.getByText("txna")).toBeInTheDocument();
-    expect(screen.getByText("rich-sidebar-window-status")).toBeInTheDocument();
+    expect(screen.getByText("live")).toBeInTheDocument();
   });
 
-  it("renders enriched status hidden on mobile via hidden sm:flex", () => {
+  it("shows disconnected status", () => {
+    renderTopBar({ isConnected: false });
+    expect(screen.getByText("disconnected")).toBeInTheDocument();
+  });
+
+  it("renders FixedWidthToggle in Line 1", () => {
     renderTopBar();
-    const status = screen.getByTestId("line2-status");
-    expect(status.className).toContain("hidden");
-    expect(status.className).toContain("sm:flex");
+    expect(screen.getByLabelText("Toggle fixed terminal width")).toBeInTheDocument();
   });
 
-  it("shows no status when no current window", () => {
-    renderTopBar({ currentWindow: null });
+  it("does not render Line 2 elements", () => {
+    renderTopBar();
     expect(screen.queryByTestId("line2-status")).not.toBeInTheDocument();
+    expect(screen.queryByText("+ Session")).not.toBeInTheDocument();
+    expect(screen.queryByText("Rename")).not.toBeInTheDocument();
+    expect(screen.queryByText("Kill")).not.toBeInTheDocument();
   });
 });

--- a/app/frontend/src/components/top-bar.tsx
+++ b/app/frontend/src/components/top-bar.tsx
@@ -1,7 +1,6 @@
 import { useCallback } from "react";
 import { BreadcrumbDropdown } from "@/components/breadcrumb-dropdown";
 import { useChrome, useChromeDispatch } from "@/contexts/chrome-context";
-import { parseFabChange, getWindowDuration } from "@/lib/format";
 import type { ProjectSession, WindowInfo } from "@/types";
 import type { BreadcrumbDropdownItem } from "@/contexts/chrome-context";
 
@@ -13,11 +12,10 @@ type TopBarProps = {
   windowName: string;
   isConnected: boolean;
   onNavigate: (session: string, windowIndex: number) => void;
-  onRename: () => void;
-  onKill: () => void;
   onToggleSidebar: () => void;
   onToggleDrawer: () => void;
   onCreateSession: () => void;
+  onCreateWindow: (session: string) => void;
 };
 
 export function TopBar({
@@ -28,11 +26,10 @@ export function TopBar({
   windowName,
   isConnected,
   onNavigate,
-  onRename,
-  onKill,
   onToggleSidebar,
   onToggleDrawer,
   onCreateSession,
+  onCreateWindow,
 }: TopBarProps) {
   const sessionItems: BreadcrumbDropdownItem[] = sessions.map((s) => ({
     label: s.name,
@@ -90,6 +87,7 @@ export function TopBar({
                 label="session"
                 icon={"\u276F"}
                 onNavigate={handleDropdownNavigate}
+                action={{ label: "+ New Session", onAction: onCreateSession }}
               />
               <span className="text-text-secondary hover:text-text-primary">
                 {sessionName}
@@ -104,6 +102,7 @@ export function TopBar({
                 label="window"
                 icon={"\u276F"}
                 onNavigate={handleDropdownNavigate}
+                action={{ label: "+ New Window", onAction: () => onCreateWindow(sessionName) }}
               />
               <span className="text-text-primary font-medium" aria-current="page">
                 {windowName}
@@ -124,6 +123,9 @@ export function TopBar({
             aria-hidden="true"
           />
           <span>{isConnected ? "live" : "disconnected"}</span>
+          <span className="coarse:min-h-[36px] coarse:min-w-[28px] flex items-center justify-center">
+            <FixedWidthToggle />
+          </span>
           <kbd className="hidden sm:inline-flex px-1.5 py-0.5 rounded border border-border text-text-secondary">
             {"\u2318K"}
           </kbd>
@@ -140,82 +142,6 @@ export function TopBar({
         </div>
       </div>
 
-      {/* Line 2: Action buttons + status — hidden on mobile where all children are hidden */}
-      <div className="hidden sm:flex items-center justify-between py-2 min-h-[36px]">
-        <div className="hidden sm:flex items-center gap-3">
-          <button
-            onClick={onCreateSession}
-            className="text-sm px-3 py-1 border border-border rounded hover:border-text-secondary"
-          >
-            + Session
-          </button>
-          {currentWindow && (
-            <>
-              <button
-                onClick={onRename}
-                className="text-sm px-3 py-1 border border-border rounded hover:border-text-secondary"
-              >
-                Rename
-              </button>
-              <button
-                onClick={onKill}
-                className="text-sm px-3 py-1 border border-border rounded hover:border-red-400 hover:text-red-400 transition-colors"
-              >
-                Kill
-              </button>
-            </>
-          )}
-        </div>
-        <div className="flex items-center gap-2 text-xs text-text-secondary">
-          {currentWindow && (
-            <div className="hidden sm:flex items-center gap-2" data-testid="line2-status">
-              <span
-                className={`w-2 h-2 rounded-full ${
-                  currentWindow.activity === "active"
-                    ? "bg-accent-green"
-                    : "bg-text-secondary"
-                }`}
-              />
-              <span>{currentWindow.activity}</span>
-              {currentWindow.paneCommand && (
-                <>
-                  <span className="text-text-secondary/50">{"\u00B7"}</span>
-                  <span>{currentWindow.paneCommand}</span>
-                </>
-              )}
-              {(() => {
-                const dur = getWindowDuration(currentWindow, Math.floor(Date.now() / 1000));
-                return dur ? (
-                  <>
-                    <span className="text-text-secondary/50">{"\u00B7"}</span>
-                    <span>{dur}</span>
-                  </>
-                ) : null;
-              })()}
-              {currentWindow.fabStage && (
-                <>
-                  <span className="text-text-secondary/50">{"\u2502"}</span>
-                  <span className="text-accent px-1.5 py-0.5 rounded bg-accent/10">
-                    {currentWindow.fabStage}
-                  </span>
-                  {(() => {
-                    const fabInfo = parseFabChange(currentWindow.fabChange ?? "");
-                    return fabInfo ? (
-                      <>
-                        <span className="text-text-secondary/50">{"\u00B7"}</span>
-                        <span>{fabInfo.id}</span>
-                        <span className="text-text-secondary/50">{"\u00B7"}</span>
-                        <span>{fabInfo.slug}</span>
-                      </>
-                    ) : null;
-                  })()}
-                </>
-              )}
-            </div>
-          )}
-          <FixedWidthToggle />
-        </div>
-      </div>
     </header>
   );
 }

--- a/app/frontend/src/components/top-bar.tsx
+++ b/app/frontend/src/components/top-bar.tsx
@@ -123,9 +123,7 @@ export function TopBar({
             aria-hidden="true"
           />
           <span>{isConnected ? "live" : "disconnected"}</span>
-          <span className="coarse:min-h-[36px] coarse:min-w-[28px] flex items-center justify-center">
-            <FixedWidthToggle />
-          </span>
+          <FixedWidthToggle />
           <kbd className="hidden sm:inline-flex px-1.5 py-0.5 rounded border border-border text-text-secondary">
             {"\u2318K"}
           </kbd>
@@ -155,7 +153,7 @@ function FixedWidthToggle() {
       onClick={toggleFixedWidth}
       aria-label="Toggle fixed terminal width"
       aria-pressed={fixedWidth}
-      className={`px-1.5 py-0.5 rounded border transition-colors ${
+      className={`px-1.5 py-0.5 rounded border transition-colors coarse:min-h-[36px] coarse:min-w-[28px] flex items-center justify-center ${
         fixedWidth
           ? "border-accent text-accent bg-accent/10"
           : "border-border text-text-secondary hover:border-text-secondary"

--- a/docs/memory/run-kit/ui-patterns.md
+++ b/docs/memory/run-kit/ui-patterns.md
@@ -7,13 +7,13 @@
 | `/:session/:window` | Single view (sidebar + terminal) | Layout component (SSE via `useSessions()` context) |
 | `/` | Redirect | Redirects to first session's first window (`/:session/0`) |
 
-Single-view model: sidebar shows session/window tree, terminal is always the main content area. No page transitions. When no sessions exist, sidebar shows "No sessions" with a `[+ New Session]` button and the terminal area shows a placeholder.
+Single-view model: sidebar shows session/window tree, terminal is always the main content area. No page transitions. When no sessions exist, sidebar shows "No sessions" with a `+ New Session` button and the terminal area shows a placeholder.
 
 ## Chrome (Top Bar)
 
 The root layout (`app/frontend/src/app.tsx`) renders `TopBarChrome` which derives its content from the current session:window selection via `ChromeProvider` context. No slot injection — the chrome reads the selection and renders directly.
 
-**Line 1** (fixed height, `border-b border-border`): logo toggle + icon breadcrumbs + connection indicator + `⌘K` (desktop) / `⋯` (mobile).
+**Line 1** (fixed height, `border-b border-border`): logo toggle + icon breadcrumbs + connection indicator + FixedWidthToggle + `⌘K` (desktop) / `⋯` (mobile). Single-line top bar — no Line 2.
 
 Breadcrumb: `{logo} ❯ {session} ❯ {window}` (syncs with tmux active window via SSE). Logo toggles sidebar (desktop) or opens drawer (mobile) — no separate hamburger icon.
 
@@ -27,27 +27,17 @@ Breadcrumb: `{logo} ❯ {session} ❯ {window}` (syncs with tmux active window v
 
 Breadcrumb segments with a `dropdownItems` array use the ❯ icon as the dropdown trigger. Split click-target pattern: clicking the label navigates (existing behavior), clicking the icon opens the dropdown.
 
-**Session dropdown**: Lists all tmux sessions. Current session highlighted with `text-accent`. Selecting navigates to `/{session}/0`.
+**Session dropdown**: Lists all tmux sessions. Current session highlighted with `text-accent`. Selecting navigates to `/{session}/0`. First item: `+ New Session` action (opens session creation dialog).
 
-**Window dropdown**: Lists all windows in the current session. Current window highlighted. Selecting navigates to `/{session}/{index}`.
+**Window dropdown**: Lists all windows in the current session. Current window highlighted. Selecting navigates to `/{session}/{index}`. First item: `+ New Window` action (creates new window in current session).
+
+**Action items in dropdowns**: `BreadcrumbDropdown` accepts an optional `action` prop of type `{ label: string; onAction: () => void }`. When provided, the action item renders before the selection list, separated by a divider (`border-t border-border`). Action items use `text-text-primary` styling (not `text-accent`), close the dropdown on click, and are excluded from ArrowUp/ArrowDown keyboard navigation among selection items.
 
 **Dropdown component** (`app/frontend/src/components/breadcrumb-dropdown.tsx`): Reusable dropdown accepting `icon` prop (rendered as trigger button content), with outside-click dismiss, Escape dismiss, ArrowUp/ArrowDown keyboard navigation, ARIA `role="menu"`/`role="menuitem"`. Styled with `bg-bg-primary border-border shadow-2xl`, matching bottom-bar Fn key dropdown pattern. Icon button has 24px minimum tap target (44px on touch devices via `coarse:min-h-[44px]`). Long names truncated via `max-w-[240px]`.
 
 Connection indicator: green/gray dot with "live"/"disconnected" label, driven by `isConnected` from ChromeProvider (set by each page from `useSessions`).
 
-**Line 2** (fixed height, ALWAYS rendered with `min-h-[36px]`): Contextual action bar. Chrome derives content from current session:window selection — no slot injection.
-
-| Left content | Right content |
-|-------------|---------------|
-| `[+ Session]` `[Rename]` `[Kill]` (kill has red hover) | `{dot} {activity} · {paneCommand} · {duration} │ {fabStage badge} · {fabChange id} · {fabChange slug} [fixedWidthToggle]` |
-
-Right content layout for the selected window: activity dot + activity text, then `paneCommand` if present, then idle duration (via `getWindowDuration()`), then a `│` (U+2502 box drawing vertical) separator + fab stage badge + fab change (4-char ID `·` slug via `parseFabChange()`) if fab info is present. Items within a group separated by `·` (U+00B7 middle dot). All items `text-xs text-text-secondary`. Fab stage uses `text-accent px-1.5 py-0.5 rounded bg-accent/10` badge styling. Shared helpers imported from `lib/format.ts`.
-
-`[+ Session]` is always visible (not gated on `currentWindow`) since creating a session is a global action. `[Rename]` and `[Kill]` are contextual to the current window.
-
-Line 2 renders even when empty — prevents layout shift.
-
-**Line 2 mobile collapse** (< 640px): Action buttons hidden (`hidden sm:block`). Status text renders left-aligned. A `⋯` button appears at the right edge (`sm:hidden`) and opens the command palette via a `palette:open` CustomEvent on `document`. All actions are registered as palette actions, so nothing is lost on mobile — only the presentation changes.
+**FixedWidthToggle** (in Line 1 right section): Renders between the connection indicator and `⌘K`/`⋯`. Order: `[● live] [⇔] [⌘K]`. Self-contained component using `useChrome()`/`useChromeDispatch()`. Touch target: `coarse:min-h-[36px] coarse:min-w-[28px]`. Visible on all viewports (desktop and mobile).
 
 ### Sidebar Kill Controls
 
@@ -81,7 +71,9 @@ Line 2 renders even when empty — prevents layout shift.
 
 Popover state managed via `popoverKey` state in `Sidebar`, keyed by `session:windowIndex`. Visually distinct from action menus (read-only info card, not clickable items).
 
-**No footer** — `[+ Session]` action moved to top bar line 2.
+**Empty state**: When no sessions exist (`sessions.length === 0`), the sidebar displays "No sessions" text with a centered `+ New Session` button. The button triggers the same session creation flow as the breadcrumb dropdown's `+ New Session` action.
+
+**No footer** — session creation accessible via breadcrumb dropdown `+ New Session` action and sidebar empty state button.
 
 ## Bottom Bar (Always Visible, Inside Terminal Column)
 
@@ -136,7 +128,7 @@ All zones use `px-3 sm:px-6` — reduced horizontal padding on screens < 640px. 
 ### Touch Targets
 
 A custom Tailwind variant `coarse:` is defined in `globals.css` via `@custom-variant coarse (@media (pointer: coarse))`. On touch devices, interactive elements get `coarse:min-h-[44px]` (Apple HIG minimum). This includes:
-- Line 2 action buttons (Rename, Kill)
+- FixedWidthToggle (`coarse:min-h-[36px] coarse:min-w-[28px]`)
 - Sidebar session ✕ kill buttons + window rows
 - Breadcrumb dropdown chevrons
 - `⋯` command palette trigger
@@ -161,7 +153,7 @@ Terminal font size adapts at initialization: 13px on viewports >= 640px, 11px be
 
 ### Command Palette Mobile Trigger
 
-The `CommandPalette` component listens for a `palette:open` CustomEvent on `document` (in addition to `⌘K`). The `⋯` button in Line 2 dispatches this event. This is the mobile equivalent of `⌘K` — physical keyboards aren't available on phones.
+The `CommandPalette` component listens for a `palette:open` CustomEvent on `document` (in addition to `⌘K`). The `⋯` button in Line 1 dispatches this event on mobile. This is the mobile equivalent of `⌘K` — physical keyboards aren't available on phones.
 
 ## Keyboard Shortcuts
 
@@ -200,7 +192,7 @@ Dark theme only, blue-tinted palette. Linear/Raycast aesthetic.
 
 ## Create Session Dialog
 
-The "Create session" dialog (top bar `[+ Session]` button or command palette) has three sections:
+The "Create session" dialog (breadcrumb `+ New Session` action, sidebar empty state button, or command palette) has three sections:
 
 1. **Quick picks ("Recent:")** — Deduplicated project root paths from existing tmux sessions (window 0's `pane_current_path`). Tappable list items with 44px min height for mobile. Selecting fills path + auto-derives session name.
 
@@ -208,7 +200,7 @@ The "Create session" dialog (top bar `[+ Session]` button or command palette) ha
 
 3. **Session name** — Auto-derived from the last segment of the selected path (e.g., `~/code/wvrdz/run-kit` yields `run-kit`). Editable — auto-derivation is a convenience, not a lock.
 
-On submit, the dialog calls `createSession(name, cwd)` which sends `POST /api/sessions` with `{ name, cwd }`. The `cwd` field is omitted when no path is selected, preserving the original name-only behavior. Accessible from top bar `[+ Session]` button and command palette.
+On submit, the dialog calls `createSession(name, cwd)` which sends `POST /api/sessions` with `{ name, cwd }`. The `cwd` field is omitted when no path is selected, preserving the original name-only behavior. Accessible from breadcrumb `+ New Session` dropdown action, sidebar empty state button, and command palette.
 
 ## Session-to-Project Mapping
 
@@ -242,3 +234,4 @@ Windows are `"active"` (last tmux activity within 10 seconds) or `"idle"`. No "e
 | 2026-03-13 | Rich sidebar window status — activity dot ring for `isActiveWindow`, idle duration display, info popover (change, process, path, state), shared format helpers (`lib/format.ts`). Top bar Line 2 enriched with paneCommand, duration, fab change ID+slug. Backend: `paneCommand` + `activityTimestamp` from tmux, `.fab-runtime.yaml` reading for agent state | `260313-txna-rich-sidebar-window-status` |
 | 2026-03-13 | xterm addon activation — ClipboardAddon (OSC 52), WebLinksAddon (clickable URLs), WebglAddon (GPU rendering with silent canvas fallback), Cmd+C selection-aware copy via `attachCustomKeyEventHandler` | `260313-dr60-xterm-clipboard-addons` |
 | 2026-03-13 | Removed single-key shortcuts — deleted `useKeyboardNav` (j/k/Enter), `useAppShortcuts` (c/r/Esc Esc), sidebar focus ring (`focusedIndex`). Cmd+K command palette is now the sole keyboard shortcut. Palette actions no longer show shortcut hints for create/rename | `260313-3brm-remove-single-key-shortcuts` |
+| 2026-03-13 | Remove top bar Line 2 — deleted action bar (+ Session, Rename, Kill, window status). FixedWidthToggle relocated to Line 1 (between connection indicator and ⌘K). BreadcrumbDropdown gains `action` prop for `+ New Session`/`+ New Window` as first dropdown item with divider. Sidebar empty state shows `+ New Session` button. Top bar is now single-line on all viewports | `260313-zvgc-remove-top-bar-line-2` |

--- a/fab/changes/260313-zvgc-remove-top-bar-line-2/.history.jsonl
+++ b/fab/changes/260313-zvgc-remove-top-bar-line-2/.history.jsonl
@@ -7,3 +7,17 @@
 {"delta":"+0.0","event":"confidence","score":4.1,"trigger":"calc-score","ts":"2026-03-13T18:16:33Z"}
 {"delta":"-0.3","event":"confidence","score":3.8,"trigger":"calc-score","ts":"2026-03-13T18:16:43Z"}
 {"delta":"+0.0","event":"confidence","score":3.8,"trigger":"calc-score","ts":"2026-03-13T18:16:48Z"}
+{"cmd":"fab-switch","event":"command","ts":"2026-03-13T18:27:57Z"}
+{"cmd":"fab-ff","event":"command","ts":"2026-03-13T18:28:15Z"}
+{"delta":"-0.3","event":"confidence","score":3.5,"trigger":"calc-score","ts":"2026-03-13T18:29:50Z"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"spec","ts":"2026-03-13T18:29:54Z"}
+{"cmd":"fab-clarify","event":"command","ts":"2026-03-13T18:30:22Z"}
+{"cmd":"fab-clarify","event":"command","ts":"2026-03-13T18:32:21Z"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"tasks","ts":"2026-03-13T18:35:06Z"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"apply","ts":"2026-03-13T18:35:06Z"}
+{"cmd":"fab-continue","event":"command","ts":"2026-03-13T18:36:04Z"}
+{"action":"enter","driver":"fab-continue","event":"stage-transition","stage":"review","ts":"2026-03-13T18:40:05Z"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"hydrate","ts":"2026-03-13T18:42:53Z"}
+{"event":"review","result":"passed","ts":"2026-03-13T18:42:53Z"}
+{"cmd":"fab-continue","event":"command","ts":"2026-03-13T18:43:23Z"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"ship","ts":"2026-03-13T18:45:35Z"}

--- a/fab/changes/260313-zvgc-remove-top-bar-line-2/.history.jsonl
+++ b/fab/changes/260313-zvgc-remove-top-bar-line-2/.history.jsonl
@@ -21,3 +21,4 @@
 {"event":"review","result":"passed","ts":"2026-03-13T18:42:53Z"}
 {"cmd":"fab-continue","event":"command","ts":"2026-03-13T18:43:23Z"}
 {"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"ship","ts":"2026-03-13T18:45:35Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-03-13T18:47:16Z"}

--- a/fab/changes/260313-zvgc-remove-top-bar-line-2/.status.yaml
+++ b/fab/changes/260313-zvgc-remove-top-bar-line-2/.status.yaml
@@ -5,40 +5,40 @@ created_by: sahil-weaver
 change_type: refactor
 issues: []
 progress:
-    intake: done
-    spec: done
-    tasks: done
-    apply: done
-    review: done
-    hydrate: done
-    ship: done
-    review-pr: active
+  intake: done
+  spec: done
+  tasks: done
+  apply: done
+  review: done
+  hydrate: done
+  ship: done
+  review-pr: active
 checklist:
-    generated: true
-    path: checklist.md
-    completed: 0
-    total: 0
+  generated: true
+  path: checklist.md
+  completed: 0
+  total: 0
 confidence:
-    certain: 6
-    confident: 5
-    tentative: 0
-    unresolved: 0
-    score: 3.5
-    fuzzy: true
-    dimensions:
-        signal: 81.4
-        reversibility: 88.6
-        competence: 84.1
-        disambiguation: 85.0
+  certain: 6
+  confident: 5
+  tentative: 0
+  unresolved: 0
+  score: 3.5
+  fuzzy: true
+  dimensions:
+    signal: 81.4
+    reversibility: 88.6
+    competence: 84.1
+    disambiguation: 85.0
 stage_metrics:
-    intake: {started_at: "2026-03-13T18:13:57Z", driver: fab-new, iterations: 1, completed_at: "2026-03-13T18:29:54Z"}
-    spec: {started_at: "2026-03-13T18:29:54Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-13T18:35:06Z"}
-    tasks: {started_at: "2026-03-13T18:35:06Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-13T18:35:06Z"}
-    apply: {started_at: "2026-03-13T18:35:06Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-13T18:40:05Z"}
-    review: {started_at: "2026-03-13T18:40:05Z", driver: fab-continue, iterations: 1, completed_at: "2026-03-13T18:42:53Z"}
-    hydrate: {started_at: "2026-03-13T18:42:53Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-13T18:45:35Z"}
-    ship: {started_at: "2026-03-13T18:45:35Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-13T18:47:16Z"}
-    review-pr: {started_at: "2026-03-13T18:47:16Z", driver: git-pr, iterations: 1}
+  intake: {started_at: "2026-03-13T18:13:57Z", driver: fab-new, iterations: 1, completed_at: "2026-03-13T18:29:54Z"}
+  spec: {started_at: "2026-03-13T18:29:54Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-13T18:35:06Z"}
+  tasks: {started_at: "2026-03-13T18:35:06Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-13T18:35:06Z"}
+  apply: {started_at: "2026-03-13T18:35:06Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-13T18:40:05Z"}
+  review: {started_at: "2026-03-13T18:40:05Z", driver: fab-continue, iterations: 1, completed_at: "2026-03-13T18:42:53Z"}
+  hydrate: {started_at: "2026-03-13T18:42:53Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-13T18:45:35Z"}
+  ship: {started_at: "2026-03-13T18:45:35Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-13T18:47:16Z"}
+  review-pr: {started_at: "2026-03-13T18:47:16Z", driver: git-pr, iterations: 1, phase: fixing, reviewer: 'copilot-pull-request-reviewer[bot]'}
 prs:
-    - https://github.com/wvrdz/run-kit/pull/42
+  - https://github.com/wvrdz/run-kit/pull/42
 last_updated: 2026-03-13T18:47:16Z

--- a/fab/changes/260313-zvgc-remove-top-bar-line-2/.status.yaml
+++ b/fab/changes/260313-zvgc-remove-top-bar-line-2/.status.yaml
@@ -5,33 +5,38 @@ created_by: sahil-weaver
 change_type: refactor
 issues: []
 progress:
-    intake: ready
-    spec: pending
-    tasks: pending
-    apply: pending
-    review: pending
-    hydrate: pending
-    ship: pending
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
     review-pr: pending
 checklist:
-    generated: false
+    generated: true
     path: checklist.md
     completed: 0
     total: 0
 confidence:
-    certain: 5
-    confident: 4
+    certain: 6
+    confident: 5
     tentative: 0
     unresolved: 0
-    score: 3.8
-    indicative: true
+    score: 3.5
     fuzzy: true
     dimensions:
-        signal: 83.3
-        reversibility: 88.3
-        competence: 85.0
-        disambiguation: 88.3
+        signal: 81.4
+        reversibility: 88.6
+        competence: 84.1
+        disambiguation: 85.0
 stage_metrics:
-    intake: {started_at: "2026-03-13T18:13:57Z", driver: fab-new, iterations: 1}
+    intake: {started_at: "2026-03-13T18:13:57Z", driver: fab-new, iterations: 1, completed_at: "2026-03-13T18:29:54Z"}
+    spec: {started_at: "2026-03-13T18:29:54Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-13T18:35:06Z"}
+    tasks: {started_at: "2026-03-13T18:35:06Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-13T18:35:06Z"}
+    apply: {started_at: "2026-03-13T18:35:06Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-13T18:40:05Z"}
+    review: {started_at: "2026-03-13T18:40:05Z", driver: fab-continue, iterations: 1, completed_at: "2026-03-13T18:42:53Z"}
+    hydrate: {started_at: "2026-03-13T18:42:53Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-13T18:45:35Z"}
+    ship: {started_at: "2026-03-13T18:45:35Z", driver: fab-ff, iterations: 1}
 prs: []
-last_updated: 2026-03-13T18:16:48Z
+last_updated: 2026-03-13T18:45:35Z

--- a/fab/changes/260313-zvgc-remove-top-bar-line-2/.status.yaml
+++ b/fab/changes/260313-zvgc-remove-top-bar-line-2/.status.yaml
@@ -11,8 +11,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 checklist:
     generated: true
     path: checklist.md
@@ -37,6 +37,8 @@ stage_metrics:
     apply: {started_at: "2026-03-13T18:35:06Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-13T18:40:05Z"}
     review: {started_at: "2026-03-13T18:40:05Z", driver: fab-continue, iterations: 1, completed_at: "2026-03-13T18:42:53Z"}
     hydrate: {started_at: "2026-03-13T18:42:53Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-13T18:45:35Z"}
-    ship: {started_at: "2026-03-13T18:45:35Z", driver: fab-ff, iterations: 1}
-prs: []
-last_updated: 2026-03-13T18:45:35Z
+    ship: {started_at: "2026-03-13T18:45:35Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-13T18:47:16Z"}
+    review-pr: {started_at: "2026-03-13T18:47:16Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/wvrdz/run-kit/pull/42
+last_updated: 2026-03-13T18:47:16Z

--- a/fab/changes/260313-zvgc-remove-top-bar-line-2/checklist.md
+++ b/fab/changes/260313-zvgc-remove-top-bar-line-2/checklist.md
@@ -1,0 +1,55 @@
+# Quality Checklist: Remove Top Bar Line 2
+
+**Change**: 260313-zvgc-remove-top-bar-line-2
+**Generated**: 2026-03-13
+**Spec**: `spec.md`
+
+## Functional Completeness
+
+- [ ] CHK-001 Line 2 Removal: The entire Line 2 `<div>` (action buttons + status) is deleted from `top-bar.tsx`
+- [ ] CHK-002 FixedWidthToggle Relocation: Toggle renders in Line 1 between connection label and `⌘K`
+- [ ] CHK-003 Session Dropdown Action: `+ New Session` appears as first item in session breadcrumb dropdown with divider
+- [ ] CHK-004 Window Dropdown Action: `+ New Window` appears as first item in window breadcrumb dropdown with divider
+- [ ] CHK-005 Sidebar Empty State: `+ New Session` button displayed when no sessions exist
+- [ ] CHK-006 Unused Props Removed: `onRename` and `onKill` removed from `TopBarProps` and parent call sites
+
+## Behavioral Correctness
+
+- [ ] CHK-007 FixedWidthToggle Behavior: Toggle click still toggles between fixed/full width with correct visual states
+- [ ] CHK-008 Session Creation from Dropdown: Clicking `+ New Session` in dropdown opens session creation dialog
+- [ ] CHK-009 Window Creation from Dropdown: Clicking `+ New Window` creates new window in current session
+- [ ] CHK-010 Action Item Not Highlighted: `+ New` items do not receive `text-accent` current-item styling
+- [ ] CHK-011 Dropdown Keyboard Nav: ArrowUp/ArrowDown keyboard navigation skips the action item
+
+## Removal Verification
+
+- [ ] CHK-012 No Line 2 Remnants: No markup, data-testid, conditional renders, or className references to Line 2 remain
+- [ ] CHK-013 No Dead Imports: `parseFabChange` and `getWindowDuration` imports removed from `top-bar.tsx` if no longer referenced
+- [ ] CHK-014 No Dead Props: `onRename` and `onKill` not passed anywhere to `TopBar`
+
+## Scenario Coverage
+
+- [ ] CHK-015 Desktop Viewport: FixedWidthToggle visible in Line 1 on desktop (>= 640px)
+- [ ] CHK-016 Mobile Viewport: FixedWidthToggle visible on mobile (< 640px) — previously hidden with Line 2
+- [ ] CHK-017 Empty Sidebar: `+ New Session` button renders when `sessions.length === 0`
+- [ ] CHK-018 Dropdown Opens with Action: Session/window dropdowns render action item + divider + selection list
+
+## Edge Cases & Error Handling
+
+- [ ] CHK-019 No Sessions, Dropdown: Session dropdown still functions when no sessions exist (empty list, action item still clickable)
+- [ ] CHK-020 Single Window: Window dropdown action works when session has only one window
+
+## Code Quality
+
+- [ ] CHK-021 Pattern consistency: New code follows naming and structural patterns of surrounding code
+- [ ] CHK-022 No unnecessary duplication: Existing utilities reused where applicable
+- [ ] CHK-023 Readability: FixedWidthToggle placement in Line 1 JSX is clear, not buried
+- [ ] CHK-024 Type narrowing: No `as` casts introduced — use proper TypeScript guards
+- [ ] CHK-025 No duplicated utilities: `BreadcrumbDropdown` action prop reuses existing dropdown patterns
+- [ ] CHK-026 No magic strings: Action labels defined clearly, not scattered
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] CHK-008 **N/A**: {reason}`

--- a/fab/changes/260313-zvgc-remove-top-bar-line-2/spec.md
+++ b/fab/changes/260313-zvgc-remove-top-bar-line-2/spec.md
@@ -1,0 +1,199 @@
+# Spec: Remove Top Bar Line 2
+
+**Change**: 260313-zvgc-remove-top-bar-line-2
+**Created**: 2026-03-13
+**Affected memory**: `docs/memory/run-kit/ui-patterns.md`
+
+## Top Bar: Line 2 Removal
+
+### Requirement: Remove Line 2 Entirely
+
+The top bar component (`app/frontend/src/components/top-bar.tsx`) SHALL remove the entire Line 2 `<div>` (lines 143–218), including all action buttons (`+ Session`, `Rename`, `Kill`), the window status display, and the `FixedWidthToggle` invocation.
+
+The Line 2 wrapper `<div className="hidden sm:flex ...">` and all its children SHALL be deleted. No remnant markup, data attributes, or conditional renders for Line 2 SHALL remain.
+
+#### Scenario: Line 2 No Longer Renders
+
+- **GIVEN** the top bar component is rendered
+- **WHEN** the viewport is any width (mobile or desktop)
+- **THEN** no Line 2 row is present in the DOM
+- **AND** the top bar consists solely of Line 1
+
+#### Scenario: Vertical Space Reclaimed
+
+- **GIVEN** the top bar previously rendered Line 2 with `min-h-[36px]` and `py-2`
+- **WHEN** Line 2 is removed
+- **THEN** the header element contains only the Line 1 `<div>`
+- **AND** the terminal area gains the vertical space previously consumed by Line 2
+
+### Requirement: Remove Line 2 Props from TopBar
+
+The `TopBarProps` type SHALL remove the `onRename`, `onKill`, and `onCreateSession` callback props that were exclusively used by Line 2 buttons. The `currentWindow` and `currentSession` props SHALL be retained only if still referenced by Line 1 logic; otherwise they SHALL also be removed.
+
+#### Scenario: Unused Props Removed
+
+- **GIVEN** `onRename`, `onKill`, and `onCreateSession` are only used in Line 2 JSX
+- **WHEN** Line 2 is deleted
+- **THEN** these props are removed from `TopBarProps`
+- **AND** their call sites in the parent component no longer pass them
+
+## Top Bar: FixedWidthToggle Relocation
+
+### Requirement: Move FixedWidthToggle to Line 1
+
+The `FixedWidthToggle` component SHALL be rendered in Line 1's right-side section, positioned between the connection status indicator (`live`/`disconnected` label) and the `⌘K` kbd element.
+
+The new rendering order in the right-side `<div>` SHALL be:
+1. Connection dot + label
+2. `<FixedWidthToggle />`
+3. `⌘K` kbd (desktop) / `⋯` button (mobile)
+
+#### Scenario: Toggle Visible on Desktop
+
+- **GIVEN** viewport width >= 640px (sm breakpoint)
+- **WHEN** the top bar renders
+- **THEN** the FixedWidthToggle appears between "live" and "⌘K"
+
+#### Scenario: Toggle Visible on Mobile
+
+- **GIVEN** viewport width < 640px
+- **WHEN** the top bar renders
+- **THEN** the FixedWidthToggle is visible (unlike before, when it was hidden with Line 2's `hidden sm:flex`)
+- **AND** the `⋯` palette trigger button appears after the toggle
+
+### Requirement: FixedWidthToggle Component Unchanged
+
+The `FixedWidthToggle` component's internal implementation (hooks, SVG icon, aria attributes, styling) SHALL NOT be modified. Only its position in the JSX tree changes.
+
+#### Scenario: Toggle Behavior Preserved
+
+- **GIVEN** the FixedWidthToggle is rendered in Line 1
+- **WHEN** the user clicks the toggle
+- **THEN** it toggles between fixed and full width as before
+- **AND** the visual states (border-accent active, border-border inactive) are preserved
+
+### Requirement: FixedWidthToggle Touch Target
+
+The FixedWidthToggle in Line 1 SHALL have touch-appropriate sizing consistent with other Line 1 buttons: `coarse:min-h-[36px] coarse:min-w-[28px]`.
+
+#### Scenario: Touch Target Sizing
+
+- **GIVEN** a touch device (pointer: coarse)
+- **WHEN** the top bar renders
+- **THEN** the FixedWidthToggle has minimum height 36px and minimum width 28px
+
+## Breadcrumb Dropdowns: New Action Items
+
+### Requirement: Session Dropdown Has New Session Action
+
+The session `BreadcrumbDropdown` SHALL render a `+ New Session` action as the first item, separated from the session list by a visual divider (`border-t border-border`).
+
+Clicking `+ New Session` SHALL trigger the same session creation flow as the old `+ Session` button (calling `onCreateSession`).
+
+The `+ New Session` item SHALL NOT participate in current-item highlight logic (no `text-accent` styling when any session is selected). It is an action, not a selection.
+
+#### Scenario: New Session Action in Dropdown
+
+- **GIVEN** the session breadcrumb dropdown is open
+- **WHEN** the user views the dropdown
+- **THEN** `+ New Session` is the first item
+- **AND** a divider separates it from the session list below
+- **AND** it is styled distinctly from selection items
+
+#### Scenario: New Session Action Triggers Creation
+
+- **GIVEN** the session breadcrumb dropdown is open
+- **WHEN** the user clicks `+ New Session`
+- **THEN** the session creation dialog opens
+- **AND** the dropdown closes
+
+### Requirement: Window Dropdown Has New Window Action
+
+The window `BreadcrumbDropdown` SHALL render a `+ New Window` action as the first item, separated from the window list by a visual divider.
+
+Clicking `+ New Window` SHALL trigger new window creation in the current session (same action as the per-session `+` icon in the sidebar).
+
+The `+ New Window` item SHALL NOT participate in current-item highlight logic.
+
+#### Scenario: New Window Action in Dropdown
+
+- **GIVEN** the window breadcrumb dropdown is open
+- **WHEN** the user views the dropdown
+- **THEN** `+ New Window` is the first item
+- **AND** a divider separates it from the window list below
+
+#### Scenario: New Window Action Triggers Creation
+
+- **GIVEN** the window breadcrumb dropdown is open
+- **WHEN** the user clicks `+ New Window`
+- **THEN** a new window is created in the current session
+- **AND** the dropdown closes
+
+### Requirement: BreadcrumbDropdown Action Item Support
+
+The `BreadcrumbDropdown` component SHALL accept an optional `action` prop of type `{ label: string; onAction: () => void }`. When provided, the action item renders before the selection list, separated by a divider. The action item:
+- Uses `text-text-primary` styling (not `text-accent` for current)
+- Has a `+` prefix or similar visual distinction
+- Does NOT receive focus-index tracking from ArrowUp/ArrowDown keyboard navigation among selection items
+- Closes the dropdown on click
+
+#### Scenario: Keyboard Navigation Skips Action Item
+
+- **GIVEN** the dropdown is open with an action item and selection items
+- **WHEN** the user presses ArrowDown
+- **THEN** focus moves among selection items only
+- **AND** the action item is not part of the keyboard navigation cycle
+
+## Sidebar: Empty State
+
+### Requirement: Empty State Shows New Session Button
+
+When no sessions exist (`sessions.length === 0`), the sidebar SHALL display a centered `+ New Session` button instead of the current "No sessions" text-only message.
+
+The button SHALL trigger the same session creation flow as the breadcrumb dropdown's `+ New Session` action.
+
+#### Scenario: Empty State with Creation Affordance
+
+- **GIVEN** no tmux sessions exist
+- **WHEN** the sidebar renders
+- **THEN** a `+ New Session` button is displayed
+- **AND** clicking it opens the session creation dialog
+
+#### Scenario: Button Replaces Text-Only Empty State
+
+- **GIVEN** the sidebar currently shows "No sessions" as plain text
+- **WHEN** this change is applied
+- **THEN** the empty state includes a clickable `+ New Session` button
+- **AND** the "No sessions" label MAY be retained as secondary text above or below the button
+
+## Deprecated Requirements
+
+### Line 2 Action Bar
+
+**Reason**: All Line 2 actions (`+ Session`, `Rename`, `Kill`, window status) are accessible through the sidebar's `(i)` popup, per-session `+ ✕` controls, and now the breadcrumb dropdown `+ New` actions. Line 2 is redundant.
+
+**Migration**: `+ Session` → breadcrumb session dropdown `+ New Session`. `Rename`/`Kill` → sidebar `(i)` popup and command palette. Window status display → sidebar window rows (activity, duration, fab stage). `FixedWidthToggle` → Line 1 right section.
+
+### Line 2 Mobile Collapse (`⋯` Pattern)
+
+**Reason**: The `hidden sm:flex` collapse of Line 2 with `⋯` command palette trigger on mobile is no longer needed — Line 2 doesn't exist. The `⋯` button remains in Line 1 for mobile command palette access.
+
+**Migration**: N/A — the `⋯` button in Line 1 already serves this purpose.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Line 2 is removed entirely, not just hidden | Confirmed from intake #1 — user explicitly discussed and confirmed | S:95 R:85 A:90 D:95 |
+| 2 | Certain | FixedWidthToggle moves between live indicator and ⌘K in Line 1 | Confirmed from intake #2 — user explicitly chose this position | S:95 R:90 A:90 D:95 |
+| 3 | Certain | No new actions added to (i) popup | Confirmed from intake #3 — actions already exist there | S:90 R:90 A:85 D:90 |
+| 4 | Certain | Breadcrumb dropdowns get `+ New` as first item with divider | Confirmed from intake #4 — user proposed this as replacement | S:90 R:85 A:85 D:90 |
+| 5 | Certain | Empty sidebar shows `+ New Session` button | Confirmed from intake #5 — user identified need for creation affordance | S:85 R:85 A:85 D:90 |
+| 6 | Certain | FixedWidthToggle component internals unchanged | Upgraded from intake Confident #6 — code review confirms component is self-contained with useChrome/useChromeDispatch | S:90 R:90 A:90 D:90 |
+| 7 | Confident | `+ New` action item excluded from ArrowUp/ArrowDown keyboard navigation cycle | Action semantically different from selection items; simplifies implementation while keeping it clickable | S:70 R:90 A:80 D:75 |
+| 8 | Confident | Touch target sizing follows existing coarse: pattern for top bar buttons | Confirmed from intake #8 — project context specifies `coarse:min-h-[36px] coarse:min-w-[28px]` | S:75 R:90 A:85 D:85 |
+| 9 | Confident | BreadcrumbDropdown accepts an `action` prop rather than mixing action items into the `items` array | Cleaner separation of concerns — action is semantically different from selection. Reversible if needed | S:65 R:90 A:75 D:70 |
+| 10 | Confident | `onRename`, `onKill`, `onCreateSession` props removed from TopBar | These callbacks are only used by Line 2 buttons — confirmed by reading top-bar.tsx | S:80 R:85 A:90 D:85 |
+| 11 | Confident | Sidebar empty state keeps "No sessions" text alongside the button | Belt-and-suspenders UX — label explains context, button provides action | S:60 R:95 A:70 D:70 |
+
+11 assumptions (6 certain, 5 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260313-zvgc-remove-top-bar-line-2/tasks.md
+++ b/fab/changes/260313-zvgc-remove-top-bar-line-2/tasks.md
@@ -1,0 +1,43 @@
+# Tasks: Remove Top Bar Line 2
+
+**Change**: 260313-zvgc-remove-top-bar-line-2
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+## Phase 1: Setup
+
+- [x] T001 Add `action` prop to `BreadcrumbDropdown` component (`app/frontend/src/components/breadcrumb-dropdown.tsx`): extend `Props` type with optional `action: { label: string; onAction: () => void }`. Render the action item before the `items.map()` list with a divider (`border-t border-border`) separating them. Action item uses `text-text-primary` styling, closes dropdown on click, and is excluded from ArrowUp/ArrowDown focus-index tracking.
+
+## Phase 2: Core Implementation
+
+- [x] T002 Remove Line 2 from `TopBar` (`app/frontend/src/components/top-bar.tsx`): delete the entire `<div className="hidden sm:flex ...">` block (lines 143–218) containing `+ Session`, `Rename`, `Kill` buttons, window status display, and `FixedWidthToggle` invocation.
+- [x] T003 Remove unused props from `TopBarProps` in `app/frontend/src/components/top-bar.tsx`: remove `onRename` and `onKill` props that were exclusively used by Line 2. Remove the `parseFabChange` and `getWindowDuration` imports (only referenced in Line 2 status display). Retain `currentSession` and `currentWindow` — both are used by Line 1 breadcrumb dropdown logic (building `windowItems` and current-item highlighting). Update the destructured parameters accordingly. <!-- clarified: currentSession and currentWindow are NOT Line-2-only — used in windowItems construction at lines 43-49 -->
+- [x] T004 Relocate `FixedWidthToggle` to Line 1 in `app/frontend/src/components/top-bar.tsx`: render `<FixedWidthToggle />` in the right-side `<div>` of Line 1, between the connection label (`<span>{isConnected ? "live" : "disconnected"}</span>`) and the `⌘K` kbd element. Add touch target sizing: `coarse:min-h-[36px] coarse:min-w-[28px]`.
+- [x] T005 [P] Wire `+ New Session` action into the session `BreadcrumbDropdown` in `app/frontend/src/components/top-bar.tsx`: pass `action={{ label: "+ New Session", onAction: onCreateSession }}` to the session dropdown. `onCreateSession` remains in `TopBarProps` (T003 only removes `onRename` and `onKill`).
+- [x] T006 [P] Wire `+ New Window` action into the window `BreadcrumbDropdown` in `app/frontend/src/components/top-bar.tsx`: pass `action={{ label: "+ New Window", onAction: onCreateWindow }}` to the window dropdown. Add `onCreateWindow` to `TopBarProps` with type `(session: string) => void`, invoked with the current `sessionName`.
+
+## Phase 3: Integration & Edge Cases
+
+- [x] T007 Update parent component(s) that render `TopBar` to remove now-unused prop passes (`onRename`, `onKill`) and add `onCreateWindow` prop. Retain `currentSession` and `currentWindow` passes (still used by Line 1). Find call sites via grep for `<TopBar`. <!-- clarified: currentSession and currentWindow retained — see T003 -->
+- [x] T008 [P] Update sidebar empty state in `app/frontend/src/components/sidebar.tsx`: replace the text-only "No sessions" `<div>` with a `+ New Session` button. Add `onCreateSession: () => void` to `SidebarProps`. Render a centered button with consistent styling. Keep "No sessions" as secondary text.
+- [x] T009 [P] Update `BreadcrumbDropdownItem` type in `app/frontend/src/contexts/chrome-context.tsx` if needed — verify no orphaned type fields after Line 2 removal.
+
+## Phase 4: Polish
+
+- [x] T010 Run `cd app/frontend && npx tsc --noEmit` to verify no type errors from prop changes.
+- [x] T011 Run `cd app/frontend && npx vitest run` to verify existing tests pass. The entire `top-bar.test.tsx` describe block ("TopBar Line 2 enriched status") tests Line 2 elements (`getByTestId("line2-status")`, fab stage badge, pane command, duration) — all of these must be removed or rewritten to test Line 1 behavior instead. The `sidebar.test.tsx` empty-state test ("shows empty state when no sessions") currently asserts only "No sessions" text — update to verify the new `+ New Session` button is present.
+- [x] T012 Update `fab/project/context.md` line 77 ("Top bar line 2 (+ Session, Rename, Kill, status, fixed-width toggle) is `hidden sm:flex` — hidden on mobile where it adds no value") — remove or replace with a note that the top bar is a single line. Also update the Touch Targets list (line 139, "Line 2 action buttons (Rename, Kill)") to remove the Line 2 reference. <!-- clarified: context.md is a project-level file read by all skills — stale Line 2 references would mislead future artifact generation -->
+
+---
+
+## Execution Order
+
+- T001 blocks T005 and T006 (dropdown action support needed before wiring)
+- T002 and T003 are sequential (remove Line 2 first, then clean up props)
+- T004 depends on T002 (toggle needs new home after Line 2 removal)
+- T005 and T006 are parallel (independent dropdown wiring)
+- T007 depends on T003, T005, T006 (parent prop alignment after all TopBar changes)
+- T008 and T009 are parallel and independent of T002–T007
+- T010 depends on T001–T009 (all code changes complete)
+- T011 depends on T010 (type check first, then test)
+- T012 is independent — can run any time after T002

--- a/fab/project/context.md
+++ b/fab/project/context.md
@@ -74,7 +74,7 @@ This workflow catches overflow issues, clipping, and layout regressions that uni
 - Touch targets use the `coarse:` custom Tailwind variant (`@media (pointer: coarse)`) for touch devices
 - Touch targets: `coarse:min-h-[36px] coarse:min-w-[28px]` (taller than wide, not square) for bottom bar buttons; `coarse:36px` square for top bar/breadcrumb buttons
 - Bottom bar toolbar fits all buttons in a single row at 375px — no wrapping, no horizontal scroll
-- Top bar line 2 (+ Session, Rename, Kill, status, fixed-width toggle) is `hidden sm:flex` — hidden on mobile where it adds no value
+- Top bar is a single line: breadcrumbs + connection status + FixedWidthToggle + command palette trigger. Session/window creation actions live in breadcrumb dropdown `+ New` items
 - Mobile sidebar drawer is `absolute` inside the main area (not `fixed inset-0`) so the top bar stays visible and the logo toggle can close the drawer
 - The `.app-shell` and terminal column have `overflow: hidden` to prevent horizontal page overflow from xterm.js canvas
 - Terminal font: 11px on mobile (`min-width: 640px` media query), 13px on desktop


### PR DESCRIPTION
## Summary

Line 2 of the top bar duplicated every action already available in the sidebar's (i) popup and per-session + × controls, consuming ~40px of vertical space for zero unique value. This change removes Line 2 entirely, relocates the FixedWidthToggle into Line 1, and adds `+ New` creation actions to the breadcrumb dropdowns so no affordance is lost.

## Changes

- Remove top bar line 2 entirely
- Relocate FixedWidthToggle to line 1
- Add `+ New` action to breadcrumb dropdowns
- Empty sidebar state shows `+ New Session` button
- Responsive behavior — toggle now accessible on mobile

## Change
| ID | Name | Issue |
|----|------|-------|
| zvgc | 260313-zvgc-remove-top-bar-line-2 | — |

## Stats
| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| refactor | 3.5 / 5.0 | 0/0 | 12/12 | Pass (1 iterations) |

[intake](https://github.com/wvrdz/run-kit/blob/zvgc/fab/changes/260313-zvgc-remove-top-bar-line-2/intake.md) → [spec](https://github.com/wvrdz/run-kit/blob/zvgc/fab/changes/260313-zvgc-remove-top-bar-line-2/spec.md) → tasks → apply → review → hydrate → ship