### PR TITLE
feat: Hostname in Browser Title

### DIFF
--- a/app/backend/api/health.go
+++ b/app/backend/api/health.go
@@ -5,5 +5,8 @@ import (
 )
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	writeJSON(w, http.StatusOK, map[string]string{
+		"status":   "ok",
+		"hostname": s.hostname,
+	})
 }

--- a/app/backend/api/health_test.go
+++ b/app/backend/api/health_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestHealthEndpoint(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
-	router := NewTestRouter(logger, nil, nil)
+	router := NewTestRouter(logger, nil, nil, "test-host")
 
 	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
 	rec := httptest.NewRecorder()
@@ -34,5 +34,36 @@ func TestHealthEndpoint(t *testing.T) {
 
 	if body["status"] != "ok" {
 		t.Errorf("body.status = %q, want %q", body["status"], "ok")
+	}
+
+	if body["hostname"] != "test-host" {
+		t.Errorf("body.hostname = %q, want %q", body["hostname"], "test-host")
+	}
+}
+
+func TestHealthEndpointEmptyHostname(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	router := NewTestRouter(logger, nil, nil, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if body["status"] != "ok" {
+		t.Errorf("body.status = %q, want %q", body["status"], "ok")
+	}
+
+	if body["hostname"] != "" {
+		t.Errorf("body.hostname = %q, want %q", body["hostname"], "")
 	}
 }

--- a/app/backend/api/router.go
+++ b/app/backend/api/router.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"os"
 	"sync"
 
 	"github.com/go-chi/chi/v5"
@@ -39,6 +40,7 @@ type Server struct {
 	logger   *slog.Logger
 	sessions SessionFetcher
 	tmux     TmuxOps
+	hostname string
 	sseHub   *sseHub
 	sseOnce  sync.Once
 }
@@ -97,20 +99,23 @@ func (p *prodTmuxOps) KillPane(paneID string) error {
 // NewRouter creates the chi router with all middleware and routes.
 // Uses production dependencies (live tmux, real session fetcher).
 func NewRouter(logger *slog.Logger) chi.Router {
+	hostname, _ := os.Hostname()
 	s := &Server{
 		logger:   logger,
 		sessions: &prodSessionFetcher{},
 		tmux:     &prodTmuxOps{},
+		hostname: hostname,
 	}
 	return s.buildRouter()
 }
 
 // NewTestRouter creates a chi router with injectable dependencies for testing.
-func NewTestRouter(logger *slog.Logger, sf SessionFetcher, ops TmuxOps) chi.Router {
+func NewTestRouter(logger *slog.Logger, sf SessionFetcher, ops TmuxOps, hostname string) chi.Router {
 	s := &Server{
 		logger:   logger,
 		sessions: sf,
 		tmux:     ops,
+		hostname: hostname,
 	}
 	return s.buildRouter()
 }

--- a/app/backend/api/sessions_test.go
+++ b/app/backend/api/sessions_test.go
@@ -118,7 +118,7 @@ func (m *mockTmuxOps) KillPane(paneID string) error {
 
 func newTestRouter(sf SessionFetcher, ops TmuxOps) http.Handler {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
-	return NewTestRouter(logger, sf, ops)
+	return NewTestRouter(logger, sf, ops, "test-host")
 }
 
 func TestSessionsList(t *testing.T) {

--- a/app/frontend/src/api/client.test.ts
+++ b/app/frontend/src/api/client.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { server } from "../../tests/msw/server";
 import { resetMockSessions } from "../../tests/msw/handlers";
 import {
+  getHealth,
   getSessions,
   createSession,
   killSession,
@@ -21,6 +22,12 @@ afterEach(() => {
 afterAll(() => server.close());
 
 describe("API client", () => {
+  it("getHealth fetches GET /api/health with hostname", async () => {
+    const health = await getHealth();
+    expect(health.status).toBe("ok");
+    expect(health.hostname).toBe("test-host");
+  });
+
   it("getSessions fetches GET /api/sessions", async () => {
     const sessions = await getSessions();
     expect(sessions).toHaveLength(2);

--- a/app/frontend/src/api/client.ts
+++ b/app/frontend/src/api/client.ts
@@ -8,6 +8,17 @@ async function throwOnError(res: Response): Promise<never> {
   throw new Error((data as { error?: string }).error ?? `Request failed: ${res.status}`);
 }
 
+export interface HealthResponse {
+  status: string;
+  hostname: string;
+}
+
+export async function getHealth(): Promise<HealthResponse> {
+  const res = await fetch("/api/health");
+  if (!res.ok) await throwOnError(res);
+  return res.json();
+}
+
 export async function getSessions(): Promise<ProjectSession[]> {
   const res = await fetch("/api/sessions");
   if (!res.ok) await throwOnError(res);

--- a/app/frontend/src/app.tsx
+++ b/app/frontend/src/app.tsx
@@ -71,8 +71,11 @@ function AppShell() {
   const [composeOpen, setComposeOpen] = useState(false);
   const [hostname, setHostname] = useState("");
 
-  // Fetch hostname once on mount
+  // Fetch hostname once on mount (guarded for StrictMode double-invoke)
+  const didFetchHostnameRef = useRef(false);
   useEffect(() => {
+    if (didFetchHostnameRef.current) return;
+    didFetchHostnameRef.current = true;
     getHealth()
       .then((data) => setHostname(data.hostname ?? ""))
       .catch(() => {});

--- a/app/frontend/src/app.tsx
+++ b/app/frontend/src/app.tsx
@@ -15,7 +15,8 @@ import { CommandPalette, type PaletteAction } from "@/components/command-palette
 import { Dialog } from "@/components/dialog";
 import { CreateSessionDialog } from "@/components/create-session-dialog";
 import { Dashboard } from "@/components/dashboard";
-import { selectWindow, createWindow, reloadTmuxConfig } from "@/api/client";
+import { selectWindow, createWindow, reloadTmuxConfig, getHealth } from "@/api/client";
+import { useBrowserTitle } from "@/hooks/use-browser-title";
 
 const SIDEBAR_STORAGE_KEY = "runkit-sidebar-width";
 const SIDEBAR_DEFAULT_WIDTH = 220;
@@ -68,6 +69,16 @@ function AppShell() {
   const windowIndex = params.window;
 
   const [composeOpen, setComposeOpen] = useState(false);
+  const [hostname, setHostname] = useState("");
+
+  // Fetch hostname once on mount
+  useEffect(() => {
+    getHealth()
+      .then((data) => setHostname(data.hostname ?? ""))
+      .catch(() => {});
+  }, []);
+
+  useBrowserTitle(sessionName, windowIndex, hostname);
 
   // Sidebar drag-resize state (desktop only)
   const [sidebarWidth, setSidebarWidth] = useState(readSidebarWidth);

--- a/app/frontend/src/hooks/use-browser-title.test.ts
+++ b/app/frontend/src/hooks/use-browser-title.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useBrowserTitle } from "./use-browser-title";
+
+describe("useBrowserTitle", () => {
+  beforeEach(() => {
+    document.title = "RunKit";
+  });
+
+  it("sets dashboard title with hostname", () => {
+    renderHook(() => useBrowserTitle(undefined, undefined, "arbaaz-dev-01"));
+    expect(document.title).toBe("RunKit \u2014 arbaaz-dev-01");
+  });
+
+  it("sets dashboard title without hostname", () => {
+    renderHook(() => useBrowserTitle(undefined, undefined, ""));
+    expect(document.title).toBe("RunKit");
+  });
+
+  it("sets terminal title with hostname", () => {
+    renderHook(() => useBrowserTitle("myproject", "0", "arbaaz-dev-01"));
+    expect(document.title).toBe("myproject/0 \u2014 arbaaz-dev-01");
+  });
+
+  it("sets terminal title without hostname", () => {
+    renderHook(() => useBrowserTitle("myproject", "0", ""));
+    expect(document.title).toBe("myproject/0");
+  });
+
+  it("updates title on navigation from dashboard to terminal", () => {
+    const { rerender } = renderHook(
+      ({ session, window, hostname }) => useBrowserTitle(session, window, hostname),
+      { initialProps: { session: undefined as string | undefined, window: undefined as string | undefined, hostname: "arbaaz-dev-01" } },
+    );
+    expect(document.title).toBe("RunKit \u2014 arbaaz-dev-01");
+
+    rerender({ session: "agent-work", window: "2", hostname: "arbaaz-dev-01" });
+    expect(document.title).toBe("agent-work/2 \u2014 arbaaz-dev-01");
+  });
+});

--- a/app/frontend/src/hooks/use-browser-title.ts
+++ b/app/frontend/src/hooks/use-browser-title.ts
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+
+/**
+ * Sets document.title based on route params and hostname.
+ *
+ * Dashboard: "RunKit — {hostname}" or "RunKit" if hostname is empty.
+ * Terminal:  "{session}/{window} — {hostname}" or "{session}/{window}" if empty.
+ */
+export function useBrowserTitle(
+  sessionName: string | undefined,
+  windowIndex: string | undefined,
+  hostname: string,
+): void {
+  useEffect(() => {
+    const suffix = hostname ? ` \u2014 ${hostname}` : "";
+    if (sessionName && windowIndex) {
+      document.title = `${sessionName}/${windowIndex}${suffix}`;
+    } else {
+      document.title = `RunKit${suffix}`;
+    }
+  }, [sessionName, windowIndex, hostname]);
+}

--- a/app/frontend/tests/msw/handlers.ts
+++ b/app/frontend/tests/msw/handlers.ts
@@ -50,6 +50,11 @@ export function resetMockSessions() {
 }
 
 export const handlers = [
+  // GET /api/health
+  http.get("/api/health", () => {
+    return HttpResponse.json({ status: "ok", hostname: "test-host" });
+  }),
+
   // GET /api/sessions
   http.get("/api/sessions", () => {
     return HttpResponse.json(sessions);

--- a/docs/memory/run-kit/architecture.md
+++ b/docs/memory/run-kit/architecture.md
@@ -80,7 +80,7 @@ All endpoints served by the single Go binary on one port. POST-only mutations wi
 
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
-| `/api/health` | GET | Returns `200 {"status":"ok"}` for supervisor health checks |
+| `/api/health` | GET | Returns `200 {"status":"ok","hostname":"..."}` for supervisor health checks. Hostname computed once at startup via `os.Hostname()`, stored in `Server` struct; falls back to `""` on error |
 | `/api/sessions` | GET | Returns `ProjectSession[]` — one per tmux session, with auto-detected fab enrichment (`fabChange`/`fabStage` on windows) |
 | `/api/sessions` | POST | Create session — JSON body `{"name":"...","cwd":"..."}`. Returns `201 {"ok":true}` |
 | `/api/sessions/:session/kill` | POST | Kill session — `:session` validated via `validate.ValidateName()`. Returns `200 {"ok":true}` |
@@ -99,6 +99,7 @@ All endpoints served by the single Go binary on one port. POST-only mutations wi
 
 | Function | Method | Path |
 |----------|--------|------|
+| `getHealth()` | GET | `/api/health` |
 | `getSessions()` | GET | `/api/sessions` |
 | `createSession(name, cwd?)` | POST | `/api/sessions` |
 | `killSession(session)` | POST | `/api/sessions/:session/kill` |
@@ -171,6 +172,8 @@ No `max-w-4xl` constraint — all zones span full width. Terminal fills all avai
 
 **iOS Touch Scroll Prevention** — Fullbleed is always active in the single-view model. The `fullbleed` class is added to `<html>` by `useVisualViewport` on mount (also present as a static default in `index.html` for FOUC prevention). `globals.css` applies `overflow: hidden` and `overscroll-behavior: none` to both `html` and `body` via `html.fullbleed` selectors, preventing iOS Safari elastic bounce scrolling. The terminal container div uses `touch-none` (`touch-action: none`) so the browser yields touch gestures to xterm.js for scrollback handling.
 
+**Browser title** — `useBrowserTitle` hook sets `document.title` dynamically based on hostname (fetched once from `GET /api/health` on app init) and route params. Dashboard: `RunKit — {hostname}`. Terminal: `{session}/{window} — {hostname}`. Omits hostname suffix when empty. Static `<title>RunKit</title>` in `index.html` remains as pre-hydration fallback.
+
 Single-view model: there are no page transitions or per-page chrome injection. The chrome reads the current selection and renders directly.
 
 ## Design Decisions
@@ -200,7 +203,8 @@ Single-view model: there are no page transitions or per-page chrome injection. T
 - **Armed modifiers bridge to physical keyboard** — When bottom-bar modifiers (Ctrl/Alt) are armed, a capture-phase `keydown` listener intercepts physical keypresses, translates them to terminal escape sequences (Ctrl+letter → control characters, Alt → ESC prefix), and sends via WebSocket. Prevents xterm from receiving the unmodified key. Ignores real Cmd/Ctrl/Alt held by the OS.
 - **File upload via server filesystem (not terminal binary injection)** — Browser uploads file to `POST /api/sessions/:session/upload`, server writes to `.uploads/` in project root, path auto-inserted into compose buffer. Works because run-kit server and tmux are always co-located; the browser is the remote part. Session identified by URL param (consistent with other session-scoped endpoints, replaces legacy form field approach)
 - **Handler files split by resource domain (not monolithic routes.go)** — Each handler file owns one resource: `sessions.go`, `windows.go`, `directories.go`, `upload.go`, `sse.go`, `relay.go`, `spa.go`, `health.go`. `router.go` owns middleware, dependency interfaces, and route registration only. (`260312-r4t9-go-backend-api`)
-- **Dependency injection via interfaces for handler testability** — `Server` struct holds `SessionFetcher` and `TmuxOps` interfaces. `NewRouter()` wires production implementations; `NewTestRouter()` accepts mocks. Enables `httptest.NewRecorder` tests without live tmux. (`260312-r4t9-go-backend-api`)
+- **Dependency injection via interfaces for handler testability** — `Server` struct holds `SessionFetcher` and `TmuxOps` interfaces, plus a `hostname` field (computed via `os.Hostname()` in `NewRouter()`, empty string on failure). `NewRouter()` wires production implementations; `NewTestRouter()` accepts mocks (including hostname). Enables `httptest.NewRecorder` tests without live tmux. (`260312-r4t9-go-backend-api`)
+- **Hostname via health endpoint (not a dedicated endpoint)** — hostname is an OS-level value computed once at startup and stored in `Server` struct. Exposed via `/api/health` response (adding a field to an existing endpoint) rather than a new `GET /api/hostname` route. Minimal surface area, consistent with the single-port architecture. (`260320-uq0k-hostname-browser-title`)
 - **Per-window fab enrichment via `fab-go pane-map` (replaces per-session file reading)** — Single `fab-go pane-map --json --all-sessions` subprocess call per SSE tick replaces per-session `.fab-status.yaml` + `.fab-runtime.yaml` file reads. Provides per-window resolution (each worktree window shows its own change/stage) instead of per-session (all windows inherited session-level state). Decouples from internal file formats. `internal/fab` package deleted entirely. (`260313-3vlx-pane-map-enrichment`, supersedes `260312-r4t9-go-backend-api` and `260313-txna-rich-sidebar-window-status` decisions)
 
 ## Testing
@@ -273,3 +277,4 @@ E2E test coverage: create/kill session via UI, SSE stream delivers real data, si
 | 2026-03-18 | **Light theme support** — ThemeProvider context (outermost, split pattern) with three modes (system/light/dark). CSS `data-theme` attribute on `<html>` switches color tokens via `globals.css` selectors. Blocking inline script in `index.html` for no-flicker init. xterm terminal theme updates live. Theme switcher in command palette. Provider tree: `ThemeProvider > ChromeProvider > SessionProvider > AppShell`. | `260318-eseg-add-light-theme-support` |
 | 2026-03-18 | **Dedicated tmux server** — All run-kit sessions live on a named tmux server `runkit` (via `tmux -L runkit`). `internal/tmux` commands prefixed with `-L runkit` and optional `-f` from `RK_TMUX_CONF` env var. `ListSessions()` queries both runkit and default servers, returning `SessionInfo` with `Server` field. `ListWindows()` accepts server parameter. `CreateSession()` uses plain `tmux new-session` on runkit server (byobu dependency removed, `sync.OnceValue` detection deleted). `ProjectSession` type gains `Server` field. Relay attaches to runkit server. New `config/tmux.conf` with dark-themed status bar and F2/F3/F4 keybindings. Frontend: `ProjectSession` type gains `server` field, sidebar shows `↗` marker for default-server sessions. | `260318-0gjh-dedicated-tmux-server` |
 | 2026-03-20 | **Multi-server relay + config reload** — `RK_TMUX_CONF` resolved to absolute path at init (fixes CWD-dependent config loading). Relay and select-window endpoints accept `?server=` query param to route to runkit or default tmux server (fixes default-server sessions not connecting). `SelectWindowOnServer()` added. `ReloadConfig(server)` hot-reloads tmux config via `source-file`. New `POST /api/tmux/reload-config` endpoint + `reloadTmuxConfig(server)` client function + "Reload tmux config" command palette action (targets current session's server). `tmuxExec`/`tmuxExecDefault` capture stderr in error messages. `TerminalClient` accepts `server` prop. | `260318-0gjh-dedicated-tmux-server` |
+| 2026-03-20 | **Hostname in browser title** — `Server` struct gains `hostname` field (computed once via `os.Hostname()` in `NewRouter()`, empty string fallback). `/api/health` response extended to `{"status":"ok","hostname":"..."}`. New `getHealth()` API client function. `useBrowserTitle` hook sets `document.title` dynamically: `RunKit — {hostname}` on Dashboard, `{session}/{window} — {hostname}` on terminal pages. Hostname suffix omitted when empty. | `260320-uq0k-hostname-browser-title` |

--- a/fab/changes/260320-uq0k-hostname-browser-title/.history.jsonl
+++ b/fab/changes/260320-uq0k-hostname-browser-title/.history.jsonl
@@ -1,0 +1,16 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-03-20T05:57:01Z"}
+{"args":"show hostname in browser title for multi-machine identification","cmd":"fab-new","event":"command","ts":"2026-03-20T05:57:01Z"}
+{"delta":"+4.4","event":"confidence","score":4.4,"trigger":"calc-score","ts":"2026-03-20T05:58:00Z"}
+{"delta":"+0.0","event":"confidence","score":4.4,"trigger":"calc-score","ts":"2026-03-20T05:58:11Z"}
+{"cmd":"fab-switch","event":"command","ts":"2026-03-20T06:14:34Z"}
+{"cmd":"fab-fff","event":"command","ts":"2026-03-20T06:14:57Z"}
+{"delta":"-0.3","event":"confidence","score":4.1,"trigger":"calc-score","ts":"2026-03-20T06:16:02Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"spec","ts":"2026-03-20T06:16:07Z"}
+{"cmd":"fab-clarify","event":"command","ts":"2026-03-20T06:16:40Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"tasks","ts":"2026-03-20T06:18:52Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-03-20T06:18:55Z"}
+{"cmd":"fab-continue","event":"command","ts":"2026-03-20T06:19:35Z"}
+{"action":"enter","driver":"fab-continue","event":"stage-transition","stage":"review","ts":"2026-03-20T06:22:58Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-03-20T06:26:03Z"}
+{"event":"review","result":"passed","ts":"2026-03-20T06:26:03Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-03-20T06:26:58Z"}

--- a/fab/changes/260320-uq0k-hostname-browser-title/.history.jsonl
+++ b/fab/changes/260320-uq0k-hostname-browser-title/.history.jsonl
@@ -14,3 +14,4 @@
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-03-20T06:26:03Z"}
 {"event":"review","result":"passed","ts":"2026-03-20T06:26:03Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-03-20T06:26:58Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-03-20T06:29:36Z"}

--- a/fab/changes/260320-uq0k-hostname-browser-title/.status.yaml
+++ b/fab/changes/260320-uq0k-hostname-browser-title/.status.yaml
@@ -11,8 +11,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 checklist:
     generated: true
     path: checklist.md
@@ -37,6 +37,8 @@ stage_metrics:
     apply: {started_at: "2026-03-20T06:18:55Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-20T06:22:58Z"}
     review: {started_at: "2026-03-20T06:22:58Z", driver: fab-continue, iterations: 1, completed_at: "2026-03-20T06:26:03Z"}
     hydrate: {started_at: "2026-03-20T06:26:03Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-20T06:26:58Z"}
-    ship: {started_at: "2026-03-20T06:26:58Z", driver: fab-fff, iterations: 1}
-prs: []
-last_updated: 2026-03-20T06:26:58Z
+    ship: {started_at: "2026-03-20T06:26:58Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-20T06:29:36Z"}
+    review-pr: {started_at: "2026-03-20T06:29:36Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/wvrdz/run-kit/pull/58
+last_updated: 2026-03-20T06:29:36Z

--- a/fab/changes/260320-uq0k-hostname-browser-title/.status.yaml
+++ b/fab/changes/260320-uq0k-hostname-browser-title/.status.yaml
@@ -1,0 +1,42 @@
+id: uq0k
+name: 260320-uq0k-hostname-browser-title
+created: 2026-03-20T05:57:01Z
+created_by: arbaaz-weaver
+change_type: feat
+issues: []
+progress:
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+checklist:
+    generated: true
+    path: checklist.md
+    completed: 19
+    total: 0
+confidence:
+    certain: 6
+    confident: 3
+    tentative: 0
+    unresolved: 0
+    score: 4.1
+    fuzzy: true
+    dimensions:
+        signal: 79.4
+        reversibility: 91.7
+        competence: 85.6
+        disambiguation: 82.2
+stage_metrics:
+    intake: {started_at: "2026-03-20T05:57:01Z", driver: fab-new, iterations: 1, completed_at: "2026-03-20T06:16:07Z"}
+    spec: {started_at: "2026-03-20T06:16:07Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-20T06:18:52Z"}
+    tasks: {started_at: "2026-03-20T06:18:52Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-20T06:18:55Z"}
+    apply: {started_at: "2026-03-20T06:18:55Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-20T06:22:58Z"}
+    review: {started_at: "2026-03-20T06:22:58Z", driver: fab-continue, iterations: 1, completed_at: "2026-03-20T06:26:03Z"}
+    hydrate: {started_at: "2026-03-20T06:26:03Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-20T06:26:58Z"}
+    ship: {started_at: "2026-03-20T06:26:58Z", driver: fab-fff, iterations: 1}
+prs: []
+last_updated: 2026-03-20T06:26:58Z

--- a/fab/changes/260320-uq0k-hostname-browser-title/checklist.md
+++ b/fab/changes/260320-uq0k-hostname-browser-title/checklist.md
@@ -1,0 +1,40 @@
+# Quality Checklist: Hostname in Browser Title
+
+**Change**: 260320-uq0k-hostname-browser-title
+**Generated**: 2026-03-20
+**Spec**: `spec.md`
+
+## Functional Completeness
+- [x] CHK-001 Hostname at startup: `os.Hostname()` called once at startup, stored in `Server` struct
+- [x] CHK-002 Health endpoint: `GET /api/health` returns `{"status":"ok","hostname":"..."}` with actual hostname
+- [x] CHK-003 Frontend fetch: `getHealth()` function exists in API client and returns hostname
+- [x] CHK-004 Dashboard title: `document.title` is `RunKit — {hostname}` on `/`
+- [x] CHK-005 Terminal title: `document.title` is `{session}/{window} — {hostname}` on `/:session/:window`
+
+## Behavioral Correctness
+- [x] CHK-006 Health response shape: Response includes both `status` and `hostname` fields (not just `status`)
+- [x] CHK-007 Title updates on navigation: Title changes when switching between dashboard and terminal routes
+
+## Scenario Coverage
+- [x] CHK-008 Empty hostname fallback: When `os.Hostname()` fails, health returns `"hostname":""` and title omits hostname suffix
+- [x] CHK-009 Title with hostname on dashboard: Verified via test
+- [x] CHK-010 Title with hostname on terminal page: Verified via test
+- [x] CHK-011 Title navigation update: Title changes when navigating from dashboard to terminal and back
+
+## Edge Cases & Error Handling
+- [x] CHK-012 Hostname failure non-fatal: Server starts normally even if `os.Hostname()` errors
+- [x] CHK-013 Static fallback preserved: `<title>RunKit</title>` in `index.html` unchanged
+
+## Code Quality
+- [x] CHK-014 Pattern consistency: New code follows naming and structural patterns of surrounding code
+- [x] CHK-015 No unnecessary duplication: Existing utilities reused where applicable
+- [x] CHK-016 Readability: Code is readable and maintainable over clever
+- [x] CHK-017 Subprocess safety: No new subprocess calls introduced (hostname is `os.Hostname()`, not shell)
+- [x] CHK-018 No polling: Hostname fetched once, not on interval
+- [x] CHK-019 No magic strings: Title format uses clear constants or inline values with obvious meaning
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] CHK-008 **N/A**: {reason}`

--- a/fab/changes/260320-uq0k-hostname-browser-title/intake.md
+++ b/fab/changes/260320-uq0k-hostname-browser-title/intake.md
@@ -1,0 +1,73 @@
+# Intake: Hostname in Browser Title
+
+**Change**: 260320-uq0k-hostname-browser-title
+**Created**: 2026-03-20
+**Status**: Draft
+
+## Origin
+
+> "we need to show the host name in browser title because i have multiple machines and it's hard to know i'm on which machine"
+
+One-shot request. User manages multiple machines running run-kit and needs to visually distinguish which machine a browser tab is connected to. The browser tab title is the only persistent, always-visible identifier across tab-switching workflows.
+
+## Why
+
+1. **Problem**: When multiple run-kit instances are open across different machines, all browser tabs show the same static title ("RunKit"), making it impossible to identify which tab connects to which host without clicking into each one.
+2. **Consequence**: The user accidentally sends commands to the wrong machine's tmux sessions — a potentially destructive mistake in an agent orchestration context.
+3. **Approach**: Expose the server's hostname from the Go backend and render it in the browser tab title. This is the minimal, non-invasive approach — no new pages, no config UI, just data flow from `os.Hostname()` to `document.title`.
+
+## What Changes
+
+### Backend: Expose hostname in `/api/health` response
+
+The `/api/health` endpoint currently returns `{"status": "ok"}`. Extend it to include the server's hostname:
+
+```json
+{ "status": "ok", "hostname": "arbaaz-dev-01" }
+```
+
+The hostname is obtained via Go's `os.Hostname()` at server startup (computed once, not per-request). This keeps the health endpoint lightweight and avoids repeated syscalls.
+
+### Frontend: Dynamic browser title with hostname
+
+On app initialization, fetch the hostname from the backend and set `document.title` to include it. Format:
+
+```
+RunKit — arbaaz-dev-01
+```
+
+When navigating to a specific session/window, the title could further include the session context:
+
+```
+mysession/0 — arbaaz-dev-01
+```
+
+The static `<title>RunKit</title>` in `index.html` remains as the fallback — it's what the user sees during initial load before the API responds.
+
+## Affected Memory
+
+- `run-kit/architecture`: (modify) Document hostname exposure via health endpoint
+
+## Impact
+
+- **Backend**: `api/router.go` (health handler), `cmd/run-kit/` or `internal/config/` (hostname init)
+- **Frontend**: Route-level title management (new), API client (minor — health endpoint shape change)
+- **API spec**: `docs/specs/api.md` — health endpoint response shape gains `hostname` field
+- **Tests**: Health endpoint test needs update for new response shape; frontend title behavior needs test coverage
+
+## Open Questions
+
+- None — the scope is clear and self-contained.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Use `os.Hostname()` for the hostname value | Go stdlib provides this; no config needed; matches what the OS reports | S:85 R:90 A:95 D:95 |
+| 2 | Certain | Expose hostname via existing `/api/health` endpoint | Avoids new endpoint; health is already fetched; constitution says minimal surface area | S:80 R:85 A:90 D:85 |
+| 3 | Confident | Title format: `RunKit — {hostname}` (with em dash) | Clean, readable; consistent with common browser title conventions | S:70 R:95 A:70 D:65 |
+| 4 | Confident | Include session/window in title when on a session route | Natural extension — `mysession/0 — hostname` gives full context per tab | S:65 R:90 A:75 D:60 |
+| 5 | Certain | Compute hostname once at startup, not per-request | Constitution requires minimal overhead; hostname doesn't change at runtime | S:85 R:90 A:95 D:90 |
+| 6 | Certain | Keep static `<title>RunKit</title>` as fallback | Standard SPA practice — title visible during initial load before JS hydration | S:90 R:95 A:90 D:95 |
+
+6 assumptions (4 certain, 2 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260320-uq0k-hostname-browser-title/spec.md
+++ b/fab/changes/260320-uq0k-hostname-browser-title/spec.md
@@ -1,0 +1,122 @@
+# Spec: Hostname in Browser Title
+
+**Change**: 260320-uq0k-hostname-browser-title
+**Created**: 2026-03-20
+**Affected memory**: `docs/memory/run-kit/architecture.md`
+
+## Backend: Hostname Exposure
+
+### Requirement: Compute Hostname at Startup
+
+The Go backend SHALL compute the server hostname via `os.Hostname()` once at startup and store it for the lifetime of the process. The hostname SHALL NOT be computed per-request.
+
+#### Scenario: Hostname Available
+- **GIVEN** the server starts on a machine with hostname `arbaaz-dev-01`
+- **WHEN** `os.Hostname()` succeeds
+- **THEN** the hostname value `arbaaz-dev-01` is stored and available to all handlers
+
+#### Scenario: Hostname Unavailable
+- **GIVEN** `os.Hostname()` returns an error
+- **WHEN** the server starts
+- **THEN** the hostname value SHALL fall back to an empty string `""`
+- **AND** the server SHALL start normally (hostname failure is not fatal)
+
+### Requirement: Health Endpoint Includes Hostname
+
+The `GET /api/health` endpoint SHALL return a JSON response that includes the `hostname` field alongside the existing `status` field.
+
+Response shape:
+```json
+{ "status": "ok", "hostname": "arbaaz-dev-01" }
+```
+
+When the hostname is unavailable (empty string fallback), the response SHALL include `"hostname": ""`.
+
+#### Scenario: Health Check with Hostname
+- **GIVEN** the server is running with hostname `arbaaz-dev-01`
+- **WHEN** a client sends `GET /api/health`
+- **THEN** the response status is `200`
+- **AND** the response body contains `{"status":"ok","hostname":"arbaaz-dev-01"}`
+
+#### Scenario: Health Check with Empty Hostname
+- **GIVEN** `os.Hostname()` failed at startup
+- **WHEN** a client sends `GET /api/health`
+- **THEN** the response body contains `{"status":"ok","hostname":""}`
+
+## Frontend: Dynamic Browser Title
+
+### Requirement: Fetch Hostname from Backend
+
+The frontend SHALL fetch the hostname from `GET /api/health` on app initialization. The API client SHALL expose a `getHealth()` function that returns the health response including the `hostname` field.
+
+#### Scenario: Hostname Fetched on Load
+- **GIVEN** the app loads in the browser
+- **WHEN** the health endpoint responds with `{"status":"ok","hostname":"arbaaz-dev-01"}`
+- **THEN** the hostname `arbaaz-dev-01` is available to the title-setting logic
+
+### Requirement: Browser Title Format
+
+The browser tab title SHALL include the hostname using the following formats:
+
+- **Dashboard** (`/`): `RunKit — {hostname}`
+- **Terminal page** (`/:session/:window`): `{session}/{window} — {hostname}`
+
+The em dash ` — ` (U+2014) SHALL be used as the separator.
+
+When the hostname is empty, the title SHALL omit the hostname suffix:
+- Dashboard: `RunKit`
+- Terminal page: `{session}/{window}`
+
+The static `<title>RunKit</title>` in `index.html` SHALL remain unchanged as the pre-hydration fallback.
+
+#### Scenario: Dashboard Title with Hostname
+- **GIVEN** the app is on the Dashboard (`/`)
+- **AND** the hostname is `arbaaz-dev-01`
+- **WHEN** the title is rendered
+- **THEN** `document.title` equals `RunKit — arbaaz-dev-01`
+
+#### Scenario: Terminal Title with Hostname
+- **GIVEN** the app is on `/:session/:window` with session `myproject` and window `0`
+- **AND** the hostname is `arbaaz-dev-01`
+- **WHEN** the title is rendered
+- **THEN** `document.title` equals `myproject/0 — arbaaz-dev-01`
+
+#### Scenario: Title Updates on Navigation
+- **GIVEN** the user is on the Dashboard with title `RunKit — arbaaz-dev-01`
+- **WHEN** the user navigates to session `agent-work` window `2`
+- **THEN** `document.title` updates to `agent-work/2 — arbaaz-dev-01`
+
+#### Scenario: Title Without Hostname
+- **GIVEN** the hostname is empty (backend fallback)
+- **WHEN** the app is on the Dashboard
+- **THEN** `document.title` equals `RunKit`
+
+## Design Decisions
+
+1. **Hostname via health endpoint (not a dedicated endpoint)**
+   - *Why*: Constitution mandates minimal surface area. Health is already fetched; adding a field is cheaper than a new endpoint.
+   - *Rejected*: `GET /api/hostname` — unnecessary new route.
+
+2. **Hostname computed once in `NewRouter()`, stored in Server struct (not in config package)**
+   - *Why*: `internal/config` reads env vars; hostname is an OS-level value, not configuration. Computing it in `NewRouter()` keeps the production path simple while `NewTestRouter()` accepts hostname as a parameter for test injection.
+   - *Rejected*: Adding to `config.Config` — hostname is not configurable, it's derived.
+
+3. **Title managed via `useEffect` in `AppShell` (not a dedicated context)**
+   - *Why*: `document.title` is a simple side effect driven by route params + a single string. A context would be over-engineering for a derived value.
+   - *Rejected*: `HostnameContext` — overkill for a single string fetched once.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Use `os.Hostname()` for the hostname value | Confirmed from intake #1. Go stdlib, no config needed | S:85 R:90 A:95 D:95 |
+| 2 | Certain | Expose hostname via existing `/api/health` endpoint | Confirmed from intake #2. Constitution: minimal surface area | S:80 R:85 A:90 D:85 |
+| 3 | Confident | Title format: `RunKit — {hostname}` with em dash | Confirmed from intake #3. Clean, readable, standard convention | S:70 R:95 A:70 D:65 |
+| 4 | Confident | Include session/window in title: `session/window — hostname` | Confirmed from intake #4. Natural multi-tab identification | S:65 R:90 A:75 D:60 |
+| 5 | Certain | Compute hostname once at startup, store in Server struct | Confirmed from intake #5. Upgraded: spec clarifies injection via Server struct | S:85 R:90 A:95 D:90 |
+| 6 | Certain | Keep static `<title>RunKit</title>` as fallback | Confirmed from intake #6. Standard SPA practice | S:90 R:95 A:90 D:95 |
+| 7 | Certain | Hostname failure falls back to empty string (non-fatal) | OS hostname is best-effort; server must start regardless | S:80 R:95 A:90 D:90 |
+| 8 | Certain | Title managed as `useEffect` side effect, not a context | Single derived string; context is overkill | S:85 R:95 A:85 D:90 |
+| 9 | Confident | Fetch hostname once via `getHealth()` on app init | Health endpoint already exists; one fetch on init is minimal overhead | S:75 R:90 A:80 D:70 |
+
+9 assumptions (6 certain, 3 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260320-uq0k-hostname-browser-title/tasks.md
+++ b/fab/changes/260320-uq0k-hostname-browser-title/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: Hostname in Browser Title
+
+**Change**: 260320-uq0k-hostname-browser-title
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+## Phase 1: Setup
+
+- [x] T001 Add `hostname` field to `Server` struct in `app/backend/api/router.go` and wire `os.Hostname()` in `app/backend/cmd/run-kit/main.go`
+
+## Phase 2: Core Implementation
+
+- [x] T002 [P] Update `handleHealth` in `app/backend/api/health.go` to include `hostname` from `Server.hostname` in the JSON response
+- [x] T003 [P] Add `getHealth()` function to `app/frontend/src/api/client.ts` returning `{ status: string; hostname: string }`
+- [x] T004 Add `useEffect` in `app/frontend/src/app.tsx` to fetch hostname on mount and set `document.title` based on route params and hostname
+
+## Phase 3: Integration & Edge Cases
+
+- [x] T005 [P] Update `app/backend/api/health_test.go` — verify `hostname` field present in response, test with injected hostname value
+- [x] T006 [P] Add frontend test for title behavior — hostname in title on dashboard and terminal routes, empty hostname fallback
+
+---
+
+## Execution Order
+
+- T001 blocks T002 (hostname field must exist before handler can read it)
+- T002 and T003 are parallel (backend handler and frontend client are independent)
+- T003 blocks T004 (client function must exist before app.tsx can call it)
+- T005 and T006 are parallel (backend and frontend tests are independent)


### PR DESCRIPTION
## Summary

When multiple run-kit instances are open across different machines, all browser tabs show the same static title, making it impossible to identify which tab connects to which host. This change exposes the server hostname via `/api/health` and renders it in the browser tab title so users can distinguish between instances at a glance.

## Changes

- Backend: Expose hostname in `/api/health` response (computed once at startup via `os.Hostname()`)
- Frontend: Dynamic browser title with hostname (`RunKit — hostname` on dashboard, `session/window — hostname` on terminal pages)
- Frontend: `useBrowserTitle` hook for reactive title management

## Change

| ID | Name | Issue |
|----|------|-------|
| uq0k | 260320-uq0k-hostname-browser-title | — |

## Stats

| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| feat | 4.1 / 5.0 | 19/0 | 6/6 | Pass (1 iterations) |

[intake](https://github.com/wvrdz/run-kit/blob/260320-uq0k-hostname-browser-title/fab/changes/260320-uq0k-hostname-browser-title/intake.md) → [spec](https://github.com/wvrdz/run-kit/blob/260320-uq0k-hostname-browser-title/fab/changes/260320-uq0k-hostname-browser-title/spec.md) → tasks → apply → review → hydrate → ship