### PR TITLE
fix: sanitize tmux server env to prevent direnv PATH corruption

### DIFF
--- a/app/backend/internal/tmux/tmux.go
+++ b/app/backend/internal/tmux/tmux.go
@@ -304,31 +304,58 @@ func CreateSession(name string, cwd string, server string) error {
 	}
 
 	full := append(serverArgs(server), args...)
-	cmd := exec.CommandContext(ctx, "tmux", full...)
-	cmd.Env = cleanEnvForServer()
+	return runTmuxWithEnv(ctx, full, cleanEnvForServer())
+}
+
+// runTmuxWithEnv executes a tmux command with an optional environment override,
+// capturing stderr for diagnostics.
+func runTmuxWithEnv(ctx context.Context, args []string, env []string) error {
+	cmd := exec.CommandContext(ctx, "tmux", args...)
+	if env != nil {
+		cmd.Env = env
+	}
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return fmt.Errorf("%w: %s", err, msg)
+		}
+		return err
 	}
 	return nil
 }
+
+// cleanPATH is the POSIX default PATH used to sanitize the tmux server environment.
+const cleanPATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 // cleanEnvForServer returns a copy of the current environment with PATH reset
 // to a clean POSIX default and all DIRENV_* variables removed. This prevents
 // the tmux server process from inheriting direnv state.
 func cleanEnvForServer() []string {
-	const cleanPATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-	var env []string
-	for _, e := range os.Environ() {
+	return sanitizeEnv(os.Environ())
+}
+
+// sanitizeEnv filters an environment slice: replaces PATH with a clean POSIX
+// default (deduplicating if present multiple times), strips DIRENV_* vars,
+// and ensures PATH is always present.
+func sanitizeEnv(environ []string) []string {
+	env := make([]string, 0, len(environ)+1)
+	pathSeen := false
+	for _, e := range environ {
 		if strings.HasPrefix(e, "DIRENV_") {
 			continue
 		}
 		if strings.HasPrefix(e, "PATH=") {
-			env = append(env, "PATH="+cleanPATH)
+			if !pathSeen {
+				env = append(env, "PATH="+cleanPATH)
+				pathSeen = true
+			}
 			continue
 		}
 		env = append(env, e)
+	}
+	if !pathSeen {
+		env = append(env, "PATH="+cleanPATH)
 	}
 	return env
 }

--- a/app/backend/internal/tmux/tmux.go
+++ b/app/backend/internal/tmux/tmux.go
@@ -286,6 +286,12 @@ func ListWindows(session string, server string) ([]WindowInfo, error) {
 
 // CreateSession creates a new detached tmux session on the specified server,
 // optionally in a specific directory.
+//
+// Because new-session may start the tmux server process, the command runs with
+// a sanitized environment: PATH is reset to a POSIX default and all DIRENV_*
+// vars are removed. Without this, the server inherits direnv-modified PATH from
+// the shell that launched run-kit, and every new pane gets stale/duplicated
+// PATH entries that corrupt direnv's diff computation.
 func CreateSession(name string, cwd string, server string) error {
 	ctx, cancel := withTimeout()
 	defer cancel()
@@ -297,8 +303,34 @@ func CreateSession(name string, cwd string, server string) error {
 		args = append(args, "-c", cwd)
 	}
 
-	_, err := tmuxExecServer(ctx, server, args...)
-	return err
+	full := append(serverArgs(server), args...)
+	cmd := exec.CommandContext(ctx, "tmux", full...)
+	cmd.Env = cleanEnvForServer()
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+// cleanEnvForServer returns a copy of the current environment with PATH reset
+// to a clean POSIX default and all DIRENV_* variables removed. This prevents
+// the tmux server process from inheriting direnv state.
+func cleanEnvForServer() []string {
+	const cleanPATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	var env []string
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "DIRENV_") {
+			continue
+		}
+		if strings.HasPrefix(e, "PATH=") {
+			env = append(env, "PATH="+cleanPATH)
+			continue
+		}
+		env = append(env, e)
+	}
+	return env
 }
 
 // CreateWindow creates a new window in an existing session on the specified server.

--- a/app/backend/internal/tmux/tmux_test.go
+++ b/app/backend/internal/tmux/tmux_test.go
@@ -265,6 +265,78 @@ func TestParseWindows(t *testing.T) {
 	}
 }
 
+func TestSanitizeEnv(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []string
+		wantHas []string // entries that must be present
+		wantNot []string // prefixes that must be absent
+	}{
+		{
+			name:    "replaces PATH and strips DIRENV vars",
+			input:   []string{"HOME=/home/user", "PATH=/dirty/path:/usr/bin", "DIRENV_DIFF=abc", "DIRENV_DIR=/foo", "SHELL=/bin/zsh"},
+			wantHas: []string{"HOME=/home/user", "PATH=" + cleanPATH, "SHELL=/bin/zsh"},
+			wantNot: []string{"DIRENV_", "/dirty/path"},
+		},
+		{
+			name:    "adds PATH when missing",
+			input:   []string{"HOME=/home/user", "SHELL=/bin/zsh"},
+			wantHas: []string{"HOME=/home/user", "PATH=" + cleanPATH, "SHELL=/bin/zsh"},
+			wantNot: nil,
+		},
+		{
+			name:    "deduplicates multiple PATH entries",
+			input:   []string{"PATH=/first", "PATH=/second"},
+			wantHas: []string{"PATH=" + cleanPATH},
+			wantNot: []string{"/first", "/second"},
+		},
+		{
+			name:    "empty input still has PATH",
+			input:   nil,
+			wantHas: []string{"PATH=" + cleanPATH},
+			wantNot: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeEnv(tt.input)
+
+			for _, want := range tt.wantHas {
+				found := false
+				for _, e := range got {
+					if e == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("missing expected entry %q in %v", want, got)
+				}
+			}
+
+			for _, prefix := range tt.wantNot {
+				for _, e := range got {
+					if strings.Contains(e, prefix) {
+						t.Errorf("unexpected entry %q containing %q", e, prefix)
+					}
+				}
+			}
+
+			// PATH should appear exactly once.
+			pathCount := 0
+			for _, e := range got {
+				if strings.HasPrefix(e, "PATH=") {
+					pathCount++
+				}
+			}
+			if pathCount != 1 {
+				t.Errorf("PATH appears %d times, want 1", pathCount)
+			}
+		})
+	}
+}
+
 // sessionInfoSliceEqual compares two SessionInfo slices, treating nil and empty as equivalent.
 func sessionInfoSliceEqual(a, b []SessionInfo) bool {
 	if len(a) == 0 && len(b) == 0 {

--- a/configs/tmux/default.conf
+++ b/configs/tmux/default.conf
@@ -11,16 +11,6 @@ set -g renumber-windows on
 set -g base-index 1
 set -g pane-base-index 1
 
-# Prevent stale direnv state from leaking into new panes.
-# The tmux server (or session) may carry DIRENV_DIFF from whichever
-# shell started it. New panes inherit this, causing direnv to reverse
-# out PATH entries that .zshrc added (like dev-shell bins) because
-# they weren't in the original diff baseline. Removing all three
-# DIRENV vars forces each new pane's direnv to start fresh.
-set-environment -g -r DIRENV_DIFF
-set-environment -g -r DIRENV_DIR
-set-environment -g -r DIRENV_WATCHES
-set-environment -g -r DIRENV_FILE
 
 # --- Prefix (explicit default) ---
 set -g prefix C-b

--- a/configs/tmux/default.conf
+++ b/configs/tmux/default.conf
@@ -11,11 +11,16 @@ set -g renumber-windows on
 set -g base-index 1
 set -g pane-base-index 1
 
-# Prevent tmux server from baking a stale PATH into new panes.
-# Without this, direnv-modified PATH from the session that started
-# the server leaks into every new pane and corrupts direnv's
-# diff computation (stripping entries it doesn't "own").
-set-environment -g -r PATH
+# Prevent stale direnv state from leaking into new panes.
+# The tmux server (or session) may carry DIRENV_DIFF from whichever
+# shell started it. New panes inherit this, causing direnv to reverse
+# out PATH entries that .zshrc added (like dev-shell bins) because
+# they weren't in the original diff baseline. Removing all three
+# DIRENV vars forces each new pane's direnv to start fresh.
+set-environment -g -r DIRENV_DIFF
+set-environment -g -r DIRENV_DIR
+set-environment -g -r DIRENV_WATCHES
+set-environment -g -r DIRENV_FILE
 
 # --- Prefix (explicit default) ---
 set -g prefix C-b

--- a/docs/wiki/tailscale.md
+++ b/docs/wiki/tailscale.md
@@ -15,8 +15,7 @@ Enable HTTPS on your tailnet in the [Tailscale admin console](https://login.tail
 Tailscale Serve acts as a reverse proxy with automatic TLS — no cert files, no config.
 
 ```sh
-# Proxy HTTPS traffic to the run-kit Go server
-tailscale serve https / http://localhost:3000
+tailscale serve --bg http://localhost:3000
 ```
 
 That's it. run-kit is now available at:
@@ -78,7 +77,7 @@ tailscale serve off
 To expose run-kit to the public internet (not just your tailnet):
 
 ```sh
-tailscale funnel https / http://localhost:3000
+tailscale funnel --bg http://localhost:3000
 ```
 
 > **Warning:** Funnel makes your terminal relay publicly accessible. Only use this if you understand the security implications.


### PR DESCRIPTION
## Summary

- Sanitize the environment in `CreateSession` before spawning the tmux server: reset PATH to a clean POSIX default and strip all `DIRENV_*` vars
- Prevents stale `DIRENV_DIFF` and direnv-modified PATH from leaking into every new pane, which caused direnv to strip PATH entries added by `.zshrc` (e.g. dev-shell bins) and duplicate the entire PATH on each pane creation
- The tmux config `set-environment` approach was insufficient — tmux 3.2a doesn't override the server process's inherited environment via `set-environment -g`

## Test plan

- [ ] Rebuild and kill the work tmux server (`tmux -L work kill-server`)
- [ ] Let run-kit recreate it, open a new pane
- [ ] `echo $PATH | tr ':' '\n' | grep dev-shell` — should show 3 entries
- [ ] `echo $PATH | tr ':' '\n' | sort | uniq -d` — should only show harmless duplicates from .zshrc (e.g. `.local/bin`, `/usr/local/bin`)
- [ ] `cd` out and back into a direnv-managed directory — PATH should survive the load/unload cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)