### PR TITLE
fix: compose buffer — image preview, path dedup, dialog pattern

### DIFF
--- a/app/frontend/src/components/compose-buffer.tsx
+++ b/app/frontend/src/components/compose-buffer.tsx
@@ -1,26 +1,108 @@
-import { useRef, useCallback, useEffect } from "react";
+import { useRef, useCallback, useEffect, useState, useId } from "react";
+import type { UploadedFile } from "@/hooks/use-file-upload";
 
 type ComposeBufferProps = {
   wsRef: React.RefObject<WebSocket | null>;
   onClose: () => void;
   initialText?: string;
+  uploadedFiles?: UploadedFile[];
   onUploadFiles?: (files: FileList) => void;
+  onRemoveFile?: (index: number) => void;
 };
 
-export function ComposeBuffer({ wsRef, onClose, initialText, onUploadFiles }: ComposeBufferProps) {
+export function ComposeBuffer({
+  wsRef,
+  onClose,
+  initialText,
+  uploadedFiles,
+  onUploadFiles,
+  onRemoveFile,
+}: ComposeBufferProps) {
+  const titleId = useId();
+  const dialogRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const lastInitialTextRef = useRef(initialText);
+  const lastInitialTextRef = useRef<string | undefined>(undefined);
   const uploadInputRef = useRef<HTMLInputElement>(null);
+  const blobUrlsRef = useRef<Map<File, string>>(new Map());
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
 
+  // Stable ref for onClose so keydown handler always calls the latest
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  // Set textarea value imperatively — no defaultValue
   useEffect(() => {
-    if (initialText && initialText !== lastInitialTextRef.current && textareaRef.current) {
+    if (!textareaRef.current) return;
+    if (initialText && initialText !== lastInitialTextRef.current) {
       const ta = textareaRef.current;
-      const current = ta.value;
-      const separator = current && !current.endsWith("\n") ? "\n" : "";
-      ta.value = current + separator + initialText;
+      if (lastInitialTextRef.current === undefined) {
+        // First mount — set value directly
+        ta.value = initialText;
+      } else {
+        // Additional upload — append only new text
+        const current = ta.value;
+        const separator = current && !current.endsWith("\n") ? "\n" : "";
+        ta.value = current + separator + initialText;
+      }
     }
     lastInitialTextRef.current = initialText;
   }, [initialText]);
+
+  // Focus trap + Escape handler (matches dialog.tsx)
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        if (expandedIndex !== null) {
+          setExpandedIndex(null);
+        } else {
+          onCloseRef.current();
+        }
+        return;
+      }
+      const dialog = dialogRef.current;
+      if (!dialog || e.key !== "Tab") return;
+      const focusable = dialog.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last?.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first?.focus();
+      }
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [expandedIndex]);
+
+  // Focus textarea on mount
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  // Get or create blob URL for a file
+  function getBlobUrl(file: File): string {
+    const existing = blobUrlsRef.current.get(file);
+    if (existing) return existing;
+    const url = URL.createObjectURL(file);
+    blobUrlsRef.current.set(file, url);
+    return url;
+  }
+
+  // Revoke all blob URLs on unmount (dialog close)
+  useEffect(() => {
+    const urlsRef = blobUrlsRef;
+    return () => {
+      for (const url of urlsRef.current.values()) {
+        URL.revokeObjectURL(url);
+      }
+      urlsRef.current.clear();
+    };
+  }, []);
 
   const send = useCallback(() => {
     const text = textareaRef.current?.value;
@@ -30,40 +112,124 @@ export function ComposeBuffer({ wsRef, onClose, initialText, onUploadFiles }: Co
     onClose();
   }, [wsRef, onClose]);
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        onClose();
-      } else if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        send();
+  const handleRemoveFile = useCallback(
+    (index: number) => {
+      if (!uploadedFiles || !onRemoveFile) return;
+      const file = uploadedFiles[index];
+      // Remove path from textarea
+      if (textareaRef.current && file) {
+        const lines = textareaRef.current.value.split("\n");
+        const pathIndex = lines.indexOf(file.path);
+        if (pathIndex !== -1) {
+          lines.splice(pathIndex, 1);
+          textareaRef.current.value = lines.join("\n");
+        }
       }
+      // Revoke blob URL
+      if (file) {
+        const url = blobUrlsRef.current.get(file.file);
+        if (url) {
+          URL.revokeObjectURL(url);
+          blobUrlsRef.current.delete(file.file);
+        }
+      }
+      if (expandedIndex === index) setExpandedIndex(null);
+      else if (expandedIndex !== null && expandedIndex > index) setExpandedIndex(expandedIndex - 1);
+      onRemoveFile(index);
     },
-    [onClose, send],
+    [uploadedFiles, onRemoveFile, expandedIndex],
   );
+
+  const hasPreviewItems = (uploadedFiles?.length ?? 0) > 0;
 
   return (
     <div
-      className="absolute inset-0 flex items-center justify-center z-50 bg-black/50"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
+      className="fixed inset-0 z-40 flex items-center justify-center"
+      onClick={onClose}
     >
-      <div className="w-full max-w-[500px] mx-4 bg-bg-primary border border-border rounded-lg p-2 shadow-2xl">
-        <h2 className="text-xs font-medium mb-2.5">Text Input</h2>
+      <div className="fixed inset-0 bg-black/50" aria-hidden="true" />
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="relative w-full max-w-[500px] mx-4 bg-bg-primary border border-border rounded-lg p-2 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id={titleId} className="text-xs font-medium mb-2.5">Text Input</h2>
+
+        {/* Image preview strip */}
+        {hasPreviewItems && (
+          <div className="flex gap-1.5 mb-2 overflow-x-auto">
+            {uploadedFiles!.map((uf, i) => {
+              const isImage = uf.file.type.startsWith("image/");
+              return (
+                <div key={`${uf.path}-${i}`} className="relative shrink-0 group">
+                  {isImage ? (
+                    <button
+                      type="button"
+                      onClick={() => setExpandedIndex(expandedIndex === i ? null : i)}
+                      className="block rounded border border-border overflow-hidden hover:border-text-secondary transition-colors"
+                    >
+                      <img
+                        src={getBlobUrl(uf.file)}
+                        alt={uf.file.name}
+                        className="h-[60px] w-auto object-cover"
+                      />
+                    </button>
+                  ) : (
+                    <div className="h-[60px] px-2 flex items-center rounded border border-border bg-bg-card">
+                      <span className="text-[10px] text-text-secondary max-w-[80px] truncate">
+                        {uf.file.name}
+                      </span>
+                    </div>
+                  )}
+                  <button
+                    type="button"
+                    aria-label={`Remove ${uf.file.name}`}
+                    onClick={() => handleRemoveFile(i)}
+                    className="absolute -top-1.5 -right-1.5 w-4 h-4 rounded-full bg-bg-primary border border-border text-text-secondary text-[10px] leading-none flex items-center justify-center opacity-0 group-hover:opacity-100 hover:text-red-500 hover:border-red-500 transition-all"
+                  >
+                    ×
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Expanded preview */}
+        {expandedIndex !== null && uploadedFiles && uploadedFiles[expandedIndex] && (
+          <div className="mb-2">
+            <button
+              type="button"
+              onClick={() => setExpandedIndex(null)}
+              className="w-full rounded border border-border overflow-hidden hover:border-text-secondary transition-colors"
+            >
+              <img
+                src={getBlobUrl(uploadedFiles[expandedIndex].file)}
+                alt={uploadedFiles[expandedIndex].file.name}
+                className="w-full h-auto max-h-[300px] object-contain bg-bg-card"
+              />
+            </button>
+          </div>
+        )}
+
         <textarea
           ref={textareaRef}
-          autoFocus
           autoComplete="off"
           autoCorrect="off"
           autoCapitalize="off"
           spellCheck={false}
           aria-label="Compose text to send to terminal"
-          defaultValue={initialText}
           placeholder="Compose text..."
           className="w-full bg-bg-card text-text-primary text-xs px-2 py-1.5 rounded border border-border outline-none resize-y min-h-[60px] max-h-[300px] placeholder:text-text-secondary focus:border-text-secondary"
-          onKeyDown={handleKeyDown}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+              e.preventDefault();
+              send();
+            }
+          }}
         />
         <div className="flex justify-end mt-1 gap-1.5">
           {onUploadFiles && (
@@ -81,6 +247,7 @@ export function ComposeBuffer({ wsRef, onClose, initialText, onUploadFiles }: Co
                 }}
               />
               <button
+                type="button"
                 aria-label="Upload file"
                 onClick={() => uploadInputRef.current?.click()}
                 className="text-xs px-2 py-1 border border-border text-text-secondary rounded hover:border-text-secondary transition-colors"
@@ -90,6 +257,7 @@ export function ComposeBuffer({ wsRef, onClose, initialText, onUploadFiles }: Co
             </>
           )}
           <button
+            type="button"
             onClick={send}
             className="text-xs px-3 py-1 bg-accent/20 border border-accent text-accent rounded hover:bg-accent/30 transition-colors"
           >

--- a/app/frontend/src/components/terminal-client.tsx
+++ b/app/frontend/src/components/terminal-client.tsx
@@ -1,6 +1,7 @@
 import "@xterm/xterm/css/xterm.css";
 import { useEffect, useRef, useCallback, useState } from "react";
 import { useFileUpload } from "@/hooks/use-file-upload";
+import type { UploadedFile } from "@/hooks/use-file-upload";
 import { useTheme } from "@/contexts/theme-context";
 import type { ResolvedTheme } from "@/contexts/theme-context";
 import { ComposeBuffer } from "@/components/compose-buffer";
@@ -78,13 +79,15 @@ export function TerminalClient({
   const [terminalReady, setTerminalReady] = useState(false);
   const [dragOver, setDragOver] = useState(false);
   const [composeInitialText, setComposeInitialText] = useState<string | undefined>();
+  const [composeFiles, setComposeFiles] = useState<UploadedFile[]>([]);
   const { uploadFiles } = useFileUpload(sessionName, windowIndex);
   const { resolved: resolvedTheme } = useTheme();
 
-  const openComposeWithPaths = useCallback(
-    (paths: string[]) => {
-      if (paths.length === 0) return;
-      setComposeInitialText(paths.join("\n"));
+  const openComposeWithUploads = useCallback(
+    (uploads: UploadedFile[]) => {
+      if (uploads.length === 0) return;
+      setComposeFiles((prev) => [...prev, ...uploads]);
+      setComposeInitialText(uploads.map((u) => u.path).join("\n"));
       setComposeOpen(true);
     },
     [setComposeOpen],
@@ -96,11 +99,11 @@ export function TerminalClient({
       const files = e.clipboardData?.files;
       if (!files || files.length === 0) return;
       e.preventDefault();
-      uploadFiles(files).then(openComposeWithPaths);
+      uploadFiles(files).then(openComposeWithUploads);
     }
     document.addEventListener("paste", handlePaste);
     return () => document.removeEventListener("paste", handlePaste);
-  }, [uploadFiles, openComposeWithPaths]);
+  }, [uploadFiles, openComposeWithUploads]);
 
   // Drag and drop
   const handleDragOver = useCallback((e: React.DragEvent) => {
@@ -120,16 +123,16 @@ export function TerminalClient({
       setDragOver(false);
       const files = e.dataTransfer.files;
       if (files.length === 0) return;
-      uploadFiles(files).then(openComposeWithPaths);
+      uploadFiles(files).then(openComposeWithUploads);
     },
-    [uploadFiles, openComposeWithPaths],
+    [uploadFiles, openComposeWithUploads],
   );
 
   const handleUploadFiles = useCallback(
     (files: FileList) => {
-      uploadFiles(files).then(openComposeWithPaths);
+      uploadFiles(files).then(openComposeWithUploads);
     },
-    [uploadFiles, openComposeWithPaths],
+    [uploadFiles, openComposeWithUploads],
   );
 
   // xterm.js init — mount only, creates terminal instance and resize observer.
@@ -368,10 +371,15 @@ export function TerminalClient({
           onClose={() => {
             setComposeOpen(false);
             setComposeInitialText(undefined);
+            setComposeFiles([]);
             xtermRef.current?.focus();
           }}
           initialText={composeInitialText}
+          uploadedFiles={composeFiles}
           onUploadFiles={handleUploadFiles}
+          onRemoveFile={(index) => {
+            setComposeFiles((prev) => prev.filter((_, i) => i !== index));
+          }}
         />
       )}
     </div>

--- a/app/frontend/src/hooks/use-file-upload.ts
+++ b/app/frontend/src/hooks/use-file-upload.ts
@@ -1,8 +1,13 @@
 import { useState, useCallback } from "react";
 import { uploadFile } from "@/api/client";
 
+export type UploadedFile = {
+  path: string;
+  file: File;
+};
+
 type UseFileUploadReturn = {
-  uploadFiles: (files: FileList) => Promise<string[]>;
+  uploadFiles: (files: FileList) => Promise<UploadedFile[]>;
   uploading: boolean;
 };
 
@@ -10,17 +15,17 @@ export function useFileUpload(session: string, windowIndex: string): UseFileUplo
   const [uploading, setUploading] = useState(false);
 
   const uploadFiles = useCallback(
-    async (files: FileList): Promise<string[]> => {
+    async (files: FileList): Promise<UploadedFile[]> => {
       if (files.length === 0) return [];
       setUploading(true);
 
-      const paths: string[] = [];
+      const results: UploadedFile[] = [];
       try {
         for (const file of Array.from(files)) {
           try {
             const result = await uploadFile(session, file, windowIndex);
             if (result.ok && result.path) {
-              paths.push(result.path);
+              results.push({ path: result.path, file });
             }
           } catch (err) {
             console.error("Upload error:", err);
@@ -30,7 +35,7 @@ export function useFileUpload(session: string, windowIndex: string): UseFileUplo
         setUploading(false);
       }
 
-      return paths;
+      return results;
     },
     [session, windowIndex],
   );

--- a/docs/memory/run-kit/ui-patterns.md
+++ b/docs/memory/run-kit/ui-patterns.md
@@ -137,13 +137,16 @@ Single row of `<kbd>` styled buttons, rendered only on terminal pages (`/:sessio
 
 ### Compose Buffer
 
-Native `<textarea>` overlay triggered by the compose button (`>_` in top bar right section). Appears above the bottom bar inside the content area. Terminal dims (`opacity-50`) while compose is open.
+Modal dialog (`fixed inset-0 z-40`) triggered by the compose button (`>_` in top bar right section). Follows the same structural pattern as `dialog.tsx`: separate backdrop layer (`fixed inset-0 bg-black/50`, `aria-hidden`), `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, focus trap (Tab/Shift+Tab cycling), two-layer click-outside close (outer `onClick={onClose}`, inner `stopPropagation`). Terminal dims (`opacity-50`) while compose is open.
 
+- **Title**: "Text Input" (`<h2>` with `aria-labelledby` ID)
 - **Open**: Tap compose button (`>_` icon in top bar)
 - **Send**: Click Send button or press Cmd/Ctrl+Enter — entire text transmitted as one WebSocket message
 - **Dismiss**: Press Escape — closes without sending, text discarded
 - **Why**: xterm is a `<canvas>`, not a native text input. iOS dictation, autocorrect, paste, IME all require a real DOM element. Also useful on desktop for pasting large text blocks over a laggy WebSocket.
-- **initialText prop**: Optional string that pre-populates the textarea. Used by file upload to insert paths. On subsequent prop changes while mounted, appends to existing textarea content with newline separator.
+- **initialText prop**: Optional string that pre-populates the textarea via imperative ref (no `defaultValue`). On subsequent prop changes while mounted, appends only new text.
+- **Image preview**: When files are uploaded, a horizontal thumbnail strip renders above the textarea (~60px height). Image files (`image/*`) show `<img>` thumbnails via `URL.createObjectURL()` blob URLs. Non-image files show filename text. Each item has a dismiss (×) button (visible on hover) that removes the file from preview and its path from the textarea. Clicking an image thumbnail toggles a larger constrained preview within the dialog. All blob URLs are revoked via `URL.revokeObjectURL()` when the dialog closes (unmount cleanup).
+- **Upload flow**: `useFileUpload` hook returns `{ path: string; file: File }[]` tuples. `terminal-client.tsx` stores both paths and `File` objects in state, passing `uploadedFiles` and `onRemoveFile` props to the compose buffer.
 
 ### File Upload
 

--- a/fab/changes/260321-ye3t-fix-compose-buffer-dialog/.history.jsonl
+++ b/fab/changes/260321-ye3t-fix-compose-buffer-dialog/.history.jsonl
@@ -1,0 +1,24 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-03-21T11:18:26Z"}
+{"args":"Fix compose buffer: image preview, path duplication, dialog pattern alignment","cmd":"fab-new","event":"command","ts":"2026-03-21T11:18:26Z"}
+{"delta":"+2.1","event":"confidence","score":2.1,"trigger":"calc-score","ts":"2026-03-21T11:19:24Z"}
+{"delta":"+0.0","event":"confidence","score":2.1,"trigger":"calc-score","ts":"2026-03-21T11:19:36Z"}
+{"cmd":"fab-new","event":"command","ts":"2026-03-21T11:19:44Z"}
+{"cmd":"fab-switch","event":"command","ts":"2026-03-21T13:05:28Z"}
+{"cmd":"fab-clarify","event":"command","ts":"2026-03-21T13:06:31Z"}
+{"delta":"+0.9","event":"confidence","score":3,"trigger":"calc-score","ts":"2026-03-21T13:15:33Z"}
+{"delta":"+0.0","event":"confidence","score":3,"trigger":"calc-score","ts":"2026-03-21T13:15:38Z"}
+{"delta":"+0.0","event":"confidence","score":3,"trigger":"calc-score","ts":"2026-03-21T16:00:18Z"}
+{"delta":"+2.0","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-03-21T16:00:26Z"}
+{"delta":"+0.0","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-03-21T16:00:32Z"}
+{"delta":"+0.0","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-03-21T16:00:37Z"}
+{"delta":"+0.0","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-03-21T16:00:43Z"}
+{"delta":"+0.0","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-03-21T16:00:48Z"}
+{"cmd":"fab-fff","event":"command","ts":"2026-03-21T16:04:44Z"}
+{"delta":"+0.0","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-03-21T16:06:01Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"spec","ts":"2026-03-21T16:06:05Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"tasks","ts":"2026-03-21T16:06:57Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-03-21T16:06:57Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-03-21T16:09:45Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-03-21T16:10:26Z"}
+{"event":"review","result":"passed","ts":"2026-03-21T16:10:26Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-03-21T16:10:51Z"}

--- a/fab/changes/260321-ye3t-fix-compose-buffer-dialog/.history.jsonl
+++ b/fab/changes/260321-ye3t-fix-compose-buffer-dialog/.history.jsonl
@@ -22,3 +22,5 @@
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-03-21T16:10:26Z"}
 {"event":"review","result":"passed","ts":"2026-03-21T16:10:26Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-03-21T16:10:51Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review-pr","ts":"2026-03-21T16:11:40Z"}
+{"event":"review","result":"passed","ts":"2026-03-21T16:11:55Z"}

--- a/fab/changes/260321-ye3t-fix-compose-buffer-dialog/.status.yaml
+++ b/fab/changes/260321-ye3t-fix-compose-buffer-dialog/.status.yaml
@@ -1,0 +1,42 @@
+id: ye3t
+name: 260321-ye3t-fix-compose-buffer-dialog
+created: 2026-03-21T11:18:26Z
+created_by: vivek-weaver
+change_type: fix
+issues: []
+progress:
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+checklist:
+    generated: true
+    path: checklist.md
+    completed: 26
+    total: 26
+confidence:
+    certain: 10
+    confident: 0
+    tentative: 0
+    unresolved: 0
+    score: 5.0
+    fuzzy: true
+    dimensions:
+        signal: 93.5
+        reversibility: 90.5
+        competence: 82.5
+        disambiguation: 86.0
+stage_metrics:
+    intake: {started_at: "2026-03-21T11:18:26Z", driver: fab-new, iterations: 1, completed_at: "2026-03-21T16:06:05Z"}
+    spec: {started_at: "2026-03-21T16:06:05Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-21T16:06:57Z"}
+    tasks: {started_at: "2026-03-21T16:06:57Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-21T16:06:57Z"}
+    apply: {started_at: "2026-03-21T16:06:57Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-21T16:09:45Z"}
+    review: {started_at: "2026-03-21T16:09:45Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-21T16:10:26Z"}
+    hydrate: {started_at: "2026-03-21T16:10:26Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-21T16:10:51Z"}
+    ship: {started_at: "2026-03-21T16:10:51Z", driver: fab-fff, iterations: 1}
+prs: []
+last_updated: 2026-03-21T16:10:51Z

--- a/fab/changes/260321-ye3t-fix-compose-buffer-dialog/.status.yaml
+++ b/fab/changes/260321-ye3t-fix-compose-buffer-dialog/.status.yaml
@@ -11,8 +11,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: done
 checklist:
     generated: true
     path: checklist.md
@@ -37,6 +37,8 @@ stage_metrics:
     apply: {started_at: "2026-03-21T16:06:57Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-21T16:09:45Z"}
     review: {started_at: "2026-03-21T16:09:45Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-21T16:10:26Z"}
     hydrate: {started_at: "2026-03-21T16:10:26Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-21T16:10:51Z"}
-    ship: {started_at: "2026-03-21T16:10:51Z", driver: fab-fff, iterations: 1}
-prs: []
-last_updated: 2026-03-21T16:10:51Z
+    ship: {started_at: "2026-03-21T16:10:51Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-21T16:11:40Z"}
+    review-pr: {started_at: "2026-03-21T16:11:40Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-21T16:11:55Z"}
+prs:
+    - https://github.com/wvrdz/run-kit/pull/68
+last_updated: 2026-03-21T16:11:55Z

--- a/fab/changes/260321-ye3t-fix-compose-buffer-dialog/checklist.md
+++ b/fab/changes/260321-ye3t-fix-compose-buffer-dialog/checklist.md
@@ -1,0 +1,52 @@
+# Quality Checklist: Fix Compose Buffer Dialog
+
+**Change**: 260321-ye3t-fix-compose-buffer-dialog
+**Generated**: 2026-03-21
+**Spec**: `spec.md`
+
+## Functional Completeness
+
+- [x] CHK-001 Upload hook returns `{ path, file }[]` tuples instead of `string[]`
+- [x] CHK-002 Terminal client threads file metadata to compose buffer props
+- [x] CHK-003 Image thumbnails render above textarea using blob URLs
+- [x] CHK-004 Non-image files show filename text in preview strip
+- [x] CHK-005 X button on each preview item removes file and path
+- [x] CHK-006 Click thumbnail toggles larger preview
+- [x] CHK-007 Blob URLs revoked on dialog close
+- [x] CHK-008 Textarea uses imperative ref only (no `defaultValue`)
+- [x] CHK-009 Dialog uses `fixed inset-0 z-40` with separate backdrop
+- [x] CHK-010 ARIA attributes: `role="dialog"`, `aria-modal`, `aria-labelledby`
+- [x] CHK-011 Focus trap cycles Tab/Shift+Tab within dialog
+- [x] CHK-012 Click-outside close uses two-layer pattern
+
+## Behavioral Correctness
+
+- [x] CHK-013 Path text appears exactly once in textarea on initial open (duplication fix verified)
+- [x] CHK-014 Additional uploads append new paths without duplicating existing ones
+- [x] CHK-015 Removing a preview item updates textarea to match remaining files
+
+## Scenario Coverage
+
+- [x] CHK-016 Single image paste: preview thumbnail shown, path in textarea, send works
+- [x] CHK-017 Multiple file drop: all thumbnails shown, all paths in textarea
+- [x] CHK-018 Paperclip upload while compose is open: new file appended correctly
+- [x] CHK-019 Mixed image/non-image upload: images get thumbnails, non-images get filename text
+
+## Edge Cases & Error Handling
+
+- [x] CHK-020 Zero files uploaded: compose opens with empty textarea, no preview strip
+- [x] CHK-021 Failed upload excluded from results (no broken preview/path)
+- [x] CHK-022 Dialog close via Escape revokes blob URLs same as close button
+
+## Code Quality
+
+- [x] CHK-023 Pattern consistency: compose buffer structure matches dialog.tsx pattern
+- [x] CHK-024 No unnecessary duplication: reuses existing patterns (dialog ARIA, focus trap logic)
+- [x] CHK-025 **N/A** No `exec()` or shell string construction (frontend-only change)
+- [x] CHK-026 Type narrowing preferred over type assertions
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] CHK-008 **N/A**: {reason}`

--- a/fab/changes/260321-ye3t-fix-compose-buffer-dialog/intake.md
+++ b/fab/changes/260321-ye3t-fix-compose-buffer-dialog/intake.md
@@ -1,0 +1,105 @@
+# Intake: Fix Compose Buffer Dialog
+
+**Change**: 260321-ye3t-fix-compose-buffer-dialog
+**Created**: 2026-03-21
+**Status**: Draft
+
+## Origin
+
+> Fix compose buffer dialog: (1) Add image preview using client-side blob URLs — thread File objects alongside paths through upload flow, show thumbnails above textarea for image files, revoke on close. (2) Fix path duplication bug — the defaultValue + useEffect append pattern causes paths to appear twice; replace with simpler approach. (3) Align compose buffer with project's Dialog pattern.
+
+Conversational `/fab-discuss` session preceded this change. User uploads images via paste/drop/file-picker to send to Claude Code running in a tmux pane. The compose buffer dialog opens with the uploaded file's absolute path as text, but no image preview is shown. The path text also appears duplicated. The dialog itself doesn't follow the established `Dialog` component pattern used by other dialogs in the project.
+
+## Why
+
+1. **No image preview**: When uploading an image to send to Claude Code, the user sees only a raw filesystem path (e.g., `/home/user/project/.uploads/260321083210-image.png`) with no visual confirmation of what they're about to send. Claude Code displays `[Image #1]` in the terminal — no way to verify the image content before or after sending.
+
+2. **Path duplication bug**: The compose buffer mixes React's `defaultValue` prop with a `useEffect` that directly manipulates `textarea.value`. This causes the uploaded path to appear twice under certain state transitions (e.g., when the compose buffer is already open and a new upload arrives, or during React re-renders). The user sends duplicate paths to the terminal.
+
+3. **Dialog inconsistency**: The compose buffer is the oldest dialog in the codebase and predates the base `Dialog` component (`dialog.tsx`). It uses `absolute inset-0` instead of `fixed inset-0`, has no separate backdrop layer, lacks ARIA attributes (`role="dialog"`, `aria-modal`), has no focus trap, and no title/header. Every other dialog in the project follows the `Dialog` pattern or matches its structure.
+
+## What Changes
+
+### 1. Image Preview in Compose Buffer
+
+Thread `File` objects alongside upload paths through the entire upload flow:
+
+- **`use-file-upload.ts`**: Return `{ path, file }` tuples instead of bare `string[]` paths
+- **`terminal-client.tsx`**: `openComposeWithPaths` accepts `{ path: string, file: File }[]`, stores both path and blob URL in state
+- **`compose-buffer.tsx`**: Render image thumbnails above the textarea for files with image MIME types (`image/*`). Use `URL.createObjectURL(file)` for the `<img src>`. Non-image files show filename only. Revoke blob URLs via `URL.revokeObjectURL()` on dialog close.
+
+Preview layout: horizontal thumbnail strip above the textarea, each thumbnail ~60px tall with the filename below. Each thumbnail has an X button to remove it before sending. Clicking a thumbnail shows a larger preview. Non-image files show their filename as text in the strip.
+
+### 2. Fix Path Duplication
+
+Replace the current `defaultValue` + `useEffect` append pattern in `compose-buffer.tsx` with a single controlled approach:
+
+- Remove `defaultValue={initialText}` from the textarea
+- Remove the `useEffect` that appends `initialText` to `textarea.value`
+- Instead, set `textarea.value` once on mount via a `useEffect` with an empty-ish dependency, and handle subsequent `initialText` changes (from additional uploads while compose is open) by appending only the new paths
+
+The key insight: `defaultValue` is a React concept for uncontrolled inputs, but the `useEffect` fights it by doing imperative DOM manipulation. Pick one approach — imperative via ref is fine since the textarea is already ref-managed for the `send()` function.
+
+### 3. Align with Dialog Pattern
+
+Refactor compose buffer to match the established `Dialog` component structure from `dialog.tsx`:
+
+- **Positioning**: Change from `absolute inset-0` to `fixed inset-0 z-40` with a separate `fixed inset-0 bg-black/50` backdrop layer (`aria-hidden="true"`)
+- **ARIA**: Add `role="dialog"`, `aria-modal="true"`, `aria-labelledby` pointing to a title element
+- **Title**: Keep existing "Text Input" header (already added by another PR on main)
+- **Focus trap**: Implement Tab cycling within the dialog (matching `dialog.tsx`'s `focusable` querySelectorAll + shift-tab/tab boundary logic)
+- **Click outside**: Keep existing click-outside-to-close but restructure to use the two-layer approach (outer container `onClick={onClose}`, inner content `onClick={e.stopPropagation()}`)
+
+Note: The compose buffer has unique features (textarea, file upload button, send button, image previews) that make it unsuitable to wrap in the generic `Dialog` component directly — but it should replicate the same structural pattern.
+
+## Affected Memory
+
+- `run-kit/ui-patterns`: (modify) Document compose buffer dialog pattern, image preview approach
+
+## Impact
+
+- **Frontend components**: `compose-buffer.tsx` (major refactor), `terminal-client.tsx` (state type changes)
+- **Frontend hooks**: `use-file-upload.ts` (return type change from `string[]` to `{ path, file }[]`)
+- **No backend changes**: Image serving not needed — blob URLs from client-side `File` objects suffice
+- **No API changes**: Upload endpoint unchanged, still returns `{ ok, path }`
+
+## Open Questions
+
+- ~~Should the image preview be dismissible (X button per thumbnail) to remove an image before sending?~~ **Yes** — X button per thumbnail to remove before sending.
+- ~~Should clicking a thumbnail show a larger preview, or is the thumbnail strip sufficient?~~ **Yes** — click to enlarge to a larger preview.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Use client-side blob URLs for preview, not a backend serve endpoint | Discussed — user agreed blob URLs are sufficient since preview only matters while compose dialog is open | S:95 R:90 A:95 D:95 |
+| 2 | Certain | No xterm.js terminal integration for preview | Discussed — xterm.js cannot render images, and Claude Code's `[Image #N]` labels can't be reliably matched to uploads | S:90 R:95 A:90 D:95 |
+| 3 | Certain | Compose buffer replicates Dialog pattern rather than wrapping Dialog component | Discussed — compose buffer has unique features (textarea, upload, send, preview) incompatible with generic Dialog wrapper | S:85 R:85 A:90 D:90 |
+| 4 | Certain | Thumbnail strip layout above textarea, ~60px height | Clarified — user confirmed | S:95 R:90 A:70 D:75 |
+| 5 | Certain | Revoke blob URLs on dialog close | Clarified — user confirmed | S:95 R:95 A:85 D:90 |
+| 6 | Certain | Fix duplication by dropping defaultValue, using only imperative ref-based value setting | Clarified — user confirmed | S:95 R:85 A:80 D:80 |
+| 7 | Certain | Keep existing "Text Input" title from main | Clarified — another PR already added the title; user chose to keep it | S:95 R:95 A:90 D:95 |
+| 8 | Certain | Non-image files show filename text only (no icon) | Clarified — user confirmed recommendation | S:95 R:90 A:65 D:60 |
+| 9 | Certain | Thumbnails are dismissible with X button | Clarified — user confirmed recommendation | S:95 R:90 A:80 D:90 |
+| 10 | Certain | Click thumbnail to show larger preview | Clarified — user confirmed recommendation | S:95 R:90 A:80 D:90 |
+
+10 assumptions (10 certain, 0 confident, 0 tentative, 0 unresolved).
+
+## Clarifications
+
+### Session 2026-03-21 (bulk confirm)
+
+| # | Action | Detail |
+|---|--------|--------|
+| 4 | Confirmed | — |
+| 5 | Confirmed | — |
+| 6 | Confirmed | — |
+
+### Session 2026-03-21 (suggest)
+
+| # | Action | Detail |
+|---|--------|--------|
+| 9 | Resolved | Thumbnails dismissible with X button — user accepted recommendation |
+| 10 | Resolved | Click thumbnail for larger preview — user accepted recommendation |
+| 7 | Resolved | Keep existing "Text Input" title from main — another PR already added it |
+| 8 | Resolved | Non-image files show filename text only — user accepted recommendation |

--- a/fab/changes/260321-ye3t-fix-compose-buffer-dialog/spec.md
+++ b/fab/changes/260321-ye3t-fix-compose-buffer-dialog/spec.md
@@ -1,0 +1,170 @@
+# Spec: Fix Compose Buffer Dialog
+
+**Change**: 260321-ye3t-fix-compose-buffer-dialog
+**Created**: 2026-03-21
+**Affected memory**: `docs/memory/run-kit/ui-patterns.md`
+
+## Non-Goals
+
+- Backend image serve endpoint — blob URLs are sufficient for compose-time preview
+- xterm.js inline image rendering — not supported by the terminal emulator
+- Post-send image preview (tracking `[Image #N]` labels in terminal output)
+
+## Upload Flow: File Object Threading
+
+### Requirement: Upload hook returns file metadata alongside paths
+
+The `useFileUpload` hook SHALL return `{ path: string; file: File }[]` instead of `string[]`. Each tuple pairs the server-assigned absolute path with the original `File` object from the browser.
+
+#### Scenario: Single image upload via paste
+- **GIVEN** a user pastes an image from clipboard
+- **WHEN** the upload completes successfully
+- **THEN** the hook returns `[{ path: "/abs/path/file.png", file: File }]`
+- **AND** the `File` object is the original from `clipboardData.files`
+
+#### Scenario: Multiple files uploaded via drag-and-drop
+- **GIVEN** a user drops 3 files onto the terminal
+- **WHEN** all uploads complete
+- **THEN** the hook returns 3 tuples in upload order
+- **AND** failed uploads are excluded from the result
+
+### Requirement: Terminal client threads file metadata to compose buffer
+
+The `openComposeWithPaths` callback in `terminal-client.tsx` SHALL accept `{ path: string; file: File }[]` and store both paths (for textarea text) and file references (for preview) in state. The compose buffer SHALL receive uploaded files as a prop.
+
+#### Scenario: Upload triggers compose buffer with preview data
+- **GIVEN** an upload completes with 2 image files
+- **WHEN** the compose buffer opens
+- **THEN** the textarea contains both paths (one per line)
+- **AND** the compose buffer receives both `File` objects for preview rendering
+
+## Compose Buffer: Image Preview
+
+### Requirement: Image thumbnails render above textarea
+
+The compose buffer SHALL render a horizontal thumbnail strip above the textarea for uploaded files. Image files (`file.type.startsWith("image/")`) SHALL display as `<img>` thumbnails using `URL.createObjectURL(file)`. Non-image files SHALL display their filename as text.
+
+#### Scenario: Image file shows thumbnail preview
+- **GIVEN** the compose buffer has an uploaded PNG file
+- **WHEN** the dialog renders
+- **THEN** a thumbnail (~60px tall) of the image appears above the textarea
+- **AND** the image source is a blob URL created from the File object
+
+#### Scenario: Non-image file shows filename
+- **GIVEN** the compose buffer has an uploaded `.json` file
+- **WHEN** the dialog renders
+- **THEN** the filename appears as text in the preview strip (no image)
+
+### Requirement: Thumbnails are dismissible
+
+Each preview item SHALL have an X button. Clicking X SHALL remove the file from the preview strip AND remove the corresponding path line from the textarea.
+
+#### Scenario: Remove uploaded image before sending
+- **GIVEN** the compose buffer shows 2 image thumbnails and 2 path lines
+- **WHEN** the user clicks X on the first thumbnail
+- **THEN** the first thumbnail is removed from the strip
+- **AND** the first path line is removed from the textarea
+- **AND** the second file remains unchanged
+
+### Requirement: Click thumbnail for larger preview
+
+Clicking a thumbnail SHALL toggle a larger preview view of the image within the dialog.
+
+#### Scenario: Enlarge and dismiss preview
+- **GIVEN** the compose buffer shows an image thumbnail
+- **WHEN** the user clicks the thumbnail
+- **THEN** a larger version of the image renders (constrained to dialog width)
+- **WHEN** the user clicks the enlarged image or presses Escape
+- **THEN** the view returns to the thumbnail strip
+
+### Requirement: Blob URLs are revoked on close
+
+All blob URLs created via `URL.createObjectURL()` SHALL be revoked via `URL.revokeObjectURL()` when the compose buffer closes (via close, send, or escape).
+
+#### Scenario: Cleanup on dialog close
+- **GIVEN** the compose buffer has 3 blob URLs for uploaded images
+- **WHEN** the user closes the dialog
+- **THEN** all 3 blob URLs are revoked
+
+## Compose Buffer: Path Duplication Fix
+
+### Requirement: Textarea value set via imperative ref only
+
+The compose buffer SHALL NOT use `defaultValue` on the textarea. Initial text SHALL be set imperatively via `textareaRef.current.value` in a single `useEffect`. Subsequent `initialText` changes (additional uploads while compose is open) SHALL append only the new text.
+
+#### Scenario: Initial open with uploaded path
+- **GIVEN** the compose buffer opens with `initialText="/path/to/image.png"`
+- **WHEN** the textarea renders
+- **THEN** the textarea contains exactly one copy of the path
+
+#### Scenario: Additional upload while compose is open
+- **GIVEN** the compose buffer is open with one path in the textarea
+- **WHEN** a second file is uploaded via the paperclip button
+- **THEN** the second path is appended on a new line
+- **AND** the first path is not duplicated
+
+## Compose Buffer: Dialog Pattern Alignment
+
+### Requirement: Fixed positioning with separate backdrop
+
+The compose buffer SHALL use `fixed inset-0 z-40` positioning (matching `dialog.tsx`) instead of `absolute inset-0 z-50`. A separate `<div className="fixed inset-0 bg-black/50" aria-hidden="true" />` SHALL serve as the backdrop layer.
+
+#### Scenario: Dialog renders above all content
+- **GIVEN** the compose buffer is open
+- **WHEN** the dialog renders
+- **THEN** the overlay covers the full viewport (`fixed inset-0`)
+- **AND** the backdrop is a separate element with `aria-hidden="true"`
+
+### Requirement: ARIA dialog attributes
+
+The compose buffer's content panel SHALL have `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` referencing the title element's ID.
+
+#### Scenario: Screen reader announces dialog
+- **GIVEN** the compose buffer opens
+- **WHEN** a screen reader reads the dialog
+- **THEN** it announces the dialog role with the "Text Input" title
+
+### Requirement: Focus trap within dialog
+
+The compose buffer SHALL trap Tab/Shift+Tab focus cycling within its focusable elements (textarea, upload button, send button, dismiss buttons). This SHALL match the focus trap implementation in `dialog.tsx`.
+
+#### Scenario: Tab cycles through dialog elements
+- **GIVEN** focus is on the Send button (last focusable element)
+- **WHEN** the user presses Tab
+- **THEN** focus moves to the textarea (first focusable element)
+
+#### Scenario: Shift+Tab wraps backward
+- **GIVEN** focus is on the textarea (first focusable element)
+- **WHEN** the user presses Shift+Tab
+- **THEN** focus moves to the Send button (last focusable element)
+
+### Requirement: Click-outside close uses two-layer pattern
+
+The compose buffer SHALL use the `dialog.tsx` two-layer close pattern: outer container has `onClick={onClose}`, inner content panel has `onClick={(e) => e.stopPropagation()}`.
+
+#### Scenario: Click outside closes dialog
+- **GIVEN** the compose buffer is open
+- **WHEN** the user clicks the backdrop
+- **THEN** the dialog closes
+
+#### Scenario: Click inside does not close
+- **GIVEN** the compose buffer is open
+- **WHEN** the user clicks the textarea or a button
+- **THEN** the dialog remains open
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Client-side blob URLs for preview | Confirmed from intake #1 — user agreed | S:95 R:90 A:95 D:95 |
+| 2 | Certain | No xterm.js terminal integration | Confirmed from intake #2 | S:90 R:95 A:90 D:95 |
+| 3 | Certain | Replicate Dialog pattern, don't wrap Dialog component | Confirmed from intake #3 — unique features | S:85 R:85 A:90 D:90 |
+| 4 | Certain | Thumbnail strip ~60px above textarea | Confirmed from intake #4 | S:95 R:90 A:70 D:75 |
+| 5 | Certain | Revoke blob URLs on dialog close | Confirmed from intake #5 | S:95 R:95 A:85 D:90 |
+| 6 | Certain | Drop defaultValue, imperative ref only | Confirmed from intake #6 | S:95 R:85 A:80 D:80 |
+| 7 | Certain | Keep existing "Text Input" title from main | Confirmed from intake #7 | S:95 R:95 A:90 D:95 |
+| 8 | Certain | Non-image files show filename text only | Confirmed from intake #8 | S:95 R:90 A:65 D:60 |
+| 9 | Certain | Thumbnails dismissible with X button | Confirmed from intake #9 | S:95 R:90 A:80 D:90 |
+| 10 | Certain | Click thumbnail for larger preview | Confirmed from intake #10 | S:95 R:90 A:80 D:90 |
+
+10 assumptions (10 certain, 0 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260321-ye3t-fix-compose-buffer-dialog/tasks.md
+++ b/fab/changes/260321-ye3t-fix-compose-buffer-dialog/tasks.md
@@ -1,0 +1,40 @@
+# Tasks: Fix Compose Buffer Dialog
+
+**Change**: 260321-ye3t-fix-compose-buffer-dialog
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+## Phase 1: Upload Flow Refactor
+
+- [x] T001 Change `useFileUpload` hook to return `{ path: string; file: File }[]` instead of `string[]` — `app/frontend/src/hooks/use-file-upload.ts`
+- [x] T002 Update `terminal-client.tsx` to thread `{ path, file }` tuples: change `openComposeWithPaths` to accept tuples, store uploaded files in state alongside text, pass files to `ComposeBuffer` — `app/frontend/src/components/terminal-client.tsx`
+
+## Phase 2: Core Implementation
+
+- [x] T003 Fix path duplication in `compose-buffer.tsx`: remove `defaultValue`, remove the append `useEffect`, set textarea value imperatively via ref on mount and on `initialText` change (append only new text) — `app/frontend/src/components/compose-buffer.tsx`
+- [x] T004 Add image preview strip to `compose-buffer.tsx`: render thumbnail strip above textarea, create blob URLs from `File` objects, show `<img>` for images and filename text for non-images, ~60px height — `app/frontend/src/components/compose-buffer.tsx`
+- [x] T005 Add dismiss (X) button per preview item: clicking removes the file from preview and its path from textarea — `app/frontend/src/components/compose-buffer.tsx`
+- [x] T006 Add click-to-enlarge: clicking a thumbnail toggles a larger constrained preview within the dialog, click or Escape dismisses — `app/frontend/src/components/compose-buffer.tsx`
+
+## Phase 3: Dialog Pattern Alignment
+
+- [x] T007 Refactor compose buffer layout to match `dialog.tsx` pattern: `fixed inset-0 z-40`, separate backdrop layer (`aria-hidden`), two-layer click-outside close (outer `onClick={onClose}`, inner `stopPropagation`) — `app/frontend/src/components/compose-buffer.tsx`
+- [x] T008 Add ARIA attributes: `role="dialog"`, `aria-modal="true"`, `aria-labelledby` referencing title ID via `useId()` — `app/frontend/src/components/compose-buffer.tsx`
+- [x] T009 Add focus trap: document-level keydown handler for Tab/Shift+Tab cycling within dialog focusable elements, matching `dialog.tsx` implementation — `app/frontend/src/components/compose-buffer.tsx`
+
+## Phase 4: Cleanup
+
+- [x] T010 Revoke all blob URLs on dialog close (close, send, escape) via cleanup in the component — `app/frontend/src/components/compose-buffer.tsx`
+- [x] T011 Run `cd app/frontend && npx tsc --noEmit` to verify no type errors
+
+---
+
+## Execution Order
+
+- T001 blocks T002 (hook return type must change before consumer)
+- T002 blocks T003-T006 (compose buffer needs file props)
+- T003 is independent of T004-T006
+- T004 blocks T005 and T006 (preview strip needed before dismiss/enlarge)
+- T007-T009 are independent of T003-T006 (dialog structure vs content)
+- T010 depends on T004 (needs blob URLs to exist)
+- T011 runs last


### PR DESCRIPTION
## Summary
- **Image preview**: Upload flow now threads `File` objects alongside paths. Compose buffer renders image thumbnails (blob URLs, ~60px) above textarea. Dismissible with X button, click to enlarge. Non-image files show filename text.
- **Path duplication fix**: Replaced `defaultValue` + `useEffect` append pattern with imperative ref-only textarea value management. Paths now appear exactly once.
- **Dialog pattern alignment**: Compose buffer now matches `dialog.tsx` structure — `fixed inset-0 z-40`, separate backdrop layer, `role="dialog"`, `aria-modal`, `aria-labelledby`, focus trap (Tab/Shift+Tab cycling), two-layer click-outside close.

## Test plan
- [ ] Upload an image via paste/drop/paperclip — verify thumbnail appears above textarea
- [ ] Upload a non-image file — verify filename text appears in preview strip
- [ ] Click X on a thumbnail — verify it's removed from both preview and textarea
- [ ] Click a thumbnail — verify larger preview toggles within dialog
- [ ] Upload image and check textarea shows path exactly once (no duplication)
- [ ] Upload additional file while compose is open — verify it appends without duplicating
- [ ] Verify Escape closes dialog (or dismisses enlarged preview first)
- [ ] Verify Tab/Shift+Tab cycles focus within dialog
- [ ] Verify clicking outside dialog closes it
- [ ] Run `tsc --noEmit` — passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)