### PR TITLE
test: Hamburger Menu Toggle

### DIFF
--- a/app/frontend/src/components/top-bar.tsx
+++ b/app/frontend/src/components/top-bar.tsx
@@ -62,10 +62,10 @@ export function TopBar({
 
   return (
     <header className="px-3 sm:px-6 border-b border-border">
-      {/* Line 1: Hamburger + Logo + Breadcrumbs + Connection + Cmd+K */}
+      {/* Line 1: Hamburger + Breadcrumbs + Connection + Cmd+K */}
       <div className="flex items-center justify-between py-2">
         <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-sm">
-          {/* Logo doubles as sidebar/drawer toggle */}
+          {/* Hamburger icon — sidebar/drawer toggle */}
           <button
             onClick={() => {
               if (window.innerWidth >= 768) {
@@ -75,7 +75,7 @@ export function TopBar({
               }
             }}
             aria-label="Toggle navigation"
-            className="hover:opacity-80 transition-opacity min-w-[24px] min-h-[24px] coarse:min-w-[36px] coarse:min-h-[36px] flex items-center justify-center"
+            className="text-text-secondary hover:text-text-primary transition-colors min-w-[24px] min-h-[24px] coarse:min-w-[36px] coarse:min-h-[36px] flex items-center justify-center"
           >
             <svg
               width="20"

--- a/app/frontend/src/components/top-bar.tsx
+++ b/app/frontend/src/components/top-bar.tsx
@@ -77,7 +77,19 @@ export function TopBar({
             aria-label="Toggle navigation"
             className="hover:opacity-80 transition-opacity min-w-[24px] min-h-[24px] coarse:min-w-[36px] coarse:min-h-[36px] flex items-center justify-center"
           >
-            <img src="/logo.svg" alt="RunKit" width={20} height={20} />
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 20 20"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            >
+              <line x1="3" y1="5" x2="17" y2="5" />
+              <line x1="3" y1="10" x2="17" y2="10" />
+              <line x1="3" y1="15" x2="17" y2="15" />
+            </svg>
           </button>
 
           {sessionName && (

--- a/docs/memory/run-kit/architecture.md
+++ b/docs/memory/run-kit/architecture.md
@@ -138,7 +138,7 @@ In development, Vite handles SPA fallback natively. In production, Go's catch-al
 
 The root layout (`app/frontend/src/app.tsx`) owns a fixed chrome skeleton (height: `var(--app-height, 100vh)`) with three zones:
 
-1. **Top chrome** (`shrink-0, border-b border-border`) — `TopBarChrome`, always-rendered two-line top bar
+1. **Top chrome** (`shrink-0, border-b border-border`) — `TopBarChrome`, always-rendered single-line top bar
 2. **Main area** (`flex-1 flex flex-row min-h-0`) — sidebar + terminal column side by side
    - **Sidebar** (drag-resizable, default 220px, min 160, max 400, `shrink-0 overflow-y-auto`, hidden on mobile < 768px) — session/window tree. Width persisted to `localStorage` key `runkit-sidebar-width`. Full height of main area (top bar to viewport bottom)
    - **Terminal column** (`flex-1 min-w-0 flex flex-col`) — contains terminal + bottom bar

--- a/docs/memory/run-kit/architecture.md
+++ b/docs/memory/run-kit/architecture.md
@@ -151,9 +151,9 @@ No `max-w-4xl` constraint — all zones span full width. Terminal fills all avai
 
 **SessionProvider** (`app/frontend/src/contexts/session-context.tsx`) — layout-level React Context that owns the single `EventSource` connection to `/api/sessions/stream`. Exposes `{ sessions, isConnected }` via `useSessions()` hook. Forwards `isConnected` to `ChromeProvider` internally. Mounted inside `ChromeProvider` in the root layout.
 
-**TopBarChrome** (`app/frontend/src/components/top-bar-chrome.tsx`) — reads from ChromeProvider. Line 1 (`border-b border-border`): `☰` toggle + icon breadcrumbs (`☰ {logo} ❯ session ❯ window`) + connection indicator + `⌘K`/`⋯`. Line 2: `[+ Session]` + contextual `[Rename]` `[Kill]`, always rendered with `min-h-[36px]` (prevents layout shift).
+**TopBarChrome** (`app/frontend/src/components/top-bar-chrome.tsx`) — reads from ChromeProvider. Line 1 (`border-b border-border`): hamburger toggle (inline SVG, three horizontal lines) + icon breadcrumbs (`☰ ❯ session ❯ window`) + connection indicator + FixedWidthToggle + `⌘K`/`⋯`. Single-line top bar — no Line 2.
 
-**Sidebar** (`app/frontend/src/components/sidebar.tsx`) — session/window tree. Desktop: drag-resizable (default 220px, min 160, max 400, persisted to `localStorage`), collapsible via `☰`. No footer (create session moved to top bar). Mobile (< 768px): drawer overlay from the left, triggered by `☰`.
+**Sidebar** (`app/frontend/src/components/sidebar.tsx`) — session/window tree. Desktop: drag-resizable (default 220px, min 160, max 400, persisted to `localStorage`), collapsible via hamburger icon. No footer (create session moved to breadcrumb dropdown). Mobile (< 768px): drawer overlay from the left, triggered by hamburger icon.
 
 **BottomBar** (`app/frontend/src/components/bottom-bar.tsx`) — always visible. Single row of `<kbd>` buttons: modifier toggles (Ctrl/Alt/Cmd with sticky armed state), arrow keys, Fn dropdown (F1-F12, PgUp/PgDn, Home/End), Esc, Tab, and compose toggle. All buttons 44px min-height for mobile touch targets. Sends ANSI escape sequences through the WebSocket ref. Modifier state managed by `useModifierState` hook.
 

--- a/docs/memory/run-kit/ui-patterns.md
+++ b/docs/memory/run-kit/ui-patterns.md
@@ -13,11 +13,11 @@ Single-view model: sidebar shows session/window tree, terminal is always the mai
 
 The root layout (`app/frontend/src/app.tsx`) renders `TopBarChrome` which derives its content from the current session:window selection via `ChromeProvider` context. No slot injection — the chrome reads the selection and renders directly.
 
-**Line 1** (fixed height, `border-b border-border`): logo toggle + icon breadcrumbs + connection indicator + FixedWidthToggle + `⌘K` (desktop) / `⋯` (mobile). Single-line top bar — no Line 2.
+**Line 1** (fixed height, `border-b border-border`): hamburger toggle + icon breadcrumbs + connection indicator + FixedWidthToggle + `⌘K` (desktop) / `⋯` (mobile). Single-line top bar — no Line 2.
 
-Breadcrumb: `{logo} ❯ {session} ❯ {window}` (syncs with tmux active window via SSE). Logo toggles sidebar (desktop) or opens drawer (mobile) — no separate hamburger icon.
+Breadcrumb: `{☰} ❯ {session} ❯ {window}` (syncs with tmux active window via SSE). Hamburger toggles sidebar (desktop) or opens drawer (mobile).
 
-- Logo SVG (`logo.svg`) — clickable button that toggles sidebar/drawer (replaces `☰` hamburger)
+- Hamburger icon (inline SVG, three horizontal lines) — clickable button that toggles sidebar/drawer
 - ❯ — Unicode heavy right angle (U+276F), unified separator/dropdown trigger icon for both session and window segments (tapping opens respective dropdown)
 - Icons are rendered inside `BreadcrumbDropdown` via `icon` prop — no separate passive span, no `›` separator spans
 - All segments except the last are clickable links
@@ -235,3 +235,4 @@ Windows are `"active"` (last tmux activity within 10 seconds) or `"idle"`. No "e
 | 2026-03-13 | xterm addon activation — ClipboardAddon (OSC 52), WebLinksAddon (clickable URLs), WebglAddon (GPU rendering with silent canvas fallback), Cmd+C selection-aware copy via `attachCustomKeyEventHandler` | `260313-dr60-xterm-clipboard-addons` |
 | 2026-03-13 | Removed single-key shortcuts — deleted `useKeyboardNav` (j/k/Enter), `useAppShortcuts` (c/r/Esc Esc), sidebar focus ring (`focusedIndex`). Cmd+K command palette is now the sole keyboard shortcut. Palette actions no longer show shortcut hints for create/rename | `260313-3brm-remove-single-key-shortcuts` |
 | 2026-03-13 | Remove top bar Line 2 — deleted action bar (+ Session, Rename, Kill, window status). FixedWidthToggle relocated to Line 1 (between connection indicator and ⌘K). BreadcrumbDropdown gains `action` prop for `+ New Session`/`+ New Window` as first dropdown item with divider. Sidebar empty state shows `+ New Session` button. Top bar is now single-line on all viewports | `260313-zvgc-remove-top-bar-line-2` |
+| 2026-03-14 | Hamburger menu toggle — replaced logo SVG with inline SVG hamburger icon (three horizontal lines) in top-left toggle button. Toggle behavior unchanged. `logo.svg` preserved | `260314-kqab-hamburger-menu-toggle` |

--- a/docs/memory/run-kit/ui-patterns.md
+++ b/docs/memory/run-kit/ui-patterns.md
@@ -47,9 +47,9 @@ Connection indicator: green/gray dot with "live"/"disconnected" label, driven by
 
 `app/frontend/src/components/sidebar.tsx` — session/window tree navigation.
 
-**Desktop** (>= 768px): Drag-resizable panel, default 220px width. Width persisted to `localStorage` key `runkit-sidebar-width`. Constraints: min 160px, max 400px. Drag handle (4-6px) on right edge with `col-resize` cursor, supports mouse and touch events. Collapsible via logo button in top bar.
+**Desktop** (>= 768px): Drag-resizable panel, default 220px width. Width persisted to `localStorage` key `runkit-sidebar-width`. Constraints: min 160px, max 400px. Drag handle (4-6px) on right edge with `col-resize` cursor, supports mouse and touch events. Collapsible via hamburger button in top bar.
 
-**Mobile** (< 768px): Hidden by default. Logo button opens a drawer overlay from the left, dimming the terminal. Selecting a window closes the drawer. Drag-resize does not apply to mobile drawer.
+**Mobile** (< 768px): Hidden by default. Hamburger button opens a drawer overlay from the left, dimming the terminal. Selecting a window closes the drawer. Drag-resize does not apply to mobile drawer.
 
 **Padding**: `px-3 sm:px-6` (matches top bar and bottom bar chrome padding).
 

--- a/fab/changes/260314-kqab-hamburger-menu-toggle/.history.jsonl
+++ b/fab/changes/260314-kqab-hamburger-menu-toggle/.history.jsonl
@@ -1,0 +1,16 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-03-14T07:05:01Z"}
+{"args":"Replace top left logo with hamburger icon that controls the left bar / menu","cmd":"fab-new","event":"command","ts":"2026-03-14T07:05:01Z"}
+{"delta":"+4.7","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-14T07:05:30Z"}
+{"delta":"+0.0","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-14T07:05:33Z"}
+{"cmd":"fab-switch","event":"command","ts":"2026-03-14T07:07:08Z"}
+{"cmd":"fab-continue","event":"command","ts":"2026-03-14T07:08:15Z"}
+{"action":"enter","driver":"fab-continue","event":"stage-transition","stage":"spec","ts":"2026-03-14T07:08:19Z"}
+{"delta":"+0.0","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-14T07:08:49Z"}
+{"delta":"+0.0","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-14T07:08:52Z"}
+{"cmd":"fab-ff","event":"command","ts":"2026-03-14T07:10:11Z"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"tasks","ts":"2026-03-14T07:10:22Z"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"apply","ts":"2026-03-14T07:10:47Z"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"review","ts":"2026-03-14T07:11:37Z"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"hydrate","ts":"2026-03-14T07:12:12Z"}
+{"event":"review","result":"passed","ts":"2026-03-14T07:12:12Z"}
+{"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"ship","ts":"2026-03-14T07:13:05Z"}

--- a/fab/changes/260314-kqab-hamburger-menu-toggle/.history.jsonl
+++ b/fab/changes/260314-kqab-hamburger-menu-toggle/.history.jsonl
@@ -14,3 +14,4 @@
 {"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"hydrate","ts":"2026-03-14T07:12:12Z"}
 {"event":"review","result":"passed","ts":"2026-03-14T07:12:12Z"}
 {"action":"enter","driver":"fab-ff","event":"stage-transition","stage":"ship","ts":"2026-03-14T07:13:05Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-03-14T07:14:32Z"}

--- a/fab/changes/260314-kqab-hamburger-menu-toggle/.status.yaml
+++ b/fab/changes/260314-kqab-hamburger-menu-toggle/.status.yaml
@@ -11,8 +11,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 checklist:
     generated: true
     path: checklist.md
@@ -37,6 +37,8 @@ stage_metrics:
     apply: {started_at: "2026-03-14T07:10:47Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-14T07:11:37Z"}
     review: {started_at: "2026-03-14T07:11:37Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-14T07:12:12Z"}
     hydrate: {started_at: "2026-03-14T07:12:12Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-14T07:13:05Z"}
-    ship: {started_at: "2026-03-14T07:13:05Z", driver: fab-ff, iterations: 1}
-prs: []
-last_updated: 2026-03-14T07:13:05Z
+    ship: {started_at: "2026-03-14T07:13:05Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-14T07:14:32Z"}
+    review-pr: {started_at: "2026-03-14T07:14:32Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/wvrdz/run-kit/pull/44
+last_updated: 2026-03-14T07:14:32Z

--- a/fab/changes/260314-kqab-hamburger-menu-toggle/.status.yaml
+++ b/fab/changes/260314-kqab-hamburger-menu-toggle/.status.yaml
@@ -5,40 +5,40 @@ created_by: sahil-weaver
 change_type: test
 issues: []
 progress:
-    intake: done
-    spec: done
-    tasks: done
-    apply: done
-    review: done
-    hydrate: done
-    ship: done
-    review-pr: active
+  intake: done
+  spec: done
+  tasks: done
+  apply: done
+  review: done
+  hydrate: done
+  ship: done
+  review-pr: active
 checklist:
-    generated: true
-    path: checklist.md
-    completed: 0
-    total: 8
+  generated: true
+  path: checklist.md
+  completed: 0
+  total: 8
 confidence:
-    certain: 4
-    confident: 1
-    tentative: 0
-    unresolved: 0
-    score: 4.7
-    fuzzy: true
-    dimensions:
-        signal: 84.0
-        reversibility: 93.0
-        competence: 89.0
-        disambiguation: 88.0
+  certain: 4
+  confident: 1
+  tentative: 0
+  unresolved: 0
+  score: 4.7
+  fuzzy: true
+  dimensions:
+    signal: 84.0
+    reversibility: 93.0
+    competence: 89.0
+    disambiguation: 88.0
 stage_metrics:
-    intake: {started_at: "2026-03-14T07:05:01Z", driver: fab-new, iterations: 1, completed_at: "2026-03-14T07:08:19Z"}
-    spec: {started_at: "2026-03-14T07:08:19Z", driver: fab-continue, iterations: 1, completed_at: "2026-03-14T07:10:22Z"}
-    tasks: {started_at: "2026-03-14T07:10:22Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-14T07:10:47Z"}
-    apply: {started_at: "2026-03-14T07:10:47Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-14T07:11:37Z"}
-    review: {started_at: "2026-03-14T07:11:37Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-14T07:12:12Z"}
-    hydrate: {started_at: "2026-03-14T07:12:12Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-14T07:13:05Z"}
-    ship: {started_at: "2026-03-14T07:13:05Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-14T07:14:32Z"}
-    review-pr: {started_at: "2026-03-14T07:14:32Z", driver: git-pr, iterations: 1}
+  intake: {started_at: "2026-03-14T07:05:01Z", driver: fab-new, iterations: 1, completed_at: "2026-03-14T07:08:19Z"}
+  spec: {started_at: "2026-03-14T07:08:19Z", driver: fab-continue, iterations: 1, completed_at: "2026-03-14T07:10:22Z"}
+  tasks: {started_at: "2026-03-14T07:10:22Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-14T07:10:47Z"}
+  apply: {started_at: "2026-03-14T07:10:47Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-14T07:11:37Z"}
+  review: {started_at: "2026-03-14T07:11:37Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-14T07:12:12Z"}
+  hydrate: {started_at: "2026-03-14T07:12:12Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-14T07:13:05Z"}
+  ship: {started_at: "2026-03-14T07:13:05Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-14T07:14:32Z"}
+  review-pr: {started_at: "2026-03-14T07:14:32Z", driver: git-pr, iterations: 1, phase: fixing, reviewer: 'copilot-pull-request-reviewer[bot]'}
 prs:
-    - https://github.com/wvrdz/run-kit/pull/44
+  - https://github.com/wvrdz/run-kit/pull/44
 last_updated: 2026-03-14T07:14:32Z

--- a/fab/changes/260314-kqab-hamburger-menu-toggle/.status.yaml
+++ b/fab/changes/260314-kqab-hamburger-menu-toggle/.status.yaml
@@ -1,0 +1,42 @@
+id: kqab
+name: 260314-kqab-hamburger-menu-toggle
+created: 2026-03-14T07:05:01Z
+created_by: sahil-weaver
+change_type: test
+issues: []
+progress:
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+checklist:
+    generated: true
+    path: checklist.md
+    completed: 0
+    total: 8
+confidence:
+    certain: 4
+    confident: 1
+    tentative: 0
+    unresolved: 0
+    score: 4.7
+    fuzzy: true
+    dimensions:
+        signal: 84.0
+        reversibility: 93.0
+        competence: 89.0
+        disambiguation: 88.0
+stage_metrics:
+    intake: {started_at: "2026-03-14T07:05:01Z", driver: fab-new, iterations: 1, completed_at: "2026-03-14T07:08:19Z"}
+    spec: {started_at: "2026-03-14T07:08:19Z", driver: fab-continue, iterations: 1, completed_at: "2026-03-14T07:10:22Z"}
+    tasks: {started_at: "2026-03-14T07:10:22Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-14T07:10:47Z"}
+    apply: {started_at: "2026-03-14T07:10:47Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-14T07:11:37Z"}
+    review: {started_at: "2026-03-14T07:11:37Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-14T07:12:12Z"}
+    hydrate: {started_at: "2026-03-14T07:12:12Z", driver: fab-ff, iterations: 1, completed_at: "2026-03-14T07:13:05Z"}
+    ship: {started_at: "2026-03-14T07:13:05Z", driver: fab-ff, iterations: 1}
+prs: []
+last_updated: 2026-03-14T07:13:05Z

--- a/fab/changes/260314-kqab-hamburger-menu-toggle/checklist.md
+++ b/fab/changes/260314-kqab-hamburger-menu-toggle/checklist.md
@@ -1,0 +1,27 @@
+# Quality Checklist: Hamburger Menu Toggle
+
+**Change**: 260314-kqab-hamburger-menu-toggle
+**Generated**: 2026-03-14
+**Spec**: `spec.md`
+
+## Functional Completeness
+- [x] CHK-001 Hamburger Icon Replaces Logo: Top-left button renders inline SVG with three horizontal lines instead of `<img src="/logo.svg">`
+- [x] CHK-002 Logo Asset Preserved: `app/frontend/public/logo.svg` still exists
+
+## Behavioral Correctness
+- [x] CHK-003 Desktop sidebar toggle: Clicking hamburger toggles sidebar open/closed on viewports >= 768px
+- [x] CHK-004 Mobile drawer toggle: Tapping hamburger opens/closes drawer on viewports < 768px
+
+## Scenario Coverage
+- [x] CHK-005 Visual rendering: Hamburger icon visible in top-left, color inherits from parent (`currentColor`)
+- [x] CHK-006 Existing tests pass: `aria-label="Toggle navigation"` based tests unaffected
+
+## Code Quality
+- [x] CHK-007 Pattern consistency: SVG uses same conventions as FixedWidthToggle (currentColor, strokeWidth, strokeLinecap)
+- [x] CHK-008 No unnecessary duplication: No new components or utilities created for a single SVG
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] CHK-008 **N/A**: {reason}`

--- a/fab/changes/260314-kqab-hamburger-menu-toggle/intake.md
+++ b/fab/changes/260314-kqab-hamburger-menu-toggle/intake.md
@@ -1,0 +1,59 @@
+# Intake: Hamburger Menu Toggle
+
+**Change**: 260314-kqab-hamburger-menu-toggle
+**Created**: 2026-03-14
+**Status**: Draft
+
+## Origin
+
+> I want to replace the top left logo with a hamburger icon that controls the left bar / menu
+
+One-shot request. User confirmed this is a visual swap — the toggle mechanism already exists.
+
+## Why
+
+The current top-left button renders the project logo SVG (`/logo.svg`) as the sidebar/drawer toggle. A hamburger icon (☰) is a universally recognized navigation toggle affordance — users immediately understand it opens/closes a menu. The logo, while functional, doesn't signal "toggle navigation" to new users. Replacing it improves discoverability of the sidebar toggle without changing any behavior.
+
+## What Changes
+
+### Replace logo image with hamburger icon in top bar
+
+In `app/frontend/src/components/top-bar.tsx`, the logo button (lines ~69-81) currently renders:
+
+```tsx
+<img src="/logo.svg" alt="RunKit" width={20} height={20} />
+```
+
+Replace with a hamburger icon — either:
+- Unicode `☰` (U+2630) rendered as text, or
+- An inline SVG (three horizontal lines)
+
+The button's `onClick` handler, `aria-label`, className, and touch target sizing (`coarse:min-w-[36px] coarse:min-h-[36px]`) remain unchanged. Only the visual content inside the button changes.
+
+### Breadcrumb separator
+
+The breadcrumb currently reads `{logo} ❯ {session} ❯ {window}`. After this change it becomes `{☰} ❯ {session} ❯ {window}`. No structural change to the `BreadcrumbDropdown` components or their behavior.
+
+## Affected Memory
+
+- `run-kit/ui-patterns`: (modify) Update Chrome section — logo toggle description changes to hamburger icon
+
+## Impact
+
+- **Files**: `app/frontend/src/components/top-bar.tsx` (1 file, ~2 lines changed)
+- **Tests**: Existing tests reference the toggle button by `aria-label="Toggle navigation"`, not by the logo image — no test changes expected
+- **Visual**: The top-left corner changes from a hexagonal logo to a ☰ icon on all viewports
+
+## Open Questions
+
+None — scope is clear.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Toggle behavior unchanged | User confirmed visual swap only — onClick, aria-label, touch targets stay the same | S:95 R:95 A:95 D:95 |
+| 2 | Confident | Use inline SVG hamburger (three lines) over Unicode ☰ | SVG gives precise control over size, stroke width, and color consistency with the design system. Unicode rendering varies across browsers/OS | S:70 R:90 A:80 D:70 |
+| 3 | Certain | No logo.svg deletion | Other parts of the app may reference it (favicon, PWA manifest). Only removing it from the toggle button | S:80 R:90 A:85 D:90 |
+
+3 assumptions (2 certain, 1 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260314-kqab-hamburger-menu-toggle/spec.md
+++ b/fab/changes/260314-kqab-hamburger-menu-toggle/spec.md
@@ -1,0 +1,55 @@
+# Spec: Hamburger Menu Toggle
+
+**Change**: 260314-kqab-hamburger-menu-toggle
+**Created**: 2026-03-14
+**Affected memory**: `docs/memory/run-kit/ui-patterns.md`
+
+## Top Bar: Navigation Toggle Icon
+
+### Requirement: Hamburger Icon Replaces Logo
+
+The top-left toggle button in `app/frontend/src/components/top-bar.tsx` SHALL render an inline SVG hamburger icon (three horizontal lines) instead of the `<img src="/logo.svg">` element.
+
+The SVG MUST:
+- Use `currentColor` for stroke color (inherits from parent text color, consistent with other inline SVGs in the codebase like `FixedWidthToggle`)
+- Be sized at 20×20 viewport (`width="20" height="20"`) to match the previous logo dimensions
+- Render three horizontal lines with `strokeWidth="2"` and `strokeLinecap="round"`
+
+The button wrapper (`<button>`) SHALL retain its existing `onClick`, `aria-label="Toggle navigation"`, `className` (including `coarse:` touch targets), and `hover:opacity-80` transition unchanged.
+
+#### Scenario: Desktop sidebar toggle
+- **GIVEN** the user is on a desktop viewport (≥ 768px)
+- **WHEN** they click the hamburger icon
+- **THEN** the sidebar toggles open/closed (same as before)
+
+#### Scenario: Mobile drawer toggle
+- **GIVEN** the user is on a mobile viewport (< 768px)
+- **WHEN** they tap the hamburger icon
+- **THEN** the drawer overlay opens/closes (same as before)
+
+#### Scenario: Visual rendering
+- **GIVEN** the top bar is rendered on any viewport
+- **WHEN** the user views the top-left corner
+- **THEN** they see a three-line hamburger icon (☰) instead of the hexagonal logo
+- **AND** the icon color matches `text-text-secondary` (inherits from breadcrumb nav context)
+
+### Requirement: Logo Asset Preserved
+
+The file `app/frontend/public/logo.svg` SHALL NOT be deleted. It MAY be referenced elsewhere (favicon, future use). This change only removes its usage from the toggle button.
+
+#### Scenario: Logo file untouched
+- **GIVEN** the change is applied
+- **WHEN** inspecting `app/frontend/public/logo.svg`
+- **THEN** the file still exists with its original content
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Toggle behavior unchanged | Confirmed from intake #1 — user explicitly stated visual swap only | S:95 R:95 A:95 D:95 |
+| 2 | Confident | Inline SVG over Unicode ☰ | Confirmed from intake #2 — SVG matches codebase pattern (FixedWidthToggle uses inline SVG). Consistent stroke styling, color inheritance via currentColor | S:75 R:90 A:85 D:75 |
+| 3 | Certain | Logo.svg not deleted | Confirmed from intake #3 — only removing from toggle button, file preserved | S:85 R:90 A:85 D:90 |
+| 4 | Certain | 20×20 SVG dimensions | Logo was 20×20; maintaining same bounding box avoids layout shift | S:85 R:95 A:90 D:90 |
+| 5 | Certain | strokeLinecap round, strokeWidth 2 | Matches FixedWidthToggle SVG styling in the same file — consistent visual language | S:80 R:95 A:90 D:90 |
+
+5 assumptions (4 certain, 1 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260314-kqab-hamburger-menu-toggle/tasks.md
+++ b/fab/changes/260314-kqab-hamburger-menu-toggle/tasks.md
@@ -1,0 +1,19 @@
+# Tasks: Hamburger Menu Toggle
+
+**Change**: 260314-kqab-hamburger-menu-toggle
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+## Phase 1: Core Implementation
+
+- [x] T001 Replace `<img src="/logo.svg">` with inline SVG hamburger icon in `app/frontend/src/components/top-bar.tsx` (line 80). SVG: 20×20 viewBox, three horizontal lines, `stroke="currentColor"`, `strokeWidth="2"`, `strokeLinecap="round"`. Button wrapper unchanged.
+
+## Phase 2: Verification
+
+- [x] T002 Run existing frontend tests (`pnpm --filter frontend test`) to confirm no regressions. Tests reference the toggle button by `aria-label="Toggle navigation"`, not the logo image — should pass without changes.
+
+---
+
+## Execution Order
+
+- T001 blocks T002


### PR DESCRIPTION
## Summary

The current top-left button renders the project logo SVG as the sidebar toggle. A hamburger icon is a universally recognized navigation toggle affordance — replacing the logo improves discoverability without changing any behavior.

## Changes

- Replace logo image with hamburger icon in top bar
- Breadcrumb separator visual update (logo to hamburger)

## Change
| ID | Name | Issue |
|----|------|-------|
| kqab | 260314-kqab-hamburger-menu-toggle | — |

## Stats
| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| test | 4.7 / 5.0 | 0/8 | 2/2 | Pass (1 iterations) |

[intake](https://github.com/wvrdz/run-kit/blob/260314-kqab-hamburger-menu-toggle/fab/changes/260314-kqab-hamburger-menu-toggle/intake.md) → [spec](https://github.com/wvrdz/run-kit/blob/260314-kqab-hamburger-menu-toggle/fab/changes/260314-kqab-hamburger-menu-toggle/spec.md) → tasks → apply → review → hydrate