### PR TITLE
fix: Theme toggle cycle broken by per-mode preference change

### DIFF
--- a/app/frontend/src/app.tsx
+++ b/app/frontend/src/app.tsx
@@ -248,14 +248,16 @@ function AppShell() {
   );
 
   // Theme
-  const { preference: themePreference } = useTheme();
+  const { preference: themePreference, resolved: themeResolved, themeDark, themeLight } = useTheme();
   const { setTheme } = useThemeActions();
+
+  const themeMode = themePreference === "system" ? "system" : themeResolved;
 
   const themeActions: PaletteAction[] = useMemo(() => {
     const options = [
-      { id: "system", label: "System" },
-      { id: "default-light", label: "Light" },
-      { id: "default-dark", label: "Dark" },
+      { mode: "system", label: "System", action: "system" },
+      { mode: "light", label: "Light", action: themeLight },
+      { mode: "dark", label: "Dark", action: themeDark },
     ];
     return [
       {
@@ -264,12 +266,12 @@ function AppShell() {
         onSelect: () => document.dispatchEvent(new CustomEvent("theme-selector:open")),
       },
       ...options.map((opt) => ({
-        id: `theme-${opt.id}`,
-        label: `Theme: ${opt.label}${themePreference === opt.id ? " (current)" : ""}`,
-        onSelect: () => setTheme(opt.id),
+        id: `theme-${opt.mode}`,
+        label: `Theme: ${opt.label}${themeMode === opt.mode ? " (current)" : ""}`,
+        onSelect: () => setTheme(opt.action),
       })),
     ] satisfies PaletteAction[];
-  }, [themePreference, setTheme]);
+  }, [themeMode, themeDark, themeLight, setTheme]);
 
   // Server management
   const handleSwitchServer = useCallback(

--- a/app/frontend/src/components/top-bar.tsx
+++ b/app/frontend/src/components/top-bar.tsx
@@ -240,16 +240,12 @@ export function TopBar({
   );
 }
 
-const THEME_CYCLE = ["system", "default-light", "default-dark"];
-const THEME_LABELS: Record<string, string> = {
-  system: "System theme",
-  "default-light": "Light theme",
-  "default-dark": "Dark theme",
-};
-
 function ThemeToggle() {
-  const { preference, resolved } = useTheme();
+  const { preference, resolved, themeDark, themeLight } = useTheme();
   const { setTheme } = useThemeActions();
+
+  // Derive current mode: system, light, or dark
+  const mode = preference === "system" ? "system" : resolved;
 
   const handleClick = (e: React.MouseEvent) => {
     if (e.ctrlKey || e.metaKey) {
@@ -258,12 +254,17 @@ function ThemeToggle() {
       return;
     }
 
-    const idx = THEME_CYCLE.indexOf(preference);
-    const next = THEME_CYCLE[(idx + 1) % THEME_CYCLE.length];
-    setTheme(next);
+    // Cycle: system → light (themeLight) → dark (themeDark) → system
+    if (mode === "system") {
+      setTheme(themeLight);
+    } else if (mode === "light") {
+      setTheme(themeDark);
+    } else {
+      setTheme("system");
+    }
   };
 
-  const label = THEME_LABELS[preference] ?? `${preference} theme`;
+  const label = mode === "system" ? "System theme" : mode === "light" ? "Light theme" : "Dark theme";
 
   return (
     <button

--- a/app/frontend/src/contexts/theme-context.tsx
+++ b/app/frontend/src/contexts/theme-context.tsx
@@ -162,10 +162,8 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   }, [preference]);
 
   const setTheme = useCallback((next: string) => {
-    const theme = getThemeById(next);
-
     if (next === "system") {
-      // Reset to system mode without changing per-mode prefs
+      // System mode — OS picks between per-mode prefs
       try {
         localStorage.setItem(THEME_STORAGE_KEY, "system");
       } catch {
@@ -179,6 +177,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       return;
     }
 
+    const theme = getThemeById(next);
     if (!theme) {
       // Unknown theme ID, fall back to system
       try {
@@ -194,7 +193,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       return;
     }
 
-    // Known theme: update per-mode preference based on category
+    // Known theme: update per-mode slot and set preference to this theme ID
     let nextDark = themeDarkRef.current;
     let nextLight = themeLightRef.current;
 
@@ -208,15 +207,15 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       themeLightRef.current = nextLight;
     }
 
-    // Stay in system mode
-    setPreference("system");
-    persistedPreferenceRef.current = "system";
+    // Preference = the specific theme ID (not "system")
+    setPreference(next);
+    persistedPreferenceRef.current = next;
     setActiveTheme(theme);
     setIsPreview(false);
 
     // Persist all values
     try {
-      localStorage.setItem(THEME_STORAGE_KEY, "system");
+      localStorage.setItem(THEME_STORAGE_KEY, next);
       localStorage.setItem(THEME_DARK_STORAGE_KEY, nextDark);
       localStorage.setItem(THEME_LIGHT_STORAGE_KEY, nextLight);
     } catch {
@@ -224,7 +223,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     }
 
     const apiPayload: { theme: string; themeDark?: string; themeLight?: string } = {
-      theme: "system",
+      theme: next,
     };
     if (theme.category === "dark") {
       apiPayload.themeDark = nextDark;


### PR DESCRIPTION
## Summary

The per-mode theme preferences change (#82) broke the theme toggle button — `setTheme` always reset `preference` to `"system"`, so the toggle could never cycle past system → light.

## Changes

- **theme-context.tsx**: `setTheme` now stores the specific theme ID as `preference` instead of always forcing `"system"`. Per-mode slot still updated by category
- **top-bar.tsx**: Toggle derives current mode (system/light/dark) from preference + resolved, cycles dynamically using stored `themeLight`/`themeDark` instead of hardcoded `default-light`/`default-dark`
- **app.tsx**: Command palette "Theme: Light/Dark" actions use per-mode prefs instead of hardcoded IDs