### PR TITLE
refactor: consolidate button sizes to two tiers and clean up toolbar layout

### DIFF
--- a/app/frontend/src/app.tsx
+++ b/app/frontend/src/app.tsx
@@ -513,7 +513,7 @@ function AppShell() {
                 </div>
                 {/* Bottom Bar — only on terminal pages */}
                 <div className="shrink-0 border-t border-border px-1.5 h-[48px]">
-                  <BottomBar wsRef={wsRef} hostname={hostname} />
+                  <BottomBar wsRef={wsRef} hostname={hostname} onOpenCompose={() => setComposeOpen((v) => !v)} />
                 </div>
               </>
             ) : (

--- a/app/frontend/src/components/arrow-pad.tsx
+++ b/app/frontend/src/components/arrow-pad.tsx
@@ -9,7 +9,7 @@ type ArrowPadProps = {
 };
 
 const ARROW_BTN =
-  "min-h-[30px] min-w-[30px] flex items-center justify-center text-sm text-text-secondary border border-border rounded select-none active:bg-bg-card hover:border-text-secondary focus-visible:outline-2 focus-visible:outline-accent";
+  "min-h-[36px] min-w-[36px] flex items-center justify-center text-sm text-text-secondary border border-border rounded select-none active:bg-bg-card hover:border-text-secondary focus-visible:outline-2 focus-visible:outline-accent";
 
 /**
  * Combined arrow key control:
@@ -96,7 +96,7 @@ export function ArrowPad({ onArrow, className }: ArrowPadProps) {
         aria-label="Arrow keys"
         aria-haspopup="true"
         aria-expanded={open}
-        className="min-h-[36px] min-w-[36px] coarse:min-h-[36px] coarse:min-w-[36px] flex items-center justify-center px-1 py-0 text-xs border border-border rounded select-none transition-colors hover:border-text-secondary active:bg-bg-card focus-visible:outline-2 focus-visible:outline-accent text-text-secondary touch-none"
+        className="min-h-[36px] min-w-[36px] flex items-center justify-center px-1 py-0 text-xs border border-border rounded select-none transition-colors hover:border-text-secondary active:bg-bg-card focus-visible:outline-2 focus-visible:outline-accent text-text-secondary touch-none"
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
         onMouseDown={handleMouseDown}

--- a/app/frontend/src/components/bottom-bar.tsx
+++ b/app/frontend/src/components/bottom-bar.tsx
@@ -5,6 +5,7 @@ import { ArrowPad } from "@/components/arrow-pad";
 type BottomBarProps = {
   wsRef: React.RefObject<WebSocket | null>;
   hostname?: string;
+  onOpenCompose?: () => void;
 };
 
 /** xterm modifier parameter: 1 + (alt?2:0) + (ctrl?4:0) */
@@ -44,14 +45,14 @@ const EXT_KEYS = [
 ] as const;
 
 const KBD_CLASS =
-  "min-h-[36px] min-w-[36px] coarse:min-h-[36px] coarse:min-w-[36px] flex items-center justify-center px-1 py-0 text-xs border border-border rounded select-none transition-colors hover:border-text-secondary active:bg-bg-card focus-visible:outline-2 focus-visible:outline-accent";
+  "min-h-[36px] min-w-[36px] flex items-center justify-center px-1 py-0 text-xs border border-border rounded select-none transition-colors hover:border-text-secondary active:bg-bg-card focus-visible:outline-2 focus-visible:outline-accent";
 
 const MODIFIER_LABELS: Record<string, string> = {
   ctrl: "Control",
   alt: "Option",
 };
 
-export function BottomBar({ wsRef, hostname }: BottomBarProps) {
+export function BottomBar({ wsRef, hostname, onOpenCompose }: BottomBarProps) {
   const mods = useModifierState();
   const [fnOpen, setFnOpen] = useState(false);
   const fnRef = useRef<HTMLDivElement>(null);
@@ -156,8 +157,6 @@ export function BottomBar({ wsRef, hostname }: BottomBarProps) {
         <kbd aria-hidden="true">{"\u21E5"}</kbd>
       </button>
 
-      <div className="w-px h-5 bg-border mx-0.5" aria-hidden="true" />
-
       {([["ctrl", "^"], ["alt", "\u2325"]] as const).map(([key, symbol]) => (
         <button
           key={key}
@@ -169,8 +168,6 @@ export function BottomBar({ wsRef, hostname }: BottomBarProps) {
           <kbd aria-hidden="true">{symbol}</kbd>
         </button>
       ))}
-
-      <div className="w-px h-5 bg-border mx-0.5" aria-hidden="true" />
 
       <div ref={fnRef} className="relative">
         <button
@@ -194,7 +191,7 @@ export function BottomBar({ wsRef, hostname }: BottomBarProps) {
                   key={fk.label}
                   role="menuitem"
                   aria-label={fk.label}
-                  className="px-2 py-1 min-h-[30px] flex items-center justify-center text-xs text-text-secondary hover:text-text-primary hover:bg-bg-card rounded focus-visible:outline-2 focus-visible:outline-accent"
+                  className="px-2 py-1 min-h-[36px] flex items-center justify-center text-xs text-text-secondary hover:text-text-primary hover:bg-bg-card rounded focus-visible:outline-2 focus-visible:outline-accent"
                   onClick={() => { sendWithMods(fk.plain, fk.mod); setFnOpen(false); }}
                 >
                   {fk.label}
@@ -208,7 +205,7 @@ export function BottomBar({ wsRef, hostname }: BottomBarProps) {
                   key={ek.label}
                   role="menuitem"
                   aria-label={ek.label}
-                  className="px-2 py-1 min-h-[30px] flex items-center justify-center text-xs text-text-secondary hover:text-text-primary hover:bg-bg-card rounded focus-visible:outline-2 focus-visible:outline-accent"
+                  className="px-2 py-1 min-h-[36px] flex items-center justify-center text-xs text-text-secondary hover:text-text-primary hover:bg-bg-card rounded focus-visible:outline-2 focus-visible:outline-accent"
                   onClick={() => { sendWithMods(ek.plain, ek.mod); setFnOpen(false); }}
                 >
                   {ek.label}
@@ -223,6 +220,16 @@ export function BottomBar({ wsRef, hostname }: BottomBarProps) {
 
       <div className="w-px h-5 bg-border mx-0.5" aria-hidden="true" />
 
+      {onOpenCompose && (
+        <button
+          type="button"
+          onClick={onOpenCompose}
+          aria-label="Compose text"
+          className={`${KBD_CLASS} text-text-secondary`}
+        >
+          &gt;_
+        </button>
+      )}
       <button
         aria-label="Open command palette"
         className={`${KBD_CLASS} text-text-secondary`}

--- a/app/frontend/src/components/breadcrumb-dropdown.tsx
+++ b/app/frontend/src/components/breadcrumb-dropdown.tsx
@@ -93,7 +93,7 @@ export function BreadcrumbDropdown({ items, label, icon, onNavigate, action, tri
         aria-expanded={open}
         aria-label={label ? `Switch ${label}` : "Switch"}
         onClick={toggle}
-        className={`min-w-[24px] min-h-[24px] coarse:min-w-[36px] coarse:min-h-[36px] flex items-center transition-colors ${triggerClassName ?? "text-text-secondary hover:text-text-primary"}`}
+        className={`min-w-[24px] min-h-[24px] flex items-center transition-colors ${triggerClassName ?? "text-text-secondary hover:text-text-primary"}`}
       >
         {icon ?? "\u25BE"}
       </button>

--- a/app/frontend/src/components/dashboard.tsx
+++ b/app/frontend/src/components/dashboard.tsx
@@ -56,7 +56,7 @@ export function Dashboard({
               {/* Session card header */}
               <button
                 onClick={() => toggleExpand(session.name)}
-                className="w-full text-left p-3 coarse:min-h-[44px] flex items-center justify-between"
+                className="w-full text-left p-3 min-h-[36px] flex items-center justify-between"
                 aria-expanded={isExpanded}
                 aria-label={`${isExpanded ? "Collapse" : "Expand"} ${session.name}`}
               >
@@ -93,7 +93,7 @@ export function Dashboard({
                       <button
                         key={win.index}
                         onClick={() => onNavigate(session.name, win.index)}
-                        className="w-full text-left p-2 rounded bg-bg-primary border border-border hover:border-text-secondary transition-colors coarse:min-h-[44px]"
+                        className="w-full text-left p-2 rounded bg-bg-primary border border-border hover:border-text-secondary transition-colors min-h-[36px]"
                         data-testid={`window-card-${session.name}-${win.index}`}
                       >
                         <div className="flex items-center justify-between gap-2">
@@ -147,7 +147,7 @@ export function Dashboard({
                       e.stopPropagation();
                       onCreateWindow(session.name);
                     }}
-                    className="text-sm text-text-secondary hover:text-text-primary transition-colors py-1.5 border border-dashed border-border rounded hover:border-text-secondary coarse:min-h-[44px] flex items-center justify-center"
+                    className="text-sm text-text-secondary hover:text-text-primary transition-colors py-1.5 border border-dashed border-border rounded hover:border-text-secondary min-h-[36px] flex items-center justify-center"
                   >
                     + New Window
                   </button>
@@ -160,7 +160,7 @@ export function Dashboard({
         {/* New Session button card */}
         <button
           onClick={onCreateSession}
-          className="border border-dashed border-border rounded p-3 text-sm text-text-secondary hover:text-text-primary hover:border-text-secondary transition-colors coarse:min-h-[44px] flex items-center justify-center"
+          className="border border-dashed border-border rounded p-3 text-sm text-text-secondary hover:text-text-primary hover:border-text-secondary transition-colors min-h-[36px] flex items-center justify-center"
         >
           + New Session
         </button>

--- a/app/frontend/src/components/sidebar.tsx
+++ b/app/frontend/src/components/sidebar.tsx
@@ -152,7 +152,7 @@ export function Sidebar({
                   <div className="flex items-center gap-0.5 min-w-0">
                     <button
                       onClick={() => toggleSession(session.name)}
-                      className="text-xs text-text-secondary hover:text-text-primary transition-colors w-5 shrink-0 min-h-[32px] coarse:min-h-[44px] flex items-center justify-center"
+                      className="text-xs text-text-secondary hover:text-text-primary transition-colors w-5 shrink-0 min-h-[36px] flex items-center justify-center"
                       aria-expanded={!isCollapsed}
                       aria-label={`${isCollapsed ? "Expand" : "Collapse"} ${session.name}`}
                     >
@@ -160,7 +160,7 @@ export function Sidebar({
                     </button>
                     <button
                       onClick={() => onSelectWindow(session.name, session.windows[0]?.index ?? 0)}
-                      className="flex items-center gap-1 text-sm text-text-secondary hover:text-text-primary transition-colors py-1 min-h-[32px] coarse:min-h-[44px] min-w-0"
+                      className="flex items-center gap-1 text-sm text-text-secondary hover:text-text-primary transition-colors py-1 min-h-[36px] min-w-0"
                       aria-label={`Navigate to ${session.name}`}
                     >
                       <span className="font-medium truncate">{session.name}</span>
@@ -170,7 +170,7 @@ export function Sidebar({
                     <button
                       onClick={() => onCreateWindow(session.name)}
                       aria-label={`New window in ${session.name}`}
-                      className="text-text-secondary hover:text-text-primary transition-colors text-[16px] px-1 min-h-[32px] coarse:min-h-[44px] flex items-center justify-center"
+                      className="text-text-secondary hover:text-text-primary transition-colors text-[16px] px-1 min-h-[36px] flex items-center justify-center"
                     >
                       +
                     </button>
@@ -183,7 +183,7 @@ export function Sidebar({
                         })
                       }
                       aria-label={`Kill session ${session.name}`}
-                      className="text-text-secondary hover:text-red-400 transition-colors text-[16px] px-1 min-h-[32px] coarse:min-h-[44px] flex items-center justify-center"
+                      className="text-text-secondary hover:text-red-400 transition-colors text-[16px] px-1 min-h-[36px] flex items-center justify-center"
                     >
                       {"\u2715"}
                     </button>
@@ -204,7 +204,7 @@ export function Sidebar({
                         <div key={win.index} className="relative group">
                           <button
                             onClick={() => onSelectWindow(session.name, win.index)}
-                            className={`w-full text-left flex items-center justify-between gap-2 py-1 pl-2 pr-6 text-sm transition-colors min-h-[28px] coarse:min-h-[44px] border-l-2 ${
+                            className={`w-full text-left flex items-center justify-between gap-2 py-1 pl-2 pr-6 text-sm transition-colors min-h-[36px] border-l-2 ${
                               isSelected
                                 ? "bg-accent/10 border-accent text-text-primary font-medium rounded-r"
                                 : "text-text-secondary hover:text-text-primary hover:bg-bg-card/50 border-transparent rounded"
@@ -269,7 +269,7 @@ export function Sidebar({
                                 windowCount: 1,
                               });
                             }}
-                            className="absolute right-0.5 top-1/2 -translate-y-1/2 text-[14px] text-text-secondary hover:text-red-400 transition-opacity cursor-pointer opacity-0 group-hover:opacity-100 coarse:opacity-100 px-1 min-h-[28px] coarse:min-h-[44px] flex items-center justify-center z-10"
+                            className="absolute right-0.5 top-1/2 -translate-y-1/2 text-[14px] text-text-secondary hover:text-red-400 transition-opacity cursor-pointer opacity-0 group-hover:opacity-100 coarse:opacity-100 px-1 min-h-[36px] flex items-center justify-center z-10"
                           >
                             {"\u2715"}
                           </button>
@@ -290,7 +290,7 @@ export function Sidebar({
           <span className="text-xs text-text-secondary">tmux server:</span>
           <button
             onClick={() => setServerDropdownOpen((v) => { if (!v) onRefreshServers(); return !v; })}
-            className="text-xs text-text-primary font-medium hover:text-accent transition-colors coarse:min-h-[44px] flex items-center"
+            className="text-xs text-text-primary font-medium hover:text-accent transition-colors min-h-[36px] flex items-center"
             aria-haspopup="listbox"
             aria-expanded={serverDropdownOpen}
           >

--- a/app/frontend/src/components/top-bar.tsx
+++ b/app/frontend/src/components/top-bar.tsx
@@ -145,7 +145,7 @@ export function TopBar({
               }
             }}
             aria-label="Toggle navigation"
-            className="text-text-primary transition-colors min-w-[24px] min-h-[24px] coarse:min-w-[36px] coarse:min-h-[36px] flex items-center justify-center"
+            className="text-text-primary transition-colors min-w-[24px] min-h-[24px] flex items-center justify-center"
           >
             <HamburgerIcon isOpen={hamburgerOpen} />
           </button>
@@ -182,8 +182,44 @@ export function TopBar({
         </nav>
 
         <div className="flex items-center gap-3 text-xs text-text-secondary">
-          {/* Logo + "Run Kit" — links to dashboard */}
+          <span className="hidden sm:flex">
+            <ThemeToggle />
+          </span>
+
+          {currentWindow && (
+            <>
+              <span className="hidden sm:flex">
+                <SplitButton
+                  session={sessionName}
+                  windowIndex={currentWindow.index}
+                />
+              </span>
+              <span className="hidden sm:flex">
+                <SplitButton
+                  horizontal
+                  session={sessionName}
+                  windowIndex={currentWindow.index}
+                />
+              </span>
+              <span className="hidden sm:flex">
+                <FixedWidthToggle />
+              </span>
+            </>
+          )}
+
+          {/* Connection dot */}
+          <span role="status" aria-live="polite" className="hidden sm:inline">
+            <span
+              className={`block w-2 h-2 rounded-full ${
+                isConnected ? "bg-accent-green" : "bg-text-secondary"
+              }`}
+              aria-label={isConnected ? "Connected" : "Disconnected"}
+            />
+          </span>
+
+          {/* "Run Kit" + Logo — links to dashboard */}
           <a href="/" className="flex items-center gap-3 text-text-secondary hover:text-text-primary transition-colors">
+            <span className="hidden sm:inline text-xs">Run Kit</span>
             <img
               src="/logo.svg"
               alt="Run Kit"
@@ -198,51 +234,7 @@ export function TopBar({
               height={30}
               className="sm:hidden"
             />
-            <span className="hidden sm:inline text-xs">Run Kit</span>
           </a>
-
-          {/* Connection dot — live region scoped to non-interactive status indicator */}
-          <span role="status" aria-live="polite" className="hidden sm:inline">
-            <span
-              className={`block w-2 h-2 rounded-full ${
-                isConnected ? "bg-accent-green" : "bg-text-secondary"
-              }`}
-              aria-label={isConnected ? "Connected" : "Disconnected"}
-            />
-          </span>
-
-          {currentWindow && (
-            <>
-              <span className="hidden sm:flex">
-                <FixedWidthToggle />
-              </span>
-              <span className="hidden sm:flex">
-                <SplitButton
-                  horizontal
-                  session={sessionName}
-                  windowIndex={currentWindow.index}
-                />
-              </span>
-              <span className="hidden sm:flex">
-                <SplitButton
-                  session={sessionName}
-                  windowIndex={currentWindow.index}
-                />
-              </span>
-              <button
-                type="button"
-                onClick={onOpenCompose}
-                aria-label="Compose text"
-                className="text-text-secondary hover:border-text-secondary transition-colors min-w-[24px] min-h-[24px] sm:min-w-[24px] sm:min-h-[24px] coarse:min-w-[36px] coarse:min-h-[36px] flex items-center justify-center border border-border rounded text-xs"
-              >
-                &gt;_
-              </button>
-            </>
-          )}
-
-          <span className="hidden sm:flex">
-            <ThemeToggle />
-          </span>
         </div>
       </div>
     </header>
@@ -271,7 +263,7 @@ function ThemeToggle() {
       type="button"
       onClick={cycle}
       aria-label={THEME_LABELS[preference]}
-      className="min-w-[24px] min-h-[24px] rounded border border-border text-text-secondary hover:border-text-secondary transition-colors coarse:min-h-[36px] coarse:min-w-[28px] flex items-center justify-center"
+      className="min-w-[24px] min-h-[24px] rounded border border-border text-text-secondary hover:border-text-secondary transition-colors flex items-center justify-center"
       title={THEME_LABELS[preference]}
     >
       {preference === "light" ? (
@@ -325,7 +317,7 @@ function SplitButton({
       type="button"
       onClick={handleClick}
       aria-label={label}
-      className="min-w-[24px] min-h-[24px] rounded border border-border text-text-secondary hover:border-text-secondary transition-colors coarse:min-h-[36px] coarse:min-w-[28px] flex items-center justify-center"
+      className="min-w-[24px] min-h-[24px] rounded border border-border text-text-secondary hover:border-text-secondary transition-colors flex items-center justify-center"
       title={label}
     >
       <svg
@@ -368,7 +360,7 @@ function FixedWidthToggle() {
       onClick={toggleFixedWidth}
       aria-label="Toggle fixed terminal width"
       aria-pressed={fixedWidth}
-      className={`min-w-[24px] min-h-[24px] rounded border transition-colors coarse:min-h-[36px] coarse:min-w-[28px] flex items-center justify-center ${
+      className={`min-w-[24px] min-h-[24px] rounded border transition-colors flex items-center justify-center ${
         fixedWidth
           ? "border-accent text-accent bg-accent/10"
           : "border-border text-text-secondary hover:border-text-secondary"

--- a/fab/changes/260323-6491-consolidate-icon-sizes-toolbar-layout/.history.jsonl
+++ b/fab/changes/260323-6491-consolidate-icon-sizes-toolbar-layout/.history.jsonl
@@ -1,0 +1,5 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-03-23T09:15:38Z"}
+{"args":"Consolidate responsive icon sizing to two flat tiers (compact 24px, standard 36px), remove all coarse: pointer-type variants, move compose button from top bar to bottom bar, remove bottom bar separators, and reverse the order of top-right toolbar icons so logo is rightmost.","cmd":"fab-new","event":"command","ts":"2026-03-23T09:15:38Z"}
+{"delta":"+4.7","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-23T09:16:30Z"}
+{"delta":"+0.0","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-23T09:16:44Z"}
+{"cmd":"fab-new","event":"command","ts":"2026-03-23T09:16:53Z"}

--- a/fab/changes/260323-6491-consolidate-icon-sizes-toolbar-layout/.status.yaml
+++ b/fab/changes/260323-6491-consolidate-icon-sizes-toolbar-layout/.status.yaml
@@ -1,0 +1,37 @@
+id: 6491
+name: 260323-6491-consolidate-icon-sizes-toolbar-layout
+created: 2026-03-23T09:15:38Z
+created_by: sahil-weaver
+change_type: refactor
+issues: []
+progress:
+    intake: ready
+    spec: pending
+    tasks: pending
+    apply: pending
+    review: pending
+    hydrate: pending
+    ship: pending
+    review-pr: pending
+checklist:
+    generated: false
+    path: checklist.md
+    completed: 0
+    total: 0
+confidence:
+    certain: 6
+    confident: 1
+    tentative: 0
+    unresolved: 0
+    score: 4.7
+    indicative: true
+    fuzzy: true
+    dimensions:
+        signal: 90.0
+        reversibility: 86.4
+        competence: 88.6
+        disambiguation: 94.3
+stage_metrics:
+    intake: {started_at: "2026-03-23T09:15:38Z", driver: fab-new, iterations: 1}
+prs: []
+last_updated: 2026-03-23T09:16:49Z

--- a/fab/changes/260323-6491-consolidate-icon-sizes-toolbar-layout/intake.md
+++ b/fab/changes/260323-6491-consolidate-icon-sizes-toolbar-layout/intake.md
@@ -1,0 +1,111 @@
+# Intake: Consolidate Icon Sizes and Toolbar Layout
+
+**Change**: 260323-6491-consolidate-icon-sizes-toolbar-layout
+**Created**: 2026-03-23
+**Status**: Draft
+
+## Origin
+
+> User reviewed all icon and button sizes across the frontend after noticing excessive conditional sizing logic. Discussion identified 6+ distinct size values applied ad-hoc per component with `coarse:` pointer-type variants creating unnecessary complexity. User directed consolidation to exactly two flat size tiers and several toolbar layout changes.
+
+Interaction mode: conversational (multi-turn discussion refining approach).
+
+## Why
+
+The frontend had accumulated one-off icon/button sizes (24px, 28px, 30px, 32px, 36px, 44px) and pointer-type conditional variants (`coarse:min-h-[44px]`, `coarse:min-w-[36px]`, asymmetric `coarse:min-h-[36px] coarse:min-w-[28px]`) across components. This made the sizing system hard to reason about, inconsistent, and error-prone when adding new buttons. The `coarse:` (touch vs mouse) distinction added a second axis of variation that didn't justify the complexity — the larger "standard" size (36px) works fine for both mouse and touch input.
+
+Additionally, the compose button (`>_`) was in the top bar but logically belongs with the other terminal key buttons in the bottom bar. The top-right icon order placed the logo leftmost, but it reads more naturally as the rightmost anchor element.
+
+## What Changes
+
+### Two-tier button sizing
+
+All interactive button/icon containers use exactly one of two sizes:
+
+- **Compact** (24×24px): Top bar toolbar buttons — hamburger, theme toggle, split horizontal, split vertical, fixed-width toggle, breadcrumb dropdown triggers
+- **Standard** (36×36px): Bottom bar keyboard buttons (Esc, Tab, Ctrl, Alt, Fn, arrow pad, CmdK, compose), sidebar session/window rows, dashboard interactive cards
+
+No `coarse:` pointer-type variants. No responsive size switching. One flat value per tier.
+
+### Files changed and specific size migrations
+
+**`app/frontend/src/components/top-bar.tsx`**:
+- Hamburger: `min-w-[24px] min-h-[24px] coarse:min-w-[36px] coarse:min-h-[36px]` → `min-w-[24px] min-h-[24px]`
+- Theme toggle: `coarse:min-h-[36px] coarse:min-w-[28px]` → removed (was already 24px base)
+- Split buttons: same as theme toggle
+- Fixed-width toggle: same as theme toggle
+- Compose button: removed entirely (moved to bottom bar)
+
+**`app/frontend/src/components/breadcrumb-dropdown.tsx`**:
+- Trigger button: `coarse:min-w-[36px] coarse:min-h-[36px]` → removed (24px base stays)
+
+**`app/frontend/src/components/bottom-bar.tsx`**:
+- `KBD_CLASS`: `min-h-[36px] min-w-[36px] coarse:min-h-[36px] coarse:min-w-[36px]` → `min-h-[36px] min-w-[36px]` (removed redundant coarse)
+- Fn/ext key popup buttons: `min-h-[30px]` → `min-h-[36px]`
+- Added compose button (`>_`) before CmdK button
+- Removed separator between Tab and Ctrl/Alt
+- Removed separator between Alt and Fn popup
+
+**`app/frontend/src/components/arrow-pad.tsx`**:
+- Main button: `min-h-[36px] min-w-[36px] coarse:...` → `min-h-[36px] min-w-[36px]`
+- Popup arrow buttons: `min-h-[30px] min-w-[30px]` → `min-h-[36px] min-w-[36px]`
+
+**`app/frontend/src/components/sidebar.tsx`**:
+- Session collapse/expand, session name, +/× buttons: `min-h-[32px] coarse:min-h-[44px]` → `min-h-[36px]`
+- Window items: `min-h-[28px] coarse:min-h-[44px]` → `min-h-[36px]`
+- Kill window button: `min-h-[28px] coarse:min-h-[44px]` → `min-h-[36px]`
+- Server selector button: `coarse:min-h-[44px]` → `min-h-[36px]`
+
+**`app/frontend/src/components/dashboard.tsx`**:
+- Session cards, window buttons, create buttons: `coarse:min-h-[44px]` → `min-h-[36px]`
+
+**`app/frontend/src/app.tsx`**:
+- Pass `onOpenCompose` prop to `BottomBar`
+
+### Compose button relocation
+
+The compose text button (`>_`) moved from the top bar (visible on all viewports) to the bottom bar (next to the CmdK button, after the separator). It receives `onOpenCompose` as an optional prop on `BottomBar`.
+
+### Bottom bar separator removal
+
+Two separators removed:
+- Between Tab and Ctrl/Alt modifier buttons
+- Between Alt and Fn popup button
+
+One separator retained: before the compose + CmdK group.
+
+### Top-right icon order reversal
+
+Previous order (left to right): Logo, "Run Kit", dot, [FixedWidth, SplitH, SplitV], Theme
+
+New order (left to right): Theme, [SplitV, SplitH, FixedWidth], dot, "Run Kit", Logo
+
+The logo is now the rightmost anchor element. The `<a>` link wrapping logo + "Run Kit" text now has text before image.
+
+## Affected Memory
+
+- `run-kit/ui-patterns`: (modify) Update button sizing conventions to document the two-tier system (compact 24px, standard 36px)
+
+## Impact
+
+- **Components**: top-bar, bottom-bar, arrow-pad, sidebar, breadcrumb-dropdown, dashboard, app.tsx
+- **Touch targets**: Touch-specific sizing removed. 36px standard buttons are within acceptable touch target range (Apple HIG recommends 44px minimum, but 36px is the pragmatic choice for density). 24px compact buttons in the top bar are desktop-only controls (split, theme, fixed-width are `hidden sm:flex`).
+- **Visual density**: Desktop sidebar rows get slightly taller (28→36px for windows, 32→36px for sessions). Bottom bar buttons get slightly smaller on desktop (were 36px, stay 36px) but lose the coarse bump to 44px on touch.
+
+## Open Questions
+
+None — all decisions made during conversation.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Two size tiers: compact (24px) and standard (36px) | Discussed — user explicitly chose these values after reviewing all existing sizes | S:95 R:85 A:90 D:95 |
+| 2 | Certain | No pointer-type (`coarse:`) conditional sizing | Discussed — user questioned the logic of pointer-type variants and chose to eliminate them | S:95 R:80 A:85 D:95 |
+| 3 | Certain | Arrow pad and fn keys use standard (36px) tier | Discussed — user explicitly said "arrow pad, function key buttons become list" (later renamed standard) | S:95 R:90 A:90 D:95 |
+| 4 | Certain | Compose button moves from top bar to bottom bar next to CmdK | Discussed — user's explicit request | S:95 R:85 A:90 D:95 |
+| 5 | Certain | Remove separators between Tab/Ctrl and Alt/Fn in bottom bar | Discussed — user specified "remove separators from between 2nd and 3rd and 4th and 5th icons" | S:95 R:90 A:90 D:95 |
+| 6 | Certain | Reverse top-right icon order so logo is rightmost | Discussed — user's explicit request with specific layout description | S:95 R:85 A:90 D:95 |
+| 7 | Confident | `coarse:opacity-100` on sidebar kill button is retained (visibility concern, not sizing) | Not discussed explicitly but logically separate from sizing consolidation | S:60 R:90 A:85 D:90 |
+
+7 assumptions (6 certain, 1 confident, 0 tentative, 0 unresolved).


### PR DESCRIPTION
## Summary
- Consolidate all button/icon sizes from 6+ one-off values to two flat tiers: **compact** (24px) for top bar controls, **standard** (36px) for bottom bar keys, sidebar rows, and dashboard cards
- Remove all `coarse:` pointer-type conditional sizing — no more touch vs mouse variants
- Move compose button (`>_`) from top bar to bottom bar (next to CmdK)
- Remove two separators in bottom bar for a cleaner layout
- Reverse top-right icon order so the logo anchors the right edge

## Test plan
- [ ] Verify top bar buttons render at 24px on desktop
- [ ] Verify bottom bar, sidebar, and dashboard buttons render at 36px
- [ ] Verify compose button appears in bottom bar next to CmdK
- [ ] Verify top-right order: Theme, splits, fixed-width, dot, "Run Kit", logo
- [ ] Check mobile viewport (375px) — no layout breaks
- [ ] Check desktop viewport (1024px+) — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)