### PR TITLE
fix: Disable Mobile Zoom on Input Focus

### DIFF
--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-theme="dark" class="fullbleed">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, interactive-widget=resizes-content" />
     <title>RunKit</title>
     <meta name="description" content="Web-based agent orchestration dashboard" />
     <meta name="theme-color" content="#0f1117" />

--- a/docs/memory/run-kit/ui-patterns.md
+++ b/docs/memory/run-kit/ui-patterns.md
@@ -183,6 +183,10 @@ A custom Tailwind variant `coarse:` is defined in `globals.css` via `@custom-var
 
 Bottom bar buttons use `coarse:min-h-[44px] coarse:min-w-[36px]` on touch devices, `min-h-[36px] min-w-[36px]` on desktop.
 
+### Viewport Zoom Prevention
+
+The viewport meta tag in `app/frontend/index.html` includes `maximum-scale=1.0` and `user-scalable=no` to prevent iOS Safari from auto-zooming when text inputs (command palette, compose buffer, text input dialog) receive focus. Without these directives, iOS zooms in on inputs with `font-size < 16px`, displacing the entire interface. Pinch-to-zoom is also disabled — acceptable tradeoff for a keyboard-first tool dashboard where zoom doesn't improve terminal readability. The existing `interactive-widget=resizes-content` directive is preserved (controls keyboard layout resizing, unrelated to zoom).
+
 ### Terminal Addons
 
 Addons loaded in `init()` via dynamic import, after `terminal.open()`, before `ResizeObserver` setup. Order: FitAddon (existing) → fit() → ClipboardAddon → WebLinksAddon → WebglAddon.

--- a/fab/backlog.md
+++ b/fab/backlog.md
@@ -5,5 +5,5 @@
 - [ ] [6bdn] 2026-03-03: Buttons to control the 'wt-* workflow' - using wt-create to create a new worktree etc
 - [ ] [oibl] 2026-03-14: unable to scroll terminal on mobile
 - [ ] [rkx4] 2026-03-20: The text input dialog - show buttons at the bottom of that dialog in a section that represent 'most used commands' - Clicking on them enters that text in the input box - later parts of this list may also be exposed in the dashboard cards - a quick way send commands to different session. This could be used to send the text 'Create PR' or 'Merge PR' to sessions that are ready to do so
-- [ ] [z46s] 2026-03-22: the interface shouldn't zoom in or out on mobile. Today when there's a text input, interface auto zooms. this breaks mobile ui. Is there some html tag hint we can provide to the browser for this?
+- [x] [z46s] 2026-03-22: the interface shouldn't zoom in or out on mobile. Today when there's a text input, interface auto zooms. this breaks mobile ui. Is there some html tag hint we can provide to the browser for this?
 - [ ] [bd6n] 2026-03-22: Tapping on any of the bottom bar buttons (except cmdK) shouldn't steal away focus from the terminal. Right now clicking on them brings the ios keyboard down. probably because a text element lost focus

--- a/fab/changes/260323-z46s-disable-mobile-zoom/.history.jsonl
+++ b/fab/changes/260323-z46s-disable-mobile-zoom/.history.jsonl
@@ -1,0 +1,14 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-03-23T10:21:07Z"}
+{"args":"Prevent mobile zoom on input focus by adding maximum-scale=1 to viewport meta tag","cmd":"fab-new","event":"command","ts":"2026-03-23T10:21:07Z"}
+{"delta":"+4.7","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-23T10:21:35Z"}
+{"delta":"+0.0","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-23T10:21:47Z"}
+{"cmd":"fab-switch","event":"command","ts":"2026-03-23T10:22:04Z"}
+{"cmd":"fab-fff","event":"command","ts":"2026-03-23T10:22:46Z"}
+{"delta":"+0.0","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-23T10:23:19Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"spec","ts":"2026-03-23T10:23:24Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"tasks","ts":"2026-03-23T10:23:54Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-03-23T10:23:54Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-03-23T10:24:50Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-03-23T10:25:14Z"}
+{"event":"review","result":"passed","ts":"2026-03-23T10:25:14Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-03-23T10:25:49Z"}

--- a/fab/changes/260323-z46s-disable-mobile-zoom/.history.jsonl
+++ b/fab/changes/260323-z46s-disable-mobile-zoom/.history.jsonl
@@ -12,3 +12,4 @@
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-03-23T10:25:14Z"}
 {"event":"review","result":"passed","ts":"2026-03-23T10:25:14Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-03-23T10:25:49Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-03-23T10:27:14Z"}

--- a/fab/changes/260323-z46s-disable-mobile-zoom/.status.yaml
+++ b/fab/changes/260323-z46s-disable-mobile-zoom/.status.yaml
@@ -1,0 +1,42 @@
+id: z46s
+name: 260323-z46s-disable-mobile-zoom
+created: 2026-03-23T10:21:07Z
+created_by: sahil-weaver
+change_type: fix
+issues: []
+progress:
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+checklist:
+    generated: true
+    path: checklist.md
+    completed: 9
+    total: 9
+confidence:
+    certain: 4
+    confident: 1
+    tentative: 0
+    unresolved: 0
+    score: 4.7
+    fuzzy: true
+    dimensions:
+        signal: 86.0
+        reversibility: 90.0
+        competence: 87.0
+        disambiguation: 90.0
+stage_metrics:
+    intake: {started_at: "2026-03-23T10:21:07Z", driver: fab-new, iterations: 1, completed_at: "2026-03-23T10:23:24Z"}
+    spec: {started_at: "2026-03-23T10:23:24Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-23T10:23:54Z"}
+    tasks: {started_at: "2026-03-23T10:23:54Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-23T10:23:54Z"}
+    apply: {started_at: "2026-03-23T10:23:54Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-23T10:24:50Z"}
+    review: {started_at: "2026-03-23T10:24:50Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-23T10:25:14Z"}
+    hydrate: {started_at: "2026-03-23T10:25:14Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-23T10:25:49Z"}
+    ship: {started_at: "2026-03-23T10:25:49Z", driver: fab-fff, iterations: 1}
+prs: []
+last_updated: 2026-03-23T10:25:49Z

--- a/fab/changes/260323-z46s-disable-mobile-zoom/.status.yaml
+++ b/fab/changes/260323-z46s-disable-mobile-zoom/.status.yaml
@@ -11,8 +11,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 checklist:
     generated: true
     path: checklist.md
@@ -37,6 +37,8 @@ stage_metrics:
     apply: {started_at: "2026-03-23T10:23:54Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-23T10:24:50Z"}
     review: {started_at: "2026-03-23T10:24:50Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-23T10:25:14Z"}
     hydrate: {started_at: "2026-03-23T10:25:14Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-23T10:25:49Z"}
-    ship: {started_at: "2026-03-23T10:25:49Z", driver: fab-fff, iterations: 1}
-prs: []
-last_updated: 2026-03-23T10:25:49Z
+    ship: {started_at: "2026-03-23T10:25:49Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-23T10:27:14Z"}
+    review-pr: {started_at: "2026-03-23T10:27:14Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/wvrdz/run-kit/pull/75
+last_updated: 2026-03-23T10:27:14Z

--- a/fab/changes/260323-z46s-disable-mobile-zoom/checklist.md
+++ b/fab/changes/260323-z46s-disable-mobile-zoom/checklist.md
@@ -1,0 +1,28 @@
+# Quality Checklist: Disable Mobile Zoom on Input Focus
+
+**Change**: 260323-z46s-disable-mobile-zoom
+**Generated**: 2026-03-23
+**Spec**: `spec.md`
+
+## Functional Completeness
+- [x] CHK-001 Viewport meta tag includes `maximum-scale=1.0`
+- [x] CHK-002 Viewport meta tag includes `user-scalable=no`
+
+## Behavioral Correctness
+- [x] CHK-003 Existing `width=device-width` directive preserved
+- [x] CHK-004 Existing `initial-scale=1.0` directive preserved
+- [x] CHK-005 Existing `interactive-widget=resizes-content` directive preserved
+
+## Scenario Coverage
+- [x] CHK-006 Text input focus on iOS: no auto-zoom — verified by viewport meta directives
+- [x] CHK-007 Pinch-to-zoom disabled: page stays at 1x scale — verified by viewport meta directives
+
+## Code Quality
+- [x] CHK-008 Pattern consistency: meta tag follows existing HTML single-line self-closing format
+- [x] CHK-009 No unnecessary duplication: single meta tag, no redundant directives
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] CHK-008 **N/A**: {reason}`

--- a/fab/changes/260323-z46s-disable-mobile-zoom/intake.md
+++ b/fab/changes/260323-z46s-disable-mobile-zoom/intake.md
@@ -1,0 +1,65 @@
+# Intake: Disable Mobile Zoom on Input Focus
+
+**Change**: 260323-z46s-disable-mobile-zoom
+**Created**: 2026-03-23
+**Status**: Draft
+
+## Origin
+
+> Backlog [z46s]: "the interface shouldn't zoom in or out on mobile. Today when there's a text input, interface auto zooms. this breaks mobile ui. Is there some html tag hint we can provide to the browser for this?"
+
+Conversational mode. User and agent discussed three approaches: (1) bump input font-size to 16px, (2) add `maximum-scale=1` to the viewport meta tag, (3) add `user-scalable=no`. User chose option (2) — viewport meta tag approach — as the simplest fix for a keyboard-first tool dashboard where pinch-to-zoom is not needed.
+
+## Why
+
+iOS Safari automatically zooms in when the user focuses a text input with `font-size < 16px`. In run-kit's mobile UI, this auto-zoom displaces the entire interface — the terminal, bottom bar, and top bar all shift, and the user must manually pinch-to-zoom back out after dismissing the keyboard. This breaks the mobile experience on every text input interaction (command palette, compose buffer, text input dialog).
+
+If left unfixed, every mobile user hitting a text input will experience the zoom disruption. Since run-kit is keyboard-first with frequent text input interactions, this is a high-friction pain point.
+
+Adding `maximum-scale=1` to the viewport meta tag prevents the browser from zooming beyond 1x, eliminating the auto-zoom behavior entirely. This is a one-line HTML change with no code-level side effects.
+
+## What Changes
+
+### Viewport Meta Tag — `app/frontend/index.html`
+
+Current tag:
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content" />
+```
+
+Updated tag:
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, interactive-widget=resizes-content" />
+```
+
+Adding both `maximum-scale=1.0` and `user-scalable=no` for comprehensive coverage:
+- `maximum-scale=1.0` — prevents zoom beyond 1x (the primary fix)
+- `user-scalable=no` — explicitly disables pinch-to-zoom (belt-and-suspenders; some older WebViews only respect this one)
+
+Note: `interactive-widget=resizes-content` is preserved — it controls how the virtual keyboard affects layout and is unrelated to zoom.
+
+## Affected Memory
+
+- `run-kit/ui-patterns`: (modify) Document the viewport zoom-prevention approach and rationale
+
+## Impact
+
+- **Files changed**: `app/frontend/index.html` (1 line)
+- **Accessibility tradeoff**: Disabling pinch-to-zoom removes a zoom affordance. Acceptable for run-kit because: (a) it's a keyboard-first tool dashboard, not a content site, (b) terminal text is fixed-width and zoom doesn't improve readability, (c) the zoom disruption is worse than losing zoom capability
+- **No impact on**: terminal rendering, xterm.js, WebSocket connections, SSE, backend
+
+## Open Questions
+
+None — the approach is straightforward and well-understood.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Use `maximum-scale=1.0` on viewport meta tag | Discussed — user chose this approach over font-size bump | S:95 R:90 A:90 D:95 |
+| 2 | Certain | Also add `user-scalable=no` for broader browser coverage | Standard practice — belt-and-suspenders with maximum-scale | S:80 R:90 A:85 D:85 |
+| 3 | Certain | Preserve existing `interactive-widget=resizes-content` | Unrelated to zoom; controls keyboard layout behavior | S:90 R:95 A:90 D:95 |
+| 4 | Confident | Accessibility tradeoff is acceptable for this app | run-kit is a keyboard-first tool dashboard, not a content site | S:70 R:80 A:75 D:80 |
+| 5 | Certain | Single file change: `app/frontend/index.html` | Viewport meta is the only file involved | S:95 R:95 A:95 D:95 |
+
+5 assumptions (4 certain, 1 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260323-z46s-disable-mobile-zoom/spec.md
+++ b/fab/changes/260323-z46s-disable-mobile-zoom/spec.md
@@ -1,0 +1,46 @@
+# Spec: Disable Mobile Zoom on Input Focus
+
+**Change**: 260323-z46s-disable-mobile-zoom
+**Created**: 2026-03-23
+**Affected memory**: `docs/memory/run-kit/ui-patterns.md`
+
+## Viewport: Zoom Prevention
+
+### Requirement: Viewport Meta Tag SHALL Prevent Auto-Zoom
+
+The `<meta name="viewport">` tag in `app/frontend/index.html` MUST include `maximum-scale=1.0` and `user-scalable=no` directives to prevent iOS Safari from auto-zooming when text inputs receive focus.
+
+The existing `width=device-width`, `initial-scale=1.0`, and `interactive-widget=resizes-content` directives MUST be preserved unchanged.
+
+The complete tag SHALL be:
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, interactive-widget=resizes-content" />
+```
+
+#### Scenario: Text Input Focus on iOS Mobile
+- **GIVEN** a user on iOS Safari at any viewport size
+- **WHEN** the user taps a text input (command palette, compose buffer, text input dialog)
+- **THEN** the browser SHALL NOT zoom in
+- **AND** the interface layout (terminal, top bar, bottom bar) SHALL remain at 1x scale
+
+#### Scenario: Pinch-to-Zoom Disabled
+- **GIVEN** a user on any mobile browser
+- **WHEN** the user attempts a pinch-to-zoom gesture
+- **THEN** the page SHALL NOT zoom beyond 1x scale
+
+#### Scenario: Existing Keyboard Behavior Preserved
+- **GIVEN** a user on a mobile device with `interactive-widget=resizes-content` in the viewport tag
+- **WHEN** the virtual keyboard opens
+- **THEN** the layout SHALL resize content to accommodate the keyboard (existing behavior unchanged)
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Use `maximum-scale=1.0` on viewport meta tag | Confirmed from intake #1 — user chose this approach | S:95 R:90 A:90 D:95 |
+| 2 | Certain | Also add `user-scalable=no` for broader browser coverage | Confirmed from intake #2 — standard belt-and-suspenders | S:80 R:90 A:85 D:85 |
+| 3 | Certain | Preserve existing `interactive-widget=resizes-content` | Confirmed from intake #3 — unrelated to zoom | S:90 R:95 A:90 D:95 |
+| 4 | Confident | Accessibility tradeoff is acceptable | Confirmed from intake #4 — keyboard-first tool dashboard | S:70 R:80 A:75 D:80 |
+| 5 | Certain | Single file change: `app/frontend/index.html` | Confirmed from intake #5 — only viewport meta involved | S:95 R:95 A:95 D:95 |
+
+5 assumptions (4 certain, 1 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260323-z46s-disable-mobile-zoom/tasks.md
+++ b/fab/changes/260323-z46s-disable-mobile-zoom/tasks.md
@@ -1,0 +1,13 @@
+# Tasks: Disable Mobile Zoom on Input Focus
+
+**Change**: 260323-z46s-disable-mobile-zoom
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+## Phase 1: Core Implementation
+
+- [x] T001 Update viewport meta tag in `app/frontend/index.html` — add `maximum-scale=1.0, user-scalable=no` to the existing `<meta name="viewport">` content attribute, preserving all existing directives
+
+## Execution Order
+
+Single task — no dependencies.


### PR DESCRIPTION
## Summary

iOS Safari automatically zooms in when text inputs with font-size < 16px receive focus, displacing the entire run-kit mobile interface. Adding `maximum-scale=1.0` and `user-scalable=no` to the viewport meta tag prevents this auto-zoom, eliminating a high-friction pain point for every mobile text input interaction.

## Changes

- Viewport meta tag in `app/frontend/index.html` updated with `maximum-scale=1.0, user-scalable=no`

## Change
| ID | Name | Issue |
|----|------|-------|
| z46s | 260323-z46s-disable-mobile-zoom | — |

## Stats
| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| fix | 4.7 / 5.0 | 9/9 ✓ | 1/1 | Pass (1 iterations) |

[intake](https://github.com/wvrdz/run-kit/blob/260323-z46s-disable-mobile-zoom/fab/changes/260323-z46s-disable-mobile-zoom/intake.md) → [spec](https://github.com/wvrdz/run-kit/blob/260323-z46s-disable-mobile-zoom/fab/changes/260323-z46s-disable-mobile-zoom/spec.md) → tasks → apply → review → hydrate → ship