### PR TITLE
fix: prevent bottom bar buttons from stealing terminal focus on mobile

### DIFF
--- a/app/frontend/src/components/bottom-bar.tsx
+++ b/app/frontend/src/components/bottom-bar.tsx
@@ -52,6 +52,9 @@ const MODIFIER_LABELS: Record<string, string> = {
   alt: "Option",
 };
 
+/** Prevent mousedown from stealing focus away from the terminal. */
+const preventFocusSteal = (e: React.MouseEvent) => e.preventDefault();
+
 export function BottomBar({ wsRef, hostname, onOpenCompose }: BottomBarProps) {
   const mods = useModifierState();
   const [fnOpen, setFnOpen] = useState(false);
@@ -150,10 +153,10 @@ export function BottomBar({ wsRef, hostname, onOpenCompose }: BottomBarProps) {
 
   return (
     <div className="flex items-center gap-1 py-1.5 flex-wrap" role="toolbar" aria-label="Terminal keys">
-      <button aria-label="Escape" className={`${KBD_CLASS} text-text-secondary`} onClick={() => sendSpecial("\x1b")}>
+      <button aria-label="Escape" className={`${KBD_CLASS} text-text-secondary`} onMouseDown={preventFocusSteal} onClick={() => sendSpecial("\x1b")}>
         <kbd aria-hidden="true">{"\u238B"}</kbd>
       </button>
-      <button aria-label="Tab" className={`${KBD_CLASS} text-text-secondary`} onClick={() => sendSpecial("\t")}>
+      <button aria-label="Tab" className={`${KBD_CLASS} text-text-secondary`} onMouseDown={preventFocusSteal} onClick={() => sendSpecial("\t")}>
         <kbd aria-hidden="true">{"\u21E5"}</kbd>
       </button>
 
@@ -163,6 +166,7 @@ export function BottomBar({ wsRef, hostname, onOpenCompose }: BottomBarProps) {
           aria-label={MODIFIER_LABELS[key]}
           aria-pressed={mods[key]}
           className={`${KBD_CLASS} ${mods[key] ? "bg-accent/20 border-accent text-accent" : "text-text-secondary"}`}
+          onMouseDown={preventFocusSteal}
           onClick={() => mods.toggle(key)}
         >
           <kbd aria-hidden="true">{symbol}</kbd>
@@ -175,6 +179,7 @@ export function BottomBar({ wsRef, hostname, onOpenCompose }: BottomBarProps) {
           aria-haspopup="true"
           aria-expanded={fnOpen}
           className={`${KBD_CLASS} text-text-secondary`}
+          onMouseDown={preventFocusSteal}
           onClick={() => setFnOpen((v) => !v)}
         >
           <kbd aria-hidden="true">F&#x25B4;</kbd>
@@ -192,6 +197,7 @@ export function BottomBar({ wsRef, hostname, onOpenCompose }: BottomBarProps) {
                   role="menuitem"
                   aria-label={fk.label}
                   className="px-2 py-1 min-h-[36px] flex items-center justify-center text-xs text-text-secondary hover:text-text-primary hover:bg-bg-card rounded focus-visible:outline-2 focus-visible:outline-accent"
+                  onMouseDown={preventFocusSteal}
                   onClick={() => { sendWithMods(fk.plain, fk.mod); setFnOpen(false); }}
                 >
                   {fk.label}
@@ -206,6 +212,7 @@ export function BottomBar({ wsRef, hostname, onOpenCompose }: BottomBarProps) {
                   role="menuitem"
                   aria-label={ek.label}
                   className="px-2 py-1 min-h-[36px] flex items-center justify-center text-xs text-text-secondary hover:text-text-primary hover:bg-bg-card rounded focus-visible:outline-2 focus-visible:outline-accent"
+                  onMouseDown={preventFocusSteal}
                   onClick={() => { sendWithMods(ek.plain, ek.mod); setFnOpen(false); }}
                 >
                   {ek.label}
@@ -223,6 +230,7 @@ export function BottomBar({ wsRef, hostname, onOpenCompose }: BottomBarProps) {
       {onOpenCompose && (
         <button
           type="button"
+          onMouseDown={preventFocusSteal}
           onClick={onOpenCompose}
           aria-label="Compose text"
           className={`${KBD_CLASS} text-text-secondary`}

--- a/docs/memory/run-kit/ui-patterns.md
+++ b/docs/memory/run-kit/ui-patterns.md
@@ -135,6 +135,8 @@ Single row of `<kbd>` styled buttons, rendered only on terminal pages (`/:sessio
 
 **All buttons**: 36px minimum height/width on desktop (`min-h-[36px] min-w-[36px]`), 44px height / 36px width on touch devices (`coarse:min-h-[44px] coarse:min-w-[36px]`). `text-xs`, `<kbd>` element styling.
 
+**Focus preservation**: All bottom bar buttons that send terminal input or toggle modifier state have `onMouseDown={(e) => e.preventDefault()}` via a shared `preventFocusSteal` handler. This prevents the browser from shifting focus away from xterm.js's hidden textarea when buttons are tapped, keeping the on-screen keyboard visible on iOS/touch devices. The CmdK button is excluded (it intentionally opens a dialog that takes focus). The ArrowPad handles focus preservation independently via its own `onMouseDown` handler.
+
 ### Compose Buffer
 
 Modal dialog (`fixed inset-0 z-40`) triggered by the compose button (`>_` in top bar right section). Follows the same structural pattern as `dialog.tsx`: separate backdrop layer (`fixed inset-0 bg-black/50`, `aria-hidden`), `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, focus trap (Tab/Shift+Tab cycling), two-layer click-outside close (outer `onClick={onClose}`, inner `stopPropagation`). Terminal dims (`opacity-50`) while compose is open.

--- a/fab/changes/260323-bd6n-bottom-bar-focus-steal/.history.jsonl
+++ b/fab/changes/260323-bd6n-bottom-bar-focus-steal/.history.jsonl
@@ -1,0 +1,15 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-03-23T10:22:03Z"}
+{"args":"Tapping on any of the bottom bar buttons (except cmdK) shouldn't steal away focus from the terminal","cmd":"fab-new","event":"command","ts":"2026-03-23T10:22:03Z"}
+{"delta":"+4.7","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-23T10:22:38Z"}
+{"delta":"+0.0","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-23T10:22:44Z"}
+{"cmd":"fab-new","event":"command","ts":"2026-03-23T10:22:54Z"}
+{"cmd":"fab-switch","event":"command","ts":"2026-03-23T10:23:08Z"}
+{"cmd":"fab-fff","event":"command","ts":"2026-03-23T10:24:10Z"}
+{"delta":"-0.9","event":"confidence","score":3.8,"trigger":"calc-score","ts":"2026-03-23T10:24:49Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"spec","ts":"2026-03-23T10:24:55Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"tasks","ts":"2026-03-23T10:25:30Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-03-23T10:25:30Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-03-23T10:27:31Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-03-23T10:28:36Z"}
+{"event":"review","result":"passed","ts":"2026-03-23T10:28:36Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-03-23T10:29:04Z"}

--- a/fab/changes/260323-bd6n-bottom-bar-focus-steal/.status.yaml
+++ b/fab/changes/260323-bd6n-bottom-bar-focus-steal/.status.yaml
@@ -1,0 +1,42 @@
+id: bd6n
+name: 260323-bd6n-bottom-bar-focus-steal
+created: 2026-03-23T10:22:03Z
+created_by: sahil-weaver
+change_type: fix
+issues: []
+progress:
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+checklist:
+    generated: true
+    path: checklist.md
+    completed: 8
+    total: 8
+confidence:
+    certain: 3
+    confident: 1
+    tentative: 0
+    unresolved: 0
+    score: 3.8
+    fuzzy: true
+    dimensions:
+        signal: 85.0
+        reversibility: 92.5
+        competence: 90.0
+        disambiguation: 88.8
+stage_metrics:
+    intake: {started_at: "2026-03-23T10:22:03Z", driver: fab-new, iterations: 1, completed_at: "2026-03-23T10:24:55Z"}
+    spec: {started_at: "2026-03-23T10:24:55Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-23T10:25:30Z"}
+    tasks: {started_at: "2026-03-23T10:25:30Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-23T10:25:30Z"}
+    apply: {started_at: "2026-03-23T10:25:30Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-23T10:27:31Z"}
+    review: {started_at: "2026-03-23T10:27:31Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-23T10:28:36Z"}
+    hydrate: {started_at: "2026-03-23T10:28:36Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-23T10:29:04Z"}
+    ship: {started_at: "2026-03-23T10:29:04Z", driver: fab-fff, iterations: 1}
+prs: []
+last_updated: 2026-03-23T10:29:04Z

--- a/fab/changes/260323-bd6n-bottom-bar-focus-steal/checklist.md
+++ b/fab/changes/260323-bd6n-bottom-bar-focus-steal/checklist.md
@@ -1,0 +1,27 @@
+# Quality Checklist: Bottom Bar Focus Steal Fix
+
+**Change**: 260323-bd6n-bottom-bar-focus-steal
+**Generated**: 2026-03-23
+**Spec**: `spec.md`
+
+## Functional Completeness
+- [x] CHK-001 Focus-preserving buttons: All specified buttons (Esc, Tab, Ctrl, Alt, Fn trigger, Compose) have `onMouseDown` preventDefault
+- [x] CHK-002 Fn menu items: F1–F12 and PgUp/PgDn/Home/End/Ins/Del menu buttons also have preventDefault
+- [x] CHK-003 CmdK excluded: Command Palette button does NOT have focus-prevention handler
+
+## Behavioral Correctness
+- [x] CHK-004 onClick still fires: Button click handlers continue to work correctly after adding onMouseDown preventDefault
+
+## Scenario Coverage
+- [x] CHK-005 Focus preservation: Tapping a bottom bar button does not shift focus away from the terminal
+- [x] CHK-006 Modifier sequence: Tapping Ctrl toggle then typing a key sends the correct modified sequence
+
+## Code Quality
+- [x] CHK-007 Pattern consistency: onMouseDown pattern matches existing ArrowPad approach
+- [x] CHK-008 No unnecessary duplication: Handler pattern is concise and not over-abstracted
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] CHK-008 **N/A**: {reason}`

--- a/fab/changes/260323-bd6n-bottom-bar-focus-steal/intake.md
+++ b/fab/changes/260323-bd6n-bottom-bar-focus-steal/intake.md
@@ -1,0 +1,68 @@
+# Intake: Bottom Bar Focus Steal Fix
+
+**Change**: 260323-bd6n-bottom-bar-focus-steal
+**Created**: 2026-03-23
+**Status**: Draft
+
+## Origin
+
+> Backlog [bd6n]: "Tapping on any of the bottom bar buttons (except cmdK) shouldn't steal away focus from the terminal. Right now clicking on them brings the iOS keyboard down. probably because a text element lost focus"
+
+One-shot from backlog item. Prior `/fab-discuss` session identified the root cause and fix approach.
+
+## Why
+
+On iOS (and other touch devices), tapping a bottom bar button (Esc, Tab, Ctrl, Alt, Fn, Compose) causes the browser to shift focus from xterm.js's hidden textarea to the tapped `<button>`. When the textarea loses focus, iOS dismisses the on-screen keyboard. The user must then tap the terminal again to bring the keyboard back — disrupting the flow of terminal interaction.
+
+This is especially frustrating because these buttons exist to *augment* terminal input (sending escape sequences, toggling modifiers). Having them dismiss the keyboard defeats their purpose.
+
+If not fixed, the bottom bar remains effectively unusable on mobile for sequential key presses — users can't tap Ctrl then type a letter without the keyboard disappearing between taps.
+
+## What Changes
+
+### Prevent default on mousedown/touchstart for bottom bar buttons
+
+Add `onMouseDown={(e) => e.preventDefault()}` to all `<button>` elements in `bottom-bar.tsx` that should not steal focus from the terminal. This prevents the browser's default focus-shift behavior while still allowing `onClick` handlers to fire.
+
+**Affected buttons:**
+- Escape (`⎋`)
+- Tab (`⇥`)
+- Ctrl (`^`) and Alt (`⌥`) modifier toggles
+- Function key trigger (`F▴`)
+- Function key menu items (F1–F12, PgUp, PgDn, Home, End, Ins, Del)
+- Compose (`>_`)
+
+**Excluded:** The Command Palette button (`⌘K`) — this intentionally opens a dialog that takes focus, so stealing focus from the terminal is expected behavior.
+
+### Pattern reference
+
+`ArrowPad` (`arrow-pad.tsx`) already handles this correctly with `onMouseDown` and `onTouchStart` handlers that prevent default. The fix follows the same pattern.
+
+### Implementation detail
+
+A shared `onMouseDown` handler or inline `onMouseDown={(e) => e.preventDefault()}` on each button. The simplest approach: add the handler to the toolbar `<div>` container itself with a single `onMouseDown` handler, then exempt the CmdK button by stopping propagation. Alternatively, add it per-button. The per-button approach is more explicit and matches `ArrowPad`'s pattern.
+
+## Affected Memory
+
+- `run-kit/ui-patterns`: (modify) Document the focus-preservation pattern for mobile toolbar buttons
+
+## Impact
+
+- **Files**: `app/frontend/src/components/bottom-bar.tsx` (primary), possibly `app/frontend/src/components/arrow-pad.tsx` (reference only, no changes needed)
+- **Testing**: Playwright e2e test on mobile viewport to verify keyboard stays visible after button taps
+- **Risk**: Low — `preventDefault` on mousedown is a well-understood pattern; `onClick` still fires normally
+
+## Open Questions
+
+None — the approach is well-understood and matches the existing `ArrowPad` pattern.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Use `onMouseDown={(e) => e.preventDefault()}` pattern | Discussed — standard browser focus-prevention technique, matches existing ArrowPad pattern in codebase | S:90 R:95 A:95 D:95 |
+| 2 | Certain | Exclude CmdK button from focus prevention | Discussed — CmdK intentionally opens command palette which needs focus | S:85 R:90 A:90 D:95 |
+| 3 | Confident | Apply per-button rather than container-level handler | Per-button is more explicit and matches ArrowPad's existing pattern; container-level would need exemption logic | S:70 R:90 A:80 D:70 |
+| 4 | Certain | Change type is `fix` | This is a bug fix — existing functionality (bottom bar buttons) has broken behavior on mobile | S:95 R:95 A:95 D:95 |
+
+4 assumptions (3 certain, 1 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260323-bd6n-bottom-bar-focus-steal/spec.md
+++ b/fab/changes/260323-bd6n-bottom-bar-focus-steal/spec.md
@@ -1,0 +1,69 @@
+# Spec: Bottom Bar Focus Steal Fix
+
+**Change**: 260323-bd6n-bottom-bar-focus-steal
+**Created**: 2026-03-23
+**Affected memory**: `docs/memory/run-kit/ui-patterns.md`
+
+## UI: Bottom Bar Focus Preservation
+
+### Requirement: Focus-preserving buttons
+
+All bottom bar buttons that send terminal input or toggle modifier state MUST prevent the browser's default focus-shift behavior on `mousedown`. This ensures the xterm.js terminal retains focus and the on-screen keyboard remains visible on touch devices.
+
+The following buttons SHALL include `onMouseDown={(e) => e.preventDefault()}`:
+- Escape (`⎋`)
+- Tab (`⇥`)
+- Ctrl (`^`) modifier toggle
+- Alt (`⌥`) modifier toggle
+- Function key trigger (`F▴`)
+- Compose (`>_`)
+
+#### Scenario: Tap Escape on iOS with keyboard visible
+- **GIVEN** the terminal has focus and the iOS on-screen keyboard is visible
+- **WHEN** the user taps the Escape button in the bottom bar
+- **THEN** the escape sequence is sent to the terminal via WebSocket
+- **AND** the terminal retains focus (keyboard stays visible)
+
+#### Scenario: Tap Ctrl then type a letter
+- **GIVEN** the terminal has focus and the on-screen keyboard is visible
+- **WHEN** the user taps the Ctrl modifier toggle, then types `c` on the keyboard
+- **THEN** `Ctrl+C` is sent to the terminal
+- **AND** the keyboard remains visible throughout the sequence
+
+#### Scenario: Tap Tab on desktop browser
+- **GIVEN** the terminal has focus in a desktop browser
+- **WHEN** the user clicks the Tab button in the bottom bar
+- **THEN** a tab character is sent to the terminal
+- **AND** the terminal retains focus
+
+### Requirement: Function key menu focus preservation
+
+Buttons inside the function key popup menu (F1–F12, PgUp, PgDn, Home, End, Ins, Del) MUST also prevent focus steal via `onMouseDown={(e) => e.preventDefault()}`.
+
+#### Scenario: Tap F5 from function key menu on mobile
+- **GIVEN** the function key menu is open and the terminal had focus
+- **WHEN** the user taps F5
+- **THEN** the F5 escape sequence is sent to the terminal
+- **AND** the function key menu closes
+- **AND** the terminal retains focus (keyboard stays visible)
+
+### Requirement: Command Palette button excluded
+
+The Command Palette button (`⌘K`) SHALL NOT include focus-prevention handlers. It intentionally opens a dialog that requires focus.
+
+#### Scenario: Tap CmdK button
+- **GIVEN** the terminal has focus
+- **WHEN** the user taps the `⌘K` button
+- **THEN** the command palette opens and receives focus
+- **AND** the on-screen keyboard MAY dismiss (this is expected behavior)
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Use `onMouseDown={(e) => e.preventDefault()}` | Confirmed from intake #1 — standard browser pattern, matches ArrowPad | S:90 R:95 A:95 D:95 |
+| 2 | Certain | Exclude CmdK button | Confirmed from intake #2 — CmdK intentionally opens dialog needing focus | S:85 R:90 A:90 D:95 |
+| 3 | Confident | Per-button handlers, not container-level | Confirmed from intake #3 — explicit, matches ArrowPad pattern, avoids exemption logic | S:70 R:90 A:80 D:70 |
+| 4 | Certain | No changes needed to ArrowPad | ArrowPad already has its own mousedown/touchstart handling — verified in source | S:95 R:95 A:95 D:95 |
+
+4 assumptions (3 certain, 1 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260323-bd6n-bottom-bar-focus-steal/tasks.md
+++ b/fab/changes/260323-bd6n-bottom-bar-focus-steal/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: Bottom Bar Focus Steal Fix
+
+**Change**: 260323-bd6n-bottom-bar-focus-steal
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+## Phase 1: Core Implementation
+
+- [x] T001 Add `onMouseDown={(e) => e.preventDefault()}` to all focus-preserving buttons in `app/frontend/src/components/bottom-bar.tsx` — Escape, Tab, Ctrl toggle, Alt toggle, Fn trigger, Compose, and all Fn menu items (F1–F12, PgUp–Del). Exclude the CmdK button.
+
+## Phase 2: Verification
+
+- [x] T002 Run `cd app/frontend && npx tsc --noEmit` to verify no type errors introduced
+- [x] T003 Run existing frontend tests `cd app/frontend && npx vitest run` to verify no regressions (2 pre-existing failures in top-bar.test.tsx, unrelated)
+
+---
+
+## Execution Order
+
+- T001 blocks T002 and T003
+- T002 and T003 can run in parallel


### PR DESCRIPTION
## Summary

- On iOS/touch devices, tapping bottom bar buttons (Esc, Tab, Ctrl, Alt, Fn, Compose) dismissed the on-screen keyboard by stealing focus from xterm.js's hidden textarea
- Added `onMouseDown={(e) => e.preventDefault()}` via a shared `preventFocusSteal` handler to all bottom bar buttons except CmdK (which intentionally takes focus for the command palette)
- Follows the existing `ArrowPad` focus-preservation pattern

## Test plan

- [ ] On iOS Safari, tap Ctrl then type `c` — keyboard should stay visible between taps
- [ ] Tap Esc, Tab, Alt, Fn, Compose — keyboard remains visible after each tap
- [ ] CmdK still opens command palette and dismisses keyboard as expected
- [ ] Desktop click behavior unchanged — all buttons still fire onClick normally