### PR TITLE
feat: Add PWA Manifest for Install-as-App

### DIFF
--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -7,6 +7,7 @@
     <meta name="description" content="Web-based agent orchestration dashboard" />
     <meta name="theme-color" content="#0f1117" />
     <link rel="apple-touch-icon" href="/icons/icon-192.png" />
+    <link rel="manifest" href="/manifest.json" />
     <script>
       // Blocking theme initialization — runs before first paint to prevent flicker.
       // Reads user preference from localStorage and resolves to "dark" or "light".

--- a/app/frontend/public/manifest.json
+++ b/app/frontend/public/manifest.json
@@ -1,0 +1,27 @@
+{
+  "name": "RunKit",
+  "short_name": "RunKit",
+  "description": "Web-based agent orchestration dashboard",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0f1117",
+  "theme_color": "#0f1117",
+  "icons": [
+    {
+      "src": "/icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    },
+    {
+      "src": "/icons/icon-512-maskable.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/fab/changes/260323-ubj4-add-pwa-manifest/.history.jsonl
+++ b/fab/changes/260323-ubj4-add-pwa-manifest/.history.jsonl
@@ -1,0 +1,4 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-03-23T08:52:21Z"}
+{"args":"Add static PWA manifest for Install as App support","cmd":"fab-new","event":"command","ts":"2026-03-23T08:52:21Z"}
+{"delta":"+4.7","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-23T08:52:48Z"}
+{"delta":"+0.0","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-23T08:53:00Z"}

--- a/fab/changes/260323-ubj4-add-pwa-manifest/.status.yaml
+++ b/fab/changes/260323-ubj4-add-pwa-manifest/.status.yaml
@@ -33,5 +33,6 @@ confidence:
         disambiguation: 90.0
 stage_metrics:
     intake: {started_at: "2026-03-23T08:52:21Z", driver: fab-new, iterations: 1}
-prs: []
-last_updated: 2026-03-23T08:53:02Z
+prs:
+    - https://github.com/wvrdz/run-kit/pull/72
+last_updated: 2026-03-23T08:54:10Z

--- a/fab/changes/260323-ubj4-add-pwa-manifest/.status.yaml
+++ b/fab/changes/260323-ubj4-add-pwa-manifest/.status.yaml
@@ -1,0 +1,37 @@
+id: ubj4
+name: 260323-ubj4-add-pwa-manifest
+created: 2026-03-23T08:52:21Z
+created_by: sahil-weaver
+change_type: feat
+issues: []
+progress:
+    intake: ready
+    spec: pending
+    tasks: pending
+    apply: pending
+    review: pending
+    hydrate: pending
+    ship: pending
+    review-pr: pending
+checklist:
+    generated: false
+    path: checklist.md
+    completed: 0
+    total: 0
+confidence:
+    certain: 4
+    confident: 1
+    tentative: 0
+    unresolved: 0
+    score: 4.7
+    indicative: true
+    fuzzy: true
+    dimensions:
+        signal: 86.0
+        reversibility: 90.0
+        competence: 88.0
+        disambiguation: 90.0
+stage_metrics:
+    intake: {started_at: "2026-03-23T08:52:21Z", driver: fab-new, iterations: 1}
+prs: []
+last_updated: 2026-03-23T08:53:02Z

--- a/fab/changes/260323-ubj4-add-pwa-manifest/intake.md
+++ b/fab/changes/260323-ubj4-add-pwa-manifest/intake.md
@@ -1,0 +1,61 @@
+# Intake: Add PWA Manifest for Install-as-App
+
+**Change**: 260323-ubj4-add-pwa-manifest
+**Created**: 2026-03-23
+**Status**: Draft
+
+## Origin
+
+> User asked whether the tmux server preference is stored in localStorage (it is, via `runkit-server` key with `?server=` URL param override). They wanted to "Install Page as App" in Chrome/Safari with each installed app targeting a specific server. The `?server=` mechanism already supports this — the browser preserves the full URL at install time — but Chrome requires a web app manifest to offer the install prompt.
+>
+> A previous PR (#59, commit `7186983`) added full PWA support via `vite-plugin-pwa`, but it was reverted the next day (commit `75034a1`) because the service worker cached stale assets with no offline benefit (the app needs live tmux connections). The revert removed the manifest and meta tags along with the service worker. The icons (`public/icons/`) survived.
+>
+> Decision: re-add just the manifest and `<link rel="manifest">` tag — no service worker, no caching plugin.
+
+## Why
+
+1. **Problem**: Chrome and Safari won't offer "Install Page as App" / "Add to Home Screen" without a valid web app manifest. Users who want dedicated per-server app windows (one installed app per `?server=` value) can't create them.
+2. **Consequence without fix**: Users must use regular browser tabs, losing standalone window mode and per-server separation.
+3. **Approach**: A static `manifest.json` in `public/` with `display: "standalone"` is the minimal requirement. No build plugin needed — Vite serves static files from `public/` as-is. The previous approach (`vite-plugin-pwa`) was over-engineered for this use case; the service worker caused more harm than good.
+
+## What Changes
+
+### `app/frontend/public/manifest.json` (new file)
+
+Static web app manifest with:
+- `name` / `short_name`: "RunKit"
+- `display`: "standalone" — opens in its own window, no browser chrome
+- `start_url`: "/" — neutral so the browser uses the actual URL at install time, preserving any `?server=` query param
+- `theme_color` / `background_color`: `#0f1117` (dark theme default, matching existing `<meta name="theme-color">`)
+- `icons`: references the three existing icons in `public/icons/` (192px, 512px, 512px maskable)
+
+### `app/frontend/index.html` (modify)
+
+Add `<link rel="manifest" href="/manifest.json" />` after the existing `<link rel="apple-touch-icon">` tag. This is the only HTML change needed — the apple-touch-icon and theme-color meta tags are already present from the previous PWA work.
+
+## Affected Memory
+
+- `run-kit/architecture`: (modify) Note that the app includes a PWA manifest for install-as-app support (no service worker)
+
+## Impact
+
+- **Frontend only** — no backend changes
+- **Two files**: one new (`manifest.json`), one modified (`index.html`)
+- **No new dependencies** — no `vite-plugin-pwa`, no build config changes
+- **Icons already exist** in `public/icons/` from the previous PWA PR
+
+## Open Questions
+
+None — scope is fully defined by the conversation.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | No service worker or caching | Discussed — user explicitly removed vite-plugin-pwa due to stale asset caching with no offline benefit | S:95 R:90 A:95 D:95 |
+| 2 | Certain | Use existing icons from public/icons/ | Icons survived the revert and are already in place | S:90 R:95 A:95 D:95 |
+| 3 | Certain | start_url is "/" not a specific server URL | Discussed — browser uses actual URL at install time, preserving ?server= param | S:90 R:85 A:90 D:90 |
+| 4 | Certain | Dark theme colors (#0f1117) for manifest | Matches existing theme-color meta tag already in index.html | S:85 R:95 A:90 D:95 |
+| 5 | Confident | No iOS apple-mobile-web-app-capable meta tag needed | Previous revert explicitly removed it; apple-touch-icon already present for home screen icon | S:70 R:85 A:70 D:75 |
+
+5 assumptions (4 certain, 1 confident, 0 tentative, 0 unresolved).


### PR DESCRIPTION
## Summary

Re-adds a static `manifest.json` and `<link rel="manifest">` tag to enable Chrome/Safari "Install Page as App". The previous PWA implementation (PR #59) was reverted because `vite-plugin-pwa`'s service worker cached stale assets with no offline benefit. This adds back only the manifest — no service worker, no caching.

## Changes

- New `app/frontend/public/manifest.json` with standalone display mode and existing icon references
- Added `<link rel="manifest">` to `app/frontend/index.html`

## Change

| ID | Name | Issue |
|----|------|-------|
| ubj4 | 260323-ubj4-add-pwa-manifest | — |

## Stats

| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| feat | 4.7 / 5.0 | — | — | — |

[intake](https://github.com/wvrdz/run-kit/blob/260323-ubj4-add-pwa-manifest/fab/changes/260323-ubj4-add-pwa-manifest/intake.md)