### PR TITLE
fix: Arrow Pad Focus Steal, Popup Persistence & Keyboard Dismiss Button

### DIFF
--- a/app/frontend/src/components/arrow-pad.tsx
+++ b/app/frontend/src/components/arrow-pad.tsx
@@ -3,6 +3,9 @@ import { useState, useRef, useCallback, useEffect } from "react";
 /** Minimum drag distance (px) to register a swipe vs a tap. */
 const DRAG_THRESHOLD = 20;
 
+/** Prevent mousedown from stealing focus away from the terminal. */
+const preventFocusSteal = (e: React.MouseEvent) => e.preventDefault();
+
 type ArrowPadProps = {
   onArrow: (code: string) => void;
   className?: string;
@@ -50,6 +53,7 @@ export function ArrowPad({ onArrow, className }: ArrowPadProps) {
   );
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
     startRef.current = { x: e.clientX, y: e.clientY };
     didDragRef.current = false;
   }, []);
@@ -113,18 +117,18 @@ export function ArrowPad({ onArrow, className }: ArrowPadProps) {
           aria-label="Arrow keys"
         >
           <div className="flex justify-center mb-0.5">
-            <button aria-label="Up arrow" className={ARROW_BTN} onClick={() => { onArrow("A"); setOpen(false); }}>
+            <button aria-label="Up arrow" className={ARROW_BTN} onMouseDown={preventFocusSteal} onClick={() => onArrow("A")}>
               {"\u2191"}
             </button>
           </div>
           <div className="flex gap-0.5">
-            <button aria-label="Left arrow" className={ARROW_BTN} onClick={() => { onArrow("D"); setOpen(false); }}>
+            <button aria-label="Left arrow" className={ARROW_BTN} onMouseDown={preventFocusSteal} onClick={() => onArrow("D")}>
               {"\u2190"}
             </button>
-            <button aria-label="Down arrow" className={ARROW_BTN} onClick={() => { onArrow("B"); setOpen(false); }}>
+            <button aria-label="Down arrow" className={ARROW_BTN} onMouseDown={preventFocusSteal} onClick={() => onArrow("B")}>
               {"\u2193"}
             </button>
-            <button aria-label="Right arrow" className={ARROW_BTN} onClick={() => { onArrow("C"); setOpen(false); }}>
+            <button aria-label="Right arrow" className={ARROW_BTN} onMouseDown={preventFocusSteal} onClick={() => onArrow("C")}>
               {"\u2192"}
             </button>
           </div>

--- a/app/frontend/src/components/bottom-bar.tsx
+++ b/app/frontend/src/components/bottom-bar.tsx
@@ -249,6 +249,21 @@ export function BottomBar({ wsRef, hostname, onOpenCompose }: BottomBarProps) {
       {hostname && (
         <span className="hidden sm:inline ml-auto min-w-0 text-xs text-text-secondary truncate">{hostname}</span>
       )}
+
+      {/* Dismiss keyboard — visible only on touch devices */}
+      <button
+        type="button"
+        aria-label="Dismiss keyboard"
+        className={`${KBD_CLASS} hidden coarse:inline-flex ml-auto text-text-secondary`}
+        onMouseDown={preventFocusSteal}
+        onClick={() => {
+          if (document.activeElement instanceof HTMLElement) {
+            document.activeElement.blur();
+          }
+        }}
+      >
+        <kbd aria-hidden="true">{"\u2304"}</kbd>
+      </button>
     </div>
   );
 }

--- a/fab/changes/260323-k26m-arrow-pad-focus-popup/.history.jsonl
+++ b/fab/changes/260323-k26m-arrow-pad-focus-popup/.history.jsonl
@@ -5,3 +5,8 @@
 {"cmd":"fab-switch","event":"command","ts":"2026-03-23T10:55:51Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"ship","ts":"2026-03-23T10:56:06Z"}
 {"delta":"+0.0","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-23T10:56:26Z"}
+{"delta":"+0.0","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-23T10:56:36Z"}
+{"delta":"+0.0","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-23T10:56:45Z"}
+{"delta":"+0.0","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-23T10:56:52Z"}
+{"delta":"+0.0","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-23T10:57:01Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-03-23T10:57:15Z"}

--- a/fab/changes/260323-k26m-arrow-pad-focus-popup/.history.jsonl
+++ b/fab/changes/260323-k26m-arrow-pad-focus-popup/.history.jsonl
@@ -1,0 +1,7 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-03-23T10:54:59Z"}
+{"args":"fix: prevent arrow pad from stealing terminal focus and keep popup open for repeated taps","cmd":"fab-new","event":"command","ts":"2026-03-23T10:54:59Z"}
+{"delta":"+4.7","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-23T10:55:26Z"}
+{"delta":"+0.0","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-23T10:55:32Z"}
+{"cmd":"fab-switch","event":"command","ts":"2026-03-23T10:55:51Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"ship","ts":"2026-03-23T10:56:06Z"}
+{"delta":"+0.0","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-23T10:56:26Z"}

--- a/fab/changes/260323-k26m-arrow-pad-focus-popup/.status.yaml
+++ b/fab/changes/260323-k26m-arrow-pad-focus-popup/.status.yaml
@@ -1,0 +1,38 @@
+id: k26m
+name: 260323-k26m-arrow-pad-focus-popup
+created: 2026-03-23T10:54:59Z
+created_by: sahil-weaver
+change_type: fix
+issues: []
+progress:
+    intake: ready
+    spec: pending
+    tasks: pending
+    apply: pending
+    review: pending
+    hydrate: pending
+    ship: active
+    review-pr: pending
+checklist:
+    generated: false
+    path: checklist.md
+    completed: 0
+    total: 0
+confidence:
+    certain: 3
+    confident: 1
+    tentative: 0
+    unresolved: 0
+    score: 4.7
+    indicative: true
+    fuzzy: true
+    dimensions:
+        signal: 87.5
+        reversibility: 92.5
+        competence: 91.3
+        disambiguation: 91.3
+stage_metrics:
+    intake: {started_at: "2026-03-23T10:54:59Z", driver: fab-new, iterations: 1}
+    ship: {started_at: "2026-03-23T10:56:06Z", driver: git-pr, iterations: 1}
+prs: []
+last_updated: 2026-03-23T10:56:26Z

--- a/fab/changes/260323-k26m-arrow-pad-focus-popup/.status.yaml
+++ b/fab/changes/260323-k26m-arrow-pad-focus-popup/.status.yaml
@@ -11,15 +11,15 @@ progress:
     apply: pending
     review: pending
     hydrate: pending
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 checklist:
     generated: false
     path: checklist.md
     completed: 0
     total: 0
 confidence:
-    certain: 3
+    certain: 5
     confident: 1
     tentative: 0
     unresolved: 0
@@ -27,12 +27,14 @@ confidence:
     indicative: true
     fuzzy: true
     dimensions:
-        signal: 87.5
-        reversibility: 92.5
-        competence: 91.3
-        disambiguation: 91.3
+        signal: 90.0
+        reversibility: 93.3
+        competence: 91.7
+        disambiguation: 92.5
 stage_metrics:
     intake: {started_at: "2026-03-23T10:54:59Z", driver: fab-new, iterations: 1}
-    ship: {started_at: "2026-03-23T10:56:06Z", driver: git-pr, iterations: 1}
-prs: []
-last_updated: 2026-03-23T10:56:26Z
+    ship: {started_at: "2026-03-23T10:56:06Z", driver: git-pr, iterations: 1, completed_at: "2026-03-23T10:57:15Z"}
+    review-pr: {started_at: "2026-03-23T10:57:15Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/wvrdz/run-kit/pull/77
+last_updated: 2026-03-23T10:57:15Z

--- a/fab/changes/260323-k26m-arrow-pad-focus-popup/intake.md
+++ b/fab/changes/260323-k26m-arrow-pad-focus-popup/intake.md
@@ -1,4 +1,4 @@
-# Intake: Arrow Pad Focus Steal & Popup Persistence
+# Intake: Arrow Pad Focus Steal, Popup Persistence & Keyboard Dismiss Button
 
 **Change**: 260323-k26m-arrow-pad-focus-popup
 **Created**: 2026-03-23
@@ -6,11 +6,12 @@
 
 ## Origin
 
-> fix: prevent arrow pad from stealing terminal focus and keep popup open for repeated taps
+> fix: prevent arrow pad from stealing terminal focus, keep popup open for repeated taps, and add mobile keyboard dismiss button
 
-Conversational — user identified two issues with the `ArrowPad` component during mobile testing:
+Conversational — user identified issues with the `ArrowPad` component during mobile testing and requested a dismiss-keyboard button:
 1. Tapping the arrow icon dismisses the mobile keyboard (steals focus from xterm textarea)
 2. Tapping any directional arrow in the popup closes it immediately, preventing repeated arrow key input
+3. No way to dismiss the on-screen keyboard without tapping outside the terminal
 
 ## Why
 
@@ -18,7 +19,9 @@ On mobile, the bottom bar buttons use `preventDefault` on `mousedown` to prevent
 
 Separately, the popup arrow buttons (`Up`, `Down`, `Left`, `Right`) each called `setOpen(false)` after sending the arrow sequence. This forced users to re-open the popup for every arrow press — unusable for navigation tasks that require multiple consecutive arrow key inputs (e.g., scrolling through command history, navigating editors).
 
-Without this fix, mobile users cannot use arrow keys without repeatedly re-opening the keyboard and the popup.
+Additionally, there is no way to dismiss the on-screen keyboard on mobile once it's open — users must tap outside the terminal area, which is awkward. A dedicated dismiss button in the bottom bar solves this.
+
+Without these fixes, mobile users cannot use arrow keys without repeatedly re-opening the keyboard and the popup, and have no clean way to dismiss the keyboard when done typing.
 
 ## What Changes
 
@@ -36,16 +39,20 @@ Add `onMouseDown={preventFocusSteal}` to all four directional arrow buttons in t
 
 Remove `setOpen(false)` from all four popup arrow button `onClick` handlers. The popup now stays open until the user taps outside it, which is handled by the existing `mousedown` document listener (lines 82–91 in the original file).
 
+### 4. Mobile keyboard dismiss button
+
+Add a down-chevron (⌄) button to the bottom bar's right edge that blurs the active element, dismissing the on-screen keyboard. Visible only on touch devices using the `coarse:` Tailwind custom variant (`@media (pointer: coarse)`). Uses `onMouseDown={preventFocusSteal}` for consistency, and `ml-auto` to push it to the trailing edge.
+
 ## Affected Memory
 
 - `run-kit/ui-patterns`: (modify) Document ArrowPad focus-steal prevention and popup persistence behavior
 
 ## Impact
 
-- **File changed**: `app/frontend/src/components/arrow-pad.tsx`
+- **Files changed**: `app/frontend/src/components/arrow-pad.tsx`, `app/frontend/src/components/bottom-bar.tsx`
 - **No API changes** — purely frontend component behavior
 - **No new dependencies**
-- **Mobile UX improvement** — arrow keys now usable without keyboard dismissal or popup re-opening
+- **Mobile UX improvement** — arrow keys now usable without keyboard dismissal or popup re-opening, and keyboard can be dismissed via dedicated button
 
 ## Open Questions
 
@@ -59,5 +66,7 @@ None — implementation is straightforward and matches established patterns.
 | 2 | Certain | Remove `setOpen(false)` from popup arrow buttons | Discussed — user explicitly requested popup stay open for repeated taps | S:95 R:95 A:90 D:95 |
 | 3 | Certain | Outside-click listener handles popup dismissal | Existing behavior — document mousedown listener already closes popup on outside click | S:90 R:95 A:95 D:95 |
 | 4 | Confident | Local `preventFocusSteal` helper rather than importing from bottom-bar | bottom-bar.tsx doesn't export it; one-liner not worth extracting to shared module | S:70 R:90 A:85 D:80 |
+| 5 | Certain | Down chevron (⌄) icon for dismiss button | Discussed — user chose chevron over checkmark as it maps to "push keyboard down" mental model | S:95 R:95 A:90 D:95 |
+| 6 | Certain | Button visible only on touch devices via `coarse:` variant | Discussed — user explicitly requested mobile-only visibility | S:95 R:95 A:95 D:95 |
 
-4 assumptions (3 certain, 1 confident, 0 tentative, 0 unresolved).
+6 assumptions (5 certain, 1 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260323-k26m-arrow-pad-focus-popup/intake.md
+++ b/fab/changes/260323-k26m-arrow-pad-focus-popup/intake.md
@@ -1,0 +1,63 @@
+# Intake: Arrow Pad Focus Steal & Popup Persistence
+
+**Change**: 260323-k26m-arrow-pad-focus-popup
+**Created**: 2026-03-23
+**Status**: Draft
+
+## Origin
+
+> fix: prevent arrow pad from stealing terminal focus and keep popup open for repeated taps
+
+Conversational — user identified two issues with the `ArrowPad` component during mobile testing:
+1. Tapping the arrow icon dismisses the mobile keyboard (steals focus from xterm textarea)
+2. Tapping any directional arrow in the popup closes it immediately, preventing repeated arrow key input
+
+## Why
+
+On mobile, the bottom bar buttons use `preventDefault` on `mousedown` to prevent focus from moving away from xterm's hidden textarea (which keeps the on-screen keyboard open). The `ArrowPad` component was missing this treatment — its `handleMouseDown` callback tracked drag start coordinates but didn't call `preventDefault`, so tapping the arrow icon dismissed the keyboard.
+
+Separately, the popup arrow buttons (`Up`, `Down`, `Left`, `Right`) each called `setOpen(false)` after sending the arrow sequence. This forced users to re-open the popup for every arrow press — unusable for navigation tasks that require multiple consecutive arrow key inputs (e.g., scrolling through command history, navigating editors).
+
+Without this fix, mobile users cannot use arrow keys without repeatedly re-opening the keyboard and the popup.
+
+## What Changes
+
+### 1. Focus steal prevention on ArrowPad trigger button
+
+Add `e.preventDefault()` to the existing `handleMouseDown` callback in `arrow-pad.tsx`. This matches the `preventFocusSteal` pattern used by all other buttons in `bottom-bar.tsx`. The drag-detection logic (start coordinates, threshold check) is preserved — `preventDefault` is called before setting the start position.
+
+A local `preventFocusSteal` helper is added to `arrow-pad.tsx` (same implementation as `bottom-bar.tsx`'s) for use on the popup buttons.
+
+### 2. Focus steal prevention on popup arrow buttons
+
+Add `onMouseDown={preventFocusSteal}` to all four directional arrow buttons in the popup (`Up`, `Down`, `Left`, `Right`).
+
+### 3. Popup stays open for repeated taps
+
+Remove `setOpen(false)` from all four popup arrow button `onClick` handlers. The popup now stays open until the user taps outside it, which is handled by the existing `mousedown` document listener (lines 82–91 in the original file).
+
+## Affected Memory
+
+- `run-kit/ui-patterns`: (modify) Document ArrowPad focus-steal prevention and popup persistence behavior
+
+## Impact
+
+- **File changed**: `app/frontend/src/components/arrow-pad.tsx`
+- **No API changes** — purely frontend component behavior
+- **No new dependencies**
+- **Mobile UX improvement** — arrow keys now usable without keyboard dismissal or popup re-opening
+
+## Open Questions
+
+None — implementation is straightforward and matches established patterns.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Use `e.preventDefault()` on mousedown to prevent focus steal | Discussed — matches exact pattern from bottom-bar.tsx `preventFocusSteal` | S:95 R:90 A:95 D:95 |
+| 2 | Certain | Remove `setOpen(false)` from popup arrow buttons | Discussed — user explicitly requested popup stay open for repeated taps | S:95 R:95 A:90 D:95 |
+| 3 | Certain | Outside-click listener handles popup dismissal | Existing behavior — document mousedown listener already closes popup on outside click | S:90 R:95 A:95 D:95 |
+| 4 | Confident | Local `preventFocusSteal` helper rather than importing from bottom-bar | bottom-bar.tsx doesn't export it; one-liner not worth extracting to shared module | S:70 R:90 A:85 D:80 |
+
+4 assumptions (3 certain, 1 confident, 0 tentative, 0 unresolved).


### PR DESCRIPTION
## Summary

On mobile, tapping the arrow pad icon steals focus from xterm's hidden textarea (dismissing the keyboard), and the directional popup closes after every tap — preventing repeated arrow key input. Additionally, a keyboard dismiss button is added for touch devices.

## Changes

- Focus steal prevention on ArrowPad trigger button via `preventDefault` on mousedown
- Focus steal prevention on popup arrow buttons
- Popup stays open for repeated taps (removed `setOpen(false)` from arrow button handlers)
- Mobile keyboard dismiss button (down-chevron, visible on touch devices only)

## Change

| ID | Name | Issue |
|----|------|-------|
| k26m | 260323-k26m-arrow-pad-focus-popup | — |

## Stats

| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| fix | 4.7 / 5.0 | — | — | — |

[intake](https://github.com/wvrdz/run-kit/blob/snowy-frog/fab/changes/260323-k26m-arrow-pad-focus-popup/intake.md)