### PR TITLE
feat: Require tmux 3.3+ for synchronized output

### DIFF
--- a/app/backend/cmd/rk/doctor.go
+++ b/app/backend/cmd/rk/doctor.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 	"runtime"
 
+	"rk/internal/tmux"
+
 	"github.com/spf13/cobra"
 )
 
@@ -23,8 +25,13 @@ var doctorCmd = &cobra.Command{
 			}
 			cmd.Printf("  [FAIL] tmux not found — %s\n", hint)
 			failed = true
+		} else if err := tmux.CheckMinVersion(3, 3); err != nil {
+			v, _ := tmux.Version()
+			cmd.Printf("  [FAIL] tmux %s — version 3.3+ required for synchronized output\n", v.Raw)
+			failed = true
 		} else {
-			cmd.Println("  [ OK ] tmux")
+			v, _ := tmux.Version()
+			cmd.Printf("  [ OK ] tmux %s\n", v.Raw)
 		}
 
 		if failed {

--- a/app/backend/cmd/rk/serve.go
+++ b/app/backend/cmd/rk/serve.go
@@ -23,6 +23,11 @@ var serveCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Start the HTTP server",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Verify tmux version supports synchronized output.
+		if err := tmux.CheckMinVersion(3, 3); err != nil {
+			return err
+		}
+
 		daemonFlag, _ := cmd.Flags().GetBool("daemon")
 		restartFlag, _ := cmd.Flags().GetBool("restart")
 		stopFlag, _ := cmd.Flags().GetBool("stop")

--- a/app/backend/internal/tmux/version.go
+++ b/app/backend/internal/tmux/version.go
@@ -1,0 +1,64 @@
+package tmux
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// VersionInfo holds the parsed tmux version.
+type VersionInfo struct {
+	Major int
+	Minor int
+	Raw   string // e.g. "3.6a", "next-3.5"
+}
+
+// versionRe matches the major.minor portion of tmux -V output.
+var versionRe = regexp.MustCompile(`(\d+)\.(\d+)`)
+
+// Version runs `tmux -V` and parses the output.
+func Version() (VersionInfo, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "tmux", "-V").Output()
+	if err != nil {
+		return VersionInfo{}, fmt.Errorf("running tmux -V: %w", err)
+	}
+
+	raw := strings.TrimSpace(string(out))
+	// Strip "tmux " prefix if present
+	raw = strings.TrimPrefix(raw, "tmux ")
+
+	m := versionRe.FindStringSubmatch(raw)
+	if m == nil {
+		return VersionInfo{Raw: raw}, fmt.Errorf("cannot parse tmux version from %q", raw)
+	}
+
+	major, _ := strconv.Atoi(m[1])
+	minor, _ := strconv.Atoi(m[2])
+
+	return VersionInfo{Major: major, Minor: minor, Raw: raw}, nil
+}
+
+// CheckMinVersion returns nil if the installed tmux is >= major.minor,
+// or an error with an upgrade message.
+func CheckMinVersion(major, minor int) error {
+	v, err := Version()
+	if err != nil {
+		return fmt.Errorf("checking tmux version: %w", err)
+	}
+
+	if v.Major > major || (v.Major == major && v.Minor >= minor) {
+		return nil
+	}
+
+	return fmt.Errorf("tmux %s found, but %d.%d+ is required for synchronized output (prevents terminal jitter)\n"+
+		"  upgrade: brew install tmux  (macOS/Linuxbrew)\n"+
+		"           or build from https://github.com/tmux/tmux/releases",
+		v.Raw, major, minor)
+}

--- a/app/backend/internal/tmux/version_test.go
+++ b/app/backend/internal/tmux/version_test.go
@@ -1,0 +1,47 @@
+package tmux
+
+import (
+	"testing"
+)
+
+func TestVersionRegex(t *testing.T) {
+	tests := []struct {
+		input string
+		major int
+		minor int
+	}{
+		{"3.6a", 3, 6},
+		{"3.3", 3, 3},
+		{"3.2a", 3, 2},
+		{"next-3.5", 3, 5},
+		{"4.0", 4, 0},
+	}
+
+	for _, tt := range tests {
+		m := versionRe.FindStringSubmatch(tt.input)
+		if m == nil {
+			t.Errorf("versionRe did not match %q", tt.input)
+			continue
+		}
+		if m[1] != itoa(tt.major) || m[2] != itoa(tt.minor) {
+			t.Errorf("versionRe(%q) = %s.%s, want %d.%d", tt.input, m[1], m[2], tt.major, tt.minor)
+		}
+	}
+}
+
+func itoa(n int) string {
+	return []string{"0", "1", "2", "3", "4", "5", "6"}[n]
+}
+
+func TestVersion(t *testing.T) {
+	v, err := Version()
+	if err != nil {
+		t.Skipf("tmux not available: %v", err)
+	}
+	if v.Raw == "" {
+		t.Error("expected non-empty Raw version string")
+	}
+	if v.Major < 1 {
+		t.Errorf("expected Major >= 1, got %d", v.Major)
+	}
+}

--- a/app/frontend/src/components/terminal-client.tsx
+++ b/app/frontend/src/components/terminal-client.tsx
@@ -150,6 +150,7 @@ export function TerminalClient({
 
       terminal = new Terminal({
         cursorBlink: true,
+        scrollback: 0,
         fontFamily:
           "JetBrainsMono Nerd Font, JetBrains Mono, Fira Code, SF Mono, Menlo, Monaco, Consolas, monospace",
         fontSize: isMobile ? 11 : 13,

--- a/fab/changes/260325-ykjt-tmux-version-check/.history.jsonl
+++ b/fab/changes/260325-ykjt-tmux-version-check/.history.jsonl
@@ -1,0 +1,5 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-03-25T12:19:21Z"}
+{"args":"Add tmux version check at server startup","cmd":"fab-new","event":"command","ts":"2026-03-25T12:19:21Z"}
+{"delta":"+4.7","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-25T12:19:55Z"}
+{"delta":"+0.0","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-25T12:20:12Z"}
+{"cmd":"fab-new","event":"command","ts":"2026-03-25T12:20:21Z"}

--- a/fab/changes/260325-ykjt-tmux-version-check/.status.yaml
+++ b/fab/changes/260325-ykjt-tmux-version-check/.status.yaml
@@ -1,0 +1,37 @@
+id: ykjt
+name: 260325-ykjt-tmux-version-check
+created: 2026-03-25T12:19:21Z
+created_by: sahil-weaver
+change_type: feat
+issues: []
+progress:
+    intake: ready
+    spec: pending
+    tasks: pending
+    apply: pending
+    review: pending
+    hydrate: pending
+    ship: pending
+    review-pr: pending
+checklist:
+    generated: false
+    path: checklist.md
+    completed: 0
+    total: 0
+confidence:
+    certain: 4
+    confident: 1
+    tentative: 0
+    unresolved: 0
+    score: 4.7
+    indicative: true
+    fuzzy: true
+    dimensions:
+        signal: 87.0
+        reversibility: 86.0
+        competence: 88.0
+        disambiguation: 90.0
+stage_metrics:
+    intake: {started_at: "2026-03-25T12:19:21Z", driver: fab-new, iterations: 1}
+prs: []
+last_updated: 2026-03-25T12:20:16Z

--- a/fab/changes/260325-ykjt-tmux-version-check/intake.md
+++ b/fab/changes/260325-ykjt-tmux-version-check/intake.md
@@ -1,0 +1,75 @@
+# Intake: Tmux Version Check
+
+**Change**: 260325-ykjt-tmux-version-check
+**Created**: 2026-03-25
+**Status**: Draft
+
+## Origin
+
+> User reported terminal jitter on tmux sessions with accumulated history: "every line of update loads pages from a few pages back, and the pages jitter back to the current position." Investigation revealed the running tmux version is 3.2a, which does not support the `sync` terminal feature (DEC mode 2026 synchronized output). The run-kit tmux config already declares `set -as terminal-features ',xterm-256color:sync'` but tmux 3.2a silently ignores it.
+
+Conversational — diagnosis led directly to this change. `scrollback: 0` was applied to xterm.js as a supplementary fix but didn't resolve the core jitter issue.
+
+## Why
+
+1. **Problem**: Without synchronized output, tmux sends screen redraws as raw escape sequences without begin/end markers. xterm.js renders each arriving chunk immediately, showing intermediate states — cursor jumps to top, rows redraw top-to-bottom — causing visible jitter that worsens as the session accumulates history.
+2. **Consequence**: Every tmux session eventually becomes visually broken, making the terminal unreliable for agent work. Users must kill and recreate sessions to temporarily fix it.
+3. **Approach**: A version check at startup is the simplest, most robust fix — fail fast with a clear upgrade message rather than silently degrading. The `rk doctor` command already checks for tmux existence but not version, so the version check extends the existing pattern.
+
+## What Changes
+
+### 1. `internal/tmux/version.go` — Version parsing
+
+Add a `Version()` function to `app/backend/internal/tmux/` that:
+- Runs `tmux -V` and parses the output (format: `tmux 3.6a`, `tmux next-3.5`)
+- Extracts the major.minor version as a comparable value
+- Returns a struct with `Major`, `Minor` int fields and the raw version string
+
+Add a `CheckMinVersion(major, minor int) error` function that:
+- Calls `Version()`
+- Returns nil if >= minimum, or an error with a clear upgrade message including the found version and required version
+
+### 2. `cmd/rk/serve.go` — Startup check
+
+Add a tmux version check early in the `serve` command's `RunE`, before the server starts listening. Call `tmux.CheckMinVersion(3, 3)` and fatal if it returns an error. The error message should include:
+- The found version
+- The required minimum (3.3)
+- Platform-appropriate install hint (brew on macOS, apt/building from source on Linux)
+
+This check runs for both foreground `rk serve` and daemon mode (`rk serve -d`).
+
+### 3. `cmd/rk/doctor.go` — Version check in doctor
+
+Extend the existing tmux check in `rk doctor` to also verify the version after confirming tmux exists. Display the found version on success, warn on failure:
+
+```
+  [ OK ] tmux 3.6a
+  [FAIL] tmux 3.2a — version 3.3+ required for synchronized output
+```
+
+## Affected Memory
+
+- `run-kit/architecture`: (modify) Note minimum tmux version requirement
+
+## Impact
+
+- **Server startup**: Will fail on systems with tmux < 3.3 — this is intentional, as the terminal relay produces broken output without sync
+- **`rk doctor`**: Now also reports tmux version
+- **No API changes**: Backend-only, no frontend impact
+- **`scrollback: 0`**: Already applied to xterm.js Terminal in this branch (supplementary fix, reduces memory)
+
+## Open Questions
+
+None — the approach was discussed and agreed upon.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Minimum version is 3.3 (not 3.3a) | Discussed — `sync` terminal feature was introduced in tmux 3.3a but 3.3 is the safe semver floor for comparison | S:90 R:85 A:90 D:90 |
+| 2 | Certain | Check runs in `serve` command, not in the tmux package init | Discussed — fail at startup with a clear message, consistent with constitution's "fail fast" posture | S:85 R:90 A:85 D:90 |
+| 3 | Certain | Version parsing lives in `internal/tmux/` | Codebase convention — all tmux operations are in this package | S:90 R:95 A:95 D:95 |
+| 4 | Confident | Fatal on version mismatch (not warn) | Discussed — terminal relay produces broken output without sync, warning would let users hit the jitter | S:80 R:70 A:75 D:80 |
+| 5 | Certain | `rk doctor` extended rather than creating a separate check command | Existing pattern — doctor already checks tmux existence | S:90 R:90 A:95 D:95 |
+
+5 assumptions (4 certain, 1 confident, 0 tentative, 0 unresolved).


### PR DESCRIPTION
## Summary
- Add tmux version check at server startup — `rk serve` now fails fast if tmux < 3.3
- Extend `rk doctor` to report tmux version alongside existence check
- Set xterm.js `scrollback: 0` to avoid double-buffering with tmux's scrollback

**Context**: tmux < 3.3 silently ignores the `sync` terminal feature (DEC mode 2026), causing visible jitter on sessions with accumulated history. Every screen redraw is sent as raw escape sequences without begin/end markers, and xterm.js renders intermediate states.

## Test plan
- [ ] Run `rk doctor` — should show `[ OK ] tmux <version>` on 3.3+, `[FAIL]` on older
- [ ] Run `rk serve` with tmux < 3.3 — should error with upgrade instructions
- [ ] Run `rk serve` with tmux 3.3+ — should start normally
- [ ] Verify terminal sessions no longer jitter after upgrading tmux

🤖 Generated with [Claude Code](https://claude.com/claude-code)