### PR TITLE
fix: Command Palette Arrow Key Scroll

### DIFF
--- a/app/frontend/src/components/command-palette.test.tsx
+++ b/app/frontend/src/components/command-palette.test.tsx
@@ -180,6 +180,26 @@ describe("CommandPalette", () => {
     expect(screen.queryByText("Create new session")).not.toBeInTheDocument();
   });
 
+  it("scrolls selected item into view on ArrowDown", () => {
+    const actions = makeActions(["First", "Second", "Third"]);
+    render(<CommandPalette actions={actions} />);
+    openPalette();
+
+    const listbox = screen.getByRole("listbox");
+    const options = listbox.querySelectorAll('[role="option"]');
+    const scrollSpy = vi.fn();
+    options.forEach((opt) => {
+      opt.scrollIntoView = scrollSpy;
+    });
+
+    const input = screen.getByPlaceholderText("Type a command...");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+
+    const selected = listbox.querySelector('[aria-selected="true"]');
+    expect(selected).toBeTruthy();
+    expect(scrollSpy).toHaveBeenCalledWith({ block: "nearest" });
+  });
+
   it("calls onSelect for theme action when selected", () => {
     const setLight = vi.fn();
     const actions: PaletteAction[] = [

--- a/app/frontend/src/components/command-palette.test.tsx
+++ b/app/frontend/src/components/command-palette.test.tsx
@@ -187,16 +187,16 @@ describe("CommandPalette", () => {
 
     const listbox = screen.getByRole("listbox");
     const options = listbox.querySelectorAll('[role="option"]');
+    const secondOption = options[1];
     const scrollSpy = vi.fn();
-    options.forEach((opt) => {
-      opt.scrollIntoView = scrollSpy;
-    });
+    (secondOption as unknown as HTMLElement).scrollIntoView = scrollSpy;
 
     const input = screen.getByPlaceholderText("Type a command...");
     fireEvent.keyDown(input, { key: "ArrowDown" });
 
     const selected = listbox.querySelector('[aria-selected="true"]');
     expect(selected).toBeTruthy();
+    expect(selected).toBe(secondOption);
     expect(scrollSpy).toHaveBeenCalledWith({ block: "nearest" });
   });
 

--- a/app/frontend/src/components/command-palette.tsx
+++ b/app/frontend/src/components/command-palette.tsx
@@ -16,6 +16,7 @@ export function CommandPalette({ actions }: CommandPaletteProps) {
   const [query, setQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
   const listId = useId();
 
   const filtered = actions.filter((a) =>
@@ -49,6 +50,15 @@ export function CommandPalette({ actions }: CommandPaletteProps) {
       inputRef.current?.focus();
     }
   }, [open]);
+
+  // Scroll selected item into view
+  useEffect(() => {
+    if (!open || !listRef.current) return;
+    const selected = listRef.current.querySelector('[aria-selected="true"]');
+    if (selected && typeof selected.scrollIntoView === "function") {
+      selected.scrollIntoView({ block: "nearest" });
+    }
+  }, [selectedIndex, open]);
 
   const handleSelect = useCallback(
     (action: PaletteAction) => {
@@ -116,6 +126,7 @@ export function CommandPalette({ actions }: CommandPaletteProps) {
         />
         <div
           id={listId}
+          ref={listRef}
           role="listbox"
           aria-label="Commands"
           className="max-h-64 overflow-y-auto py-1"

--- a/docs/memory/run-kit/ui-patterns.md
+++ b/docs/memory/run-kit/ui-patterns.md
@@ -230,6 +230,10 @@ Terminal font size adapts at initialization: 13px on viewports >= 640px, 11px be
 
 The `CommandPalette` component listens for a `palette:open` CustomEvent on `document` (in addition to `⌘K`). The `⋯` button in Line 1 dispatches this event on mobile. This is the mobile equivalent of `⌘K` — physical keyboards aren't available on phones.
 
+### Keyboard-Navigable List Scroll Pattern
+
+Both `CommandPalette` and `ThemeSelector` use the same scroll-into-view pattern for arrow key navigation: a `listRef` on the listbox container plus a `useEffect` on `[selectedIndex, open]` that queries `[aria-selected="true"]` and calls `scrollIntoView({ block: "nearest" })`. This ensures the selected item stays visible when navigating past the `max-h-64` scroll boundary. New keyboard-navigable list components SHOULD follow this pattern.
+
 ## Keyboard Shortcuts
 
 ### Global

--- a/fab/changes/260324-yxjs-command-palette-arrow-scroll/.history.jsonl
+++ b/fab/changes/260324-yxjs-command-palette-arrow-scroll/.history.jsonl
@@ -12,3 +12,4 @@
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-03-24T03:06:50Z"}
 {"event":"review","result":"passed","ts":"2026-03-24T03:06:50Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-03-24T03:07:17Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-03-24T03:08:57Z"}

--- a/fab/changes/260324-yxjs-command-palette-arrow-scroll/.history.jsonl
+++ b/fab/changes/260324-yxjs-command-palette-arrow-scroll/.history.jsonl
@@ -1,0 +1,14 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-03-24T02:43:49Z"}
+{"args":"Moving up and down the Command Palette using arrow keys don't automatically scroll it when you reach the bottom (\u0026 also when you reach the top)","cmd":"fab-new","event":"command","ts":"2026-03-24T02:43:49Z"}
+{"delta":"+4.7","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-24T02:44:27Z"}
+{"delta":"+0.0","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-24T02:44:36Z"}
+{"cmd":"fab-switch","event":"command","ts":"2026-03-24T03:01:17Z"}
+{"cmd":"fab-fff","event":"command","ts":"2026-03-24T03:02:17Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"spec","ts":"2026-03-24T03:02:39Z"}
+{"delta":"+0.0","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-24T03:03:06Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"tasks","ts":"2026-03-24T03:03:15Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-03-24T03:03:38Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-03-24T03:05:30Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-03-24T03:06:50Z"}
+{"event":"review","result":"passed","ts":"2026-03-24T03:06:50Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-03-24T03:07:17Z"}

--- a/fab/changes/260324-yxjs-command-palette-arrow-scroll/.status.yaml
+++ b/fab/changes/260324-yxjs-command-palette-arrow-scroll/.status.yaml
@@ -1,0 +1,42 @@
+id: yxjs
+name: 260324-yxjs-command-palette-arrow-scroll
+created: 2026-03-24T02:43:49Z
+created_by: sahil-weaver
+change_type: fix
+issues: []
+progress:
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+checklist:
+    generated: true
+    path: checklist.md
+    completed: 12
+    total: 12
+confidence:
+    certain: 4
+    confident: 1
+    tentative: 0
+    unresolved: 0
+    score: 4.7
+    fuzzy: true
+    dimensions:
+        signal: 86.0
+        reversibility: 93.0
+        competence: 91.0
+        disambiguation: 92.0
+stage_metrics:
+    intake: {started_at: "2026-03-24T02:43:49Z", driver: fab-new, iterations: 1, completed_at: "2026-03-24T03:02:39Z"}
+    spec: {started_at: "2026-03-24T03:02:39Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-24T03:03:15Z"}
+    tasks: {started_at: "2026-03-24T03:03:15Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-24T03:03:38Z"}
+    apply: {started_at: "2026-03-24T03:03:38Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-24T03:05:30Z"}
+    review: {started_at: "2026-03-24T03:05:30Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-24T03:06:50Z"}
+    hydrate: {started_at: "2026-03-24T03:06:50Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-24T03:07:17Z"}
+    ship: {started_at: "2026-03-24T03:07:17Z", driver: fab-fff, iterations: 1}
+prs: []
+last_updated: 2026-03-24T03:07:17Z

--- a/fab/changes/260324-yxjs-command-palette-arrow-scroll/.status.yaml
+++ b/fab/changes/260324-yxjs-command-palette-arrow-scroll/.status.yaml
@@ -38,7 +38,7 @@ stage_metrics:
   review: {started_at: "2026-03-24T03:05:30Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-24T03:06:50Z"}
   hydrate: {started_at: "2026-03-24T03:06:50Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-24T03:07:17Z"}
   ship: {started_at: "2026-03-24T03:07:17Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-24T03:08:57Z"}
-  review-pr: {started_at: "2026-03-24T03:08:57Z", driver: git-pr, iterations: 1, phase: fixing, reviewer: 'copilot-pull-request-reviewer[bot]'}
+  review-pr: {started_at: "2026-03-24T03:08:57Z", driver: git-pr, iterations: 1, phase: replying, reviewer: 'copilot-pull-request-reviewer[bot]'}
 prs:
   - https://github.com/wvrdz/run-kit/pull/80
 last_updated: 2026-03-24T03:09:25Z

--- a/fab/changes/260324-yxjs-command-palette-arrow-scroll/.status.yaml
+++ b/fab/changes/260324-yxjs-command-palette-arrow-scroll/.status.yaml
@@ -5,40 +5,40 @@ created_by: sahil-weaver
 change_type: fix
 issues: []
 progress:
-    intake: done
-    spec: done
-    tasks: done
-    apply: done
-    review: done
-    hydrate: done
-    ship: done
-    review-pr: active
+  intake: done
+  spec: done
+  tasks: done
+  apply: done
+  review: done
+  hydrate: done
+  ship: done
+  review-pr: active
 checklist:
-    generated: true
-    path: checklist.md
-    completed: 12
-    total: 12
+  generated: true
+  path: checklist.md
+  completed: 12
+  total: 12
 confidence:
-    certain: 4
-    confident: 1
-    tentative: 0
-    unresolved: 0
-    score: 4.7
-    fuzzy: true
-    dimensions:
-        signal: 86.0
-        reversibility: 93.0
-        competence: 91.0
-        disambiguation: 92.0
+  certain: 4
+  confident: 1
+  tentative: 0
+  unresolved: 0
+  score: 4.7
+  fuzzy: true
+  dimensions:
+    signal: 86.0
+    reversibility: 93.0
+    competence: 91.0
+    disambiguation: 92.0
 stage_metrics:
-    intake: {started_at: "2026-03-24T02:43:49Z", driver: fab-new, iterations: 1, completed_at: "2026-03-24T03:02:39Z"}
-    spec: {started_at: "2026-03-24T03:02:39Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-24T03:03:15Z"}
-    tasks: {started_at: "2026-03-24T03:03:15Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-24T03:03:38Z"}
-    apply: {started_at: "2026-03-24T03:03:38Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-24T03:05:30Z"}
-    review: {started_at: "2026-03-24T03:05:30Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-24T03:06:50Z"}
-    hydrate: {started_at: "2026-03-24T03:06:50Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-24T03:07:17Z"}
-    ship: {started_at: "2026-03-24T03:07:17Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-24T03:08:57Z"}
-    review-pr: {started_at: "2026-03-24T03:08:57Z", driver: git-pr, iterations: 1}
+  intake: {started_at: "2026-03-24T02:43:49Z", driver: fab-new, iterations: 1, completed_at: "2026-03-24T03:02:39Z"}
+  spec: {started_at: "2026-03-24T03:02:39Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-24T03:03:15Z"}
+  tasks: {started_at: "2026-03-24T03:03:15Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-24T03:03:38Z"}
+  apply: {started_at: "2026-03-24T03:03:38Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-24T03:05:30Z"}
+  review: {started_at: "2026-03-24T03:05:30Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-24T03:06:50Z"}
+  hydrate: {started_at: "2026-03-24T03:06:50Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-24T03:07:17Z"}
+  ship: {started_at: "2026-03-24T03:07:17Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-24T03:08:57Z"}
+  review-pr: {started_at: "2026-03-24T03:08:57Z", driver: git-pr, iterations: 1, phase: fixing, reviewer: 'copilot-pull-request-reviewer[bot]'}
 prs:
-    - https://github.com/wvrdz/run-kit/pull/80
-last_updated: 2026-03-24T03:08:57Z
+  - https://github.com/wvrdz/run-kit/pull/80
+last_updated: 2026-03-24T03:09:25Z

--- a/fab/changes/260324-yxjs-command-palette-arrow-scroll/.status.yaml
+++ b/fab/changes/260324-yxjs-command-palette-arrow-scroll/.status.yaml
@@ -11,8 +11,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 checklist:
     generated: true
     path: checklist.md
@@ -37,6 +37,8 @@ stage_metrics:
     apply: {started_at: "2026-03-24T03:03:38Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-24T03:05:30Z"}
     review: {started_at: "2026-03-24T03:05:30Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-24T03:06:50Z"}
     hydrate: {started_at: "2026-03-24T03:06:50Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-24T03:07:17Z"}
-    ship: {started_at: "2026-03-24T03:07:17Z", driver: fab-fff, iterations: 1}
-prs: []
-last_updated: 2026-03-24T03:07:17Z
+    ship: {started_at: "2026-03-24T03:07:17Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-24T03:08:57Z"}
+    review-pr: {started_at: "2026-03-24T03:08:57Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/wvrdz/run-kit/pull/80
+last_updated: 2026-03-24T03:08:57Z

--- a/fab/changes/260324-yxjs-command-palette-arrow-scroll/checklist.md
+++ b/fab/changes/260324-yxjs-command-palette-arrow-scroll/checklist.md
@@ -1,0 +1,33 @@
+# Quality Checklist: Command Palette Arrow Key Scroll
+
+**Change**: 260324-yxjs-command-palette-arrow-scroll
+**Generated**: 2026-03-24
+**Spec**: `spec.md`
+
+## Functional Completeness
+- [x] CHK-001 Scroll-into-view on arrow key navigation: `listRef` attached to listbox, `useEffect` calls `scrollIntoView({ block: "nearest" })` on `[aria-selected="true"]` element
+- [x] CHK-002 Listbox ref attachment: `<div role="listbox">` has `ref={listRef}` attribute
+- [x] CHK-003 No wrapping behavior change: ArrowDown at last item stays on last, ArrowUp at first stays on first
+
+## Behavioral Correctness
+- [x] CHK-004 Arrow down past visible area scrolls container down
+- [x] CHK-005 Arrow up past visible area scrolls container up
+- [x] CHK-006 Selection within visible area does not trigger unnecessary scroll
+
+## Scenario Coverage
+- [x] CHK-007 Palette reopens with selection at top and list unscrolled
+- [x] CHK-008 scrollIntoView called on ArrowDown: test exists in command-palette.test.tsx
+
+## Edge Cases & Error Handling
+- [x] CHK-009 Empty filtered list: no scroll-into-view error when no items match query
+- [x] CHK-010 Single item list: arrow keys don't cause scroll errors
+
+## Code Quality
+- [x] CHK-011 Pattern consistency: scroll-into-view implementation matches theme-selector.tsx pattern
+- [x] CHK-012 No unnecessary duplication: reuses existing `useRef`/`useEffect` patterns, no new utilities
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] CHK-008 **N/A**: {reason}`

--- a/fab/changes/260324-yxjs-command-palette-arrow-scroll/intake.md
+++ b/fab/changes/260324-yxjs-command-palette-arrow-scroll/intake.md
@@ -1,0 +1,61 @@
+# Intake: Command Palette Arrow Key Scroll
+
+**Change**: 260324-yxjs-command-palette-arrow-scroll
+**Created**: 2026-03-24
+**Status**: Draft
+
+## Origin
+
+> Moving up and down the Command Palette using arrow keys don't automatically scroll it when you reach the bottom (& also when you reach the top)
+
+One-shot bug report. The Command Palette list container has `max-h-64 overflow-y-auto` but no scroll-into-view logic — when keyboard navigation moves the selection beyond the visible area, the viewport doesn't follow.
+
+## Why
+
+The Command Palette is the primary discovery mechanism for actions (Constitution V: Keyboard-First). When the list is long enough to scroll (more items than fit in the 256px `max-h-64` container), arrow-key navigation moves the `selectedIndex` and updates `aria-selected` but the scroll position stays put. The selected item disappears below or above the visible area, making keyboard-only navigation effectively broken for long lists.
+
+Without this fix, users must resort to mouse scrolling to find items beyond the visible area, which violates the keyboard-first principle.
+
+## What Changes
+
+### Add scroll-into-view on selection change
+
+Add a `useEffect` that scrolls the currently selected item into view whenever `selectedIndex` changes. The implementation follows the existing pattern in `app/frontend/src/components/theme-selector.tsx` (lines 69-76):
+
+1. Add a `listRef` (`useRef<HTMLDivElement>`) to the listbox container (`<div id={listId} role="listbox">`)
+2. Add a `useEffect` that fires on `[selectedIndex, open]` changes:
+   - Query `listRef.current` for the element with `[aria-selected="true"]`
+   - Call `selected.scrollIntoView({ block: "nearest" })` — this scrolls with minimal movement (only scrolls if the element is outside the visible area)
+
+Target file: `app/frontend/src/components/command-palette.tsx`
+
+### No behavioral changes
+
+- Arrow key clamping (min 0, max length-1) remains unchanged
+- No wrapping behavior added (that's a separate concern)
+- No mouse-enter suppression needed (Command Palette doesn't have hover-to-select during keyboard nav)
+
+## Affected Memory
+
+- `run-kit/ui-patterns`: (modify) Document scroll-into-view as a standard pattern for keyboard-navigable lists
+
+## Impact
+
+- **Files changed**: `app/frontend/src/components/command-palette.tsx` (add ref + useEffect)
+- **Tests**: `app/frontend/src/components/command-palette.test.tsx` (add test for scroll-into-view behavior)
+- **Risk**: Minimal — additive change, no existing behavior modified
+
+## Open Questions
+
+None — the fix is well-scoped and follows an established pattern in the codebase.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Use `scrollIntoView({ block: "nearest" })` | Established pattern in theme-selector.tsx; standard DOM API | S:90 R:95 A:95 D:95 |
+| 2 | Certain | Add `listRef` to the listbox container | Required for querying `aria-selected` elements; same pattern as theme-selector | S:90 R:95 A:95 D:95 |
+| 3 | Certain | Keep clamped navigation (no wrap-around) | Description only mentions scroll; wrapping is a separate concern | S:85 R:90 A:90 D:90 |
+| 4 | Confident | No mouse-enter suppression needed | Command Palette doesn't have hover-to-select during keyboard nav (unlike theme-selector which previews on hover) | S:75 R:90 A:80 D:85 |
+
+4 assumptions (3 certain, 1 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260324-yxjs-command-palette-arrow-scroll/spec.md
+++ b/fab/changes/260324-yxjs-command-palette-arrow-scroll/spec.md
@@ -1,0 +1,74 @@
+# Spec: Command Palette Arrow Key Scroll
+
+**Change**: 260324-yxjs-command-palette-arrow-scroll
+**Created**: 2026-03-24
+**Affected memory**: `docs/memory/run-kit/ui-patterns.md`
+
+## Command Palette: Keyboard Navigation Scroll
+
+### Requirement: Scroll-into-view on arrow key navigation
+
+The Command Palette (`app/frontend/src/components/command-palette.tsx`) SHALL scroll the currently selected item into view whenever `selectedIndex` changes due to arrow key navigation.
+
+The implementation SHALL use a `useRef<HTMLDivElement>` attached to the listbox container and a `useEffect` that queries for the `[aria-selected="true"]` element and calls `scrollIntoView({ block: "nearest" })`.
+
+The `scrollIntoView({ block: "nearest" })` option SHALL be used to minimize scroll displacement — the container scrolls only when the selected item is outside the visible area.
+
+#### Scenario: Arrow down past visible area
+- **GIVEN** the Command Palette is open with more items than fit in the `max-h-64` container
+- **WHEN** the user presses ArrowDown until the selected item is below the visible scroll area
+- **THEN** the listbox container scrolls down so the selected item is visible
+
+#### Scenario: Arrow up past visible area
+- **GIVEN** the Command Palette is open, scrolled down, with the selection near the bottom
+- **WHEN** the user presses ArrowUp until the selected item is above the visible scroll area
+- **THEN** the listbox container scrolls up so the selected item is visible
+
+#### Scenario: Selection within visible area
+- **GIVEN** the Command Palette is open with the selected item already visible
+- **WHEN** the user presses ArrowDown or ArrowUp
+- **THEN** the selection moves but no scroll occurs (block: "nearest" is a no-op when already visible)
+
+#### Scenario: Palette opens with selection at top
+- **GIVEN** the Command Palette was previously scrolled
+- **WHEN** the user reopens the palette (Cmd+K)
+- **THEN** `selectedIndex` resets to 0 and the list starts at the top (existing behavior preserved)
+
+### Requirement: Listbox ref attachment
+
+The listbox container (`<div id={listId} role="listbox">`) SHALL have a `ref={listRef}` attribute where `listRef` is a `useRef<HTMLDivElement>(null)`.
+
+#### Scenario: Ref available for scroll queries
+- **GIVEN** the Command Palette is open
+- **WHEN** the `useEffect` fires on `selectedIndex` change
+- **THEN** `listRef.current` is the listbox DOM element and `querySelector('[aria-selected="true"]')` returns the selected option
+
+### Requirement: No wrapping behavior change
+
+The existing clamped navigation (ArrowDown stops at last item, ArrowUp stops at first item) SHALL NOT be changed. Wrap-around is out of scope.
+
+#### Scenario: ArrowDown at last item
+- **GIVEN** the last item in the filtered list is selected
+- **WHEN** the user presses ArrowDown
+- **THEN** the selection stays on the last item (no wrap to first)
+
+### Requirement: Test coverage
+
+A test SHALL verify that `scrollIntoView` is called on the selected element when `selectedIndex` changes via arrow key navigation.
+
+#### Scenario: scrollIntoView called on ArrowDown
+- **GIVEN** the Command Palette is open with items
+- **WHEN** the user presses ArrowDown
+- **THEN** `scrollIntoView({ block: "nearest" })` is called on the newly selected element
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Use `scrollIntoView({ block: "nearest" })` | Confirmed from intake #1 — established pattern in theme-selector.tsx, standard DOM API | S:90 R:95 A:95 D:95 |
+| 2 | Certain | Add `listRef` to the listbox container | Confirmed from intake #2 — required for querying `aria-selected` elements | S:90 R:95 A:95 D:95 |
+| 3 | Certain | Keep clamped navigation (no wrap-around) | Confirmed from intake #3 — description only mentions scroll, wrapping is separate | S:85 R:90 A:90 D:90 |
+| 4 | Confident | No mouse-enter suppression needed | Confirmed from intake #4 — Command Palette has no hover-to-select during keyboard nav | S:75 R:90 A:80 D:85 |
+| 5 | Certain | useEffect fires on `[selectedIndex, open]` | Matching theme-selector pattern exactly; both dependencies needed | S:90 R:95 A:95 D:95 |
+
+5 assumptions (4 certain, 1 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260324-yxjs-command-palette-arrow-scroll/tasks.md
+++ b/fab/changes/260324-yxjs-command-palette-arrow-scroll/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: Command Palette Arrow Key Scroll
+
+**Change**: 260324-yxjs-command-palette-arrow-scroll
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+## Phase 1: Core Implementation
+
+- [x] T001 Add `listRef` to Command Palette listbox container in `app/frontend/src/components/command-palette.tsx` — declare `const listRef = useRef<HTMLDivElement>(null)` and attach `ref={listRef}` to the `<div id={listId} role="listbox">` element
+- [x] T002 Add scroll-into-view `useEffect` in `app/frontend/src/components/command-palette.tsx` — fires on `[selectedIndex, open]`, queries `listRef.current` for `[aria-selected="true"]`, calls `scrollIntoView({ block: "nearest" })`
+
+## Phase 2: Testing
+
+- [x] T003 Add test for scroll-into-view behavior in `app/frontend/src/components/command-palette.test.tsx` — verify `scrollIntoView` is called on the selected element after ArrowDown key press
+
+---
+
+## Execution Order
+
+- T001 blocks T002 (ref must exist before useEffect can reference it)
+- T003 depends on T001 + T002


### PR DESCRIPTION
## Summary

The Command Palette is the primary discovery mechanism for actions (keyboard-first principle). When the list is long enough to scroll, arrow-key navigation moves the selection but the scroll position stays put, making the selected item disappear beyond the visible area. This fix adds a `useEffect` with `scrollIntoView({ block: "nearest" })` so the viewport follows keyboard navigation.

## Changes

- Add scroll-into-view on selection change
- No behavioral changes (clamping preserved, no wrap-around)

## Change
| ID | Name | Issue |
|----|------|-------|
| yxjs | 260324-yxjs-command-palette-arrow-scroll | — |

## Stats
| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| fix | 4.7 / 5.0 | 12/12 ✓ | 3/3 | Pass (1 iterations) |

[intake](https://github.com/wvrdz/run-kit/blob/260324-yxjs-command-palette-arrow-scroll/fab/changes/260324-yxjs-command-palette-arrow-scroll/intake.md) → [spec](https://github.com/wvrdz/run-kit/blob/260324-yxjs-command-palette-arrow-scroll/fab/changes/260324-yxjs-command-palette-arrow-scroll/spec.md) → tasks → apply → review → hydrate → ship