### PR TITLE
refactor: tmux Server Switcher

### DIFF
--- a/app/backend/api/relay.go
+++ b/app/backend/api/relay.go
@@ -71,10 +71,7 @@ func (s *Server) handleRelay(w http.ResponseWriter, r *http.Request) {
 	defer conn.Close()
 
 	// Determine which tmux server this session lives on
-	server := r.URL.Query().Get("server")
-	if server != "default" {
-		server = "runkit"
-	}
+	server := serverFromRequest(r)
 
 	// Verify the session exists and select the target window
 	windows, err := s.tmux.ListWindows(session, server)
@@ -84,7 +81,7 @@ func (s *Server) handleRelay(w http.ResponseWriter, r *http.Request) {
 			websocket.FormatCloseMessage(4004, "Session not found"))
 		return
 	}
-	if err := tmux.SelectWindowOnServer(session, winIdx, server); err != nil {
+	if err := s.tmux.SelectWindow(session, winIdx, server); err != nil {
 		slog.Error("select-window failed", "err", err, "session", session, "window", windowIndex)
 		conn.WriteMessage(websocket.CloseMessage,
 			websocket.FormatCloseMessage(4004, "Window not found"))
@@ -111,8 +108,8 @@ func (s *Server) handleRelay(w http.ResponseWriter, r *http.Request) {
 	// Attach to the session via PTY — renders the selected window as-is (no split)
 	ctx, cancel := context.WithCancel(context.Background())
 	var attachArgs []string
-	if server == "runkit" {
-		attachArgs = []string{"-L", "runkit"}
+	if server != "default" {
+		attachArgs = []string{"-L", server}
 		if confPath := tmux.ConfigPath(); confPath != "" {
 			attachArgs = append(attachArgs, "-f", confPath)
 		}

--- a/app/backend/api/router.go
+++ b/app/backend/api/router.go
@@ -62,7 +62,7 @@ func serverFromRequest(r *http.Request) string {
 	if s == "" {
 		return "default"
 	}
-	if validate.ValidateName(s, "Server name") != "" {
+	if validate.ValidateServerName(s) != "" {
 		return "default"
 	}
 	return s

--- a/app/backend/api/router.go
+++ b/app/backend/api/router.go
@@ -13,26 +13,29 @@ import (
 
 	"run-kit/internal/sessions"
 	"run-kit/internal/tmux"
+	"run-kit/internal/validate"
 )
 
 // SessionFetcher fetches enriched session data.
 type SessionFetcher interface {
-	FetchSessions() ([]sessions.ProjectSession, error)
+	FetchSessions(server string) ([]sessions.ProjectSession, error)
 }
 
 // TmuxOps defines tmux operations used by handlers.
 type TmuxOps interface {
-	CreateSession(name, cwd string) error
-	KillSession(session string) error
-	RenameSession(session, name string) error
-	CreateWindow(session, name, cwd string) error
-	KillWindow(session string, index int) error
-	RenameWindow(session string, index int, name string) error
-	SendKeys(session string, window int, keys string) error
-	SelectWindow(session string, index int) error
-	ListWindows(session string, server string) ([]tmux.WindowInfo, error)
-	SplitWindow(session string, window int) (string, error)
-	KillPane(paneID string) error
+	CreateSession(name, cwd, server string) error
+	KillSession(session, server string) error
+	RenameSession(session, name, server string) error
+	CreateWindow(session, name, cwd, server string) error
+	KillWindow(session string, index int, server string) error
+	RenameWindow(session string, index int, name, server string) error
+	SendKeys(session string, window int, keys, server string) error
+	SelectWindow(session string, index int, server string) error
+	ListWindows(session, server string) ([]tmux.WindowInfo, error)
+	SplitWindow(session string, window int, server string) (string, error)
+	KillPane(paneID, server string) error
+	ListServers() ([]string, error)
+	KillServer(server string) error
 }
 
 // Server holds handler dependencies.
@@ -52,48 +55,67 @@ func (s *Server) initSSEHub() {
 	})
 }
 
+// serverFromRequest extracts and validates the server query parameter from the
+// request, defaulting to "default" if absent or invalid.
+func serverFromRequest(r *http.Request) string {
+	s := r.URL.Query().Get("server")
+	if s == "" {
+		return "default"
+	}
+	if validate.ValidateName(s, "Server name") != "" {
+		return "default"
+	}
+	return s
+}
+
 // prodSessionFetcher wraps the sessions package for production use.
 type prodSessionFetcher struct{}
 
-func (p *prodSessionFetcher) FetchSessions() ([]sessions.ProjectSession, error) {
-	return sessions.FetchSessions()
+func (p *prodSessionFetcher) FetchSessions(server string) ([]sessions.ProjectSession, error) {
+	return sessions.FetchSessions(server)
 }
 
 // prodTmuxOps wraps the tmux package for production use.
 type prodTmuxOps struct{}
 
-func (p *prodTmuxOps) CreateSession(name, cwd string) error {
-	return tmux.CreateSession(name, cwd)
+func (p *prodTmuxOps) CreateSession(name, cwd, server string) error {
+	return tmux.CreateSession(name, cwd, server)
 }
-func (p *prodTmuxOps) KillSession(session string) error {
-	return tmux.KillSession(session)
+func (p *prodTmuxOps) KillSession(session, server string) error {
+	return tmux.KillSession(session, server)
 }
-func (p *prodTmuxOps) RenameSession(session, name string) error {
-	return tmux.RenameSession(session, name)
+func (p *prodTmuxOps) RenameSession(session, name, server string) error {
+	return tmux.RenameSession(session, name, server)
 }
-func (p *prodTmuxOps) CreateWindow(session, name, cwd string) error {
-	return tmux.CreateWindow(session, name, cwd)
+func (p *prodTmuxOps) CreateWindow(session, name, cwd, server string) error {
+	return tmux.CreateWindow(session, name, cwd, server)
 }
-func (p *prodTmuxOps) KillWindow(session string, index int) error {
-	return tmux.KillWindow(session, index)
+func (p *prodTmuxOps) KillWindow(session string, index int, server string) error {
+	return tmux.KillWindow(session, index, server)
 }
-func (p *prodTmuxOps) RenameWindow(session string, index int, name string) error {
-	return tmux.RenameWindow(session, index, name)
+func (p *prodTmuxOps) RenameWindow(session string, index int, name, server string) error {
+	return tmux.RenameWindow(session, index, name, server)
 }
-func (p *prodTmuxOps) SendKeys(session string, window int, keys string) error {
-	return tmux.SendKeys(session, window, keys)
+func (p *prodTmuxOps) SendKeys(session string, window int, keys, server string) error {
+	return tmux.SendKeys(session, window, keys, server)
 }
-func (p *prodTmuxOps) SelectWindow(session string, index int) error {
-	return tmux.SelectWindow(session, index)
+func (p *prodTmuxOps) SelectWindow(session string, index int, server string) error {
+	return tmux.SelectWindow(session, index, server)
 }
-func (p *prodTmuxOps) ListWindows(session string, server string) ([]tmux.WindowInfo, error) {
+func (p *prodTmuxOps) ListWindows(session, server string) ([]tmux.WindowInfo, error) {
 	return tmux.ListWindows(session, server)
 }
-func (p *prodTmuxOps) SplitWindow(session string, window int) (string, error) {
-	return tmux.SplitWindow(session, window)
+func (p *prodTmuxOps) SplitWindow(session string, window int, server string) (string, error) {
+	return tmux.SplitWindow(session, window, server)
 }
-func (p *prodTmuxOps) KillPane(paneID string) error {
-	return tmux.KillPane(paneID)
+func (p *prodTmuxOps) KillPane(paneID, server string) error {
+	return tmux.KillPane(paneID, server)
+}
+func (p *prodTmuxOps) ListServers() ([]string, error) {
+	return tmux.ListServers()
+}
+func (p *prodTmuxOps) KillServer(server string) error {
+	return tmux.KillServer(server)
 }
 
 // NewRouter creates the chi router with all middleware and routes.
@@ -149,6 +171,11 @@ func (s *Server) buildRouter() chi.Router {
 	r.Post("/api/sessions/{session}/upload", s.handleUpload)
 	r.Get("/api/sessions/stream", s.handleSSE)
 	r.Post("/api/tmux/reload-config", s.handleTmuxReloadConfig)
+
+	// Server management routes
+	r.Get("/api/servers", s.handleServersList)
+	r.Post("/api/servers", s.handleServerCreate)
+	r.Post("/api/servers/kill", s.handleServerKill)
 
 	// WebSocket relay
 	r.Get("/relay/{session}/{window}", s.handleRelay)

--- a/app/backend/api/servers.go
+++ b/app/backend/api/servers.go
@@ -29,7 +29,7 @@ func (s *Server) handleServerCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if errMsg := validate.ValidateName(body.Name, "Server name"); errMsg != "" {
+	if errMsg := validate.ValidateServerName(body.Name); errMsg != "" {
 		writeError(w, http.StatusBadRequest, errMsg)
 		return
 	}
@@ -57,7 +57,7 @@ func (s *Server) handleServerKill(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if errMsg := validate.ValidateName(body.Name, "Server name"); errMsg != "" {
+	if errMsg := validate.ValidateServerName(body.Name); errMsg != "" {
 		writeError(w, http.StatusBadRequest, errMsg)
 		return
 	}

--- a/app/backend/api/servers.go
+++ b/app/backend/api/servers.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+
+	"run-kit/internal/validate"
+)
+
+func (s *Server) handleServersList(w http.ResponseWriter, r *http.Request) {
+	servers, err := s.tmux.ListServers()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if servers == nil {
+		servers = []string{}
+	}
+	writeJSON(w, http.StatusOK, servers)
+}
+
+func (s *Server) handleServerCreate(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid JSON body")
+		return
+	}
+
+	if errMsg := validate.ValidateName(body.Name, "Server name"); errMsg != "" {
+		writeError(w, http.StatusBadRequest, errMsg)
+		return
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "Could not determine home directory")
+		return
+	}
+
+	if err := s.tmux.CreateSession("0", homeDir, body.Name); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]bool{"ok": true})
+}
+
+func (s *Server) handleServerKill(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid JSON body")
+		return
+	}
+
+	if errMsg := validate.ValidateName(body.Name, "Server name"); errMsg != "" {
+		writeError(w, http.StatusBadRequest, errMsg)
+		return
+	}
+
+	if err := s.tmux.KillServer(body.Name); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}

--- a/app/backend/api/sessions.go
+++ b/app/backend/api/sessions.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *Server) handleSessionsList(w http.ResponseWriter, r *http.Request) {
-	result, err := s.sessions.FetchSessions()
+	result, err := s.sessions.FetchSessions(serverFromRequest(r))
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -47,7 +47,7 @@ func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
 		resolvedCwd = expanded
 	}
 
-	if err := s.tmux.CreateSession(body.Name, resolvedCwd); err != nil {
+	if err := s.tmux.CreateSession(body.Name, resolvedCwd, serverFromRequest(r)); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -75,7 +75,7 @@ func (s *Server) handleSessionRename(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.tmux.RenameSession(session, body.Name); err != nil {
+	if err := s.tmux.RenameSession(session, body.Name, serverFromRequest(r)); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -90,7 +90,7 @@ func (s *Server) handleSessionKill(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.tmux.KillSession(session); err != nil {
+	if err := s.tmux.KillSession(session, serverFromRequest(r)); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/app/backend/api/sessions_test.go
+++ b/app/backend/api/sessions_test.go
@@ -19,7 +19,7 @@ type mockSessionFetcher struct {
 	err    error
 }
 
-func (m *mockSessionFetcher) FetchSessions() ([]sessions.ProjectSession, error) {
+func (m *mockSessionFetcher) FetchSessions(server string) ([]sessions.ProjectSession, error) {
 	return m.result, m.err
 }
 
@@ -59,60 +59,66 @@ type mockTmuxOps struct {
 	err error
 }
 
-func (m *mockTmuxOps) CreateSession(name, cwd string) error {
+func (m *mockTmuxOps) CreateSession(name, cwd, server string) error {
 	m.createSessionCalled = true
 	m.createSessionName = name
 	m.createSessionCwd = cwd
 	return m.err
 }
-func (m *mockTmuxOps) KillSession(session string) error {
+func (m *mockTmuxOps) KillSession(session, server string) error {
 	m.killSessionCalled = true
 	m.killSessionName = session
 	return m.err
 }
-func (m *mockTmuxOps) RenameSession(session, name string) error {
+func (m *mockTmuxOps) RenameSession(session, name, server string) error {
 	m.renameSessionCalled = true
 	m.renameSessionSession = session
 	m.renameSessionName = name
 	return m.err
 }
-func (m *mockTmuxOps) CreateWindow(session, name, cwd string) error {
+func (m *mockTmuxOps) CreateWindow(session, name, cwd, server string) error {
 	m.createWindowCalled = true
 	m.createWindowSession = session
 	m.createWindowName = name
 	m.createWindowCwd = cwd
 	return m.err
 }
-func (m *mockTmuxOps) KillWindow(session string, index int) error {
+func (m *mockTmuxOps) KillWindow(session string, index int, server string) error {
 	m.killWindowCalled = true
 	m.killWindowSession = session
 	m.killWindowIndex = index
 	return m.err
 }
-func (m *mockTmuxOps) RenameWindow(session string, index int, name string) error {
+func (m *mockTmuxOps) RenameWindow(session string, index int, name, server string) error {
 	m.renameWindowCalled = true
 	m.renameWindowSession = session
 	m.renameWindowIndex = index
 	m.renameWindowName = name
 	return m.err
 }
-func (m *mockTmuxOps) SendKeys(session string, window int, keys string) error {
+func (m *mockTmuxOps) SendKeys(session string, window int, keys, server string) error {
 	m.sendKeysCalled = true
 	m.sendKeysSession = session
 	m.sendKeysWindow = window
 	m.sendKeysKeys = keys
 	return m.err
 }
-func (m *mockTmuxOps) ListWindows(session string, server string) ([]tmux.WindowInfo, error) {
+func (m *mockTmuxOps) ListWindows(session, server string) ([]tmux.WindowInfo, error) {
 	return m.listWindowsResult, m.listWindowsErr
 }
-func (m *mockTmuxOps) SplitWindow(session string, window int) (string, error) {
+func (m *mockTmuxOps) SplitWindow(session string, window int, server string) (string, error) {
 	return m.splitWindowResult, m.splitWindowErr
 }
-func (m *mockTmuxOps) SelectWindow(session string, index int) error {
+func (m *mockTmuxOps) SelectWindow(session string, index int, server string) error {
 	return nil
 }
-func (m *mockTmuxOps) KillPane(paneID string) error {
+func (m *mockTmuxOps) KillPane(paneID, server string) error {
+	return nil
+}
+func (m *mockTmuxOps) ListServers() ([]string, error) {
+	return []string{"default"}, nil
+}
+func (m *mockTmuxOps) KillServer(server string) error {
 	return nil
 }
 

--- a/app/backend/api/sse.go
+++ b/app/backend/api/sse.go
@@ -15,21 +15,23 @@ const (
 )
 
 type sseClient struct {
-	ch chan []byte
+	ch     chan []byte
+	server string
 }
 
 type sseHub struct {
 	mu           sync.RWMutex
 	clients      map[*sseClient]struct{}
-	previousJSON string
+	previousJSON map[string]string // per-server JSON cache
 	polling      bool
 	fetcher      SessionFetcher
 }
 
 func newSSEHub(fetcher SessionFetcher) *sseHub {
 	return &sseHub{
-		clients: make(map[*sseClient]struct{}),
-		fetcher: fetcher,
+		clients:      make(map[*sseClient]struct{}),
+		previousJSON: make(map[string]string),
+		fetcher:      fetcher,
 	}
 }
 
@@ -40,9 +42,9 @@ func (h *sseHub) addClient(c *sseClient) {
 	h.clients[c] = struct{}{}
 
 	// Send cached snapshot immediately
-	if h.previousJSON != "" {
+	if prev, ok := h.previousJSON[c.server]; ok && prev != "" {
 		select {
-		case c.ch <- []byte(fmt.Sprintf("event: sessions\ndata: %s\n\n", h.previousJSON)):
+		case c.ch <- []byte(fmt.Sprintf("event: sessions\ndata: %s\n\n", prev)):
 		default:
 		}
 	}
@@ -68,36 +70,45 @@ func (h *sseHub) poll() {
 			h.mu.Unlock()
 			return
 		}
+
+		// Collect distinct servers that have active clients
+		serverSet := make(map[string]struct{})
+		for c := range h.clients {
+			serverSet[c.server] = struct{}{}
+		}
 		h.mu.Unlock()
 
-		result, err := h.fetcher.FetchSessions()
-		if err != nil {
-			slog.Warn("SSE poll error", "err", err)
-			time.Sleep(ssePollInterval)
-			continue
-		}
+		// Poll each server and broadcast to matching clients
+		for server := range serverSet {
+			result, err := h.fetcher.FetchSessions(server)
+			if err != nil {
+				slog.Warn("SSE poll error", "err", err, "server", server)
+				continue
+			}
 
-		jsonBytes, err := json.Marshal(result)
-		if err != nil {
-			time.Sleep(ssePollInterval)
-			continue
-		}
-		jsonStr := string(jsonBytes)
+			jsonBytes, err := json.Marshal(result)
+			if err != nil {
+				continue
+			}
+			jsonStr := string(jsonBytes)
 
-		h.mu.Lock()
-		if jsonStr != h.previousJSON {
-			h.previousJSON = jsonStr
-			event := []byte(fmt.Sprintf("event: sessions\ndata: %s\n\n", jsonStr))
+			h.mu.Lock()
+			if jsonStr != h.previousJSON[server] {
+				h.previousJSON[server] = jsonStr
+				event := []byte(fmt.Sprintf("event: sessions\ndata: %s\n\n", jsonStr))
 
-			for c := range h.clients {
-				select {
-				case c.ch <- event:
-				default:
-					// Client buffer full — skip
+				for c := range h.clients {
+					if c.server == server {
+						select {
+						case c.ch <- event:
+						default:
+							// Client buffer full — skip
+						}
+					}
 				}
 			}
+			h.mu.Unlock()
 		}
-		h.mu.Unlock()
 
 		time.Sleep(ssePollInterval)
 	}
@@ -115,7 +126,8 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Connection", "keep-alive")
 
 	client := &sseClient{
-		ch: make(chan []byte, 8),
+		ch:     make(chan []byte, 8),
+		server: serverFromRequest(r),
 	}
 
 	// Lazy-init the hub on first SSE connection

--- a/app/backend/api/sse_test.go
+++ b/app/backend/api/sse_test.go
@@ -18,7 +18,7 @@ type slowSessionFetcher struct {
 	result []sessions.ProjectSession
 }
 
-func (s *slowSessionFetcher) FetchSessions() ([]sessions.ProjectSession, error) {
+func (s *slowSessionFetcher) FetchSessions(server string) ([]sessions.ProjectSession, error) {
 	return s.result, nil
 }
 

--- a/app/backend/api/tmux_config.go
+++ b/app/backend/api/tmux_config.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"log/slog"
 	"net/http"
 
@@ -9,15 +8,10 @@ import (
 )
 
 func (s *Server) handleTmuxReloadConfig(w http.ResponseWriter, r *http.Request) {
-	var body struct {
-		Server string `json:"server"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || (body.Server != "default" && body.Server != "runkit") {
-		body.Server = "runkit"
-	}
+	server := serverFromRequest(r)
 
-	if err := tmux.ReloadConfig(body.Server); err != nil {
-		slog.Error("tmux config reload failed", "err", err, "server", body.Server)
+	if err := tmux.ReloadConfig(server); err != nil {
+		slog.Error("tmux config reload failed", "err", err, "server", server)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}

--- a/app/backend/api/upload.go
+++ b/app/backend/api/upload.go
@@ -63,7 +63,7 @@ func (s *Server) handleUpload(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get project root via tmux windows
-	windows, err := s.tmux.ListWindows(session, "runkit")
+	windows, err := s.tmux.ListWindows(session, serverFromRequest(r))
 	if err != nil || len(windows) == 0 {
 		writeError(w, http.StatusBadRequest, "Session not found or has no windows")
 		return

--- a/app/backend/api/windows.go
+++ b/app/backend/api/windows.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"run-kit/internal/tmux"
-
 	"run-kit/internal/validate"
 )
 
@@ -34,6 +32,8 @@ func (s *Server) handleWindowCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	server := serverFromRequest(r)
+
 	var resolvedCwd string
 	if body.CWD != "" {
 		if errMsg := validate.ValidatePath(body.CWD, "Working directory"); errMsg != "" {
@@ -48,12 +48,12 @@ func (s *Server) handleWindowCreate(w http.ResponseWriter, r *http.Request) {
 		resolvedCwd = expanded
 	} else {
 		// Default to the cwd of the first window in the session.
-		if windows, err := s.tmux.ListWindows(session, "runkit"); err == nil && len(windows) > 0 {
+		if windows, err := s.tmux.ListWindows(session, server); err == nil && len(windows) > 0 {
 			resolvedCwd = windows[0].WorktreePath
 		}
 	}
 
-	if err := s.tmux.CreateWindow(session, body.Name, resolvedCwd); err != nil {
+	if err := s.tmux.CreateWindow(session, body.Name, resolvedCwd, server); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -84,7 +84,7 @@ func (s *Server) handleWindowKill(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.tmux.KillWindow(session, index); err != nil {
+	if err := s.tmux.KillWindow(session, index, serverFromRequest(r)); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -118,7 +118,7 @@ func (s *Server) handleWindowRename(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.tmux.RenameWindow(session, index, body.Name); err != nil {
+	if err := s.tmux.RenameWindow(session, index, body.Name, serverFromRequest(r)); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -139,11 +139,7 @@ func (s *Server) handleWindowSelect(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	server := r.URL.Query().Get("server")
-	if server != "default" {
-		server = "runkit"
-	}
-	if err := tmux.SelectWindowOnServer(session, index, server); err != nil {
+	if err := s.tmux.SelectWindow(session, index, serverFromRequest(r)); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -177,7 +173,7 @@ func (s *Server) handleWindowKeys(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.tmux.SendKeys(session, index, body.Keys); err != nil {
+	if err := s.tmux.SendKeys(session, index, body.Keys, serverFromRequest(r)); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/app/backend/cmd/run-kit/status.go
+++ b/app/backend/cmd/run-kit/status.go
@@ -12,7 +12,8 @@ var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show tmux session summary",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		sessions, err := tmux.ListSessions()
+		server := "runkit"
+		sessions, err := tmux.ListSessions(server)
 		if err != nil {
 			return fmt.Errorf("listing sessions: %w", err)
 		}
@@ -23,7 +24,7 @@ var statusCmd = &cobra.Command{
 		}
 
 		for _, s := range sessions {
-			windows, err := tmux.ListWindows(s.Name, "")
+			windows, err := tmux.ListWindows(s.Name, server)
 			if err != nil {
 				fmt.Printf("  %s (error listing windows)\n", s.Name)
 				continue

--- a/app/backend/internal/sessions/sessions.go
+++ b/app/backend/internal/sessions/sessions.go
@@ -17,7 +17,6 @@ import (
 // ProjectSession is a tmux session with its windows and optional fab enrichment.
 type ProjectSession struct {
 	Name    string            `json:"name"`
-	Server  string            `json:"server"` // "runkit" or "default"
 	Windows []tmux.WindowInfo `json:"windows"`
 }
 
@@ -98,9 +97,9 @@ func derefStr(s *string) string {
 	return *s
 }
 
-// FetchSessions fetches all sessions, derives project roots from tmux, and enriches with fab state.
-func FetchSessions() ([]ProjectSession, error) {
-	sessionInfos, err := tmux.ListSessions()
+// FetchSessions fetches all sessions from the specified server, derives project roots from tmux, and enriches with fab state.
+func FetchSessions(server string) ([]ProjectSession, error) {
+	sessionInfos, err := tmux.ListSessions(server)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +121,7 @@ func FetchSessions() ([]ProjectSession, error) {
 		wg.Add(1)
 		go func(idx int, si tmux.SessionInfo) {
 			defer wg.Done()
-			windows, _ := tmux.ListWindows(si.Name, si.Server)
+			windows, _ := tmux.ListWindows(si.Name, server)
 			if windows == nil {
 				windows = []tmux.WindowInfo{}
 			}
@@ -168,16 +167,15 @@ func FetchSessions() ([]ProjectSession, error) {
 				sd.windows[j].AgentIdleDuration = derefStr(entry.AgentIdleDuration)
 			}
 		}
-		result[i] = ProjectSession{Name: sd.info.Name, Server: sd.info.Server, Windows: sd.windows}
+		result[i] = ProjectSession{Name: sd.info.Name, Windows: sd.windows}
 	}
 
 	return result, nil
 }
 
 // ProjectRoot derives the project root from a session's target window.
-// Defaults to querying the runkit server.
-func ProjectRoot(session string, windowIndex int) (string, error) {
-	windows, err := tmux.ListWindows(session, "runkit")
+func ProjectRoot(session string, windowIndex int, server string) (string, error) {
+	windows, err := tmux.ListWindows(session, server)
 	if err != nil {
 		return "", err
 	}

--- a/app/backend/internal/sessions/sessions_test.go
+++ b/app/backend/internal/sessions/sessions_test.go
@@ -59,8 +59,7 @@ func TestProjectRootDerivation(t *testing.T) {
 
 func TestProjectSessionStruct(t *testing.T) {
 	ps := ProjectSession{
-		Name:   "my-project",
-		Server: "runkit",
+		Name: "my-project",
 		Windows: []tmux.WindowInfo{
 			{Index: 0, Name: "main", WorktreePath: "/home/user/project", Activity: "active", IsActiveWindow: true},
 			{Index: 1, Name: "build", WorktreePath: "/tmp/build", Activity: "idle", IsActiveWindow: false},
@@ -69,9 +68,6 @@ func TestProjectSessionStruct(t *testing.T) {
 
 	if ps.Name != "my-project" {
 		t.Errorf("Name = %q, want %q", ps.Name, "my-project")
-	}
-	if ps.Server != "runkit" {
-		t.Errorf("Server = %q, want %q", ps.Server, "runkit")
 	}
 	if len(ps.Windows) != 2 {
 		t.Fatalf("Windows count = %d, want 2", len(ps.Windows))
@@ -84,24 +80,18 @@ func TestProjectSessionStruct(t *testing.T) {
 	}
 }
 
-func TestProjectSessionServerFieldJSON(t *testing.T) {
-	// Verify the Server field round-trips through JSON correctly for both values.
-	for _, server := range []string{"runkit", "default"} {
-		ps := ProjectSession{Name: "test", Server: server}
-		data, err := json.Marshal(ps)
-		if err != nil {
-			t.Fatalf("json.Marshal failed for server=%q: %v", server, err)
-		}
-		var decoded ProjectSession
-		if err := json.Unmarshal(data, &decoded); err != nil {
-			t.Fatalf("json.Unmarshal failed for server=%q: %v", server, err)
-		}
-		if decoded.Server != server {
-			t.Errorf("round-trip Server = %q, want %q", decoded.Server, server)
-		}
-		if decoded.Name != "test" {
-			t.Errorf("round-trip Name = %q, want %q", decoded.Name, "test")
-		}
+func TestProjectSessionNameFieldJSON(t *testing.T) {
+	ps := ProjectSession{Name: "test"}
+	data, err := json.Marshal(ps)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	var decoded ProjectSession
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	if decoded.Name != "test" {
+		t.Errorf("round-trip Name = %q, want %q", decoded.Name, "test")
 	}
 }
 

--- a/app/backend/internal/tmux/tmux.go
+++ b/app/backend/internal/tmux/tmux.go
@@ -54,7 +54,7 @@ func ReloadConfig(server string) error {
 
 // serverArgs returns the argument prefix for commands targeting a given server.
 // For "default", returns an empty slice (no -L flag). For any other name, returns
-// ["-L", name] plus the config flag if RK_TMUX_CONF is set.
+// ["-L", name] plus the config flag included when a config path is available.
 func serverArgs(server string) []string {
 	if server == "default" {
 		return nil
@@ -168,7 +168,14 @@ func ListSessions(server string) ([]SessionInfo, error) {
 
 	format := fmt.Sprintf("#{session_name}%s#{session_grouped}%s#{session_group}", listDelim, listDelim)
 
-	lines, _ := tmuxExecServer(ctx, server, "list-sessions", "-F", format)
+	lines, err := tmuxExecServer(ctx, server, "list-sessions", "-F", format)
+	if err != nil {
+		errMsg := err.Error()
+		if strings.Contains(errMsg, "no server running") || strings.Contains(errMsg, "failed to connect") {
+			return nil, nil
+		}
+		return nil, err
+	}
 	sessions := parseSessions(lines)
 
 	if len(sessions) == 0 {
@@ -366,9 +373,17 @@ func ListServers() ([]string, error) {
 
 	var servers []string
 	for _, e := range entries {
-		if !e.IsDir() {
-			servers = append(servers, e.Name())
+		if e.IsDir() {
+			continue
 		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if info.Mode()&os.ModeSocket == 0 {
+			continue
+		}
+		servers = append(servers, e.Name())
 	}
 	sort.Strings(servers)
 	return servers, nil

--- a/app/backend/internal/tmux/tmux.go
+++ b/app/backend/internal/tmux/tmux.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -47,17 +48,18 @@ func ReloadConfig(server string) error {
 	}
 	ctx, cancel := withTimeout()
 	defer cancel()
-	if server == "default" {
-		_, err := tmuxExecDefault(ctx, "source-file", configPath)
-		return err
-	}
-	_, err := tmuxExec(ctx, "source-file", configPath)
+	_, err := tmuxExecServer(ctx, server, "source-file", configPath)
 	return err
 }
 
-// runkitPrefix returns the argument prefix for commands targeting the runkit server.
-func runkitPrefix() []string {
-	args := []string{"-L", "runkit"}
+// serverArgs returns the argument prefix for commands targeting a given server.
+// For "default", returns an empty slice (no -L flag). For any other name, returns
+// ["-L", name] plus the config flag if RK_TMUX_CONF is set.
+func serverArgs(server string) []string {
+	if server == "default" {
+		return nil
+	}
+	args := []string{"-L", server}
 	if configPath != "" {
 		args = append(args, "-f", configPath)
 	}
@@ -88,9 +90,9 @@ type WindowInfo struct {
 	FabStage          string `json:"fabStage,omitempty"`
 }
 
-// tmuxExec runs a tmux command targeting the runkit server and returns stdout lines (empty lines filtered).
-func tmuxExec(ctx context.Context, args ...string) ([]string, error) {
-	full := append(runkitPrefix(), args...)
+// tmuxExecServer runs a tmux command targeting the specified server and returns stdout lines (empty lines filtered).
+func tmuxExecServer(ctx context.Context, server string, args ...string) ([]string, error) {
+	full := append(serverArgs(server), args...)
 	cmd := exec.CommandContext(ctx, "tmux", full...)
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
@@ -112,9 +114,9 @@ func tmuxExec(ctx context.Context, args ...string) ([]string, error) {
 	return result, nil
 }
 
-// tmuxExecRaw runs a tmux command targeting the runkit server and returns raw stdout.
-func tmuxExecRaw(ctx context.Context, args ...string) (string, error) {
-	full := append(runkitPrefix(), args...)
+// tmuxExecRawServer runs a tmux command targeting the specified server and returns raw stdout.
+func tmuxExecRawServer(ctx context.Context, server string, args ...string) (string, error) {
+	full := append(serverArgs(server), args...)
 	cmd := exec.CommandContext(ctx, "tmux", full...)
 	out, err := cmd.Output()
 	if err != nil {
@@ -123,44 +125,20 @@ func tmuxExecRaw(ctx context.Context, args ...string) (string, error) {
 	return string(out), nil
 }
 
-// tmuxExecDefault runs a tmux command against the default server (no -L, no -f).
-func tmuxExecDefault(ctx context.Context, args ...string) ([]string, error) {
-	cmd := exec.CommandContext(ctx, "tmux", args...)
-	var stderr strings.Builder
-	cmd.Stderr = &stderr
-	out, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
-	}
-	raw := strings.TrimSpace(string(out))
-	if raw == "" {
-		return nil, nil
-	}
-	lines := strings.Split(raw, "\n")
-	var result []string
-	for _, l := range lines {
-		if l != "" {
-			result = append(result, l)
-		}
-	}
-	return result, nil
-}
-
 // withTimeout creates a context with the default tmux timeout.
 func withTimeout() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), TmuxTimeout)
 }
 
-// SessionInfo describes a tmux session with metadata about its origin server.
+// SessionInfo describes a tmux session.
 type SessionInfo struct {
-	Name   string `json:"name"`
-	Server string `json:"server"` // "runkit" or "default"
+	Name string `json:"name"`
 }
 
 // parseSessions parses tmux list-sessions output lines into SessionInfo structs,
-// filtering out session-group copies. The server parameter tags each result.
+// filtering out session-group copies.
 // Exported for testing.
-func parseSessions(lines []string, server string) []SessionInfo {
+func parseSessions(lines []string) []SessionInfo {
 	var sessions []SessionInfo
 	for _, line := range lines {
 		parts := strings.Split(line, listDelim)
@@ -175,35 +153,28 @@ func parseSessions(lines []string, server string) []SessionInfo {
 		// Filter out session-group copies: keep if ungrouped or if name matches group
 		if grouped == "0" || name == group {
 			sessions = append(sessions, SessionInfo{
-				Name:   name,
-				Server: server,
+				Name: name,
 			})
 		}
 	}
 	return sessions
 }
 
-// ListSessions returns sessions from both the runkit and default tmux servers,
-// filtering out session-group copies. Returns nil if no servers are running.
-func ListSessions() ([]SessionInfo, error) {
+// ListSessions returns sessions from the specified tmux server,
+// filtering out session-group copies. Returns nil if no server is running.
+func ListSessions(server string) ([]SessionInfo, error) {
 	ctx, cancel := withTimeout()
 	defer cancel()
 
 	format := fmt.Sprintf("#{session_name}%s#{session_grouped}%s#{session_group}", listDelim, listDelim)
 
-	// Query runkit server
-	runkitLines, _ := tmuxExec(ctx, "list-sessions", "-F", format)
-	runkitSessions := parseSessions(runkitLines, "runkit")
+	lines, _ := tmuxExecServer(ctx, server, "list-sessions", "-F", format)
+	sessions := parseSessions(lines)
 
-	// Query default server
-	defaultLines, _ := tmuxExecDefault(ctx, "list-sessions", "-F", format)
-	defaultSessions := parseSessions(defaultLines, "default")
-
-	all := append(runkitSessions, defaultSessions...)
-	if len(all) == 0 {
+	if len(sessions) == 0 {
 		return nil, nil
 	}
-	return all, nil
+	return sessions, nil
 }
 
 // parseWindows parses tmux list-windows output lines into WindowInfo structs.
@@ -240,8 +211,8 @@ func parseWindows(lines []string, nowUnix int64) []WindowInfo {
 	return windows
 }
 
-// ListWindows returns windows for a given session. The server parameter selects
-// which tmux server to query: "runkit" or "default". Returns nil if session does not exist.
+// ListWindows returns windows for a given session on the specified server.
+// Returns nil if session does not exist.
 func ListWindows(session string, server string) ([]WindowInfo, error) {
 	ctx, cancel := withTimeout()
 	defer cancel()
@@ -255,13 +226,7 @@ func ListWindows(session string, server string) ([]WindowInfo, error) {
 		"#{pane_current_command}",
 	}, listDelim)
 
-	var lines []string
-	var err error
-	if server == "default" {
-		lines, err = tmuxExecDefault(ctx, "list-windows", "-t", session, "-F", format)
-	} else {
-		lines, err = tmuxExec(ctx, "list-windows", "-t", session, "-F", format)
-	}
+	lines, err := tmuxExecServer(ctx, server, "list-windows", "-t", session, "-F", format)
 	if err != nil {
 		return nil, nil
 	}
@@ -269,9 +234,9 @@ func ListWindows(session string, server string) ([]WindowInfo, error) {
 	return parseWindows(lines, time.Now().Unix()), nil
 }
 
-// CreateSession creates a new detached tmux session on the runkit server,
+// CreateSession creates a new detached tmux session on the specified server,
 // optionally in a specific directory.
-func CreateSession(name string, cwd string) error {
+func CreateSession(name string, cwd string, server string) error {
 	ctx, cancel := withTimeout()
 	defer cancel()
 
@@ -280,93 +245,84 @@ func CreateSession(name string, cwd string) error {
 		args = append(args, "-c", cwd)
 	}
 
-	_, err := tmuxExec(ctx, args...)
+	_, err := tmuxExecServer(ctx, server, args...)
 	return err
 }
 
-// CreateWindow creates a new window in an existing session.
-func CreateWindow(session, name, cwd string) error {
+// CreateWindow creates a new window in an existing session on the specified server.
+func CreateWindow(session, name, cwd string, server string) error {
 	ctx, cancel := withTimeout()
 	defer cancel()
 
-	_, err := tmuxExec(ctx, "new-window", "-t", session, "-n", name, "-c", cwd)
+	_, err := tmuxExecServer(ctx, server, "new-window", "-t", session, "-n", name, "-c", cwd)
 	return err
 }
 
-// KillSession kills an entire tmux session.
-func KillSession(session string) error {
+// KillSession kills an entire tmux session on the specified server.
+func KillSession(session string, server string) error {
 	ctx, cancel := withTimeout()
 	defer cancel()
 
-	_, err := tmuxExec(ctx, "kill-session", "-t", session)
+	_, err := tmuxExecServer(ctx, server, "kill-session", "-t", session)
 	return err
 }
 
-// KillWindow kills a window by session and index.
-func KillWindow(session string, index int) error {
-	ctx, cancel := withTimeout()
-	defer cancel()
-
-	target := fmt.Sprintf("%s:%d", session, index)
-	_, err := tmuxExec(ctx, "kill-window", "-t", target)
-	return err
-}
-
-// RenameSession renames a tmux session.
-func RenameSession(session, name string) error {
-	ctx, cancel := withTimeout()
-	defer cancel()
-
-	_, err := tmuxExec(ctx, "rename-session", "-t", session, name)
-	return err
-}
-
-// RenameWindow renames a window by session and index.
-func RenameWindow(session string, index int, name string) error {
+// KillWindow kills a window by session and index on the specified server.
+func KillWindow(session string, index int, server string) error {
 	ctx, cancel := withTimeout()
 	defer cancel()
 
 	target := fmt.Sprintf("%s:%d", session, index)
-	_, err := tmuxExec(ctx, "rename-window", "-t", target, name)
+	_, err := tmuxExecServer(ctx, server, "kill-window", "-t", target)
 	return err
 }
 
-// SendKeys sends keystrokes to a tmux window.
-func SendKeys(session string, window int, keys string) error {
+// RenameSession renames a tmux session on the specified server.
+func RenameSession(session, name string, server string) error {
+	ctx, cancel := withTimeout()
+	defer cancel()
+
+	_, err := tmuxExecServer(ctx, server, "rename-session", "-t", session, name)
+	return err
+}
+
+// RenameWindow renames a window by session and index on the specified server.
+func RenameWindow(session string, index int, name string, server string) error {
+	ctx, cancel := withTimeout()
+	defer cancel()
+
+	target := fmt.Sprintf("%s:%d", session, index)
+	_, err := tmuxExecServer(ctx, server, "rename-window", "-t", target, name)
+	return err
+}
+
+// SendKeys sends keystrokes to a tmux window on the specified server.
+func SendKeys(session string, window int, keys string, server string) error {
 	ctx, cancel := withTimeout()
 	defer cancel()
 
 	target := fmt.Sprintf("%s:%d", session, window)
-	_, err := tmuxExec(ctx, "send-keys", "-t", target, keys, "Enter")
+	_, err := tmuxExecServer(ctx, server, "send-keys", "-t", target, keys, "Enter")
 	return err
 }
 
-// SelectWindow selects (focuses) a window by session and index.
-func SelectWindow(session string, index int) error {
-	return SelectWindowOnServer(session, index, "runkit")
-}
-
-// SelectWindowOnServer selects a window, targeting the specified server ("runkit" or "default").
-func SelectWindowOnServer(session string, index int, server string) error {
+// SelectWindow selects (focuses) a window by session and index on the specified server.
+func SelectWindow(session string, index int, server string) error {
 	ctx, cancel := withTimeout()
 	defer cancel()
 
 	target := fmt.Sprintf("%s:%d", session, index)
-	if server == "default" {
-		_, err := tmuxExecDefault(ctx, "select-window", "-t", target)
-		return err
-	}
-	_, err := tmuxExec(ctx, "select-window", "-t", target)
+	_, err := tmuxExecServer(ctx, server, "select-window", "-t", target)
 	return err
 }
 
-// SplitWindow splits a window to create an independent pane. Returns the new pane ID.
-func SplitWindow(session string, window int) (string, error) {
+// SplitWindow splits a window to create an independent pane on the specified server. Returns the new pane ID.
+func SplitWindow(session string, window int, server string) (string, error) {
 	ctx, cancel := withTimeout()
 	defer cancel()
 
 	target := fmt.Sprintf("%s:%d", session, window)
-	lines, err := tmuxExec(ctx, "split-window", "-t", target, "-d", "-P", "-F", "#{pane_id}")
+	lines, err := tmuxExecServer(ctx, server, "split-window", "-t", target, "-d", "-P", "-F", "#{pane_id}")
 	if err != nil {
 		return "", err
 	}
@@ -376,22 +332,53 @@ func SplitWindow(session string, window int) (string, error) {
 	return lines[0], nil
 }
 
-// KillPane kills a specific pane by ID.
-func KillPane(paneID string) error {
+// KillPane kills a specific pane by ID on the specified server.
+func KillPane(paneID string, server string) error {
 	ctx, cancel := withTimeout()
 	defer cancel()
 
-	_, err := tmuxExec(ctx, "kill-pane", "-t", paneID)
+	_, err := tmuxExecServer(ctx, server, "kill-pane", "-t", paneID)
 	// Pane may already be dead — ignore errors
 	_ = err
 	return nil
 }
 
-// CapturePane captures pane content (last N lines). Preserves blank lines.
-func CapturePane(paneID string, lines int) (string, error) {
+// CapturePane captures pane content (last N lines) on the specified server. Preserves blank lines.
+func CapturePane(paneID string, lines int, server string) (string, error) {
 	ctx, cancel := withTimeout()
 	defer cancel()
 
 	start := -lines
-	return tmuxExecRaw(ctx, "capture-pane", "-t", paneID, "-p", "-S", strconv.Itoa(start))
+	return tmuxExecRawServer(ctx, server, "capture-pane", "-t", paneID, "-p", "-S", strconv.Itoa(start))
+}
+
+// ListServers discovers available tmux servers by scanning the tmux socket directory
+// at /tmp/tmux-{uid}/. Returns sorted server names.
+func ListServers() ([]string, error) {
+	uid := os.Getuid()
+	socketDir := fmt.Sprintf("/tmp/tmux-%d", uid)
+
+	entries, err := os.ReadDir(socketDir)
+	if err != nil {
+		// Directory doesn't exist or can't be read — no servers running
+		return nil, nil
+	}
+
+	var servers []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			servers = append(servers, e.Name())
+		}
+	}
+	sort.Strings(servers)
+	return servers, nil
+}
+
+// KillServer kills a tmux server by name.
+func KillServer(server string) error {
+	ctx, cancel := withTimeout()
+	defer cancel()
+
+	_, err := tmuxExecServer(ctx, server, "kill-server")
+	return err
 }

--- a/app/backend/internal/tmux/tmux_test.go
+++ b/app/backend/internal/tmux/tmux_test.go
@@ -18,10 +18,9 @@ func windowLine(index int, name, path string, activityTs int64, active int, pane
 
 func TestParseSessions(t *testing.T) {
 	tests := []struct {
-		name   string
-		lines  []string
-		server string
-		want   []SessionInfo
+		name  string
+		lines []string
+		want  []SessionInfo
 	}{
 		{
 			name: "standard sessions with session_grouped=0",
@@ -29,8 +28,7 @@ func TestParseSessions(t *testing.T) {
 				sessionLine("alpha", "0", "alpha"),
 				sessionLine("beta", "0", "beta"),
 			},
-			server: "runkit",
-			want:   []SessionInfo{{Name: "alpha", Server: "runkit"}, {Name: "beta", Server: "runkit"}},
+			want: []SessionInfo{{Name: "alpha"}, {Name: "beta"}},
 		},
 		{
 			name: "filters out session-group copies (grouped=1, name != group)",
@@ -38,28 +36,24 @@ func TestParseSessions(t *testing.T) {
 				sessionLine("devshell", "0", "devshell"),
 				sessionLine("devshell-82", "1", "devshell"),
 			},
-			server: "default",
-			want:   []SessionInfo{{Name: "devshell", Server: "default"}},
+			want: []SessionInfo{{Name: "devshell"}},
 		},
 		{
 			name: "keeps group-named session (grouped=1, name == group)",
 			lines: []string{
 				sessionLine("mygroup", "1", "mygroup"),
 			},
-			server: "default",
-			want:   []SessionInfo{{Name: "mygroup", Server: "default"}},
+			want: []SessionInfo{{Name: "mygroup"}},
 		},
 		{
-			name:   "empty input returns nil",
-			lines:  nil,
-			server: "runkit",
-			want:   nil,
+			name:  "empty input returns nil",
+			lines: nil,
+			want:  nil,
 		},
 		{
-			name:   "empty slice returns nil",
-			lines:  []string{},
-			server: "runkit",
-			want:   nil,
+			name:  "empty slice returns nil",
+			lines: []string{},
+			want:  nil,
 		},
 		{
 			name: "malformed line with fewer than 2 fields is skipped",
@@ -67,16 +61,14 @@ func TestParseSessions(t *testing.T) {
 				"onlyname",
 				sessionLine("good", "0", "good"),
 			},
-			server: "runkit",
-			want:   []SessionInfo{{Name: "good", Server: "runkit"}},
+			want: []SessionInfo{{Name: "good"}},
 		},
 		{
 			name: "ungrouped session with no session_group field (2 fields only)",
 			lines: []string{
 				"mysession\t0",
 			},
-			server: "default",
-			want:   []SessionInfo{{Name: "mysession", Server: "default"}},
+			want: []SessionInfo{{Name: "mysession"}},
 		},
 		{
 			name: "multiple session-group copies filtered, original kept",
@@ -85,25 +77,23 @@ func TestParseSessions(t *testing.T) {
 				sessionLine("proj-1", "1", "proj"),
 				sessionLine("proj-2", "1", "proj"),
 			},
-			server: "runkit",
-			want:   []SessionInfo{{Name: "proj", Server: "runkit"}},
+			want: []SessionInfo{{Name: "proj"}},
 		},
 		{
-			name: "mixed grouped and ungrouped sessions tagged with server",
+			name: "mixed grouped and ungrouped sessions",
 			lines: []string{
 				sessionLine("alpha", "0", "alpha"),
 				sessionLine("beta", "1", "beta"),
 				sessionLine("beta-N", "1", "beta"),
 				sessionLine("gamma", "0", "gamma"),
 			},
-			server: "default",
-			want:   []SessionInfo{{Name: "alpha", Server: "default"}, {Name: "beta", Server: "default"}, {Name: "gamma", Server: "default"}},
+			want: []SessionInfo{{Name: "alpha"}, {Name: "beta"}, {Name: "gamma"}},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parseSessions(tt.lines, tt.server)
+			got := parseSessions(tt.lines)
 			if !sessionInfoSliceEqual(got, tt.want) {
 				t.Errorf("parseSessions() = %v, want %v", got, tt.want)
 			}
@@ -121,14 +111,14 @@ func TestParseSessionsMultiServer(t *testing.T) {
 		sessionLine("gamma", "0", "gamma"),
 	}
 
-	runkitSessions := parseSessions(runkitLines, "runkit")
-	defaultSessions := parseSessions(defaultLines, "default")
+	runkitSessions := parseSessions(runkitLines)
+	defaultSessions := parseSessions(defaultLines)
 	all := append(runkitSessions, defaultSessions...)
 
 	want := []SessionInfo{
-		{Name: "alpha", Server: "runkit"},
-		{Name: "beta", Server: "runkit"},
-		{Name: "gamma", Server: "default"},
+		{Name: "alpha"},
+		{Name: "beta"},
+		{Name: "gamma"},
 	}
 
 	if !sessionInfoSliceEqual(all, want) {

--- a/app/backend/internal/validate/validate.go
+++ b/app/backend/internal/validate/validate.go
@@ -32,6 +32,27 @@ func ValidateName(name, label string) string {
 	return ""
 }
 
+// serverNamePattern matches valid server names: alphanumeric, hyphens, underscores.
+var serverNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// MaxServerNameLength is the maximum allowed length for server names.
+const MaxServerNameLength = 64
+
+// ValidateServerName validates a tmux server name against a strict pattern.
+// Returns empty string if valid, error message if invalid.
+func ValidateServerName(name string) string {
+	if name == "" {
+		return "Server name cannot be empty"
+	}
+	if len(name) > MaxServerNameLength {
+		return fmt.Sprintf("Server name exceeds maximum length of %d characters", MaxServerNameLength)
+	}
+	if !serverNamePattern.MatchString(name) {
+		return "Server name must contain only alphanumeric characters, hyphens, and underscores"
+	}
+	return ""
+}
+
 // ExpandTilde expands a leading ~ to $HOME and resolves the path.
 // Returns the expanded path and an empty error string on success,
 // or an empty path and error message on failure.

--- a/app/frontend/src/api/client.ts
+++ b/app/frontend/src/api/client.ts
@@ -2,6 +2,19 @@ import type { ProjectSession } from "@/types";
 
 export type { ProjectSession };
 
+// Module-level server getter — set by SessionProvider
+let _getServer: () => string = () => "runkit";
+
+export function setServerGetter(fn: () => string) {
+  _getServer = fn;
+}
+
+/** Append ?server= to a URL (handles existing query params). */
+function withServer(url: string): string {
+  const sep = url.includes("?") ? "&" : "?";
+  return `${url}${sep}server=${encodeURIComponent(_getServer())}`;
+}
+
 /** Throw an error from a JSON error response, falling back to status text. */
 async function throwOnError(res: Response): Promise<never> {
   const data = await res.json().catch(() => ({}));
@@ -20,7 +33,7 @@ export async function getHealth(): Promise<HealthResponse> {
 }
 
 export async function getSessions(): Promise<ProjectSession[]> {
-  const res = await fetch("/api/sessions");
+  const res = await fetch(withServer("/api/sessions"));
   if (!res.ok) await throwOnError(res);
   return res.json();
 }
@@ -31,7 +44,7 @@ export async function createSession(
 ): Promise<{ ok: boolean }> {
   const body: Record<string, string> = { name };
   if (cwd) body.cwd = cwd;
-  const res = await fetch("/api/sessions", {
+  const res = await fetch(withServer("/api/sessions"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
@@ -45,7 +58,7 @@ export async function renameSession(
   name: string,
 ): Promise<{ ok: boolean }> {
   const res = await fetch(
-    `/api/sessions/${encodeURIComponent(session)}/rename`,
+    withServer(`/api/sessions/${encodeURIComponent(session)}/rename`),
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -57,7 +70,7 @@ export async function renameSession(
 }
 
 export async function killSession(session: string): Promise<{ ok: boolean }> {
-  const res = await fetch(`/api/sessions/${encodeURIComponent(session)}/kill`, {
+  const res = await fetch(withServer(`/api/sessions/${encodeURIComponent(session)}/kill`), {
     method: "POST",
   });
   if (!res.ok) await throwOnError(res);
@@ -71,7 +84,7 @@ export async function createWindow(
 ): Promise<{ ok: boolean }> {
   const body: Record<string, string> = { name };
   if (cwd) body.cwd = cwd;
-  const res = await fetch(`/api/sessions/${encodeURIComponent(session)}/windows`, {
+  const res = await fetch(withServer(`/api/sessions/${encodeURIComponent(session)}/windows`), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
@@ -85,7 +98,7 @@ export async function killWindow(
   index: number,
 ): Promise<{ ok: boolean }> {
   const res = await fetch(
-    `/api/sessions/${encodeURIComponent(session)}/windows/${index}/kill`,
+    withServer(`/api/sessions/${encodeURIComponent(session)}/windows/${index}/kill`),
     { method: "POST" },
   );
   if (!res.ok) await throwOnError(res);
@@ -98,7 +111,7 @@ export async function renameWindow(
   name: string,
 ): Promise<{ ok: boolean }> {
   const res = await fetch(
-    `/api/sessions/${encodeURIComponent(session)}/windows/${index}/rename`,
+    withServer(`/api/sessions/${encodeURIComponent(session)}/windows/${index}/rename`),
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -115,7 +128,7 @@ export async function sendKeys(
   keys: string,
 ): Promise<{ ok: boolean }> {
   const res = await fetch(
-    `/api/sessions/${encodeURIComponent(session)}/windows/${index}/keys`,
+    withServer(`/api/sessions/${encodeURIComponent(session)}/windows/${index}/keys`),
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -129,10 +142,9 @@ export async function sendKeys(
 export async function selectWindow(
   session: string,
   index: number,
-  server: "runkit" | "default" = "runkit",
 ): Promise<{ ok: boolean }> {
   const res = await fetch(
-    `/api/sessions/${encodeURIComponent(session)}/windows/${index}/select?server=${server}`,
+    withServer(`/api/sessions/${encodeURIComponent(session)}/windows/${index}/select`),
     { method: "POST" },
   );
   if (!res.ok) await throwOnError(res);
@@ -146,11 +158,11 @@ export async function getDirectories(prefix: string): Promise<string[]> {
   return data.directories ?? [];
 }
 
-export async function reloadTmuxConfig(server: "runkit" | "default"): Promise<{ ok: boolean }> {
-  const res = await fetch("/api/tmux/reload-config", {
+export async function reloadTmuxConfig(): Promise<{ ok: boolean }> {
+  const res = await fetch(withServer("/api/tmux/reload-config"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ server }),
+    body: JSON.stringify({}),
   });
   if (!res.ok) await throwOnError(res);
   return { ok: true };
@@ -165,9 +177,37 @@ export async function uploadFile(
   formData.append("file", file);
   if (window) formData.append("window", window);
 
-  const res = await fetch(`/api/sessions/${encodeURIComponent(session)}/upload`, {
+  const res = await fetch(withServer(`/api/sessions/${encodeURIComponent(session)}/upload`), {
     method: "POST",
     body: formData,
+  });
+  if (!res.ok) await throwOnError(res);
+  return res.json();
+}
+
+// --- Server management ---
+
+export async function listServers(): Promise<string[]> {
+  const res = await fetch("/api/servers");
+  if (!res.ok) await throwOnError(res);
+  return res.json();
+}
+
+export async function createServer(name: string): Promise<{ ok: boolean }> {
+  const res = await fetch("/api/servers", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
+  if (!res.ok) await throwOnError(res);
+  return res.json();
+}
+
+export async function killServer(name: string): Promise<{ ok: boolean }> {
+  const res = await fetch("/api/servers/kill", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
   });
   if (!res.ok) await throwOnError(res);
   return res.json();

--- a/app/frontend/src/app.tsx
+++ b/app/frontend/src/app.tsx
@@ -15,7 +15,8 @@ import { CommandPalette, type PaletteAction } from "@/components/command-palette
 import { Dialog } from "@/components/dialog";
 import { CreateSessionDialog } from "@/components/create-session-dialog";
 import { Dashboard } from "@/components/dashboard";
-import { selectWindow, createWindow, reloadTmuxConfig, getHealth } from "@/api/client";
+import { selectWindow, createWindow, reloadTmuxConfig, getHealth, createServer, killServer as killServerApi } from "@/api/client";
+import { useSessionContext } from "@/contexts/session-context";
 import { useBrowserTitle } from "@/hooks/use-browser-title";
 
 const SIDEBAR_STORAGE_KEY = "runkit-sidebar-width";
@@ -56,6 +57,7 @@ function AppShell() {
   useVisualViewport();
 
   const { sessions, isConnected } = useSessions();
+  const { server, setServer, servers, refreshServers } = useSessionContext();
   const { sidebarOpen, drawerOpen, fixedWidth } = useChrome();
   const { setCurrentSession, setCurrentWindow, setDrawerOpen, setSidebarOpen } = useChromeDispatch();
   const navigate = useNavigate();
@@ -70,6 +72,9 @@ function AppShell() {
 
   const [composeOpen, setComposeOpen] = useState(false);
   const [hostname, setHostname] = useState("");
+  const [showCreateServerDialog, setShowCreateServerDialog] = useState(false);
+  const [createServerName, setCreateServerName] = useState("");
+  const [showKillServerConfirm, setShowKillServerConfirm] = useState(false);
 
   // Fetch hostname once on mount (guarded for StrictMode double-invoke)
   const didFetchHostnameRef = useRef(false);
@@ -194,10 +199,9 @@ function AppShell() {
       });
       setDrawerOpen(false);
       // Fire-and-forget: tell tmux to select this window too
-      const server = sessions.find((s) => s.name === session)?.server ?? "runkit";
-      selectWindow(session, windowIdx, server).catch(() => {});
+      selectWindow(session, windowIdx).catch(() => {});
     },
-    [navigate, setDrawerOpen, sessions],
+    [navigate, setDrawerOpen],
   );
 
   // Dialog state management
@@ -220,7 +224,7 @@ function AppShell() {
 
   // Keep dialogOpenRef in sync so the activeWindow effect can check it without deps
   dialogOpenRef.current =
-    dialogs.showCreateDialog || dialogs.showRenameDialog || dialogs.showRenameSessionDialog || dialogs.showKillConfirm || dialogs.showKillSessionConfirm;
+    dialogs.showCreateDialog || dialogs.showRenameDialog || dialogs.showRenameSessionDialog || dialogs.showKillConfirm || dialogs.showKillSessionConfirm || showCreateServerDialog || showKillServerConfirm;
 
   // Flat window list for palette actions
   const flatWindows = useMemo(() => {
@@ -253,6 +257,48 @@ function AppShell() {
       onSelect: () => setTheme(opt),
     }));
   }, [themePreference, setTheme]);
+
+  // Server management
+  const handleSwitchServer = useCallback(
+    (name: string) => {
+      if (name !== server) {
+        setServer(name);
+        navigate({ to: "/", replace: true });
+      }
+    },
+    [server, setServer, navigate],
+  );
+
+  const handleCreateServer = useCallback(async () => {
+    const trimmed = createServerName.trim();
+    if (!trimmed) return;
+    try {
+      await createServer(trimmed);
+      await refreshServers();
+      handleSwitchServer(trimmed);
+    } catch {
+      // error
+    }
+    setShowCreateServerDialog(false);
+    setCreateServerName("");
+  }, [createServerName, refreshServers, handleSwitchServer]);
+
+  const handleKillServer = useCallback(async () => {
+    try {
+      await killServerApi(server);
+      const res = await fetch("/api/servers");
+      if (res.ok) {
+        const remaining: string[] = await res.json();
+        refreshServers();
+        if (remaining.length > 0) {
+          handleSwitchServer(remaining[0]);
+        }
+      }
+    } catch {
+      // error
+    }
+    setShowKillServerConfirm(false);
+  }, [server, refreshServers, handleSwitchServer]);
 
   // File upload ref for palette
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -315,15 +361,30 @@ function AppShell() {
       {
         id: "reload-tmux-config",
         label: "Reload tmux config",
-        onSelect: () => { reloadTmuxConfig(currentSession?.server ?? "runkit").catch(() => {}); },
+        onSelect: () => { reloadTmuxConfig().catch(() => {}); },
       },
+      {
+        id: "create-server",
+        label: "Create tmux server",
+        onSelect: () => setShowCreateServerDialog(true),
+      },
+      {
+        id: "kill-server",
+        label: "Kill tmux server",
+        onSelect: () => setShowKillServerConfirm(true),
+      },
+      ...servers.map((s) => ({
+        id: `switch-server-${s}`,
+        label: `Switch tmux server: ${s}${s === server ? " (current)" : ""}`,
+        onSelect: () => handleSwitchServer(s),
+      })),
       ...flatWindows.map((fw) => ({
         id: `terminal-${fw.session}-${fw.window.index}`,
         label: `Terminal: ${fw.session}/${fw.window.name}`,
         onSelect: () => navigateToWindow(fw.session, fw.window.index),
       })),
     ],
-    [sessionName, currentWindow, flatWindows, navigateToWindow, handleCreateWindow, dialogs, themeActions],
+    [sessionName, currentWindow, flatWindows, navigateToWindow, handleCreateWindow, dialogs, themeActions, servers, server, handleSwitchServer],
   );
 
   const displayName = currentWindow?.name ?? windowIndex ?? "";
@@ -367,6 +428,9 @@ function AppShell() {
                 onSelectWindow={navigateToWindow}
                 onCreateWindow={handleCreateWindow}
                 onCreateSession={dialogs.openCreateDialog}
+                server={server}
+                servers={servers}
+                onSwitchServer={handleSwitchServer}
               />
             </div>
             {/* Drag handle */}
@@ -396,7 +460,7 @@ function AppShell() {
                   <TerminalClient
                     sessionName={sessionName}
                     windowIndex={windowIndex}
-                    server={currentSession?.server ?? "runkit"}
+                    server={server}
                     wsRef={wsRef}
                     composeOpen={composeOpen}
                     setComposeOpen={setComposeOpen}
@@ -436,6 +500,9 @@ function AppShell() {
                 }}
                 onCreateWindow={handleCreateWindow}
                 onCreateSession={dialogs.openCreateDialog}
+                server={server}
+                servers={servers}
+                onSwitchServer={handleSwitchServer}
               />
             </div>
           </div>
@@ -530,6 +597,54 @@ function AppShell() {
             </button>
             <button
               onClick={dialogs.handleKillSession}
+              className="flex-1 text-sm py-1.5 bg-red-900/30 border border-red-900 rounded hover:bg-red-900/50"
+            >
+              Kill
+            </button>
+          </div>
+        </Dialog>
+      )}
+
+      {showCreateServerDialog && (
+        <Dialog title="Create tmux server" onClose={() => { setShowCreateServerDialog(false); setCreateServerName(""); }}>
+          <input
+            autoFocus
+            type="text"
+            value={createServerName}
+            onChange={(e) => setCreateServerName(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleCreateServer()}
+            onFocus={(e) => e.target.select()}
+            aria-label="Server name"
+            placeholder="Server name..."
+            className="w-full bg-transparent text-text-primary text-sm p-2 border border-border rounded outline-none placeholder:text-text-secondary"
+          />
+          <p className="text-xs text-text-secondary mt-1.5">
+            Alphanumeric, hyphens, and underscores only.
+          </p>
+          <button
+            onClick={handleCreateServer}
+            disabled={!createServerName.trim() || !/^[a-zA-Z0-9_-]+$/.test(createServerName.trim())}
+            className="mt-3 w-full text-sm py-1.5 bg-bg-card border border-border rounded hover:border-text-secondary disabled:opacity-50"
+          >
+            Create
+          </button>
+        </Dialog>
+      )}
+
+      {showKillServerConfirm && (
+        <Dialog title="Kill tmux server?" onClose={() => setShowKillServerConfirm(false)}>
+          <p className="text-sm text-text-secondary mb-3">
+            Kill server <strong>{server}</strong> and all its sessions? This cannot be undone.
+          </p>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setShowKillServerConfirm(false)}
+              className="flex-1 text-sm py-1.5 border border-border rounded hover:border-text-secondary"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleKillServer}
               className="flex-1 text-sm py-1.5 bg-red-900/30 border border-red-900 rounded hover:bg-red-900/50"
             >
               Kill

--- a/app/frontend/src/app.tsx
+++ b/app/frontend/src/app.tsx
@@ -271,7 +271,7 @@ function AppShell() {
 
   const handleCreateServer = useCallback(async () => {
     const trimmed = createServerName.trim();
-    if (!trimmed) return;
+    if (!trimmed || !/^[a-zA-Z0-9_-]+$/.test(trimmed)) return;
     try {
       await createServer(trimmed);
       await refreshServers();
@@ -292,13 +292,15 @@ function AppShell() {
         refreshServers();
         if (remaining.length > 0) {
           handleSwitchServer(remaining[0]);
+        } else {
+          setServer("");
         }
       }
     } catch {
       // error
     }
     setShowKillServerConfirm(false);
-  }, [server, refreshServers, handleSwitchServer]);
+  }, [server, refreshServers, handleSwitchServer, setServer]);
 
   // File upload ref for palette
   const fileInputRef = useRef<HTMLInputElement>(null);

--- a/app/frontend/src/components/dashboard.test.tsx
+++ b/app/frontend/src/components/dashboard.test.tsx
@@ -8,7 +8,6 @@ const nowSeconds = Math.floor(Date.now() / 1000);
 const sessions: ProjectSession[] = [
   {
     name: "run-kit",
-    server: "runkit",
     windows: [
       {
         index: 0,
@@ -35,7 +34,6 @@ const sessions: ProjectSession[] = [
   },
   {
     name: "ao-server",
-    server: "runkit",
     windows: [
       {
         index: 0,

--- a/app/frontend/src/components/sidebar.test.tsx
+++ b/app/frontend/src/components/sidebar.test.tsx
@@ -14,7 +14,6 @@ vi.mock("@/api/client", async (importOriginal) => {
 const sessions: ProjectSession[] = [
   {
     name: "run-kit",
-    server: "runkit",
     windows: [
       {
         index: 0,
@@ -45,7 +44,6 @@ const sessions: ProjectSession[] = [
   },
   {
     name: "ao-server",
-    server: "default",
     windows: [
       {
         index: 0,
@@ -69,6 +67,9 @@ function renderSidebar(overrides: Partial<React.ComponentProps<typeof Sidebar>> 
       onSelectWindow={vi.fn()}
       onCreateWindow={vi.fn()}
       onCreateSession={vi.fn()}
+      server="runkit"
+      servers={["runkit"]}
+      onSwitchServer={vi.fn()}
       {...overrides}
     />,
   );
@@ -275,19 +276,8 @@ describe("Sidebar", () => {
     });
   });
 
-  it("shows external marker for default-server sessions", () => {
+  it("does not show external marker (removed in single-server model)", () => {
     renderSidebar();
-    // ao-server has server: "default" — should show the arrow marker
-    const marker = screen.getByLabelText("external session");
-    expect(marker).toBeInTheDocument();
-    expect(marker.textContent).toBe("\u2197");
-  });
-
-  it("does not show external marker for runkit-server sessions", () => {
-    renderSidebar();
-    // run-kit has server: "runkit" — should have no external marker
-    const markers = screen.getAllByLabelText("external session");
-    // Only one marker total (for ao-server)
-    expect(markers).toHaveLength(1);
+    expect(screen.queryByLabelText("external session")).not.toBeInTheDocument();
   });
 });

--- a/app/frontend/src/components/sidebar.tsx
+++ b/app/frontend/src/components/sidebar.tsx
@@ -294,7 +294,7 @@ export function Sidebar({
             <span className="ml-0.5 text-text-secondary text-[10px]">{serverDropdownOpen ? "\u25B4" : "\u25BE"}</span>
           </button>
           {serverDropdownOpen && (
-            <div className="absolute bottom-full left-0 mb-1 bg-bg-primary border border-border rounded shadow-2xl z-50 min-w-[140px] py-1">
+            <div role="listbox" className="absolute bottom-full left-0 mb-1 bg-bg-primary border border-border rounded shadow-2xl z-50 min-w-[140px] py-1">
               {servers.length === 0 ? (
                 <div className="text-xs text-text-secondary px-3 py-1.5">No servers</div>
               ) : (

--- a/app/frontend/src/components/sidebar.tsx
+++ b/app/frontend/src/components/sidebar.tsx
@@ -11,6 +11,9 @@ type SidebarProps = {
   onSelectWindow: (session: string, windowIndex: number) => void;
   onCreateWindow: (session: string) => void;
   onCreateSession: () => void;
+  server: string;
+  servers: string[];
+  onSwitchServer: (name: string) => void;
 };
 
 export function Sidebar({
@@ -20,6 +23,9 @@ export function Sidebar({
   onSelectWindow,
   onCreateWindow,
   onCreateSession,
+  server,
+  servers,
+  onSwitchServer,
 }: SidebarProps) {
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
   const [killTarget, setKillTarget] = useState<{
@@ -34,6 +40,21 @@ export function Sidebar({
   const inputRef = useRef<HTMLInputElement>(null);
   const cancelledRef = useRef(false);
   const originalNameRef = useRef("");
+
+  const [serverDropdownOpen, setServerDropdownOpen] = useState(false);
+  const serverDropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close server dropdown on outside click
+  useEffect(() => {
+    if (!serverDropdownOpen) return;
+    function handleClick(e: MouseEvent) {
+      if (serverDropdownRef.current && !serverDropdownRef.current.contains(e.target as Node)) {
+        setServerDropdownOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [serverDropdownOpen]);
 
   useEffect(() => {
     if (editingWindow && inputRef.current) {
@@ -106,7 +127,7 @@ export function Sidebar({
 
   return (
     <nav aria-label="Sessions" className="flex flex-col h-full py-2">
-      <div className="flex-1 overflow-y-auto px-3 sm:px-4">
+      <div className="flex-1 min-h-0 overflow-y-auto px-3 sm:px-4">
         {sessions.length === 0 ? (
           <div className="text-text-secondary text-xs py-4 text-center flex flex-col items-center gap-2">
             <span>No sessions</span>
@@ -139,9 +160,6 @@ export function Sidebar({
                       aria-label={`Navigate to ${session.name}`}
                     >
                       <span className="font-medium truncate">{session.name}</span>
-                      {session.server === "default" && (
-                        <span className="text-[10px] text-text-secondary/50 shrink-0" aria-label="external session">{"\u2197"}</span>
-                      )}
                     </button>
                   </div>
                   <div className="flex items-center">
@@ -260,6 +278,46 @@ export function Sidebar({
             );
           })
         )}
+      </div>
+
+      {/* Server selector — pinned at bottom */}
+      <div className="shrink-0 border-t border-border px-3 sm:px-4 py-2" ref={serverDropdownRef}>
+        <div className="flex items-center gap-1.5 relative">
+          <span className="text-xs text-text-secondary">Server:</span>
+          <button
+            onClick={() => setServerDropdownOpen((v) => !v)}
+            className="text-xs text-text-primary font-medium hover:text-accent transition-colors coarse:min-h-[44px] flex items-center"
+            aria-haspopup="listbox"
+            aria-expanded={serverDropdownOpen}
+          >
+            {server}
+            <span className="ml-0.5 text-text-secondary text-[10px]">{serverDropdownOpen ? "\u25B4" : "\u25BE"}</span>
+          </button>
+          {serverDropdownOpen && (
+            <div className="absolute bottom-full left-0 mb-1 bg-bg-primary border border-border rounded shadow-2xl z-50 min-w-[140px] py-1">
+              {servers.length === 0 ? (
+                <div className="text-xs text-text-secondary px-3 py-1.5">No servers</div>
+              ) : (
+                servers.map((s) => (
+                  <button
+                    key={s}
+                    onClick={() => {
+                      onSwitchServer(s);
+                      setServerDropdownOpen(false);
+                    }}
+                    className={`w-full text-left text-xs px-3 py-1.5 hover:bg-bg-card transition-colors ${
+                      s === server ? "text-accent font-medium" : "text-text-primary"
+                    }`}
+                    role="option"
+                    aria-selected={s === server}
+                  >
+                    {s}
+                  </button>
+                ))
+              )}
+            </div>
+          )}
+        </div>
       </div>
 
       {/* Kill confirmation */}

--- a/app/frontend/src/components/terminal-client.tsx
+++ b/app/frontend/src/components/terminal-client.tsx
@@ -40,7 +40,7 @@ export async function copyToClipboard(text: string): Promise<void> {
 type TerminalClientProps = {
   sessionName: string;
   windowIndex: string;
-  server: "runkit" | "default";
+  server: string;
   wsRef: React.MutableRefObject<WebSocket | null>;
   composeOpen: boolean;
   setComposeOpen: (open: boolean | ((prev: boolean) => boolean)) => void;

--- a/app/frontend/src/components/top-bar.test.tsx
+++ b/app/frontend/src/components/top-bar.test.tsx
@@ -33,12 +33,10 @@ const nonFabIdleWindow: WindowInfo = {
 const sessions: ProjectSession[] = [
   {
     name: "run-kit",
-    server: "runkit",
     windows: [fabWindow],
   },
   {
     name: "ao-server",
-    server: "runkit",
     windows: [nonFabIdleWindow],
   },
 ];

--- a/app/frontend/src/contexts/session-context.tsx
+++ b/app/frontend/src/contexts/session-context.tsx
@@ -1,10 +1,28 @@
-import { createContext, useContext, useState, useEffect, useMemo } from "react";
+import { createContext, useContext, useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { useChromeDispatch } from "./chrome-context";
+import { setServerGetter } from "@/api/client";
 import type { ProjectSession } from "@/types";
+
+const SERVER_STORAGE_KEY = "runkit-server";
+const DEFAULT_SERVER = "runkit";
+
+function readStoredServer(): string {
+  try {
+    const stored = localStorage.getItem(SERVER_STORAGE_KEY);
+    if (stored) return stored;
+  } catch {
+    // localStorage unavailable
+  }
+  return DEFAULT_SERVER;
+}
 
 type SessionContextType = {
   sessions: ProjectSession[];
   isConnected: boolean;
+  server: string;
+  setServer: (name: string) => void;
+  servers: string[];
+  refreshServers: () => void;
 };
 
 const SessionContext = createContext<SessionContextType | null>(null);
@@ -16,10 +34,46 @@ type SessionProviderProps = {
 export function SessionProvider({ children }: SessionProviderProps) {
   const [sessions, setSessions] = useState<ProjectSession[]>([]);
   const [isConnected, setIsConnected] = useState(false);
+  const [server, setServerState] = useState(readStoredServer);
+  const [servers, setServers] = useState<string[]>([]);
   const { setIsConnected: setChromeConnected } = useChromeDispatch();
 
+  // Keep API client in sync with current server
+  const serverRef = useRef(server);
+  serverRef.current = server;
   useEffect(() => {
-    const es = new EventSource("/api/sessions/stream");
+    setServerGetter(() => serverRef.current);
+  }, []);
+
+  const fetchServers = useCallback(async () => {
+    try {
+      const res = await fetch("/api/servers");
+      if (res.ok) {
+        const data = await res.json();
+        setServers(Array.isArray(data) ? data : []);
+      }
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  // Fetch server list on mount and when server changes
+  useEffect(() => {
+    fetchServers();
+  }, [fetchServers, server]);
+
+  const setServer = useCallback((name: string) => {
+    setServerState(name);
+    try {
+      localStorage.setItem(SERVER_STORAGE_KEY, name);
+    } catch {
+      // localStorage unavailable
+    }
+  }, []);
+
+  // SSE connection — reconnects when server changes
+  useEffect(() => {
+    const es = new EventSource(`/api/sessions/stream?server=${encodeURIComponent(server)}`);
 
     es.addEventListener("sessions", (e) => {
       try {
@@ -45,9 +99,12 @@ export function SessionProvider({ children }: SessionProviderProps) {
     return () => {
       es.close();
     };
-  }, [setChromeConnected]);
+  }, [setChromeConnected, server]);
 
-  const value = useMemo(() => ({ sessions, isConnected }), [sessions, isConnected]);
+  const value = useMemo(
+    () => ({ sessions, isConnected, server, setServer, servers, refreshServers: fetchServers }),
+    [sessions, isConnected, server, setServer, servers, fetchServers],
+  );
 
   return (
     <SessionContext.Provider value={value}>

--- a/app/frontend/src/contexts/session-context.tsx
+++ b/app/frontend/src/contexts/session-context.tsx
@@ -10,6 +10,7 @@ function readStoredServer(): string {
   try {
     const stored = localStorage.getItem(SERVER_STORAGE_KEY);
     if (stored) return stored;
+    localStorage.setItem(SERVER_STORAGE_KEY, DEFAULT_SERVER);
   } catch {
     // localStorage unavailable
   }

--- a/app/frontend/src/types.ts
+++ b/app/frontend/src/types.ts
@@ -1,7 +1,6 @@
 /** A tmux session with its windows and optional fab enrichment. */
 export type ProjectSession = {
   name: string;
-  server: "runkit" | "default";
   windows: WindowInfo[];
 };
 

--- a/app/frontend/tests/msw/handlers.ts
+++ b/app/frontend/tests/msw/handlers.ts
@@ -5,7 +5,6 @@ import type { ProjectSession } from "@/types";
 export const mockSessions: ProjectSession[] = [
   {
     name: "run-kit",
-    server: "runkit",
     windows: [
       {
         index: 0,
@@ -29,7 +28,6 @@ export const mockSessions: ProjectSession[] = [
   },
   {
     name: "ao-server",
-    server: "runkit",
     windows: [
       {
         index: 0,
@@ -65,7 +63,6 @@ export const handlers = [
     const body = (await request.json()) as { name: string; cwd?: string };
     const newSession: ProjectSession = {
       name: body.name,
-      server: "runkit",
       windows: [
         {
           index: 0,

--- a/docs/memory/run-kit/architecture.md
+++ b/docs/memory/run-kit/architecture.md
@@ -13,7 +13,7 @@ In development, `just dev` runs two concurrent processes:
 
 Configuration via env vars: `.env` (committed) defines `RK_PORT` and `RK_HOST`, `.env.local` (gitignored) for overrides. Go backend and Vite both read `RK_PORT`/`RK_HOST` directly — no intermediate `BACKEND_*` vars. In dev mode, `dev.sh` is the translation layer: it passes `RK_PORT+1` to the Go backend and `RK_PORT` to Vite. `dev.sh` accepts `--port` for ad-hoc overrides. Tmux config defaults to `~/.run-kit/tmux.conf` (scaffolded by `run-kit init-conf`), overridable via `RK_TMUX_CONF` env var. The config is embedded in the binary via `go:embed` and written to disk by `init-conf`. All consumers use `tmux.ConfigPath()` getter — no direct env var reads elsewhere.
 
-run-kit sessions live on a **dedicated tmux server** named `runkit` (via `tmux -L runkit`). Sessions on the user's default tmux server are also discovered and displayed read-only. The tmux server is an external dependency — never started or stopped by run-kit.
+run-kit connects to **one tmux server at a time**, selected by the user via the sidebar server selector or command palette. The active server is sent as a `?server=` query parameter on every API request (SSE, REST, WebSocket). The backend is stateless — it defaults to the `default` tmux server when the parameter is absent. Server discovery scans `/tmp/tmux-{uid}/` for socket files. The frontend persists the active server in localStorage (`runkit-server`, default `runkit`). Server lifecycle: create (implicit via first session creation), kill (`tmux kill-server`), switch (SSE reconnect + navigate to `/`).
 
 ## Repository Structure
 
@@ -41,6 +41,7 @@ app/
       sse.go          # GET /api/sessions/stream (hub singleton)
       relay.go        # WS /relay/:session/:window
       tmux_config.go  # POST /api/tmux/reload-config
+      servers.go      # GET /api/servers, POST /api/servers, POST /api/servers/kill
       spa.go          # SPA static serving — dual-mode (embedded FS or filesystem)
     frontend/         # Embedded frontend assets
       embed.go        # //go:embed all:dist → embed.FS
@@ -109,7 +110,10 @@ All endpoints served by the single Go binary on one port. POST-only mutations wi
 | `/api/directories` | GET | Server-side directory listing for autocomplete — `?prefix=~/code/wvr` returns matching dirs under `$HOME` |
 | `/api/sessions/:session/upload` | POST | File upload — session from URL path (not form field). Multipart with `file` field, optional `window` field (defaults to `"0"`). Resolves project root via `ListWindows`, writes to `.uploads/{timestamp}-{name}`, auto-manages `.gitignore`. 50MB limit. Returns `200 {"ok":true,"path":"..."}` |
 | `/api/sessions/stream` | GET | SSE — hub singleton polls tmux every 2.5s, fans out full snapshots to all connected clients on change. Deduplicates polling across browser tabs. 30-minute lifetime cap per connection |
-| `/api/tmux/reload-config` | POST | Reload tmux config — JSON body `{"server":"runkit"|"default"}`. Runs `source-file` on the specified server. Returns `200 {"status":"ok"}` |
+| `/api/tmux/reload-config` | POST | Reload tmux config — server from `?server=` param (default `"default"`). Runs `source-file` on the specified server. Returns `200 {"status":"ok"}` |
+| `/api/servers` | GET | List available tmux servers — scans socket dir, returns JSON array of names |
+| `/api/servers` | POST | Create tmux server — JSON body `{"name":"..."}`. Creates session "0" in `$HOME`. Returns `201 {"ok":true}` |
+| `/api/servers/kill` | POST | Kill tmux server — JSON body `{"name":"..."}`. Returns `200 {"ok":true}` |
 
 ### Frontend API Client
 
@@ -126,11 +130,14 @@ All endpoints served by the single Go binary on one port. POST-only mutations wi
 | `renameWindow(session, index, name)` | POST | `/api/sessions/:session/windows/:index/rename` |
 | `sendKeys(session, index, keys)` | POST | `/api/sessions/:session/windows/:index/keys` |
 | `getDirectories(prefix)` | GET | `/api/directories?prefix=...` |
-| `selectWindow(session, index, server?)` | POST | `/api/sessions/:session/windows/:index/select?server=...` |
-| `reloadTmuxConfig(server)` | POST | `/api/tmux/reload-config` |
-| `uploadFile(session, file, window?)` | POST | `/api/sessions/:session/upload` |
+| `selectWindow(session, index)` | POST | `/api/sessions/:session/windows/:index/select?server=...` |
+| `reloadTmuxConfig()` | POST | `/api/tmux/reload-config?server=...` |
+| `uploadFile(session, file, window?)` | POST | `/api/sessions/:session/upload?server=...` |
+| `listServers()` | GET | `/api/servers` |
+| `createServer(name)` | POST | `/api/servers` |
+| `killServer(name)` | POST | `/api/servers/kill` |
 
-No multiplexed `action` field — each mutation is a separate function with its own URL path.
+All API functions (except `listServers`, `createServer`, `killServer`, `getDirectories`, `getHealth`) append `?server={active}` via a module-level `setServerGetter()` mechanism. The `SessionProvider` sets the getter on mount. No multiplexed `action` field — each mutation is a separate function with its own URL path.
 
 ## Terminal Relay
 
@@ -385,3 +392,4 @@ E2E test coverage: create/kill session via UI, SSE stream delivers real data, si
 | 2026-03-20 | **Hostname in browser title** — `Server` struct gains `hostname` field (computed once via `os.Hostname()` in `NewRouter()`, empty string fallback). `/api/health` response extended to `{"status":"ok","hostname":"..."}`. New `getHealth()` API client function. `useBrowserTitle` hook sets `document.title` dynamically: `RunKit — {hostname}` on Dashboard, `{session}/{window} — {hostname}` on terminal pages. Hostname suffix omitted when empty. | `260320-uq0k-hostname-browser-title` |
 | 2026-03-20 | **PWA compliance** — `vite-plugin-pwa` with autoUpdate, manifest from plugin config (standalone display, dark theme colors), Workbox service worker (precache static, NetworkOnly for API/WebSocket), iOS meta tags, theme-color sync. No backend changes. | `260320-j9a2-pwa-compliance` |
 | 2026-03-20 | **Release pipeline + update command** — `release.sh` rewritten (fab-kit/tu style: better arg parsing, help flag, detached HEAD guard). CI workflow gains "Update Homebrew tap" step: computes SHA256s from built tarballs, generates `Formula/run-kit.rb` in `wvrdz/homebrew-tap` via `BUILD_TOKEN` org secret. In-repo `Formula/run-kit.rb` deleted (now CI-generated). `upgrade` subcommand renamed to `update` (alias: `upgrade`): checks latest version via `brew info --json=v2`, skips if up-to-date, shows version transition. Mirrors tu's update UX. | — |
+| 2026-03-20 | **Single-active-server model** — Replaced dual-server merge with single-server-at-a-time. Backend stateless: `?server=` on every request, defaults to `"default"`. Unified `tmuxExec`/`tmuxExecDefault` into `tmuxExecServer`. All tmux functions accept `server` param. `serverFromRequest()` validates names. New `ListServers()` (socket scan), `KillServer()`. SSE hub polls per-server. Removed `SessionInfo.Server`, `ProjectSession.Server`. New `GET/POST /api/servers`, `POST /api/servers/kill`. Frontend: `SessionProvider` manages server state (localStorage `runkit-server`), sidebar server dropdown, palette commands (Create/Kill/Switch server). `setServerGetter()` mechanism appends `?server=` to all API calls. | `260320-1335-tmux-server-switcher` |

--- a/docs/memory/run-kit/tmux-sessions.md
+++ b/docs/memory/run-kit/tmux-sessions.md
@@ -1,12 +1,24 @@
 # tmux Session Enumeration
 
-## Multi-Server Architecture
+## Single-Active-Server Model
 
-run-kit uses a **dedicated tmux server** named `runkit` (via `tmux -L runkit`) for sessions it creates. It also discovers sessions on the user's **default tmux server** for read-only display. `ListSessions()` queries both servers and merges the results, tagging each `SessionInfo` with a `Server` field (`"runkit"` or `"default"`).
+run-kit connects to **one tmux server at a time**. The active server is selected by the user via the sidebar server selector or command palette. The backend is stateless — the frontend sends `?server={name}` on every API request (SSE, REST, WebSocket relay). If the parameter is omitted, the backend defaults to the `default` tmux server.
+
+All tmux operations use `tmuxExecServer(ctx, server, args...)` which prepends `-L {server}` for named servers. The `"default"` server uses no `-L` flag, connecting to the user's standard tmux server. The config flag `-f {path}` is applied to all named servers (not just runkit).
+
+### Server Discovery
+
+`ListServers()` discovers available tmux servers by scanning the socket directory at `/tmp/tmux-{uid}/`. Each socket file represents a running server. Returns sorted server names.
+
+### Server Lifecycle
+
+- **Create**: Implicit — `CreateSession("0", $HOME, serverName)` starts a new server when the first session is created on it
+- **Kill**: `KillServer(server)` runs `tmux [-L server] kill-server`, destroying all sessions
+- **Switch**: Frontend updates localStorage `"runkit-server"` and reconnects SSE with updated `?server=` param
 
 ## Session-Group Filtering
 
-tmux has a **session groups** feature. When multiple clients attach to the same session (e.g., via byobu or `tmux attach`), tmux may create derived session-group copies. This means `tmux list-sessions` returns both the original and derived copies:
+tmux has a **session groups** feature. When multiple clients attach to the same session (e.g., via `tmux attach`), tmux may create derived session-group copies. This means `tmux list-sessions` returns both the original and derived copies:
 
 ```
 devshell     grouped=1  group=devshell    ← primary
@@ -26,7 +38,7 @@ Grouped sessions share the same windows, so displaying both is incorrect — it 
 | `#{session_grouped}` | `1` if the session belongs to ANY group, `0` otherwise |
 | `#{session_group}` | The group name (e.g., `devshell`) — empty if not grouped |
 
-**Filter rule**: keep sessions where `grouped=0` OR `name === group`. Applied identically to both the runkit and default server results.
+**Filter rule**: keep sessions where `grouped=0` OR `name === group`. Applied to the queried server's results.
 
 - `devshell` → grouped=1, name=group → **keep** (primary)
 - `devshell-82` → grouped=1, name≠group → **filter out** (derived copy)
@@ -38,20 +50,34 @@ Grouped sessions share the same windows, so displaying both is incorrect — it 
 
 ## Impact on Other Operations
 
-- `ListWindows(session, server)` — accepts a `server` parameter (`"runkit"` or `"default"`) to route the query to the correct tmux server
-- `SelectWindowOnServer(session, index, server)` — selects a window on the specified server. The `handleWindowSelect` handler and relay handler read a `?server=` query param to determine the target
-- `CreateSession(name, cwd)` — creates sessions on the runkit server using plain `tmux new-session` (no byobu dependency). Sessions get the runkit server's custom config (`config/tmux.conf`)
-- `ReloadConfig(server)` — hot-reloads `config/tmux.conf` via `source-file` on the specified server. Exposed via `POST /api/tmux/reload-config` and the "Reload tmux config" command palette action (targets whichever server the current session belongs to)
-- `killSession(session)` — kills only the named session on the runkit server; other group members survive
-- `sendKeys(session, window, keys)` — targets the correct window on the runkit server regardless of group membership
+All tmux functions accept a `server string` parameter:
+
+- `ListSessions(server)` — queries only the specified server
+- `ListWindows(session, server)` — lists windows for a session on the specified server
+- `SelectWindow(session, index, server)` — selects a window on the specified server
+- `CreateSession(name, cwd, server)` — creates sessions on the specified server
+- `ReloadConfig(server)` — hot-reloads config via `source-file` on the specified server
+- `KillSession(session, server)` — kills the named session on the specified server
+- `SendKeys(session, window, keys, server)` — targets the correct window on the specified server
+
+## API Server Parameter
+
+All API endpoints accept `?server=` query parameter via `serverFromRequest(r)` helper. The helper validates the server name using `validate.ValidateName` and defaults to `"default"` on invalid/missing input. The SSE hub polls per-server — only servers with active SSE clients are polled.
+
+Server management endpoints:
+- `GET /api/servers` — lists available servers via socket directory scan
+- `POST /api/servers` — creates a server (starts session "0" in $HOME)
+- `POST /api/servers/kill` — kills a server via `tmux kill-server`
 
 ## Related Files
 
-- `app/backend/internal/tmux/tmux.go` — `ListSessions()` queries both servers, `parseSessions()` implements the filter, `CreateSession()` creates on the runkit server, `SelectWindowOnServer()` routes to correct server, `ReloadConfig()` hot-reloads config, `ConfigPath()` exposes resolved absolute config path
-- `app/backend/internal/sessions/sessions.go` — calls `ListSessions()` to build the dashboard view, propagates `Server` field to `ProjectSession`
+- `app/backend/internal/tmux/tmux.go` — `serverArgs()`, `tmuxExecServer()`, `ListSessions()`, `ListServers()`, `KillServer()`, `CreateSession()`, `SelectWindow()`, `ReloadConfig()`, `ConfigPath()`
+- `app/backend/internal/sessions/sessions.go` — `FetchSessions(server)` builds the dashboard view, `ProjectSession` has `Name` and `Windows` (no `Server` field)
+- `app/backend/api/router.go` — `serverFromRequest()` helper, `TmuxOps` interface with server params, route registration
+- `app/backend/api/servers.go` — server list/create/kill handlers
+- `app/backend/api/sse.go` — per-server SSE polling hub
 - `app/backend/api/relay.go` — WebSocket relay reads `?server=` query param to attach to the correct tmux server
-- `app/backend/api/tmux_config.go` — `POST /api/tmux/reload-config` handler
-- `config/tmux.conf` — tmux configuration for the runkit server (dark-themed status bar, F2/F3/F4 keybindings)
+- `config/tmux.conf` — tmux configuration (applied to all named servers)
 
 ## Changelog
 
@@ -59,3 +85,4 @@ Grouped sessions share the same windows, so displaying both is incorrect — it 
 |------|--------|-----------|
 | 2026-03-18 | Rewrote for multi-server architecture — dedicated `runkit` tmux server replaces byobu integration. `ListSessions()` queries both runkit and default servers. `parseSessions()` extracted as testable function with server tagging. `CreateSession()` uses plain `tmux new-session` (byobu dependency removed). `ListWindows()` accepts server parameter. | `260318-0gjh-dedicated-tmux-server` |
 | 2026-03-20 | Multi-server operations — `SelectWindowOnServer()` routes select-window to correct server. `ReloadConfig(server)` hot-reloads config on specified server. Relay and select-window endpoints accept `?server=` query param. `RK_TMUX_CONF` resolved to absolute path at init. Stderr captured in tmux exec errors. | `260318-0gjh-dedicated-tmux-server` |
+| 2026-03-20 | Single-active-server model — replaced dual-server merge with `?server=` on every request. All tmux functions accept `server` param. Unified `tmuxExec`/`tmuxExecDefault` into `tmuxExecServer`. Added `ListServers()` (socket scan), `KillServer()`. SSE hub polls per-server. Removed `SessionInfo.Server` and `ProjectSession.Server` fields. New endpoints: `GET/POST /api/servers`, `POST /api/servers/kill`. `serverFromRequest()` validates input. | `260320-1335-tmux-server-switcher` |

--- a/docs/memory/run-kit/ui-patterns.md
+++ b/docs/memory/run-kit/ui-patterns.md
@@ -88,7 +88,7 @@ Connection indicator: green/gray dot only (no text label), driven by `isConnecte
 
 **Padding**: `px-3 sm:px-6` (matches top bar and bottom bar chrome padding).
 
-**Session rows**: Chevron toggle (left, expands/collapses window list), session name (navigates to first window in session via `onSelectWindow(session, 0)`), optional `↗` marker for default-server (external) sessions (`text-[10px] text-text-secondary/50`, `aria-label="external session"`), + new window button (right), ✕ kill button (right, always visible). Click session name navigates to `/:session/0`; click chevron toggles expand/collapse.
+**Session rows**: Chevron toggle (left, expands/collapses window list), session name (navigates to first window in session via `onSelectWindow(session, 0)`), + new window button (right), ✕ kill button (right, always visible). Click session name navigates to `/:session/0`; click chevron toggles expand/collapse. No server marker — all sessions belong to the active server.
 
 **Window rows**: Single line with activity dot + window name (left), right-side info (fab stage, duration, info button). All rows have `border-l-2` (transparent when not selected to prevent layout shift). Currently selected window highlighted with `bg-accent/10` + `border-accent` + `font-medium` + `rounded-r`. Click navigates to `/:session/:window`.
 
@@ -110,7 +110,7 @@ Popover state managed via `popoverKey` state in `Sidebar`, keyed by `session:win
 
 **Inline window rename** (double-click): Double-clicking a window name `<span>` replaces it with a text `<input>` pre-filled with the current name, auto-focused with all text selected. Enter or blur commits the rename via `renameWindow(session, index, newName)` from `api/client.ts` — SSE pushes the updated name automatically, no optimistic UI. Escape cancels editing and reverts to the original name. Empty or whitespace-only input cancels (same as Escape). If the name is unchanged, no API call is made. Single-click behavior (navigate to window) is preserved — only `onDoubleClick` triggers editing. Editing state is local to the `Sidebar` component: `editingWindow: { session: string; index: number } | null` and `editingName: string`. Only one window may be in editing mode at a time. A `cancelledRef` prevents blur from committing after an Escape cancel. The existing command palette "Rename current window" dialog remains unchanged — inline editing is an additional path.
 
-**No footer** — session creation accessible via breadcrumb dropdown `+ New Session` action and sidebar empty state button.
+**Server selector footer** — pinned at the bottom of the sidebar below the scrollable session tree, separated by `border-t border-border`. Displays `Server: {name}` with a dropdown trigger. Clicking opens a dropdown listing all available tmux servers (from `GET /api/servers`); the current server is highlighted with `text-accent`. Selecting a different server calls `setServer(name)`, which updates localStorage (`runkit-server`), reconnects SSE, and navigates to `/`. The session tree area is `flex-1 min-h-0 overflow-y-auto` above the pinned footer.
 
 ## Bottom Bar (Terminal Pages Only, Inside Terminal Column)
 
@@ -202,7 +202,7 @@ The `CommandPalette` component listens for a `palette:open` CustomEvent on `docu
 
 No single-key shortcuts (`j`/`k`/`c`/`r`) or `Esc Esc` — these conflicted with xterm.js terminal input. All actions are accessible via `Cmd+K` command palette or top bar buttons.
 
-Command palette actions include: create/rename/kill session, create/rename/kill window, theme switching, "Reload tmux config" (targets whichever tmux server the current session belongs to), and terminal navigation (jump to any session/window).
+Command palette actions include: create/rename/kill session, create/rename/kill window, theme switching, "Reload tmux config" (targets the active server via `?server=` param), "Create tmux server" (opens name dialog, creates session "0" in $HOME), "Kill tmux server" (confirmation dialog, kills active server, switches to next available), "Switch tmux server: {name}" (one entry per available server, current marked), and terminal navigation (jump to any session/window).
 
 ## Visual Design
 
@@ -332,3 +332,4 @@ Windows are `"active"` (last tmux activity within 10 seconds) or `"idle"`. No "e
 | 2026-03-18 | Sidebar external session marker — `ProjectSession` type gains `server` field (`"runkit"` or `"default"`). Session rows show `↗` marker for default-server sessions (`text-[10px] text-text-secondary/50`, `aria-label="external session"`). Runkit-server sessions have no marker. | `260318-0gjh-dedicated-tmux-server` |
 | 2026-03-20 | Multi-server terminal support — `TerminalClient` accepts `server` prop, WebSocket URL includes `?server=` param. "Reload tmux config" command palette action targets current session's server. `selectWindow` API call passes server for correct routing. | `260318-0gjh-dedicated-tmux-server` |
 | 2026-03-20 | PWA meta tags and theme-color sync — `theme-color`, `apple-mobile-web-app-capable`, `apple-mobile-web-app-status-bar-style`, `apple-touch-icon` in `index.html`. Theme-color updated by blocking script (initial) and `applyTheme()` (runtime). Dark `#0f1117`, light `#f8f9fb`. Icon set in `public/icons/`. Standalone display mode. | `260320-j9a2-pwa-compliance` |
+| 2026-03-20 | Single-active-server model — Sidebar server selector at bottom (`Server: <dropdown>`, pinned below scrollable session tree). Command palette: "Create tmux server" (name dialog), "Kill tmux server" (confirmation), "Switch tmux server: {name}" per server. Removed `↗` external session marker and `ProjectSession.server` field. `SessionProvider` manages `server`/`setServer`/`servers`/`refreshServers` state. Active server persisted in localStorage `runkit-server` (default: `runkit`). All API calls append `?server=` via `setServerGetter()` mechanism. SSE reconnects on server switch. Navigate to `/` on switch. | `260320-1335-tmux-server-switcher` |

--- a/fab/changes/260320-1335-tmux-server-switcher/.history.jsonl
+++ b/fab/changes/260320-1335-tmux-server-switcher/.history.jsonl
@@ -17,3 +17,4 @@
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-03-20T08:57:07Z"}
 {"event":"review","result":"passed","ts":"2026-03-20T08:57:07Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-03-20T08:59:43Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-03-20T09:01:22Z"}

--- a/fab/changes/260320-1335-tmux-server-switcher/.history.jsonl
+++ b/fab/changes/260320-1335-tmux-server-switcher/.history.jsonl
@@ -1,0 +1,19 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-03-20T08:10:56Z"}
+{"args":"Add server dropdown to sidebar, command palette server management, single-server-at-a-time model","cmd":"fab-new","event":"command","ts":"2026-03-20T08:10:56Z"}
+{"delta":"+2.5","event":"confidence","score":2.5,"trigger":"calc-score","ts":"2026-03-20T08:12:09Z"}
+{"delta":"+0.0","event":"confidence","score":2.5,"trigger":"calc-score","ts":"2026-03-20T08:12:20Z"}
+{"delta":"+0.0","event":"confidence","score":2.5,"trigger":"calc-score","ts":"2026-03-20T08:30:39Z"}
+{"delta":"+0.0","event":"confidence","score":2.5,"trigger":"calc-score","ts":"2026-03-20T08:30:46Z"}
+{"delta":"+0.0","event":"confidence","score":2.5,"trigger":"calc-score","ts":"2026-03-20T08:30:53Z"}
+{"delta":"+0.0","event":"confidence","score":2.5,"trigger":"calc-score","ts":"2026-03-20T08:30:57Z"}
+{"delta":"+2.5","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-03-20T08:31:30Z"}
+{"delta":"+0.0","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-03-20T08:31:34Z"}
+{"cmd":"fab-fff","event":"command","ts":"2026-03-20T08:32:23Z"}
+{"delta":"-1.2","event":"confidence","score":3.8,"trigger":"calc-score","ts":"2026-03-20T08:35:29Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"spec","ts":"2026-03-20T08:35:33Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"tasks","ts":"2026-03-20T08:36:46Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-03-20T08:36:46Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-03-20T08:53:34Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-03-20T08:57:07Z"}
+{"event":"review","result":"passed","ts":"2026-03-20T08:57:07Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-03-20T08:59:43Z"}

--- a/fab/changes/260320-1335-tmux-server-switcher/.status.yaml
+++ b/fab/changes/260320-1335-tmux-server-switcher/.status.yaml
@@ -11,8 +11,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 checklist:
     generated: true
     path: checklist.md
@@ -37,6 +37,8 @@ stage_metrics:
     apply: {started_at: "2026-03-20T08:36:46Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-20T08:53:34Z"}
     review: {started_at: "2026-03-20T08:53:34Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-20T08:57:07Z"}
     hydrate: {started_at: "2026-03-20T08:57:07Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-20T08:59:43Z"}
-    ship: {started_at: "2026-03-20T08:59:43Z", driver: fab-fff, iterations: 1}
-prs: []
-last_updated: 2026-03-20T08:59:43Z
+    ship: {started_at: "2026-03-20T08:59:43Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-20T09:01:22Z"}
+    review-pr: {started_at: "2026-03-20T09:01:22Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/wvrdz/run-kit/pull/60
+last_updated: 2026-03-20T09:01:22Z

--- a/fab/changes/260320-1335-tmux-server-switcher/.status.yaml
+++ b/fab/changes/260320-1335-tmux-server-switcher/.status.yaml
@@ -1,0 +1,42 @@
+id: 1335
+name: 260320-1335-tmux-server-switcher
+created: 2026-03-20T08:10:56Z
+created_by: sahil-weaver
+change_type: refactor
+issues: []
+progress:
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+checklist:
+    generated: true
+    path: checklist.md
+    completed: 0
+    total: 0
+confidence:
+    certain: 11
+    confident: 4
+    tentative: 0
+    unresolved: 0
+    score: 3.8
+    fuzzy: true
+    dimensions:
+        signal: 86.7
+        reversibility: 82.3
+        competence: 82.3
+        disambiguation: 87.7
+stage_metrics:
+    intake: {started_at: "2026-03-20T08:10:56Z", driver: fab-new, iterations: 1, completed_at: "2026-03-20T08:35:33Z"}
+    spec: {started_at: "2026-03-20T08:35:33Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-20T08:36:46Z"}
+    tasks: {started_at: "2026-03-20T08:36:46Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-20T08:36:46Z"}
+    apply: {started_at: "2026-03-20T08:36:46Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-20T08:53:34Z"}
+    review: {started_at: "2026-03-20T08:53:34Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-20T08:57:07Z"}
+    hydrate: {started_at: "2026-03-20T08:57:07Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-20T08:59:43Z"}
+    ship: {started_at: "2026-03-20T08:59:43Z", driver: fab-fff, iterations: 1}
+prs: []
+last_updated: 2026-03-20T08:59:43Z

--- a/fab/changes/260320-1335-tmux-server-switcher/checklist.md
+++ b/fab/changes/260320-1335-tmux-server-switcher/checklist.md
@@ -1,0 +1,61 @@
+# Quality Checklist: tmux Server Switcher
+
+**Change**: 260320-1335-tmux-server-switcher
+**Generated**: 2026-03-20
+**Spec**: `spec.md`
+
+## Functional Completeness
+- [ ] CHK-001 Server-parameterized tmux layer: All tmux functions accept server parameter and route commands correctly
+- [ ] CHK-002 ListSessions single-server: Queries only the specified server, no dual-server merge
+- [ ] CHK-003 ListServers discovery: Scans socket directory and returns running server names
+- [ ] CHK-004 KillServer: Kills the specified tmux server via kill-server command
+- [ ] CHK-005 Server creation via session: CreateSession on non-existent server starts the server with cwd=$HOME
+- [ ] CHK-006 All API endpoints accept ?server= query param with "default" fallback
+- [ ] CHK-007 GET /api/servers returns server list
+- [ ] CHK-008 POST /api/servers creates server with initial session
+- [ ] CHK-009 POST /api/servers/kill kills the server
+- [ ] CHK-010 SSE endpoint filters to requested server
+- [ ] CHK-011 Frontend server state in localStorage with "runkit" default
+- [ ] CHK-012 SessionProvider exposes server, setServer, servers, refreshServers
+- [ ] CHK-013 Sidebar server dropdown at bottom, pinned below scrollable session tree
+- [ ] CHK-014 Command palette: Create tmux server (with dialog)
+- [ ] CHK-015 Command palette: Kill tmux server (with confirmation)
+- [ ] CHK-016 Command palette: Switch tmux server
+
+## Behavioral Correctness
+- [ ] CHK-017 Default server is "default" when ?server= param is absent (not "runkit")
+- [ ] CHK-018 SSE reconnects when server is switched (new EventSource with updated param)
+- [ ] CHK-019 Navigate to "/" on server switch (current session may not exist on new server)
+
+## Removal Verification
+- [ ] CHK-020 ProjectSession.Server field removed from Go struct and TypeScript type
+- [ ] CHK-021 ↗ server marker removed from sidebar session rows
+- [ ] CHK-022 tmuxExecDefault() function removed
+- [ ] CHK-023 Dual-server merge logic removed from ListSessions
+- [ ] CHK-024 SessionInfo.Server field removed
+
+## Scenario Coverage
+- [ ] CHK-025 Named server command execution includes -L flag
+- [ ] CHK-026 Default server command execution has no -L flag
+- [ ] CHK-027 Create server via palette → session created on new server → UI switches
+- [ ] CHK-028 Kill server → switches to next available server or empty state
+- [ ] CHK-029 Switch server via sidebar dropdown → sessions update
+- [ ] CHK-030 SSE with explicit server param → receives only that server's data
+
+## Edge Cases & Error Handling
+- [ ] CHK-031 No servers running → empty server list, sidebar shows empty state
+- [ ] CHK-032 Kill last server → no crash, empty state shown
+- [ ] CHK-033 Server name validation rejects empty, spaces, special characters
+- [ ] CHK-034 Socket directory missing or empty → ListServers returns empty slice
+
+## Code Quality
+- [ ] CHK-035 Pattern consistency: New code follows naming and structural patterns of surrounding code
+- [ ] CHK-036 No unnecessary duplication: Existing utilities reused where applicable
+- [ ] CHK-037 All exec.CommandContext calls use timeouts (constitution requirement)
+- [ ] CHK-038 No shell string construction — argument slices only
+- [ ] CHK-039 Server name validated before passing to subprocess (security)
+- [ ] CHK-040 No polling from client — uses SSE stream
+
+## Security
+- [ ] CHK-041 Server name input sanitized to prevent shell injection in tmux -L argument
+- [ ] CHK-042 serverFromRequest validates/sanitizes the query param value

--- a/fab/changes/260320-1335-tmux-server-switcher/intake.md
+++ b/fab/changes/260320-1335-tmux-server-switcher/intake.md
@@ -1,0 +1,103 @@
+# Intake: tmux Server Switcher
+
+**Change**: 260320-1335-tmux-server-switcher
+**Created**: 2026-03-20
+**Status**: Draft
+
+## Origin
+
+> At the bottom of the left panel, add 'Server: <dropdown>' which shows you the current tmux server you are connected to and allows you to change it. Add these to Command Palette: 'Create tmux server' (should show a dialog where you can select a tmux server name), 'Kill tmux server', 'Switch tmux server'. Change run-kit behaviour to connect only to one server at a time. We no longer need the server label in the session entries.
+
+One-shot description. User wants to shift from the current dual-server merge model to a single-active-server model with explicit UI for switching between servers.
+
+## Why
+
+run-kit currently queries both the `runkit` and `default` tmux servers simultaneously, merging all sessions into a single list with a small `↗` marker to distinguish external sessions. This creates several problems:
+
+1. **Cognitive overhead** — Users see sessions from both servers interleaved, with no clear grouping or control over which server they're interacting with.
+2. **No server management** — There's no way to create a new tmux server, kill an existing one, or explicitly choose which server to work with.
+3. **Scaling concern** — As users create more tmux servers (e.g., per-project servers), the merged view becomes unwieldy. A single-server-at-a-time model keeps the UI focused.
+
+The change introduces a deliberate "connect to one server" model where the user explicitly picks which tmux server to view and manage, with full lifecycle controls (create, kill, switch) accessible from the sidebar and command palette.
+
+## What Changes
+
+### Sidebar Server Selector (Bottom of Left Panel)
+
+Add a server selector at the very bottom of the sidebar, below the session/window tree:
+
+- **Format**: `Server: <dropdown>` — static label "Server:" followed by a dropdown showing the current server name
+- **Dropdown contents**: List of available tmux servers (discovered from the system), with the active one highlighted
+- **Selection**: Clicking a different server switches the active server — the session list updates to show only sessions from that server
+- **Styling**: Matches sidebar conventions — `px-3 sm:px-6` padding, `text-xs text-text-secondary` for the label, server name in `text-text-primary`
+
+### Command Palette Actions
+
+Three new commands in the command palette:
+
+1. **"Create tmux server"** — Opens a dialog where the user enters a server name. On submit, creates the server by starting an initial session with `cwd: $HOME` (tmux servers don't exist without sessions — this is the stateless approach). The active server switches to the new one immediately.
+2. **"Kill tmux server"** — Kills the currently active tmux server (all sessions destroyed). Shows a confirmation dialog: "Kill server **{name}** and all its sessions?" After killing, switches to another available server (or shows empty state).
+3. **"Switch tmux server"** — Opens the same server selection as the sidebar dropdown, but via the command palette. Lists available servers with the current one marked.
+
+### Single-Server-at-a-Time Backend
+
+Replace the current dual-server merge in `ListSessions()`. The backend is fully stateless — it does not track which server is active. The frontend sends the active server as a `?server=` query parameter on every request (SSE, API calls). If the parameter is omitted, the backend defaults to the `default` tmux server.
+
+- **Session listing**: `FetchSessions()` accepts a server parameter and queries only that server. The `Server` field on `ProjectSession` becomes unnecessary since all returned sessions are from the requested server.
+- **SSE stream**: The EventSource URL includes `?server={name}`. The `sessions` event sends only sessions from the specified server. When the user switches servers, the frontend closes the old EventSource and opens a new one with the updated param.
+- **Session creation**: `CreateSession()` accepts a server parameter (not hardcoded to `runkit`).
+- **Window operations**: All window select, rename, kill operations accept the server as a parameter.
+
+### API Changes
+
+- **`GET /api/servers`** — Returns list of available tmux servers discovered via socket directory scan. Each entry includes the server name.
+- **`POST /api/servers/create`** — Creates a new tmux server by starting a session with `cwd: $HOME`. Body: `{ "server": "name" }`. Returns the created session.
+- **`POST /api/servers/kill`** — Kills a tmux server via `tmux -L {name} kill-server`. Body: `{ "server": "name" }`.
+- All existing session/window endpoints accept `?server=` query param (already present on some endpoints). If omitted, defaults to `default` tmux server. The frontend always sends it from localStorage state.
+
+### Remove Server Label from Session Entries
+
+- Remove the `↗` marker from sidebar session rows (the `session.server === "default"` check)
+- Remove `server` field from `ProjectSession` type — no longer needed
+- Remove `server` parameter from `ListWindows()`, `SelectWindowOnServer()`, etc. — all operations target the active server
+- Remove `tmuxExecDefault()` and the dual-query logic in `ListSessions()`
+
+### Server Discovery
+
+tmux servers are identified by their socket files. Available servers can be discovered by:
+- Checking known server names (at minimum: `runkit` and `default`)
+- Scanning the tmux socket directory (`/tmp/tmux-{uid}/`) for active server sockets
+- A running server responds to `tmux -L {name} list-sessions` without error
+
+## Affected Memory
+
+- `run-kit/architecture`: (modify) Update backend structure to reflect single-server model, new API endpoints
+- `run-kit/tmux-sessions`: (modify) Rewrite multi-server section to single-active-server model, document server discovery and switching
+- `run-kit/ui-patterns`: (modify) Add sidebar server selector, new command palette actions, remove server label from sessions
+
+## Impact
+
+- **Backend**: `internal/tmux/tmux.go` (server switching, remove dual-query), `internal/sessions/sessions.go` (single-server fetch), `api/` (new server endpoints, remove `?server=` params), `api/sse.go` (filter to active server)
+- **Frontend**: `components/sidebar.tsx` (server selector footer), `app.tsx` (command palette commands, create server dialog), `types.ts` (remove `server` from `ProjectSession`), `api/client.ts` (new server API calls), `contexts/session-context.tsx` (active server state)
+- **Tests**: Backend tmux tests need updating for single-server model, frontend tests for new UI components
+
+## Open Questions
+
+(None — all resolved during discussion.)
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Server selector goes at the bottom of the sidebar | User explicitly specified "bottom of the left panel" | S:95 R:90 A:95 D:95 |
+| 2 | Certain | Three command palette actions: Create, Kill, Switch | User explicitly listed these | S:95 R:90 A:95 D:95 |
+| 3 | Certain | Single-server-at-a-time model replaces dual-server merge | User explicitly requested "connect only to one server at a time" | S:95 R:85 A:90 D:95 |
+| 4 | Certain | Remove server label (↗) from session entries | User explicitly stated "we no longer need the server label" | S:95 R:90 A:95 D:95 |
+| 5 | Certain | Default active server is "runkit" on first launch | Clarified — user confirmed | S:95 R:85 A:80 D:95 |
+| 6 | Certain | Active server persisted in localStorage (frontend) | Clarified — user confirmed. Follows theme/sidebar-width pattern | S:95 R:80 A:75 D:95 |
+| 7 | Certain | Server discovery via tmux socket directory scan | Clarified — user confirmed socket scan approach | S:95 R:75 A:70 D:95 |
+| 8 | Certain | "Create tmux server" creates first session with cwd=$HOME | Clarified — user chose stateless approach with $HOME as starting directory. Server comes into existence via `tmux -L {name} new-session -c $HOME` | S:95 R:80 A:80 D:95 |
+| 9 | Certain | Kill server uses `tmux -L {name} kill-server` | Clarified — user confirmed | S:95 R:70 A:85 D:95 |
+| 10 | Certain | Backend is stateless — frontend sends `?server=` on every request, defaults to `default` if omitted | Clarified — user chose option A (query param). Aligns with constitution: "state derived from tmux and filesystem at request time" | S:95 R:85 A:90 D:95 |
+
+10 assumptions (10 certain, 0 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260320-1335-tmux-server-switcher/spec.md
+++ b/fab/changes/260320-1335-tmux-server-switcher/spec.md
@@ -1,0 +1,389 @@
+# Spec: tmux Server Switcher
+
+**Change**: 260320-1335-tmux-server-switcher
+**Created**: 2026-03-20
+**Affected memory**: `docs/memory/run-kit/tmux-sessions.md`, `docs/memory/run-kit/ui-patterns.md`, `docs/memory/run-kit/architecture.md`
+
+## Non-Goals
+
+- Multi-server simultaneous view — this change deliberately moves to single-server-at-a-time
+- Backend server state persistence — backend remains stateless per constitution
+- Custom tmux config per server — all servers use the same `RK_TMUX_CONF` config file
+
+## Backend: Server-Parameterized tmux Layer
+
+### Requirement: All tmux operations accept a server parameter
+
+The tmux layer in `internal/tmux/tmux.go` SHALL accept a `server string` parameter on all public functions instead of hardcoding `"runkit"` or using separate `tmuxExec`/`tmuxExecDefault` paths. The `runkitPrefix()` function SHALL be replaced with `serverArgs(server string)` that returns `[]string{"-L", server}` for any server name. When `server` is `"default"`, the function SHALL return an empty slice (no `-L` flag), preserving the behavior of connecting to the user's default tmux server.
+
+The `tmuxExec()` and `tmuxExecDefault()` functions SHALL be unified into a single `tmuxExecServer(server string, args ...string)` function.
+
+#### Scenario: Named server command execution
+- **GIVEN** a tmux operation targeting server `"runkit"`
+- **WHEN** the operation is executed
+- **THEN** the tmux command includes `-L runkit` in the argument prefix
+- **AND** the config file flag `-f {path}` is included if `RK_TMUX_CONF` is set
+
+#### Scenario: Default server command execution
+- **GIVEN** a tmux operation targeting server `"default"`
+- **WHEN** the operation is executed
+- **THEN** the tmux command has no `-L` flag (connects to the user's default server)
+- **AND** no `-f` flag is included (default server uses its own config)
+
+#### Scenario: Arbitrary named server
+- **GIVEN** a tmux operation targeting server `"myproject"`
+- **WHEN** the operation is executed
+- **THEN** the tmux command includes `-L myproject`
+- **AND** the config file flag `-f {path}` is included if `RK_TMUX_CONF` is set
+
+### Requirement: ListSessions accepts server parameter
+
+`ListSessions(server string)` SHALL query only the specified server. The current dual-query logic (querying both runkit and default, merging results) SHALL be removed. The `SessionInfo.Server` field SHALL be removed — all returned sessions belong to the requested server.
+
+#### Scenario: Single server session listing
+- **GIVEN** the runkit server has sessions `["alpha", "bravo"]` and the default server has `["personal"]`
+- **WHEN** `ListSessions("runkit")` is called
+- **THEN** only `["alpha", "bravo"]` are returned
+- **AND** no `Server` field is present on the results
+
+### Requirement: ListWindows, SelectWindow, and other window operations accept server parameter
+
+All window-level functions (`ListWindows`, `SelectWindowOnServer`, `CreateSession`, `KillSession`, `RenameSession`, `CreateWindow`, `KillWindow`, `RenameWindow`, `SendKeys`) SHALL accept a `server string` parameter and route the command to the specified server.
+
+`SelectWindowOnServer` SHALL be renamed to `SelectWindow` since the "OnServer" suffix is redundant when all functions take a server parameter.
+
+#### Scenario: Window listing on a named server
+- **GIVEN** session `"alpha"` exists on server `"runkit"` with windows `[0: "main", 1: "tests"]`
+- **WHEN** `ListWindows("alpha", "runkit")` is called
+- **THEN** windows `[0: "main", 1: "tests"]` are returned
+
+### Requirement: Server discovery via socket directory scan
+
+A new function `ListServers() []string` SHALL discover available tmux servers by scanning the tmux socket directory at `/tmp/tmux-{uid}/` (where `{uid}` is the current user's UID). Each socket file in that directory represents a running tmux server. The function SHALL return server names derived from the socket file names. The `"default"` server socket is named `"default"` in the directory.
+
+#### Scenario: Multiple servers running
+- **GIVEN** socket files `/tmp/tmux-1000/default`, `/tmp/tmux-1000/runkit`, `/tmp/tmux-1000/myproject` exist
+- **WHEN** `ListServers()` is called
+- **THEN** `["default", "myproject", "runkit"]` is returned (alphabetically sorted)
+
+#### Scenario: No servers running
+- **GIVEN** the tmux socket directory is empty or doesn't exist
+- **WHEN** `ListServers()` is called
+- **THEN** an empty slice is returned
+
+### Requirement: Kill server
+
+A new function `KillServer(server string) error` SHALL kill a tmux server by running `tmux -L {server} kill-server`. For the `"default"` server, it SHALL run `tmux kill-server` (no `-L` flag).
+
+#### Scenario: Kill named server
+- **GIVEN** server `"runkit"` is running with sessions
+- **WHEN** `KillServer("runkit")` is called
+- **THEN** `tmux -L runkit kill-server` is executed
+- **AND** all sessions on that server are destroyed
+
+### Requirement: Create server (via session creation)
+
+Server creation is implicit — `CreateSession(name, cwd, server)` on a non-existent server causes tmux to start that server automatically. No separate `CreateServer` function is needed.
+
+When creating a server via the "Create tmux server" palette action, `CreateSession("0", "$HOME", server)` SHALL be called — the session is named `"0"` (tmux default) and starts in the user's home directory.
+
+#### Scenario: Create session on new server
+- **GIVEN** no server named `"myproject"` exists
+- **WHEN** `CreateSession("0", "/home/user", "myproject")` is called
+- **THEN** `tmux -L myproject new-session -d -s 0 -c /home/user` is executed
+- **AND** the server `"myproject"` comes into existence
+
+## Backend: API Endpoints
+
+### Requirement: All endpoints accept `?server=` query parameter
+
+Every session/window API endpoint SHALL read the `server` query parameter from the request URL. If the parameter is absent, the server SHALL default to `"default"`. This replaces the current hardcoded `"runkit"` default — the frontend always sends the parameter from localStorage state.
+
+The following endpoints are affected:
+- `GET /api/sessions` → `handleSessionsList`
+- `POST /api/sessions` → `handleSessionCreate`
+- `POST /api/sessions/{session}/kill` → `handleSessionKill`
+- `POST /api/sessions/{session}/rename` → `handleSessionRename`
+- `POST /api/sessions/{session}/windows` → `handleWindowCreate`
+- `POST /api/sessions/{session}/windows/{index}/kill` → `handleWindowKill`
+- `POST /api/sessions/{session}/windows/{index}/rename` → `handleWindowRename`
+- `POST /api/sessions/{session}/windows/{index}/keys` → `handleWindowKeys`
+- `POST /api/sessions/{session}/windows/{index}/select` → `handleWindowSelect`
+- `GET /api/sessions/stream` → `handleSSE`
+- `GET /relay/{session}/{window}` → `handleRelay` (already has `?server=`)
+- `POST /api/tmux/reload-config` → `handleTmuxReloadConfig`
+- `POST /api/sessions/{session}/upload` → `handleUpload`
+
+A helper function `serverFromRequest(r *http.Request) string` SHALL extract the server parameter, defaulting to `"default"`.
+
+#### Scenario: Explicit server parameter
+- **GIVEN** a request to `GET /api/sessions?server=runkit`
+- **WHEN** the handler processes the request
+- **THEN** sessions are fetched from the `runkit` server only
+
+#### Scenario: Missing server parameter
+- **GIVEN** a request to `GET /api/sessions` (no `?server=`)
+- **WHEN** the handler processes the request
+- **THEN** sessions are fetched from the `default` server
+
+### Requirement: New GET /api/servers endpoint
+
+A new endpoint `GET /api/servers` SHALL return the list of available tmux servers as a JSON array of strings.
+
+#### Scenario: List servers
+- **GIVEN** servers `["default", "runkit"]` are running
+- **WHEN** `GET /api/servers` is called
+- **THEN** response is `["default", "runkit"]` with status 200
+
+### Requirement: New POST /api/servers endpoint (create)
+
+A new endpoint `POST /api/servers` SHALL create a tmux server by starting an initial session. Request body: `{ "name": "myproject" }`. The endpoint SHALL call `CreateSession("0", os.UserHomeDir(), server)` — session named `"0"`, cwd is `$HOME`.
+
+#### Scenario: Create new server
+- **GIVEN** no server `"myproject"` exists
+- **WHEN** `POST /api/servers` with body `{ "name": "myproject" }` is called
+- **THEN** a tmux session `"0"` is created on server `"myproject"` with cwd `$HOME`
+- **AND** response is `{ "ok": true }` with status 200
+
+#### Scenario: Server name validation
+- **GIVEN** a request with `{ "name": "" }` or `{ "name": "has spaces" }`
+- **WHEN** `POST /api/servers` is called
+- **THEN** response is 400 with error message
+
+### Requirement: New POST /api/servers/kill endpoint
+
+A new endpoint `POST /api/servers/kill` SHALL kill a tmux server. Request body: `{ "name": "runkit" }`. Calls `KillServer(name)`.
+
+#### Scenario: Kill existing server
+- **GIVEN** server `"runkit"` is running
+- **WHEN** `POST /api/servers/kill` with body `{ "name": "runkit" }` is called
+- **THEN** the server is killed and response is `{ "ok": true }`
+
+### Requirement: SSE endpoint accepts server parameter
+
+The SSE endpoint (`GET /api/sessions/stream`) SHALL read the `?server=` query parameter and poll only that server. The `sseHub` SHALL be updated to support per-server polling — when a client connects with `?server=runkit`, it receives session data from the runkit server only.
+
+Since multiple browser tabs might connect to different servers, the SSE hub SHALL support multiple concurrent server subscriptions. Implementation: the hub polls all servers that have active clients, and routes session data to the appropriate clients.
+
+#### Scenario: SSE with server filter
+- **GIVEN** a client connects to `/api/sessions/stream?server=runkit`
+- **WHEN** sessions change on the runkit server
+- **THEN** the client receives updated session data for runkit only
+- **AND** sessions from other servers are not included
+
+#### Scenario: SSE reconnect on server switch
+- **GIVEN** a client was connected to `/api/sessions/stream?server=runkit`
+- **WHEN** the user switches to server `"default"` in the UI
+- **THEN** the frontend closes the old EventSource and opens a new one to `/api/sessions/stream?server=default`
+
+## Backend: Cleanup
+
+### Requirement: Remove dual-server merge
+
+The following SHALL be removed:
+- `tmuxExecDefault()` function in `tmux.go`
+- The dual-query logic in `ListSessions()` that queries both servers and merges
+- `SessionInfo.Server` field
+- The `"runkit"` default fallback in `relay.go` — replaced by `serverFromRequest()` defaulting to `"default"`
+
+### Requirement: Remove server field from ProjectSession
+
+`ProjectSession.Server` field in `internal/sessions/sessions.go` SHALL be removed. The API response no longer includes a server field per session — all sessions in a response belong to the server specified in the request.
+
+#### Scenario: API response without server field
+- **GIVEN** sessions fetched from server `"runkit"`
+- **WHEN** the response JSON is serialized
+- **THEN** each session object has `name` and `windows` fields but no `server` field
+
+## Frontend: Server State Management
+
+### Requirement: Active server stored in localStorage
+
+The active server name SHALL be stored in `localStorage` key `"runkit-server"`. Default value on first launch: `"runkit"`. The `SessionProvider` context SHALL manage this state and expose it to consumers.
+
+#### Scenario: First launch
+- **GIVEN** no `"runkit-server"` key in localStorage
+- **WHEN** the app loads
+- **THEN** the active server defaults to `"runkit"`
+- **AND** `"runkit"` is written to localStorage
+
+#### Scenario: Server switch persists
+- **GIVEN** the user switches to server `"default"`
+- **WHEN** the page is refreshed
+- **THEN** the app loads with server `"default"` active
+
+### Requirement: SessionProvider manages server state
+
+The `SessionProvider` SHALL expose:
+- `server: string` — the currently active server name
+- `setServer: (name: string) => void` — switches the active server, updates localStorage, and reconnects SSE
+- `servers: string[]` — list of available servers (fetched from `GET /api/servers`)
+- `refreshServers: () => void` — re-fetches the server list
+
+The SSE EventSource URL SHALL include `?server={activeServer}`. When `setServer` is called, the provider SHALL close the current EventSource and open a new one with the updated server parameter.
+
+#### Scenario: Server switch triggers SSE reconnect
+- **GIVEN** the active server is `"runkit"` and SSE is connected
+- **WHEN** `setServer("default")` is called
+- **THEN** the current EventSource is closed
+- **AND** a new EventSource opens to `/api/sessions/stream?server=default`
+- **AND** sessions update to show only default server sessions
+
+### Requirement: All API calls include server parameter
+
+The `api/client.ts` functions SHALL accept an optional `server` parameter (or read it from a module-level getter). All fetch calls SHALL append `?server={activeServer}` to the URL. The `selectWindow` function's existing `server` parameter SHALL be replaced by this global mechanism.
+
+#### Scenario: Session creation with server
+- **GIVEN** the active server is `"myproject"`
+- **WHEN** `createSession("alpha", "/home/user")` is called
+- **THEN** the request is `POST /api/sessions?server=myproject` with body `{ "name": "alpha", "cwd": "/home/user" }`
+
+## Frontend: Remove Server from ProjectSession
+
+### Requirement: Remove server field from types
+
+The `server` field SHALL be removed from the `ProjectSession` type in `types.ts`. All code referencing `session.server` SHALL be updated or removed.
+
+#### Scenario: Type definition
+- **GIVEN** the updated `ProjectSession` type
+- **WHEN** TypeScript compiles
+- **THEN** only `name: string` and `windows: WindowInfo[]` fields exist
+
+## Frontend: Sidebar Server Selector
+
+### Requirement: Server dropdown at sidebar bottom
+
+The sidebar SHALL render a server selector at the very bottom, below the session/window tree. The selector is always visible (not scrollable with the session list).
+
+Layout: `Server: {dropdown}` — "Server:" is a static label, followed by a dropdown trigger showing the current server name.
+
+The dropdown SHALL list all available servers (from `servers` in SessionProvider). The current server is highlighted with `text-accent`. Selecting a different server calls `setServer(name)`.
+
+Styling:
+- Container: `border-t border-border px-3 sm:px-6 py-2` — separated from the session tree by a top border
+- Label: `text-xs text-text-secondary`
+- Server name trigger: `text-xs text-text-primary font-medium`
+- Touch target: `coarse:min-h-[44px]` on the trigger
+- The session tree area above SHALL be scrollable (`flex-1 min-h-0 overflow-y-auto`) while the server selector remains pinned at the bottom
+
+#### Scenario: Server selector display
+- **GIVEN** the active server is `"runkit"` and servers `["default", "runkit"]` are available
+- **WHEN** the sidebar renders
+- **THEN** the bottom shows `Server: runkit` with a dropdown trigger
+- **AND** clicking the trigger opens a dropdown with `["default", "runkit"]`
+
+#### Scenario: Switch server via sidebar
+- **GIVEN** the active server is `"runkit"`
+- **WHEN** the user selects `"default"` from the server dropdown
+- **THEN** `setServer("default")` is called
+- **AND** the session list updates to show default server sessions
+- **AND** the URL navigates to `/` (dashboard) since the current session/window may not exist on the new server
+
+### Requirement: Remove server label from session rows
+
+The `↗` marker for `session.server === "default"` sessions SHALL be removed from sidebar session rows. All sessions are displayed identically regardless of which server they came from (since there's only one server active at a time).
+
+#### Scenario: Session row without server marker
+- **GIVEN** any session from any server
+- **WHEN** the sidebar renders the session row
+- **THEN** no `↗` marker or server indicator is displayed
+
+## Frontend: Command Palette Actions
+
+### Requirement: "Create tmux server" command
+
+A new command palette action `"Create tmux server"` SHALL open a dialog where the user enters a server name. On submit:
+1. Call `POST /api/servers` with the name
+2. Call `refreshServers()` to update the server list
+3. Call `setServer(name)` to switch to the new server
+
+The dialog SHALL validate the name: non-empty, no spaces, no special characters beyond hyphens and underscores.
+
+#### Scenario: Create server via palette
+- **GIVEN** the command palette is open
+- **WHEN** the user selects "Create tmux server" and enters "myproject"
+- **THEN** a dialog appears with a name input
+- **AND** on submit, the server is created and the UI switches to it
+
+### Requirement: "Kill tmux server" command
+
+A new command palette action `"Kill tmux server"` SHALL show a confirmation dialog: `Kill server "{name}" and all its sessions?`. On confirm:
+1. Call `POST /api/servers/kill` with the current server name
+2. Call `refreshServers()` to update the server list
+3. Switch to the first available server, or show empty state if none remain
+
+#### Scenario: Kill current server
+- **GIVEN** the active server is `"runkit"` and `"default"` is also available
+- **WHEN** the user confirms "Kill tmux server"
+- **THEN** the runkit server is killed
+- **AND** the UI switches to `"default"`
+
+#### Scenario: Kill last server
+- **GIVEN** the active server is `"runkit"` and no other servers exist
+- **WHEN** the user confirms "Kill tmux server"
+- **THEN** the server is killed
+- **AND** the sidebar shows empty state (no sessions)
+
+### Requirement: "Switch tmux server" command
+
+A new command palette action `"Switch tmux server"` SHALL display available servers as sub-actions in the palette (replacing the action list with server names). The current server is marked with `(current)`. Selecting a server calls `setServer(name)`.
+
+#### Scenario: Switch via palette
+- **GIVEN** the active server is `"runkit"` and servers `["default", "runkit"]` are available
+- **WHEN** the user selects "Switch tmux server"
+- **THEN** the palette shows `"default"` and `"runkit (current)"`
+- **AND** selecting `"default"` switches to it
+
+## Deprecated Requirements
+
+### Multi-server merge in ListSessions
+**Reason**: Replaced by single-server-at-a-time model. `ListSessions()` now takes a server parameter.
+**Migration**: All callers pass the server parameter explicitly.
+
+### ProjectSession.Server field
+**Reason**: Redundant — all sessions in a response belong to the queried server.
+**Migration**: Remove from Go struct and TypeScript type. Remove `↗` sidebar marker.
+
+### tmuxExecDefault function
+**Reason**: Unified into `tmuxExecServer(server, args...)` which handles both named and default servers.
+**Migration**: All callers use `tmuxExecServer` with explicit server parameter.
+
+## Design Decisions
+
+1. **Stateless backend with `?server=` query param**: The backend does not track which server is active. The frontend sends `?server=` on every request. This aligns with the constitution ("state derived from tmux and filesystem at request time") and avoids multi-tab state conflicts.
+   - *Why*: Keeps the backend stateless; each request is self-contained.
+   - *Rejected*: Backend in-memory state — would require synchronization across tabs and resets on server restart.
+
+2. **Default to `"default"` when `?server=` is absent**: If no server parameter is provided, the backend uses the user's default tmux server. This makes the API usable without run-kit-specific client configuration.
+   - *Why*: Safe fallback; `"default"` is the standard tmux server.
+   - *Rejected*: Defaulting to `"runkit"` — would break clients that don't send the parameter and expect standard tmux behavior.
+
+3. **Server creation via initial session with `$HOME` cwd**: "Create tmux server" creates a session named `"0"` in `$HOME` rather than starting an empty server (tmux servers can't exist without sessions).
+   - *Why*: Stateless — no intermediate "server exists but has no sessions" state. `$HOME` is a safe universal starting directory.
+   - *Rejected*: Prompting for a directory — adds friction; user can navigate from `$HOME`.
+
+4. **SSE hub supports per-server polling**: Rather than having one global poll, the hub tracks which servers have active clients and polls only those.
+   - *Why*: Avoids polling servers nobody is watching; supports multi-tab with different servers.
+   - *Rejected*: Polling all discovered servers — wasteful; could poll dead servers.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Server selector at sidebar bottom | Confirmed from intake #1 — user specified | S:95 R:90 A:95 D:95 |
+| 2 | Certain | Three palette commands: Create, Kill, Switch | Confirmed from intake #2 — user specified | S:95 R:90 A:95 D:95 |
+| 3 | Certain | Single-server-at-a-time replaces dual-server merge | Confirmed from intake #3 — user specified | S:95 R:85 A:90 D:95 |
+| 4 | Certain | Remove ↗ server label from sessions | Confirmed from intake #4 — user specified | S:95 R:90 A:95 D:95 |
+| 5 | Certain | Default active server is "runkit" (localStorage) | Confirmed from intake #5 — user confirmed | S:95 R:85 A:80 D:95 |
+| 6 | Certain | Active server in localStorage key "runkit-server" | Confirmed from intake #6 — user confirmed | S:95 R:80 A:75 D:95 |
+| 7 | Certain | Server discovery via socket dir scan /tmp/tmux-{uid}/ | Confirmed from intake #7 — user confirmed | S:95 R:75 A:70 D:95 |
+| 8 | Certain | Create server = create session "0" with cwd=$HOME | Confirmed from intake #8 — user chose stateless + $HOME | S:95 R:80 A:80 D:95 |
+| 9 | Certain | Kill server via tmux kill-server | Confirmed from intake #9 — user confirmed | S:95 R:70 A:85 D:95 |
+| 10 | Certain | Backend stateless — ?server= on every request, default "default" | Confirmed from intake #10 — user chose option A | S:95 R:85 A:90 D:95 |
+| 11 | Certain | Config flag (-f) applied to all named servers, not just runkit | Follows from unifying tmuxExec — config is server-agnostic | S:85 R:80 A:85 D:90 |
+| 12 | Confident | SSE hub polls per-server (only servers with active clients) | Multi-tab scenario requires per-server routing; avoids wasteful polling | S:70 R:75 A:75 D:70 |
+| 13 | Confident | Navigate to "/" on server switch | Current session/window likely doesn't exist on the new server; safest UX | S:65 R:85 A:70 D:65 |
+| 14 | Confident | Server name validation: alphanumeric + hyphens + underscores | Matches tmux socket naming constraints; prevents shell injection | S:70 R:80 A:80 D:75 |
+| 15 | Confident | Initial session name "0" for server creation | tmux default session name; minimal footprint | S:60 R:85 A:70 D:65 |
+
+15 assumptions (11 certain, 4 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260320-1335-tmux-server-switcher/tasks.md
+++ b/fab/changes/260320-1335-tmux-server-switcher/tasks.md
@@ -1,0 +1,65 @@
+# Tasks: tmux Server Switcher
+
+**Change**: 260320-1335-tmux-server-switcher
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+## Phase 1: Backend tmux Layer Refactor
+
+- [x] T001 Unify `tmuxExec`/`tmuxExecDefault` into `tmuxExecServer(server string, args ...string)` and replace `runkitPrefix()` with `serverArgs(server string)` in `app/backend/internal/tmux/tmux.go`. `serverArgs("default")` returns empty slice; any other name returns `["-L", name]`. Config flag `-f` applied to all named servers.
+- [x] T002 Update `ListSessions(server string)` to query only the specified server. Remove the dual-query merge logic and the `SessionInfo.Server` field in `app/backend/internal/tmux/tmux.go`.
+- [x] T003 [P] Update `ListWindows`, `CreateSession`, `KillSession`, `RenameSession`, `CreateWindow`, `KillWindow`, `RenameWindow`, `SendKeys` to accept `server string` parameter. Rename `SelectWindowOnServer` to `SelectWindow`. All use `tmuxExecServer`. In `app/backend/internal/tmux/tmux.go`.
+- [x] T004 [P] Add `ListServers() ([]string, error)` function to `app/backend/internal/tmux/tmux.go` — scan `/tmp/tmux-{uid}/` for socket files, return sorted server names.
+- [x] T005 [P] Add `KillServer(server string) error` function to `app/backend/internal/tmux/tmux.go` — run `tmux [-L server] kill-server`.
+- [x] T006 Remove `tmuxExecDefault()` and the `parseSessions()` server-tagging logic. Remove `SessionInfo.Server` field. Clean up dead code in `app/backend/internal/tmux/tmux.go`.
+
+## Phase 2: Backend API Layer
+
+- [x] T007 Add `serverFromRequest(r *http.Request) string` helper in `app/backend/api/router.go` — extracts `?server=` query param, defaults to `"default"`.
+- [x] T008 Update `handleSessionsList`, `handleSessionCreate`, `handleSessionKill`, `handleSessionRename` in `app/backend/api/sessions.go` to use `serverFromRequest()` and pass server to tmux functions.
+- [x] T009 [P] Update `handleWindowCreate`, `handleWindowKill`, `handleWindowRename`, `handleWindowKeys`, `handleWindowSelect` in `app/backend/api/windows.go` (or wherever they live) to use `serverFromRequest()`.
+- [x] T010 [P] Update `handleRelay` in `app/backend/api/relay.go` — replace hardcoded `"runkit"` default with `serverFromRequest()` defaulting to `"default"`.
+- [x] T011 [P] Update `handleTmuxReloadConfig` in `app/backend/api/tmux_config.go` — read server from `?server=` param (or body) via `serverFromRequest()`.
+- [x] T012 Update `handleSSE` in `app/backend/api/sse.go` — read `?server=` from request, pass to session fetching. Update `sseHub` to support per-server polling (poll only servers with active clients, route data to appropriate clients).
+- [x] T013 Add `handleServersList` (`GET /api/servers`) endpoint in new file `app/backend/api/servers.go` — calls `tmux.ListServers()`, returns JSON array.
+- [x] T014 [P] Add `handleServerCreate` (`POST /api/servers`) endpoint in `app/backend/api/servers.go` — validate name (alphanumeric/hyphens/underscores, non-empty), call `tmux.CreateSession("0", os.UserHomeDir(), name)`.
+- [x] T015 [P] Add `handleServerKill` (`POST /api/servers/kill`) endpoint in `app/backend/api/servers.go` — call `tmux.KillServer(name)`.
+- [x] T016 Register new routes in `app/backend/api/router.go`: `GET /api/servers`, `POST /api/servers`, `POST /api/servers/kill`.
+- [x] T017 Remove `ProjectSession.Server` field from `app/backend/internal/sessions/sessions.go`. Update `FetchSessions()` to accept `server string` and pass it to `tmux.ListSessions(server)`.
+- [x] T018 Update `TmuxOps` interface in `app/backend/api/router.go` to match new function signatures (server params on all methods, add `ListServers`, `KillServer`).
+
+## Phase 3: Frontend Changes
+
+- [x] T019 Remove `server` field from `ProjectSession` type in `app/frontend/src/types.ts`.
+- [x] T020 Add server state management to `SessionProvider` in `app/frontend/src/contexts/session-context.tsx` — `server` (from localStorage `"runkit-server"`, default `"runkit"`), `setServer()`, `servers[]`, `refreshServers()`. SSE EventSource URL includes `?server=`. Reconnects on server change.
+- [x] T021 Add API functions in `app/frontend/src/api/client.ts`: `listServers()`, `createServer(name)`, `killServer(name)`. Add `getServer()/setServerGetter()` module-level mechanism so all fetch calls append `?server=`. Remove explicit `server` param from `selectWindow()` and `reloadTmuxConfig()`.
+- [x] T022 Add server selector component at sidebar bottom in `app/frontend/src/components/sidebar.tsx` — pinned footer with `border-t`, dropdown showing available servers, current highlighted. Remove `↗` server marker from session rows. Make session tree area scrollable above the pinned footer.
+- [x] T023 Add "Create tmux server", "Kill tmux server", "Switch tmux server" commands to command palette in `app/frontend/src/app.tsx`. Create server opens dialog (name input, validation). Kill server shows confirmation dialog. Switch server shows server list.
+- [x] T024 Update `app.tsx` — remove `session.server` references from `navigateToWindow`, `TerminalClient` server prop, and "Reload tmux config" command. Navigate to `/` on server switch.
+
+## Phase 4: Tests & Cleanup
+
+- [x] T025 [P] Update Go tests in `app/backend/internal/tmux/` for new function signatures (server params). Add tests for `ListServers()`, `KillServer()`, `serverArgs()`.
+- [x] T026 [P] Update Go tests in `app/backend/api/` for `serverFromRequest()`, new server endpoints, and updated handler signatures.
+- [x] T027 [P] Update frontend tests for removed `server` field, new SessionProvider server state, sidebar server selector, and command palette actions.
+- [x] T028 Run full test suite (`just test`) and fix any breakage.
+
+---
+
+## Execution Order
+
+- T001 blocks T002, T003, T004, T005, T006 (unified exec function needed first)
+- T002, T003, T004, T005 can run in parallel after T001
+- T006 runs after T002 (cleanup after merge removal)
+- T007 blocks T008-T012 (helper needed for endpoint updates)
+- T008 blocks T017 (sessions handler needs updating before struct removal)
+- T013-T015 can run in parallel (independent new endpoints)
+- T016 depends on T013-T015 (routes for new endpoints)
+- T017 depends on T002, T008 (both tmux and API layers updated)
+- T018 depends on T003, T004, T005 (interface matches new signatures)
+- T019 depends on T017 (backend field removed first)
+- T020 depends on T019 (types updated first)
+- T021 depends on T020 (server state available)
+- T022, T023, T024 depend on T020, T021 (server context and API available)
+- T025-T027 run in parallel after implementation
+- T028 runs last


### PR DESCRIPTION
## Summary

Replace dual-server merge model (runkit + default shown together) with a single-active-server model where users explicitly choose which tmux server to view and manage. Backend is stateless — frontend sends `?server=` on every request.

## Changes

- Sidebar server selector at bottom (pinned footer with dropdown)
- Command palette: "Create tmux server" (name dialog), "Kill tmux server" (confirmation), "Switch tmux server" per-server actions
- Backend: unified `tmuxExecServer`, all functions accept `server` param, `serverFromRequest` with validation, per-server SSE polling
- New API endpoints: `GET/POST /api/servers`, `POST /api/servers/kill`
- Server discovery via socket directory scan (`/tmp/tmux-{uid}/`)
- Removed `ProjectSession.Server` field, `↗` marker, `tmuxExecDefault`, dual-query merge

## Change

| ID | Name | Issue |
|----|------|-------|
| 1335 | 260320-1335-tmux-server-switcher | — |

## Stats

| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| refactor | 3.8 / 5.0 | — | 28/28 | Pass (1 iteration) |

[intake](https://github.com/wvrdz/run-kit/blob/ljhu/fab/changes/260320-1335-tmux-server-switcher/intake.md) → [spec](https://github.com/wvrdz/run-kit/blob/ljhu/fab/changes/260320-1335-tmux-server-switcher/spec.md) → tasks → apply → review → hydrate → ship