### PR TITLE
INFRA-345 fix: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,17 +12,17 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: app/backend/go.mod
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 9
 
@@ -87,7 +87,7 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           files: dist/*.tar.gz
           generate_release_notes: true

--- a/fab/changes/260321-73w3-supply-chain-sha-pin/.history.jsonl
+++ b/fab/changes/260321-73w3-supply-chain-sha-pin/.history.jsonl
@@ -1,0 +1,11 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-03-21T08:03:44Z"}
+{"args":"INFRA-345: Supply Chain Hardening — SHA-pin all external GitHub Actions in release.yml","cmd":"fab-new","event":"command","ts":"2026-03-21T08:03:44Z"}
+{"delta":"+5.0","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-03-21T08:04:32Z"}
+{"cmd":"fab-fff","event":"command","ts":"2026-03-21T08:04:47Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"spec","ts":"2026-03-21T08:05:13Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"tasks","ts":"2026-03-21T08:05:51Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-03-21T08:05:51Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-03-21T08:05:55Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-03-21T08:07:13Z"}
+{"event":"review","result":"passed","ts":"2026-03-21T08:07:13Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-03-21T08:07:18Z"}

--- a/fab/changes/260321-73w3-supply-chain-sha-pin/.status.yaml
+++ b/fab/changes/260321-73w3-supply-chain-sha-pin/.status.yaml
@@ -1,0 +1,44 @@
+id: 73w3
+name: 260321-73w3-supply-chain-sha-pin
+created: 2026-03-21T08:03:44Z
+created_by: pulkit-weaver
+change_type: fix
+issues:
+    - INFRA-345
+progress:
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+checklist:
+    generated: true
+    path: checklist.md
+    completed: 9
+    total: 9
+confidence:
+    certain: 5
+    confident: 0
+    tentative: 0
+    unresolved: 0
+    score: 5.0
+    indicative: true
+    fuzzy: true
+    dimensions:
+        signal: 93.0
+        reversibility: 93.0
+        competence: 93.0
+        disambiguation: 94.0
+stage_metrics:
+    intake: {started_at: "2026-03-21T08:03:44Z", driver: fab-new, iterations: 1, completed_at: "2026-03-21T08:05:13Z"}
+    spec: {started_at: "2026-03-21T08:05:13Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-21T08:05:51Z"}
+    tasks: {started_at: "2026-03-21T08:05:51Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-21T08:05:51Z"}
+    apply: {started_at: "2026-03-21T08:05:51Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-21T08:05:55Z"}
+    review: {started_at: "2026-03-21T08:05:55Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-21T08:07:13Z"}
+    hydrate: {started_at: "2026-03-21T08:07:13Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-21T08:07:18Z"}
+    ship: {started_at: "2026-03-21T08:07:18Z", driver: fab-fff, iterations: 1}
+prs: []
+last_updated: 2026-03-21T08:07:18Z

--- a/fab/changes/260321-73w3-supply-chain-sha-pin/checklist.md
+++ b/fab/changes/260321-73w3-supply-chain-sha-pin/checklist.md
@@ -1,0 +1,30 @@
+# Quality Checklist: Supply Chain Hardening — SHA-Pin GitHub Actions
+
+**Change**: 260321-73w3-supply-chain-sha-pin
+**Generated**: 2026-03-21
+**Spec**: `spec.md`
+
+## Functional Completeness
+- [x] CHK-001 Immutable Action References: All 5 external actions use 40-char commit SHAs, not mutable tags
+- [x] CHK-002 Tag Comment Preservation: Each SHA-pinned line ends with `# vN` comment
+
+## Behavioral Correctness
+- [x] CHK-003 Functional Equivalence: SHAs resolve to same code as original tags (verified by matching tag to SHA)
+
+## Scenario Coverage
+- [x] CHK-004 All external actions pinned: Exactly 5 external `uses:` directives are SHA-pinned
+- [x] CHK-005 No unpinned external refs: No external action uses a mutable tag
+
+## Code Quality
+- [x] CHK-006 Pattern consistency: SHA + comment format is consistent across all 5 references
+- [x] CHK-007 YAML validity: `release.yml` is valid YAML after changes
+
+## Security
+- [x] CHK-008 Supply chain immutability: Action references cannot be altered by upstream force-push
+- [x] CHK-009 Internal actions unchanged: `wvrdz/` org actions are not pinned (intentional)
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] CHK-008 **N/A**: {reason}`

--- a/fab/changes/260321-73w3-supply-chain-sha-pin/intake.md
+++ b/fab/changes/260321-73w3-supply-chain-sha-pin/intake.md
@@ -53,7 +53,7 @@ None — no memory files affected. This is a CI-only change with no impact on ap
 
 ## Impact
 
-- **File**: `.github/workflows/release.yml` (only file changed)
+- **File**: `.github/workflows/release.yml` (only source/workflow file changed; fab tracking artifacts are also added)
 - **CI/CD**: Release workflow. No functional change — same action code executes, now referenced immutably.
 - **Risk**: Minimal. SHA-pinning is safe and non-functional. The workflow already has top-level `permissions: contents: write`.
 

--- a/fab/changes/260321-73w3-supply-chain-sha-pin/intake.md
+++ b/fab/changes/260321-73w3-supply-chain-sha-pin/intake.md
@@ -1,0 +1,74 @@
+# Intake: Supply Chain Hardening — SHA-Pin GitHub Actions
+
+**Change**: 260321-73w3-supply-chain-sha-pin
+**Created**: 2026-03-21
+**Status**: Draft
+
+## Origin
+
+> INFRA-345: Supply Chain Hardening — SHA-pin all external GitHub Actions in release.yml to commit SHAs for immutable references.
+
+Linear: INFRA-345 — "Supply chain hardening: SHA-pin GitHub Actions, scope secrets, harden permissions"
+One-shot description. Code changes already committed on branch `fix/supply-chain-hardening`.
+
+## Why
+
+Two major supply chain attacks in early 2026 prompted an org-wide posture assessment:
+
+1. **Shai-Hulud 2.0** (Nov 2025) — npm worm compromised PostHog + 754 packages via `preinstall` hooks. Exfiltrated AWS/GCP/Azure creds, npm tokens, GitHub PATs.
+2. **Trivy Tag Poisoning** (Mar 2026) — TeamPCP force-pushed 75/76 version tags in `aquasecurity/trivy-action`. Payload dumped runner process memory and exfiltrated CI secrets.
+
+Assessment found **0/358 GitHub Action references were SHA-pinned** across the org (all used mutable tags). Mutable version tags (e.g., `@v4`) can be force-pushed by compromised maintainers, replacing trusted code with malicious payloads. SHA-pinning makes action references immutable — a force-pushed tag no longer affects us.
+
+## What Changes
+
+### SHA-Pin All External GitHub Actions in `release.yml`
+
+Every `uses:` line referencing an external action by version tag has been replaced with the full 40-character commit SHA. The original tag is preserved as a trailing comment for readability and upgrade tracking:
+
+```yaml
+# Before
+uses: actions/checkout@v4
+# After
+uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+```
+
+**5 actions pinned** in `.github/workflows/release.yml`:
+
+| Action | Original Tag | SHA |
+|--------|-------------|-----|
+| `actions/checkout` | `v4` | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
+| `actions/setup-go` | `v5` | `40f1582b2485089dde7abd97c1529aa768e1baff` |
+| `actions/setup-node` | `v4` | `49933ea5288caeca8642d1e84afbd3f7d6820020` |
+| `pnpm/action-setup` | `v4` | `fc06bc1257f339d1d5d8b3a19a8cae5388b55320` |
+| `softprops/action-gh-release` | `v2` | `153bb8e04406b158c6c84fc1615b65b24149a1fe` |
+
+Internal actions (`wvrdz/github-actions@stable`) are left unchanged — they are org-controlled and not a supply chain risk.
+
+This is a non-functional change — the pinned SHAs resolve to the exact same code the tags pointed to at time of pinning.
+
+## Affected Memory
+
+None — no memory files affected. This is a CI-only change with no impact on application behavior or architecture.
+
+## Impact
+
+- **File**: `.github/workflows/release.yml` (only file changed)
+- **CI/CD**: Release workflow. No functional change — same action code executes, now referenced immutably.
+- **Risk**: Minimal. SHA-pinning is safe and non-functional. The workflow already has top-level `permissions: contents: write`.
+
+## Open Questions
+
+None — all decisions are deterministic.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Pin only external actions | Internal `wvrdz/` actions are org-controlled, per INFRA-345 scope | S:95 R:90 A:95 D:95 |
+| 2 | Certain | Preserve original tags as comments | Standard practice for readability and upgrade tracking | S:95 R:95 A:90 D:95 |
+| 3 | Certain | No permissions changes needed | `release.yml` already has explicit `permissions: contents: write` at top level | S:90 R:90 A:95 D:95 |
+| 4 | Certain | Only `release.yml` in scope | run-kit has only one workflow file | S:95 R:95 A:95 D:95 |
+| 5 | Certain | Change type is `fix` (security hardening) | Linear title and context indicate security fix | S:90 R:95 A:90 D:90 |
+
+5 assumptions (5 certain, 0 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260321-73w3-supply-chain-sha-pin/spec.md
+++ b/fab/changes/260321-73w3-supply-chain-sha-pin/spec.md
@@ -1,0 +1,63 @@
+# Spec: Supply Chain Hardening — SHA-Pin GitHub Actions
+
+**Change**: 260321-73w3-supply-chain-sha-pin
+**Created**: 2026-03-21
+**Affected memory**: None
+
+## Non-Goals
+
+- Pinning internal org actions (`wvrdz/github-actions@stable`) — org-controlled, not a supply chain vector
+- Adding or modifying `permissions:` blocks — `release.yml` already has explicit top-level permissions
+- Scoping secrets to step-level — not applicable to this repo's workflow
+
+## CI: SHA-Pinning External GitHub Actions
+
+### Requirement: Immutable Action References
+
+All `uses:` directives referencing external (non-org) GitHub Actions in `.github/workflows/release.yml` SHALL use the full 40-character commit SHA instead of a mutable version tag.
+
+#### Scenario: External action is SHA-pinned
+
+- **GIVEN** an external action reference in `release.yml`
+- **WHEN** the workflow file is inspected
+- **THEN** the `uses:` value SHALL contain a 40-character hexadecimal commit SHA after the `@` symbol
+- **AND** the reference SHALL NOT use a mutable tag (e.g., `v4`, `v5`, `v2`)
+
+#### Scenario: All 5 external actions are pinned
+
+- **GIVEN** the `release.yml` workflow
+- **WHEN** all `uses:` directives are enumerated
+- **THEN** exactly 5 external action references SHALL be SHA-pinned: `actions/checkout`, `actions/setup-go`, `actions/setup-node`, `pnpm/action-setup`, `softprops/action-gh-release`
+
+### Requirement: Tag Comment Preservation
+
+Each SHA-pinned action reference SHALL include the original version tag as a trailing `# vX` comment on the same line.
+
+#### Scenario: Tag comment is present
+
+- **GIVEN** an SHA-pinned action reference
+- **WHEN** the line is inspected
+- **THEN** it SHALL end with a comment in the format `# v{N}` where `{N}` is the original major version tag
+- **AND** the comment SHALL be separated from the SHA by a single space
+
+### Requirement: Functional Equivalence
+
+The pinned commit SHAs SHALL resolve to the exact same code as the original version tags at the time of pinning. This change SHALL NOT alter any workflow behavior.
+
+#### Scenario: Workflow behavior unchanged
+
+- **GIVEN** the `release.yml` workflow with SHA-pinned actions
+- **WHEN** a release tag is pushed
+- **THEN** the workflow SHALL execute identically to before the change (same build, same artifacts, same release)
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Pin only external actions | Confirmed from intake #1 — internal `wvrdz/` actions are org-controlled per INFRA-345 scope | S:95 R:90 A:95 D:95 |
+| 2 | Certain | Preserve original tags as comments | Confirmed from intake #2 — standard practice for readability | S:95 R:95 A:90 D:95 |
+| 3 | Certain | No permissions changes needed | Confirmed from intake #3 — already has explicit `permissions: contents: write` | S:90 R:90 A:95 D:95 |
+| 4 | Certain | Only `release.yml` in scope | Confirmed from intake #4 — only workflow file in repo | S:95 R:95 A:95 D:95 |
+| 5 | Certain | Non-functional change | SHAs resolve to same code as tags at pinning time | S:95 R:95 A:95 D:95 |
+
+5 assumptions (5 certain, 0 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260321-73w3-supply-chain-sha-pin/tasks.md
+++ b/fab/changes/260321-73w3-supply-chain-sha-pin/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: Supply Chain Hardening — SHA-Pin GitHub Actions
+
+**Change**: 260321-73w3-supply-chain-sha-pin
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+## Phase 1: Core Implementation
+
+- [x] T001 [P] Pin `actions/checkout@v4` to SHA `34e114876b0b11c390a56381ad16ebd13914f8d5` in `.github/workflows/release.yml`
+- [x] T002 [P] Pin `actions/setup-go@v5` to SHA `40f1582b2485089dde7abd97c1529aa768e1baff` in `.github/workflows/release.yml`
+- [x] T003 [P] Pin `actions/setup-node@v4` to SHA `49933ea5288caeca8642d1e84afbd3f7d6820020` in `.github/workflows/release.yml`
+- [x] T004 [P] Pin `pnpm/action-setup@v4` to SHA `fc06bc1257f339d1d5d8b3a19a8cae5388b55320` in `.github/workflows/release.yml`
+- [x] T005 [P] Pin `softprops/action-gh-release@v2` to SHA `153bb8e04406b158c6c84fc1615b65b24149a1fe` in `.github/workflows/release.yml`
+
+All tasks completed in commit `1e11d57`.
+
+---
+
+## Execution Order
+
+All tasks are independent ([P]) — no ordering dependencies.


### PR DESCRIPTION
## Summary

- SHA-pin all 5 external GitHub Actions in `release.yml` to immutable commit SHAs
- Prompted by Shai-Hulud 2.0 (npm worm) and Trivy tag poisoning (GitHub Actions) supply chain attacks
- Non-functional change — pinned SHAs resolve to same code as original tags

## Actions Pinned

| Action | Tag | SHA |
|--------|-----|-----|
| `actions/checkout` | v4 | `34e1148` |
| `actions/setup-go` | v5 | `40f1582` |
| `actions/setup-node` | v4 | `49933ea` |
| `pnpm/action-setup` | v4 | `fc06bc1` |
| `softprops/action-gh-release` | v2 | `153bb8e` |

## Test plan

- [x] YAML syntax validated
- [x] All 5 external actions use 40-char commit SHAs
- [x] Original version tags preserved as trailing comments
- [x] No internal (`wvrdz/`) actions modified
- [x] Fab review checklist: 9/9 items passed