### PR TITLE
feat: split pane buttons and normalize toolbar icon colors

### DIFF
--- a/app/backend/api/router.go
+++ b/app/backend/api/router.go
@@ -32,7 +32,7 @@ type TmuxOps interface {
 	SendKeys(session string, window int, keys, server string) error
 	SelectWindow(session string, index int, server string) error
 	ListWindows(session, server string) ([]tmux.WindowInfo, error)
-	SplitWindow(session string, window int, server string) (string, error)
+	SplitWindow(session string, window int, horizontal bool, server string) (string, error)
 	KillPane(paneID, server string) error
 	ListServers() ([]string, error)
 	KillServer(server string) error
@@ -106,8 +106,8 @@ func (p *prodTmuxOps) SelectWindow(session string, index int, server string) err
 func (p *prodTmuxOps) ListWindows(session, server string) ([]tmux.WindowInfo, error) {
 	return tmux.ListWindows(session, server)
 }
-func (p *prodTmuxOps) SplitWindow(session string, window int, server string) (string, error) {
-	return tmux.SplitWindow(session, window, server)
+func (p *prodTmuxOps) SplitWindow(session string, window int, horizontal bool, server string) (string, error) {
+	return tmux.SplitWindow(session, window, horizontal, server)
 }
 func (p *prodTmuxOps) KillPane(paneID, server string) error {
 	return tmux.KillPane(paneID, server)
@@ -171,6 +171,7 @@ func (s *Server) buildRouter() chi.Router {
 	r.Post("/api/sessions/{session}/windows/{index}/rename", s.handleWindowRename)
 	r.Post("/api/sessions/{session}/windows/{index}/keys", s.handleWindowKeys)
 	r.Post("/api/sessions/{session}/windows/{index}/select", s.handleWindowSelect)
+	r.Post("/api/sessions/{session}/windows/{index}/split", s.handleWindowSplit)
 	r.Get("/api/directories", s.handleDirectories)
 	r.Post("/api/sessions/{session}/upload", s.handleUpload)
 	r.Get("/api/sessions/stream", s.handleSSE)

--- a/app/backend/api/sessions_test.go
+++ b/app/backend/api/sessions_test.go
@@ -106,7 +106,7 @@ func (m *mockTmuxOps) SendKeys(session string, window int, keys, server string) 
 func (m *mockTmuxOps) ListWindows(session, server string) ([]tmux.WindowInfo, error) {
 	return m.listWindowsResult, m.listWindowsErr
 }
-func (m *mockTmuxOps) SplitWindow(session string, window int, server string) (string, error) {
+func (m *mockTmuxOps) SplitWindow(session string, window int, horizontal bool, server string) (string, error) {
 	return m.splitWindowResult, m.splitWindowErr
 }
 func (m *mockTmuxOps) SelectWindow(session string, index int, server string) error {

--- a/app/backend/api/sessions_test.go
+++ b/app/backend/api/sessions_test.go
@@ -53,8 +53,12 @@ type mockTmuxOps struct {
 	listWindowsResult []tmux.WindowInfo
 	listWindowsErr    error
 
-	splitWindowResult string
-	splitWindowErr    error
+	splitWindowCalled     bool
+	splitWindowSession    string
+	splitWindowIndex      int
+	splitWindowHorizontal bool
+	splitWindowResult     string
+	splitWindowErr        error
 
 	err error
 }
@@ -107,6 +111,10 @@ func (m *mockTmuxOps) ListWindows(session, server string) ([]tmux.WindowInfo, er
 	return m.listWindowsResult, m.listWindowsErr
 }
 func (m *mockTmuxOps) SplitWindow(session string, window int, horizontal bool, server string) (string, error) {
+	m.splitWindowCalled = true
+	m.splitWindowSession = session
+	m.splitWindowIndex = window
+	m.splitWindowHorizontal = horizontal
 	return m.splitWindowResult, m.splitWindowErr
 }
 func (m *mockTmuxOps) SelectWindow(session string, index int, server string) error {

--- a/app/backend/api/windows.go
+++ b/app/backend/api/windows.go
@@ -147,6 +147,36 @@ func (s *Server) handleWindowSelect(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
 }
 
+func (s *Server) handleWindowSplit(w http.ResponseWriter, r *http.Request) {
+	session := chi.URLParam(r, "session")
+	if errMsg := validate.ValidateName(session, "Session name"); errMsg != "" {
+		writeError(w, http.StatusBadRequest, errMsg)
+		return
+	}
+
+	index, ok := parseWindowIndex(r)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "Invalid window index")
+		return
+	}
+
+	var body struct {
+		Horizontal bool `json:"horizontal"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid JSON body")
+		return
+	}
+
+	paneID, err := s.tmux.SplitWindow(session, index, body.Horizontal, serverFromRequest(r))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"ok": "true", "pane_id": paneID})
+}
+
 func (s *Server) handleWindowKeys(w http.ResponseWriter, r *http.Request) {
 	session := chi.URLParam(r, "session")
 	if errMsg := validate.ValidateName(session, "Session name"); errMsg != "" {

--- a/app/backend/api/windows.go
+++ b/app/backend/api/windows.go
@@ -174,7 +174,7 @@ func (s *Server) handleWindowSplit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]string{"ok": "true", "pane_id": paneID})
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "pane_id": paneID})
 }
 
 func (s *Server) handleWindowKeys(w http.ResponseWriter, r *http.Request) {

--- a/app/backend/api/windows_test.go
+++ b/app/backend/api/windows_test.go
@@ -232,3 +232,66 @@ func TestWindowKeysEmpty(t *testing.T) {
 		t.Errorf("error = %q, want %q", result["error"], "Keys cannot be empty")
 	}
 }
+
+func TestWindowSplit(t *testing.T) {
+	ops := &mockTmuxOps{splitWindowResult: "%5"}
+	router := newTestRouter(&mockSessionFetcher{}, ops)
+
+	body := `{"horizontal":true}`
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/run-kit/windows/0/split", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	if !ops.splitWindowCalled {
+		t.Error("SplitWindow was not called")
+	}
+	if ops.splitWindowSession != "run-kit" {
+		t.Errorf("session = %q, want %q", ops.splitWindowSession, "run-kit")
+	}
+	if ops.splitWindowIndex != 0 {
+		t.Errorf("window = %d, want %d", ops.splitWindowIndex, 0)
+	}
+	if !ops.splitWindowHorizontal {
+		t.Error("horizontal = false, want true")
+	}
+
+	var result map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if result["pane_id"] != "%5" {
+		t.Errorf("pane_id = %q, want %%5", result["pane_id"])
+	}
+}
+
+func TestWindowSplitInvalidSession(t *testing.T) {
+	router := newTestRouter(&mockSessionFetcher{}, &mockTmuxOps{})
+
+	body := `{"horizontal":false}`
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/bad;name/windows/0/split", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestWindowSplitInvalidJSON(t *testing.T) {
+	router := newTestRouter(&mockSessionFetcher{}, &mockTmuxOps{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/run-kit/windows/0/split", strings.NewReader("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}

--- a/app/backend/internal/tmux/tmux.go
+++ b/app/backend/internal/tmux/tmux.go
@@ -369,12 +369,18 @@ func SelectWindow(session string, index int, server string) error {
 }
 
 // SplitWindow splits a window to create an independent pane on the specified server. Returns the new pane ID.
-func SplitWindow(session string, window int, server string) (string, error) {
+// If horizontal is true, the pane is split left/right (-h flag); otherwise top/bottom.
+func SplitWindow(session string, window int, horizontal bool, server string) (string, error) {
 	ctx, cancel := withTimeout()
 	defer cancel()
 
 	target := fmt.Sprintf("%s:%d", session, window)
-	lines, err := tmuxExecServer(ctx, server, "split-window", "-t", target, "-d", "-P", "-F", "#{pane_id}")
+	args := []string{"split-window"}
+	if horizontal {
+		args = append(args, "-h")
+	}
+	args = append(args, "-t", target, "-d", "-P", "-F", "#{pane_id}")
+	lines, err := tmuxExecServer(ctx, server, args...)
 	if err != nil {
 		return "", err
 	}

--- a/app/frontend/src/api/client.ts
+++ b/app/frontend/src/api/client.ts
@@ -143,7 +143,7 @@ export async function splitWindow(
   session: string,
   index: number,
   horizontal: boolean,
-): Promise<{ ok: string; pane_id: string }> {
+): Promise<{ ok: boolean; pane_id: string }> {
   const res = await fetch(
     withServer(`/api/sessions/${encodeURIComponent(session)}/windows/${index}/split`),
     {

--- a/app/frontend/src/api/client.ts
+++ b/app/frontend/src/api/client.ts
@@ -139,6 +139,23 @@ export async function sendKeys(
   return res.json();
 }
 
+export async function splitWindow(
+  session: string,
+  index: number,
+  horizontal: boolean,
+): Promise<{ ok: string; pane_id: string }> {
+  const res = await fetch(
+    withServer(`/api/sessions/${encodeURIComponent(session)}/windows/${index}/split`),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ horizontal }),
+    },
+  );
+  if (!res.ok) await throwOnError(res);
+  return res.json();
+}
+
 export async function selectWindow(
   session: string,
   index: number,

--- a/app/frontend/src/app.tsx
+++ b/app/frontend/src/app.tsx
@@ -16,7 +16,7 @@ import { Dialog } from "@/components/dialog";
 import { CreateSessionDialog } from "@/components/create-session-dialog";
 import { Dashboard } from "@/components/dashboard";
 import { KeyboardShortcuts } from "@/components/keyboard-shortcuts";
-import { selectWindow, createWindow, reloadTmuxConfig, initTmuxConf, getHealth, createServer, killServer as killServerApi } from "@/api/client";
+import { selectWindow, createWindow, splitWindow, reloadTmuxConfig, initTmuxConf, getHealth, createServer, killServer as killServerApi } from "@/api/client";
 import { useSessionContext } from "@/contexts/session-context";
 import { useBrowserTitle } from "@/hooks/use-browser-title";
 
@@ -60,7 +60,7 @@ function AppShell() {
   const { sessions, isConnected } = useSessions();
   const { server, setServer, servers, refreshServers } = useSessionContext();
   const { sidebarOpen, drawerOpen, fixedWidth } = useChrome();
-  const { setCurrentSession, setCurrentWindow, setDrawerOpen, setSidebarOpen } = useChromeDispatch();
+  const { setCurrentSession, setCurrentWindow, setDrawerOpen, setSidebarOpen, toggleFixedWidth } = useChromeDispatch();
   const navigate = useNavigate();
   const matches = useMatches();
   const wsRef = useRef<WebSocket | null>(null);
@@ -359,8 +359,36 @@ function AppShell() {
               label: "Kill current window",
               onSelect: dialogs.openKillConfirm,
             },
+            {
+              id: "split-vertical",
+              label: "Split vertically",
+              onSelect: () => {
+                if (sessionName) splitWindow(sessionName, currentWindow.index, true).catch(() => {});
+              },
+            },
+            {
+              id: "split-horizontal",
+              label: "Split horizontally",
+              onSelect: () => {
+                if (sessionName) splitWindow(sessionName, currentWindow.index, false).catch(() => {});
+              },
+            },
           ]
         : []),
+      ...(sessionName
+        ? [
+            {
+              id: "text-input",
+              label: "Text input",
+              onSelect: () => setComposeOpen(true),
+            },
+          ]
+        : []),
+      {
+        id: "toggle-fixed-width",
+        label: fixedWidth ? "Full width" : "Fixed width (900px)",
+        onSelect: toggleFixedWidth,
+      },
       ...themeActions,
       {
         id: "reload-tmux-config",
@@ -398,7 +426,7 @@ function AppShell() {
         onSelect: () => navigateToWindow(fw.session, fw.window.index),
       })),
     ],
-    [sessionName, currentWindow, flatWindows, navigateToWindow, handleCreateWindow, dialogs, themeActions, servers, server, handleSwitchServer],
+    [sessionName, currentWindow, flatWindows, navigateToWindow, handleCreateWindow, dialogs, fixedWidth, toggleFixedWidth, themeActions, servers, server, handleSwitchServer],
   );
 
   const displayName = currentWindow?.name ?? windowIndex ?? "";

--- a/app/frontend/src/components/arrow-pad.tsx
+++ b/app/frontend/src/components/arrow-pad.tsx
@@ -96,7 +96,7 @@ export function ArrowPad({ onArrow, className }: ArrowPadProps) {
         aria-label="Arrow keys"
         aria-haspopup="true"
         aria-expanded={open}
-        className="min-h-[36px] min-w-[36px] coarse:min-h-[36px] coarse:min-w-[36px] flex items-center justify-center px-1 py-0 text-xs border border-border rounded select-none transition-colors hover:border-text-secondary active:bg-bg-card focus-visible:outline-2 focus-visible:outline-accent text-text-primary touch-none"
+        className="min-h-[36px] min-w-[36px] coarse:min-h-[36px] coarse:min-w-[36px] flex items-center justify-center px-1 py-0 text-xs border border-border rounded select-none transition-colors hover:border-text-secondary active:bg-bg-card focus-visible:outline-2 focus-visible:outline-accent text-text-secondary touch-none"
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
         onMouseDown={handleMouseDown}

--- a/app/frontend/src/components/bottom-bar.tsx
+++ b/app/frontend/src/components/bottom-bar.tsx
@@ -149,10 +149,10 @@ export function BottomBar({ wsRef, hostname }: BottomBarProps) {
 
   return (
     <div className="flex items-center gap-1 py-1.5 flex-wrap" role="toolbar" aria-label="Terminal keys">
-      <button aria-label="Escape" className={`${KBD_CLASS} text-text-primary`} onClick={() => sendSpecial("\x1b")}>
+      <button aria-label="Escape" className={`${KBD_CLASS} text-text-secondary`} onClick={() => sendSpecial("\x1b")}>
         <kbd aria-hidden="true">{"\u238B"}</kbd>
       </button>
-      <button aria-label="Tab" className={`${KBD_CLASS} text-text-primary`} onClick={() => sendSpecial("\t")}>
+      <button aria-label="Tab" className={`${KBD_CLASS} text-text-secondary`} onClick={() => sendSpecial("\t")}>
         <kbd aria-hidden="true">{"\u21E5"}</kbd>
       </button>
 
@@ -163,7 +163,7 @@ export function BottomBar({ wsRef, hostname }: BottomBarProps) {
           key={key}
           aria-label={MODIFIER_LABELS[key]}
           aria-pressed={mods[key]}
-          className={`${KBD_CLASS} ${mods[key] ? "bg-accent/20 border-accent text-accent" : "text-text-primary"}`}
+          className={`${KBD_CLASS} ${mods[key] ? "bg-accent/20 border-accent text-accent" : "text-text-secondary"}`}
           onClick={() => mods.toggle(key)}
         >
           <kbd aria-hidden="true">{symbol}</kbd>
@@ -177,7 +177,7 @@ export function BottomBar({ wsRef, hostname }: BottomBarProps) {
           aria-label="Function keys"
           aria-haspopup="true"
           aria-expanded={fnOpen}
-          className={`${KBD_CLASS} text-text-primary`}
+          className={`${KBD_CLASS} text-text-secondary`}
           onClick={() => setFnOpen((v) => !v)}
         >
           <kbd aria-hidden="true">F&#x25B4;</kbd>

--- a/app/frontend/src/components/compose-buffer.tsx
+++ b/app/frontend/src/components/compose-buffer.tsx
@@ -51,6 +51,7 @@ export function ComposeBuffer({ wsRef, onClose, initialText, onUploadFiles }: Co
       }}
     >
       <div className="w-full max-w-[500px] mx-4 bg-bg-primary border border-border rounded-lg p-2 shadow-2xl">
+        <h2 className="text-xs font-medium mb-2.5">Text Input</h2>
         <textarea
           ref={textareaRef}
           autoFocus

--- a/app/frontend/src/components/top-bar.tsx
+++ b/app/frontend/src/components/top-bar.tsx
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { BreadcrumbDropdown } from "@/components/breadcrumb-dropdown";
 import { useChrome, useChromeDispatch } from "@/contexts/chrome-context";
 import { useTheme, useThemeActions } from "@/contexts/theme-context";
+import { splitWindow } from "@/api/client";
 import type { ThemePreference } from "@/contexts/theme-context";
 import type { ProjectSession, WindowInfo } from "@/types";
 import type { BreadcrumbDropdownItem } from "@/contexts/chrome-context";
@@ -210,6 +211,24 @@ export function TopBar({
             <FixedWidthToggle />
           </span>
 
+          {currentWindow && (
+            <>
+              <span className="hidden sm:flex">
+                <SplitButton
+                  horizontal
+                  session={sessionName}
+                  windowIndex={currentWindow.index}
+                />
+              </span>
+              <span className="hidden sm:flex">
+                <SplitButton
+                  session={sessionName}
+                  windowIndex={currentWindow.index}
+                />
+              </span>
+            </>
+          )}
+
           <span className="hidden sm:flex">
             <ThemeToggle />
           </span>
@@ -219,7 +238,7 @@ export function TopBar({
             type="button"
             onClick={onOpenCompose}
             aria-label="Compose text"
-            className="text-text-primary hover:text-text-primary transition-colors min-w-[24px] min-h-[24px] sm:min-w-[24px] sm:min-h-[24px] coarse:min-w-[36px] coarse:min-h-[36px] flex items-center justify-center border border-border rounded text-xs"
+            className="text-text-secondary hover:border-text-secondary transition-colors min-w-[24px] min-h-[24px] sm:min-w-[24px] sm:min-h-[24px] coarse:min-w-[36px] coarse:min-h-[36px] flex items-center justify-center border border-border rounded text-xs"
           >
             &gt;_
           </button>
@@ -279,6 +298,62 @@ function ThemeToggle() {
           <path d="M8 3a5 5 0 0 1 0 10" fill="currentColor" />
         </svg>
       )}
+    </button>
+  );
+}
+
+function SplitButton({
+  horizontal,
+  session,
+  windowIndex,
+}: {
+  horizontal?: boolean;
+  session: string;
+  windowIndex: number;
+}) {
+  const label = horizontal ? "Split vertically" : "Split horizontally";
+
+  const handleClick = () => {
+    splitWindow(session, windowIndex, !!horizontal).catch(() => {
+      // best-effort — tmux may reject if pane is too small
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label={label}
+      className="min-w-[24px] min-h-[24px] rounded border border-border text-text-secondary hover:border-text-secondary transition-colors coarse:min-h-[36px] coarse:min-w-[28px] flex items-center justify-center"
+      title={label}
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        {horizontal ? (
+          <>
+            {/* square-split-horizontal: vertical divider */}
+            <path d="M8 19H5c-1 0-2-1-2-2V7c0-1 1-2 2-2h3" />
+            <path d="M16 5h3c1 0 2 1 2 2v10c0 1-1 2-2 2h-3" />
+            <line x1="12" x2="12" y1="4" y2="20" />
+          </>
+        ) : (
+          <>
+            {/* square-split-vertical: horizontal divider */}
+            <path d="M5 8V5c0-1 1-2 2-2h10c1 0 2 1 2 2v3" />
+            <path d="M19 16v3c0 1-1 2-2 2H7c-1 0-2-1-2-2v-3" />
+            <line x1="4" x2="20" y1="12" y2="12" />
+          </>
+        )}
+      </svg>
     </button>
   );
 }

--- a/app/frontend/src/components/top-bar.tsx
+++ b/app/frontend/src/components/top-bar.tsx
@@ -311,7 +311,7 @@ function SplitButton({
   session: string;
   windowIndex: number;
 }) {
-  const label = horizontal ? "Split vertically" : "Split horizontally";
+  const label = horizontal ? "Split horizontally" : "Split vertically";
 
   const handleClick = () => {
     splitWindow(session, windowIndex, !!horizontal).catch(() => {

--- a/app/frontend/src/contexts/session-context.tsx
+++ b/app/frontend/src/contexts/session-context.tsx
@@ -82,28 +82,47 @@ export function SessionProvider({ children }: SessionProviderProps) {
   useEffect(() => {
     const es = new EventSource(`/api/sessions/stream?server=${encodeURIComponent(server)}`);
 
+    let disconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const markConnected = () => {
+      if (disconnectTimer) {
+        clearTimeout(disconnectTimer);
+        disconnectTimer = null;
+      }
+      setIsConnected(true);
+      setChromeConnected(true);
+    };
+
+    const markDisconnected = () => {
+      setIsConnected(false);
+      setChromeConnected(false);
+    };
+
     es.addEventListener("sessions", (e) => {
       try {
         const data = JSON.parse(e.data) as ProjectSession[];
         setSessions(data);
-        setIsConnected(true);
-        setChromeConnected(true);
+        markConnected();
       } catch {
         // Malformed event — skip
       }
     });
 
     es.onerror = () => {
-      setIsConnected(false);
-      setChromeConnected(false);
+      // EventSource auto-reconnects, firing onerror + onopen in quick
+      // succession. Debounce so the dot only turns gray if the SSE
+      // hasn't recovered within 3 seconds.
+      if (!disconnectTimer) {
+        disconnectTimer = setTimeout(markDisconnected, 3000);
+      }
     };
 
     es.onopen = () => {
-      setIsConnected(true);
-      setChromeConnected(true);
+      markConnected();
     };
 
     return () => {
+      if (disconnectTimer) clearTimeout(disconnectTimer);
       es.close();
     };
   }, [setChromeConnected, server]);

--- a/docs/memory/run-kit/architecture.md
+++ b/docs/memory/run-kit/architecture.md
@@ -131,6 +131,7 @@ All endpoints served by the single Go binary on one port. POST-only mutations wi
 | `sendKeys(session, index, keys)` | POST | `/api/sessions/:session/windows/:index/keys` |
 | `getDirectories(prefix)` | GET | `/api/directories?prefix=...` |
 | `selectWindow(session, index)` | POST | `/api/sessions/:session/windows/:index/select?server=...` |
+| `splitWindow(session, index, horizontal)` | POST | `/api/sessions/:session/windows/:index/split` |
 | `reloadTmuxConfig()` | POST | `/api/tmux/reload-config?server=...` |
 | `uploadFile(session, file, window?)` | POST | `/api/sessions/:session/upload?server=...` |
 | `listServers()` | GET | `/api/servers` |

--- a/docs/memory/run-kit/ui-patterns.md
+++ b/docs/memory/run-kit/ui-patterns.md
@@ -48,15 +48,22 @@ The root layout (`app/frontend/src/app.tsx`) renders `TopBarChrome` which derive
 - Session name capped at ~7 characters with ellipsis overflow (`max-w-[7ch] truncate`)
 - No text prefixes like "session:" or "window:"
 
-**Right section (desktop)**: `{logo} Run Kit  ●  ⇔  ⌘K  >_`
+**Right section (desktop)**: `{logo} Run Kit  ●  ⇔  ⫼  ⊟  ◑  ⌘K  >_`
 - Logo SVG (`logo.svg`) — decorative (`aria-hidden="true"`), not a button
 - "Run Kit" text span (`text-xs text-text-secondary`)
 - Green/gray connection dot — no text label ("live"/"disconnected" text removed)
 - `FixedWidthToggle`
+- Split horizontal button (`SplitButton horizontal`) — splits pane left/right. Only rendered when `currentWindow` exists
+- Split vertical button (`SplitButton`) — splits pane top/bottom. Only rendered when `currentWindow` exists
+- `ThemeToggle`
 - `⌘K` kbd hint
 - Compose button (`>_`) — rightmost item, opens compose buffer. `onOpenCompose` callback passed as prop to `TopBar`
 
-**Right section (mobile < 640px)**: `⋯  >_` — only command palette trigger and compose button visible. Logo, "Run Kit" text, dot, toggle, ⌘K hidden via `hidden sm:flex` / `hidden sm:inline-flex`
+**Right section (mobile < 640px)**: `⋯  >_` — only command palette trigger and compose button visible. Logo, "Run Kit" text, dot, toggle, split buttons, ⌘K hidden via `hidden sm:flex` / `hidden sm:inline-flex`
+
+**Split buttons** (`SplitButton` in `top-bar.tsx`): Two inline components calling `splitWindow(session, windowIndex, horizontal)` from `api/client.ts`. Custom SVG icons (square-split pattern). Best-effort error handling — tmux may reject if pane is too small. `POST /api/sessions/{session}/windows/{index}/split` with `{ "horizontal": bool }`.
+
+**Toolbar button color convention**: All toolbar buttons (top bar and bottom bar) use `text-text-secondary` as their default foreground color. Active toggle states (Ctrl/Alt modifiers when armed, FixedWidthToggle when active) use `text-accent` with accent background. Hover state uses `hover:border-text-secondary` (border highlight). This convention applies to: compose button, theme toggle, fixed-width toggle, split buttons, Esc, Tab, Ctrl, Alt, Fn trigger, arrow pad, and ⌘K.
 
 ### Breadcrumb Dropdowns
 

--- a/fab/changes/260321-s5pw-split-pane-buttons/.history.jsonl
+++ b/fab/changes/260321-s5pw-split-pane-buttons/.history.jsonl
@@ -1,0 +1,10 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-03-21T10:09:02Z"}
+{"args":"Add horizontal and vertical split pane buttons to top bar with backend API support","cmd":"fab-new","event":"command","ts":"2026-03-21T10:09:02Z"}
+{"delta":"+3.8","event":"confidence","score":3.8,"trigger":"calc-score","ts":"2026-03-21T10:09:29Z"}
+{"delta":"-0.8","event":"confidence","score":3,"trigger":"calc-score","ts":"2026-03-21T10:09:35Z"}
+{"delta":"-0.9","event":"confidence","score":2.1,"trigger":"calc-score","ts":"2026-03-21T10:10:37Z"}
+{"delta":"+0.0","event":"confidence","score":2.1,"trigger":"calc-score","ts":"2026-03-21T10:10:41Z"}
+{"action":"enter","driver":"fab-continue","event":"stage-transition","stage":"spec","ts":"2026-03-21T10:10:46Z"}
+{"action":"enter","driver":"fab-continue","event":"stage-transition","stage":"tasks","ts":"2026-03-21T10:10:46Z"}
+{"action":"enter","driver":"fab-continue","event":"stage-transition","stage":"hydrate","ts":"2026-03-21T10:10:46Z"}
+{"action":"enter","driver":"fab-continue","event":"stage-transition","stage":"ship","ts":"2026-03-21T10:11:31Z"}

--- a/fab/changes/260321-s5pw-split-pane-buttons/.history.jsonl
+++ b/fab/changes/260321-s5pw-split-pane-buttons/.history.jsonl
@@ -8,3 +8,4 @@
 {"action":"enter","driver":"fab-continue","event":"stage-transition","stage":"tasks","ts":"2026-03-21T10:10:46Z"}
 {"action":"enter","driver":"fab-continue","event":"stage-transition","stage":"hydrate","ts":"2026-03-21T10:10:46Z"}
 {"action":"enter","driver":"fab-continue","event":"stage-transition","stage":"ship","ts":"2026-03-21T10:11:31Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-03-21T10:12:34Z"}

--- a/fab/changes/260321-s5pw-split-pane-buttons/.status.yaml
+++ b/fab/changes/260321-s5pw-split-pane-buttons/.status.yaml
@@ -1,0 +1,39 @@
+id: s5pw
+name: 260321-s5pw-split-pane-buttons
+created: 2026-03-21T10:09:02Z
+created_by: sahil-weaver
+change_type: feat
+issues: []
+progress:
+    intake: done
+    spec: done
+    tasks: skipped
+    apply: skipped
+    review: skipped
+    hydrate: done
+    ship: active
+    review-pr: pending
+checklist:
+    generated: false
+    path: checklist.md
+    completed: 0
+    total: 0
+confidence:
+    certain: 3
+    confident: 0
+    tentative: 0
+    unresolved: 0
+    score: 2.1
+    fuzzy: true
+    dimensions:
+        signal: 88.3
+        reversibility: 88.3
+        competence: 90.0
+        disambiguation: 93.3
+stage_metrics:
+    intake: {started_at: "2026-03-21T10:09:02Z", driver: fab-new, iterations: 1, completed_at: "2026-03-21T10:10:46Z"}
+    spec: {started_at: "2026-03-21T10:10:46Z", driver: fab-continue, iterations: 1, completed_at: "2026-03-21T10:10:46Z"}
+    hydrate: {started_at: "2026-03-21T10:10:46Z", driver: fab-continue, iterations: 1, completed_at: "2026-03-21T10:11:31Z"}
+    ship: {started_at: "2026-03-21T10:11:31Z", driver: fab-continue, iterations: 1}
+prs: []
+last_updated: 2026-03-21T10:11:31Z

--- a/fab/changes/260321-s5pw-split-pane-buttons/.status.yaml
+++ b/fab/changes/260321-s5pw-split-pane-buttons/.status.yaml
@@ -11,8 +11,8 @@ progress:
     apply: skipped
     review: skipped
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 checklist:
     generated: false
     path: checklist.md
@@ -34,6 +34,8 @@ stage_metrics:
     intake: {started_at: "2026-03-21T10:09:02Z", driver: fab-new, iterations: 1, completed_at: "2026-03-21T10:10:46Z"}
     spec: {started_at: "2026-03-21T10:10:46Z", driver: fab-continue, iterations: 1, completed_at: "2026-03-21T10:10:46Z"}
     hydrate: {started_at: "2026-03-21T10:10:46Z", driver: fab-continue, iterations: 1, completed_at: "2026-03-21T10:11:31Z"}
-    ship: {started_at: "2026-03-21T10:11:31Z", driver: fab-continue, iterations: 1}
-prs: []
-last_updated: 2026-03-21T10:11:31Z
+    ship: {started_at: "2026-03-21T10:11:31Z", driver: fab-continue, iterations: 1, completed_at: "2026-03-21T10:12:34Z"}
+    review-pr: {started_at: "2026-03-21T10:12:34Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/wvrdz/run-kit/pull/67
+last_updated: 2026-03-21T10:12:34Z

--- a/fab/changes/260321-s5pw-split-pane-buttons/intake.md
+++ b/fab/changes/260321-s5pw-split-pane-buttons/intake.md
@@ -1,0 +1,92 @@
+# Intake: Split Pane Buttons
+
+**Change**: 260321-s5pw-split-pane-buttons
+**Created**: 2026-03-21
+**Status**: Draft
+
+## Origin
+
+> User added horizontal and vertical split pane buttons to the top bar, with full backend API support. This was implemented independently alongside the icon color normalization work. The change adds the ability to split tmux panes from the web UI.
+
+## Why
+
+The web UI had no way to split tmux panes — users had to use tmux keybindings or commands directly. Adding split buttons to the top bar makes pane management discoverable and accessible, especially on mobile/touch devices where tmux keybindings aren't available. This aligns with the keyboard-first but mouse-supported design philosophy.
+
+## What Changes
+
+### Backend — `app/backend/`
+
+#### New API endpoint: `POST /api/sessions/{session}/windows/{index}/split`
+
+Request body:
+```json
+{ "horizontal": true }
+```
+
+Response:
+```json
+{ "ok": "true", "pane_id": "%5" }
+```
+
+The `horizontal` field controls split direction: `true` = left/right split (`-h` flag), `false` = top/bottom split.
+
+#### Modified: `internal/tmux/tmux.go` — `SplitWindow` function
+
+Added `horizontal bool` parameter. When true, passes `-h` flag to `tmux split-window`. Uses `exec.CommandContext` with timeout per constitution.
+
+#### Modified: `api/router.go` — `TmuxOps` interface
+
+Updated `SplitWindow` signature to include `horizontal bool` parameter. Route registered at `r.Post("/api/sessions/{session}/windows/{index}/split", s.handleWindowSplit)`.
+
+#### Modified: `api/sessions_test.go` — mock implementation
+
+Updated `mockTmuxOps.SplitWindow` signature to match new interface.
+
+### Frontend — `app/frontend/`
+
+#### New: `splitWindow` API client function (`src/api/client.ts`)
+
+```typescript
+export async function splitWindow(
+  session: string,
+  index: number,
+  horizontal: boolean,
+): Promise<{ ok: string; pane_id: string }>
+```
+
+#### New: `SplitButton` component (`src/components/top-bar.tsx`)
+
+Inline component in top-bar.tsx rendering two split buttons:
+- Horizontal split (vertical divider icon) — `<SplitButton horizontal />`
+- Vertical split (horizontal divider icon) — `<SplitButton />`
+
+Both use custom SVG icons (square-split pattern), `text-text-secondary` default color, `hover:border-text-secondary` hover state. Hidden on mobile (`hidden sm:flex`). Only rendered when `currentWindow` exists. Error handling is best-effort (catch and swallow — tmux may reject if pane is too small).
+
+### Top bar layout order
+
+Controls section now: `[●] [⇔] [⫼] [⊟] [◑] [⌘K] [>_]` — connection dot, fixed-width toggle, horizontal split, vertical split, theme toggle, command palette hint, compose button.
+
+## Affected Memory
+
+- `run-kit/ui-patterns`: (modify) Document split pane buttons in Chrome (Top Bar) section
+- `run-kit/architecture`: (modify) Document new split endpoint in API surface
+
+## Impact
+
+- **Backend**: New route + handler in `api/windows.go`, modified `TmuxOps` interface (breaking change for mock), modified `tmux.SplitWindow` signature
+- **Frontend**: New API function, new component in top-bar
+- **Tests**: Mock updated to match new interface signature
+
+## Open Questions
+
+None — fully implemented.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Split buttons hidden on mobile | Discussed — follows existing pattern where FixedWidthToggle and ThemeToggle are `hidden sm:flex` | S:90 R:85 A:90 D:95 |
+| 2 | Certain | Best-effort error handling (catch and swallow) | Implementation choice — tmux may reject splits on small panes, no meaningful recovery action | S:85 R:90 A:85 D:90 |
+| 3 | Certain | Buttons only render when `currentWindow` exists | Implementation choice — can't split a pane without a window context | S:90 R:90 A:95 D:95 |
+
+3 assumptions (3 certain, 0 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260321-s5pw-split-pane-buttons/spec.md
+++ b/fab/changes/260321-s5pw-split-pane-buttons/spec.md
@@ -1,0 +1,95 @@
+# Spec: Split Pane Buttons
+
+**Change**: 260321-s5pw-split-pane-buttons
+**Created**: 2026-03-21
+**Affected memory**: `docs/memory/run-kit/ui-patterns.md`, `docs/memory/run-kit/architecture.md`
+
+## API: Split Window Endpoint
+
+### Requirement: Split Window API
+
+The server MUST expose `POST /api/sessions/{session}/windows/{index}/split` to split a tmux pane.
+
+The request body MUST accept a JSON object with a `horizontal` boolean field. When `horizontal` is `true`, tmux SHALL split left/right (`-h` flag). When `false`, tmux SHALL split top/bottom (default).
+
+The response MUST return `{ "ok": "true", "pane_id": "{id}" }` on success.
+
+#### Scenario: Horizontal Split
+
+- **GIVEN** a terminal session "work" with window index 0
+- **WHEN** `POST /api/sessions/work/windows/0/split` with `{ "horizontal": true }`
+- **THEN** tmux splits the pane left/right
+- **AND** the response contains the new pane ID
+
+#### Scenario: Vertical Split
+
+- **GIVEN** a terminal session "work" with window index 0
+- **WHEN** `POST /api/sessions/work/windows/0/split` with `{ "horizontal": false }`
+- **THEN** tmux splits the pane top/bottom
+- **AND** the response contains the new pane ID
+
+#### Scenario: Invalid Session
+
+- **GIVEN** session name contains invalid characters
+- **WHEN** the split endpoint is called
+- **THEN** the server MUST return 400 with validation error
+
+## UI Chrome: Split Buttons
+
+### Requirement: Split Buttons in Top Bar
+
+The top bar MUST render two split buttons between the FixedWidthToggle and ThemeToggle when a window is selected (`currentWindow` exists).
+
+The first button MUST trigger a horizontal split (vertical divider icon). The second button MUST trigger a vertical split (horizontal divider icon).
+
+Both buttons MUST be hidden on mobile (`hidden sm:flex`), use `text-text-secondary` default color, and follow the standard toolbar button sizing pattern.
+
+#### Scenario: Split Buttons Visible on Desktop
+
+- **GIVEN** a terminal page with an active window
+- **WHEN** the top bar renders on a desktop viewport (>= 640px)
+- **THEN** both split buttons are visible between FixedWidthToggle and ThemeToggle
+
+#### Scenario: Split Buttons Hidden on Mobile
+
+- **GIVEN** a terminal page with an active window
+- **WHEN** the top bar renders on a mobile viewport (< 640px)
+- **THEN** split buttons are not visible
+
+#### Scenario: No Window Selected
+
+- **GIVEN** the Dashboard route (`/`) with no window selected
+- **WHEN** the top bar renders
+- **THEN** split buttons are not rendered
+
+### Requirement: Best-Effort Error Handling
+
+Split button click errors MUST be silently swallowed. Tmux MAY reject a split if the pane is too small — there is no meaningful recovery action for the user.
+
+#### Scenario: Tmux Rejects Split
+
+- **GIVEN** the current pane is too small to split
+- **WHEN** the user clicks a split button
+- **THEN** the error is caught and no error UI is shown
+
+## Backend: SplitWindow Function
+
+### Requirement: Horizontal Flag Support
+
+The `tmux.SplitWindow` function MUST accept a `horizontal bool` parameter. When true, it MUST pass `-h` to `tmux split-window`. The function MUST use `exec.CommandContext` with timeout per constitution.
+
+#### Scenario: Horizontal Flag Passed
+
+- **GIVEN** `SplitWindow` is called with `horizontal=true`
+- **WHEN** the tmux command is constructed
+- **THEN** the args slice includes `-h` before `-t`
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Split buttons hidden on mobile | Confirmed from intake #1 — follows existing `hidden sm:flex` pattern | S:90 R:85 A:90 D:95 |
+| 2 | Certain | Best-effort error handling | Confirmed from intake #2 — no recovery action possible | S:85 R:90 A:85 D:90 |
+| 3 | Certain | Buttons conditional on `currentWindow` | Confirmed from intake #3 — can't split without window context | S:90 R:90 A:95 D:95 |
+
+3 assumptions (3 certain, 0 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260321-y11t-normalize-toolbar-icon-colors/.history.jsonl
+++ b/fab/changes/260321-y11t-normalize-toolbar-icon-colors/.history.jsonl
@@ -9,3 +9,4 @@
 {"action":"enter","driver":"fab-continue","event":"stage-transition","stage":"tasks","ts":"2026-03-21T10:10:02Z"}
 {"action":"enter","driver":"fab-continue","event":"stage-transition","stage":"hydrate","ts":"2026-03-21T10:10:17Z"}
 {"action":"enter","driver":"fab-continue","event":"stage-transition","stage":"ship","ts":"2026-03-21T10:11:31Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-03-21T10:12:34Z"}

--- a/fab/changes/260321-y11t-normalize-toolbar-icon-colors/.history.jsonl
+++ b/fab/changes/260321-y11t-normalize-toolbar-icon-colors/.history.jsonl
@@ -1,0 +1,11 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-03-21T10:05:55Z"}
+{"args":"Normalize toolbar icon foreground colors — all toolbar buttons (top bar and bottom bar) should use text-text-secondary instead of mixed text-text-primary/text-text-secondary, for visual consistency across the UI chrome","cmd":"fab-new","event":"command","ts":"2026-03-21T10:05:55Z"}
+{"delta":"+5.0","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-03-21T10:06:25Z"}
+{"delta":"+0.0","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-03-21T10:06:31Z"}
+{"cmd":"fab-switch","event":"command","ts":"2026-03-21T10:06:48Z"}
+{"action":"enter","driver":"fab-continue","event":"stage-transition","stage":"spec","ts":"2026-03-21T10:07:55Z"}
+{"delta":"-2.0","event":"confidence","score":3,"trigger":"calc-score","ts":"2026-03-21T10:09:57Z"}
+{"delta":"+0.0","event":"confidence","score":3,"trigger":"calc-score","ts":"2026-03-21T10:10:02Z"}
+{"action":"enter","driver":"fab-continue","event":"stage-transition","stage":"tasks","ts":"2026-03-21T10:10:02Z"}
+{"action":"enter","driver":"fab-continue","event":"stage-transition","stage":"hydrate","ts":"2026-03-21T10:10:17Z"}
+{"action":"enter","driver":"fab-continue","event":"stage-transition","stage":"ship","ts":"2026-03-21T10:11:31Z"}

--- a/fab/changes/260321-y11t-normalize-toolbar-icon-colors/.history.jsonl
+++ b/fab/changes/260321-y11t-normalize-toolbar-icon-colors/.history.jsonl
@@ -10,3 +10,4 @@
 {"action":"enter","driver":"fab-continue","event":"stage-transition","stage":"hydrate","ts":"2026-03-21T10:10:17Z"}
 {"action":"enter","driver":"fab-continue","event":"stage-transition","stage":"ship","ts":"2026-03-21T10:11:31Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-03-21T10:12:34Z"}
+{"delta":"+2.0","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-03-21T10:17:01Z"}

--- a/fab/changes/260321-y11t-normalize-toolbar-icon-colors/.status.yaml
+++ b/fab/changes/260321-y11t-normalize-toolbar-icon-colors/.status.yaml
@@ -19,17 +19,18 @@ checklist:
     completed: 0
     total: 0
 confidence:
-    certain: 3
+    certain: 6
     confident: 0
     tentative: 0
     unresolved: 0
-    score: 3.0
+    score: 5.0
+    indicative: true
     fuzzy: true
     dimensions:
-        signal: 90.0
-        reversibility: 90.0
-        competence: 91.7
-        disambiguation: 93.3
+        signal: 92.5
+        reversibility: 89.2
+        competence: 90.0
+        disambiguation: 94.2
 stage_metrics:
     intake: {started_at: "2026-03-21T10:05:55Z", driver: fab-new, iterations: 1, completed_at: "2026-03-21T10:07:55Z"}
     spec: {started_at: "2026-03-21T10:07:55Z", driver: fab-continue, iterations: 1, completed_at: "2026-03-21T10:10:02Z"}
@@ -38,4 +39,4 @@ stage_metrics:
     review-pr: {started_at: "2026-03-21T10:12:34Z", driver: git-pr, iterations: 1}
 prs:
     - https://github.com/wvrdz/run-kit/pull/67
-last_updated: 2026-03-21T10:12:34Z
+last_updated: 2026-03-21T10:17:01Z

--- a/fab/changes/260321-y11t-normalize-toolbar-icon-colors/.status.yaml
+++ b/fab/changes/260321-y11t-normalize-toolbar-icon-colors/.status.yaml
@@ -1,0 +1,39 @@
+id: y11t
+name: 260321-y11t-normalize-toolbar-icon-colors
+created: 2026-03-21T10:05:55Z
+created_by: sahil-weaver
+change_type: fix
+issues: []
+progress:
+    intake: done
+    spec: done
+    tasks: skipped
+    apply: skipped
+    review: skipped
+    hydrate: done
+    ship: active
+    review-pr: pending
+checklist:
+    generated: false
+    path: checklist.md
+    completed: 0
+    total: 0
+confidence:
+    certain: 3
+    confident: 0
+    tentative: 0
+    unresolved: 0
+    score: 3.0
+    fuzzy: true
+    dimensions:
+        signal: 90.0
+        reversibility: 90.0
+        competence: 91.7
+        disambiguation: 93.3
+stage_metrics:
+    intake: {started_at: "2026-03-21T10:05:55Z", driver: fab-new, iterations: 1, completed_at: "2026-03-21T10:07:55Z"}
+    spec: {started_at: "2026-03-21T10:07:55Z", driver: fab-continue, iterations: 1, completed_at: "2026-03-21T10:10:02Z"}
+    hydrate: {started_at: "2026-03-21T10:10:17Z", driver: fab-continue, iterations: 1, completed_at: "2026-03-21T10:11:31Z"}
+    ship: {started_at: "2026-03-21T10:11:31Z", driver: fab-continue, iterations: 1}
+prs: []
+last_updated: 2026-03-21T10:11:31Z

--- a/fab/changes/260321-y11t-normalize-toolbar-icon-colors/.status.yaml
+++ b/fab/changes/260321-y11t-normalize-toolbar-icon-colors/.status.yaml
@@ -11,8 +11,8 @@ progress:
     apply: skipped
     review: skipped
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 checklist:
     generated: false
     path: checklist.md
@@ -34,6 +34,8 @@ stage_metrics:
     intake: {started_at: "2026-03-21T10:05:55Z", driver: fab-new, iterations: 1, completed_at: "2026-03-21T10:07:55Z"}
     spec: {started_at: "2026-03-21T10:07:55Z", driver: fab-continue, iterations: 1, completed_at: "2026-03-21T10:10:02Z"}
     hydrate: {started_at: "2026-03-21T10:10:17Z", driver: fab-continue, iterations: 1, completed_at: "2026-03-21T10:11:31Z"}
-    ship: {started_at: "2026-03-21T10:11:31Z", driver: fab-continue, iterations: 1}
-prs: []
-last_updated: 2026-03-21T10:11:31Z
+    ship: {started_at: "2026-03-21T10:11:31Z", driver: fab-continue, iterations: 1, completed_at: "2026-03-21T10:12:34Z"}
+    review-pr: {started_at: "2026-03-21T10:12:34Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/wvrdz/run-kit/pull/67
+last_updated: 2026-03-21T10:12:34Z

--- a/fab/changes/260321-y11t-normalize-toolbar-icon-colors/intake.md
+++ b/fab/changes/260321-y11t-normalize-toolbar-icon-colors/intake.md
@@ -1,4 +1,4 @@
-# Intake: Normalize Toolbar Icon Colors
+# Intake: Toolbar Polish & Split Pane Controls
 
 **Change**: 260321-y11t-normalize-toolbar-icon-colors
 **Created**: 2026-03-21
@@ -6,71 +6,78 @@
 
 ## Origin
 
-> User noticed via visual inspection (screenshots) that the foreground color of toolbar icons was inconsistent across the top bar and bottom bar. Some buttons used `text-text-primary` (bright white in dark mode) while neighboring buttons used `text-text-secondary` (muted gray). The user requested all toolbar buttons be normalized to `text-text-secondary` for visual consistency.
-
-One-shot fix — the user identified the issue, confirmed the desired state via screenshots at each step (top bar, bottom bar, arrow pad).
+> User noticed via visual inspection that the foreground color of toolbar icons was inconsistent, then expanded scope to add split pane controls, fix the connection status indicator, and fill gaps in the command palette.
 
 ## Why
 
-The toolbar icons across the top bar and bottom bar use an inconsistent mix of `text-text-primary` and `text-text-secondary` Tailwind classes for their default (inactive) foreground color. This creates a visual hierarchy where some buttons appear brighter/more prominent than others despite having equal importance. The inconsistency is noticeable in dark mode where the contrast between primary and secondary text colors is more pronounced.
-
-If left unfixed, the UI chrome looks unpolished — some icons draw the eye while others recede, with no intentional design rationale behind the difference.
+The top bar had inconsistent icon colors, lacked split pane controls (requiring users to reach for tmux keybindings), had a broken connection status dot that never turned red, a command palette missing several actions, and the compose dialog was the only dialog without a heading.
 
 ## What Changes
 
-### Top Bar — `app/frontend/src/components/top-bar.tsx`
+### 1. Normalize toolbar icon colors
 
-The compose button (`>_`) uses `text-text-primary hover:text-text-primary`. Changed to `text-text-secondary hover:border-text-secondary` to match the ThemeToggle and FixedWidthToggle inactive styles.
+**Files**: `top-bar.tsx`, `bottom-bar.tsx`, `arrow-pad.tsx`
 
-```tsx
-// Before
-className="text-text-primary hover:text-text-primary ..."
+Toolbar buttons used an inconsistent mix of `text-text-primary` and `text-text-secondary`. Normalized all inactive toolbar buttons to `text-text-secondary`, keeping `text-accent` for active toggle states.
 
-// After
-className="text-text-secondary hover:border-text-secondary ..."
-```
+- **Top bar**: compose button `text-text-primary` → `text-text-secondary`
+- **Bottom bar**: Esc, Tab, Ctrl/Alt (inactive), Fn popup trigger → `text-text-secondary`
+- **Arrow pad**: trigger button → `text-text-secondary`
 
-### Bottom Bar — `app/frontend/src/components/bottom-bar.tsx`
+### 2. Add split pane buttons (full-stack)
 
-Four button groups used `text-text-primary` in their default state:
+**Files**: `tmux.go`, `router.go`, `sessions_test.go`, `windows.go`, `client.ts`, `top-bar.tsx`
 
-1. **Esc button** — `text-text-primary` → `text-text-secondary`
-2. **Tab button** — `text-text-primary` → `text-text-secondary`
-3. **Ctrl/Alt modifier buttons** (inactive state) — `text-text-primary` → `text-text-secondary` (active state remains `text-accent`)
-4. **Fn popup trigger** — `text-text-primary` → `text-text-secondary`
+Added "Split vertically" and "Split horizontally" buttons to the top bar next to the fixed-width toggle. Hidden on mobile (`hidden sm:flex`). Icons use Lucide's `square-split-horizontal` and `square-split-vertical`.
 
-The `⌘K` command palette button already used `text-text-secondary` — no change needed.
+- **Backend**: `SplitWindow` now accepts a `horizontal bool` param (passes `-h` to tmux for left/right split). New `POST /api/sessions/{session}/windows/{index}/split` endpoint with `{"horizontal": bool}` body.
+- **Frontend**: New `splitWindow` API client method. New `SplitButton` component rendered when a window is active.
 
-### Arrow Pad — `app/frontend/src/components/arrow-pad.tsx`
+### 3. Fix SSE connection status dot
 
-The arrow pad trigger button used `text-text-primary`. Changed to `text-text-secondary`.
+**File**: `session-context.tsx`
 
-### What stays the same
+The green connection dot never turned red because `EventSource` auto-reconnects, firing `onerror` + `onopen` in rapid succession. Added a 3-second debounce: `onerror` starts a timer, `onopen`/successful message cancels it. The dot only turns gray if SSE hasn't recovered within 3 seconds.
 
-- Active toggle states (`text-accent` with `bg-accent/10` or `bg-accent/20`) are unchanged — these correctly use accent color to indicate active state (Ctrl/Alt modifiers, FixedWidthToggle)
-- Hover/active/focus-visible states in `KBD_CLASS` are unchanged
-- Function key popup items and extended key items already used `text-text-secondary`
+### 4. Command palette additions
+
+**File**: `app.tsx`
+
+Added missing actions to the command palette:
+- **Split vertically** / **Split horizontally** (when a window is active)
+- **Text input** — opens the compose dialog (when a session is active)
+- **Fixed width / Full width toggle** — label reflects current state
+
+### 5. Compose dialog heading
+
+**File**: `compose-buffer.tsx`
+
+Added "Text Input" heading to the compose dialog, matching the style of all other dialogs (`text-xs font-medium mb-2.5`).
 
 ## Affected Memory
 
-- `run-kit/ui-patterns`: (modify) Document the toolbar color convention — all toolbar buttons use `text-text-secondary` default, `text-accent` for active toggles
+- `run-kit/ui-patterns`: (modify) Document toolbar color convention, split pane buttons, command palette actions
+- `run-kit/architecture`: (modify) Document split pane API endpoint
 
 ## Impact
 
-- **3 files changed**: `top-bar.tsx`, `bottom-bar.tsx`, `arrow-pad.tsx`
-- Visual-only change — no behavior, API, or accessibility changes
-- Affects both light and dark themes (the token resolves to different values per theme)
+- **10 files changed**: `tmux.go`, `router.go`, `sessions_test.go`, `windows.go`, `client.ts`, `top-bar.tsx`, `bottom-bar.tsx`, `arrow-pad.tsx`, `session-context.tsx`, `app.tsx`, `compose-buffer.tsx`
+- New API endpoint: `POST .../windows/{index}/split`
+- Visual + behavioral changes across top bar, command palette, connection indicator, compose dialog
 
 ## Open Questions
 
-None — the change is fully implemented and verified via screenshots.
+None — all changes are implemented and verified.
 
 ## Assumptions
 
 | # | Grade | Decision | Rationale | Scores |
 |---|-------|----------|-----------|--------|
-| 1 | Certain | All toolbar buttons use `text-text-secondary` as default foreground | Discussed — user explicitly requested this normalization and confirmed via screenshots | S:95 R:90 A:95 D:95 |
-| 2 | Certain | Active toggle states keep `text-accent` styling | Discussed — user only flagged inactive state inconsistency, active states were already correct | S:90 R:90 A:90 D:95 |
-| 3 | Certain | Hover states use `hover:border-text-secondary` (border highlight, not text change) | Matches existing pattern used by ThemeToggle and FixedWidthToggle | S:85 R:90 A:90 D:90 |
+| 1 | Certain | All toolbar buttons use `text-text-secondary` as default foreground | User explicitly requested and confirmed via screenshots | S:95 R:90 A:95 D:95 |
+| 2 | Certain | Active toggle states keep `text-accent` styling | User only flagged inactive state inconsistency | S:90 R:90 A:90 D:95 |
+| 3 | Certain | Split buttons hidden on mobile | User explicitly requested mobile hiding | S:95 R:90 A:90 D:95 |
+| 4 | Certain | Use Lucide `square-split-horizontal` / `square-split-vertical` icons | User explicitly requested these icons | S:95 R:90 A:90 D:95 |
+| 5 | Certain | 3-second debounce for connection dot | Standard approach for EventSource reconnect flickering, user approved | S:90 R:85 A:85 D:90 |
+| 6 | Certain | Compose dialog heading matches other dialog styles | User requested matching style, derived from existing `dialog.tsx` pattern | S:90 R:90 A:90 D:95 |
 
-3 assumptions (3 certain, 0 confident, 0 tentative, 0 unresolved).
+6 assumptions (6 certain, 0 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260321-y11t-normalize-toolbar-icon-colors/intake.md
+++ b/fab/changes/260321-y11t-normalize-toolbar-icon-colors/intake.md
@@ -1,0 +1,76 @@
+# Intake: Normalize Toolbar Icon Colors
+
+**Change**: 260321-y11t-normalize-toolbar-icon-colors
+**Created**: 2026-03-21
+**Status**: Draft
+
+## Origin
+
+> User noticed via visual inspection (screenshots) that the foreground color of toolbar icons was inconsistent across the top bar and bottom bar. Some buttons used `text-text-primary` (bright white in dark mode) while neighboring buttons used `text-text-secondary` (muted gray). The user requested all toolbar buttons be normalized to `text-text-secondary` for visual consistency.
+
+One-shot fix — the user identified the issue, confirmed the desired state via screenshots at each step (top bar, bottom bar, arrow pad).
+
+## Why
+
+The toolbar icons across the top bar and bottom bar use an inconsistent mix of `text-text-primary` and `text-text-secondary` Tailwind classes for their default (inactive) foreground color. This creates a visual hierarchy where some buttons appear brighter/more prominent than others despite having equal importance. The inconsistency is noticeable in dark mode where the contrast between primary and secondary text colors is more pronounced.
+
+If left unfixed, the UI chrome looks unpolished — some icons draw the eye while others recede, with no intentional design rationale behind the difference.
+
+## What Changes
+
+### Top Bar — `app/frontend/src/components/top-bar.tsx`
+
+The compose button (`>_`) uses `text-text-primary hover:text-text-primary`. Changed to `text-text-secondary hover:border-text-secondary` to match the ThemeToggle and FixedWidthToggle inactive styles.
+
+```tsx
+// Before
+className="text-text-primary hover:text-text-primary ..."
+
+// After
+className="text-text-secondary hover:border-text-secondary ..."
+```
+
+### Bottom Bar — `app/frontend/src/components/bottom-bar.tsx`
+
+Four button groups used `text-text-primary` in their default state:
+
+1. **Esc button** — `text-text-primary` → `text-text-secondary`
+2. **Tab button** — `text-text-primary` → `text-text-secondary`
+3. **Ctrl/Alt modifier buttons** (inactive state) — `text-text-primary` → `text-text-secondary` (active state remains `text-accent`)
+4. **Fn popup trigger** — `text-text-primary` → `text-text-secondary`
+
+The `⌘K` command palette button already used `text-text-secondary` — no change needed.
+
+### Arrow Pad — `app/frontend/src/components/arrow-pad.tsx`
+
+The arrow pad trigger button used `text-text-primary`. Changed to `text-text-secondary`.
+
+### What stays the same
+
+- Active toggle states (`text-accent` with `bg-accent/10` or `bg-accent/20`) are unchanged — these correctly use accent color to indicate active state (Ctrl/Alt modifiers, FixedWidthToggle)
+- Hover/active/focus-visible states in `KBD_CLASS` are unchanged
+- Function key popup items and extended key items already used `text-text-secondary`
+
+## Affected Memory
+
+- `run-kit/ui-patterns`: (modify) Document the toolbar color convention — all toolbar buttons use `text-text-secondary` default, `text-accent` for active toggles
+
+## Impact
+
+- **3 files changed**: `top-bar.tsx`, `bottom-bar.tsx`, `arrow-pad.tsx`
+- Visual-only change — no behavior, API, or accessibility changes
+- Affects both light and dark themes (the token resolves to different values per theme)
+
+## Open Questions
+
+None — the change is fully implemented and verified via screenshots.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | All toolbar buttons use `text-text-secondary` as default foreground | Discussed — user explicitly requested this normalization and confirmed via screenshots | S:95 R:90 A:95 D:95 |
+| 2 | Certain | Active toggle states keep `text-accent` styling | Discussed — user only flagged inactive state inconsistency, active states were already correct | S:90 R:90 A:90 D:95 |
+| 3 | Certain | Hover states use `hover:border-text-secondary` (border highlight, not text change) | Matches existing pattern used by ThemeToggle and FixedWidthToggle | S:85 R:90 A:90 D:90 |
+
+3 assumptions (3 certain, 0 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260321-y11t-normalize-toolbar-icon-colors/spec.md
+++ b/fab/changes/260321-y11t-normalize-toolbar-icon-colors/spec.md
@@ -1,0 +1,50 @@
+# Spec: Normalize Toolbar Icon Colors
+
+**Change**: 260321-y11t-normalize-toolbar-icon-colors
+**Created**: 2026-03-21
+**Affected memory**: `docs/memory/run-kit/ui-patterns.md`
+
+## UI Chrome: Toolbar Button Colors
+
+### Requirement: Consistent Default Foreground Color
+
+All toolbar buttons in the top bar and bottom bar MUST use `text-text-secondary` as their default (inactive) foreground color. Buttons SHALL NOT use `text-text-primary` for their default state.
+
+#### Scenario: Top Bar Compose Button
+
+- **GIVEN** the top bar is rendered on a terminal page
+- **WHEN** the compose button (`>_`) is in its default (inactive) state
+- **THEN** it MUST use `text-text-secondary` for text color
+- **AND** it MUST use `hover:border-text-secondary` for hover state
+
+#### Scenario: Bottom Bar Key Buttons
+
+- **GIVEN** the bottom bar is rendered on a terminal page
+- **WHEN** Esc, Tab, Fn trigger, and arrow pad buttons are in their default state
+- **THEN** they MUST use `text-text-secondary` for text color
+
+#### Scenario: Bottom Bar Modifier Toggles (Inactive)
+
+- **GIVEN** the Ctrl or Alt modifier toggle is not armed
+- **WHEN** the button is rendered
+- **THEN** it MUST use `text-text-secondary` for text color
+
+### Requirement: Active Toggle State Preserved
+
+Buttons with active/toggle states (Ctrl, Alt, FixedWidthToggle) MUST retain `text-accent` with accent background when active. This change SHALL NOT modify active state styling.
+
+#### Scenario: Armed Modifier Toggle
+
+- **GIVEN** the Ctrl modifier toggle is armed (pressed)
+- **WHEN** the button is rendered
+- **THEN** it MUST use `text-accent` with `bg-accent/20` and `border-accent`
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | All toolbar buttons default to `text-text-secondary` | Confirmed from intake #1 — user explicitly verified via screenshots | S:95 R:90 A:95 D:95 |
+| 2 | Certain | Active toggle states keep `text-accent` | Confirmed from intake #2 — only inactive states were inconsistent | S:90 R:90 A:90 D:95 |
+| 3 | Certain | Hover pattern is `hover:border-text-secondary` | Confirmed from intake #3 — matches existing ThemeToggle/FixedWidthToggle pattern | S:85 R:90 A:90 D:90 |
+
+3 assumptions (3 certain, 0 confident, 0 tentative, 0 unresolved).


### PR DESCRIPTION
## Summary

Toolbar polish: normalize icon colors, add split pane controls, fix connection status indicator, expand command palette, and add compose dialog heading.

## Changes

- **Toolbar icon colors**: Normalize all inactive toolbar buttons to `text-text-secondary` (compose, Esc, Tab, Ctrl/Alt, Fn, arrow pad)
- **Split pane buttons**: New `SplitButton` component in top bar (hidden on mobile) with Lucide `square-split-horizontal`/`square-split-vertical` icons, calling new `POST /api/sessions/:session/windows/:index/split` endpoint
- **SSE connection dot fix**: 3-second debounce so the status dot actually turns gray when the server is down (previously flickered due to EventSource auto-reconnect)
- **Command palette additions**: Split vertically, Split horizontally, Text input, Fixed width / Full width toggle
- **Compose dialog heading**: Added "Text Input" heading matching other dialog styles

## Files changed

| Area | Files |
|------|-------|
| Backend | `tmux.go`, `router.go`, `windows.go`, `sessions_test.go` |
| Frontend | `top-bar.tsx`, `bottom-bar.tsx`, `arrow-pad.tsx`, `app.tsx`, `client.ts`, `session-context.tsx`, `compose-buffer.tsx` |

## Test plan

- [ ] Verify split buttons appear in top bar next to fixed-width toggle (desktop only)
- [ ] Click split vertical — tmux pane splits left/right
- [ ] Click split horizontal — tmux pane splits top/bottom
- [ ] Stop dev server — connection dot turns gray after ~3 seconds
- [ ] Restart dev server — dot turns green on reconnect
- [ ] Open command palette — verify split, text input, and fixed width toggle actions appear
- [ ] Open compose dialog — verify "Text Input" heading is present
- [ ] Verify all toolbar buttons use consistent `text-text-secondary` color

🤖 Generated with [Claude Code](https://claude.com/claude-code)