### PR TITLE
feat: Close Pane Button

### DIFF
--- a/app/backend/api/router.go
+++ b/app/backend/api/router.go
@@ -34,6 +34,7 @@ type TmuxOps interface {
 	ListWindows(session, server string) ([]tmux.WindowInfo, error)
 	SplitWindow(session string, window int, horizontal bool, server string) (string, error)
 	KillPane(paneID, server string) error
+	KillActivePane(session string, window int, server string) error
 	ListServers() ([]string, error)
 	KillServer(server string) error
 	ListKeys(server string) ([]string, error)
@@ -112,6 +113,9 @@ func (p *prodTmuxOps) SplitWindow(session string, window int, horizontal bool, s
 func (p *prodTmuxOps) KillPane(paneID, server string) error {
 	return tmux.KillPane(paneID, server)
 }
+func (p *prodTmuxOps) KillActivePane(session string, window int, server string) error {
+	return tmux.KillActivePane(session, window, server)
+}
 func (p *prodTmuxOps) ListServers() ([]string, error) {
 	return tmux.ListServers()
 }
@@ -172,6 +176,7 @@ func (s *Server) buildRouter() chi.Router {
 	r.Post("/api/sessions/{session}/windows/{index}/keys", s.handleWindowKeys)
 	r.Post("/api/sessions/{session}/windows/{index}/select", s.handleWindowSelect)
 	r.Post("/api/sessions/{session}/windows/{index}/split", s.handleWindowSplit)
+	r.Post("/api/sessions/{session}/windows/{index}/close-pane", s.handleClosePaneKill)
 	r.Get("/api/directories", s.handleDirectories)
 	r.Post("/api/sessions/{session}/upload", s.handleUpload)
 	r.Get("/api/sessions/stream", s.handleSSE)

--- a/app/backend/api/sessions_test.go
+++ b/app/backend/api/sessions_test.go
@@ -60,6 +60,10 @@ type mockTmuxOps struct {
 	splitWindowResult     string
 	splitWindowErr        error
 
+	killActivePaneCalled  bool
+	killActivePaneSession string
+	killActivePaneIndex   int
+
 	err error
 }
 
@@ -122,6 +126,12 @@ func (m *mockTmuxOps) SelectWindow(session string, index int, server string) err
 }
 func (m *mockTmuxOps) KillPane(paneID, server string) error {
 	return nil
+}
+func (m *mockTmuxOps) KillActivePane(session string, window int, server string) error {
+	m.killActivePaneCalled = true
+	m.killActivePaneSession = session
+	m.killActivePaneIndex = window
+	return m.err
 }
 func (m *mockTmuxOps) ListServers() ([]string, error) {
 	return []string{"default"}, nil
@@ -291,6 +301,77 @@ func TestSessionKill(t *testing.T) {
 	}
 	if ops.killSessionName != "test-session" {
 		t.Errorf("killSessionName = %q, want %q", ops.killSessionName, "test-session")
+	}
+}
+
+func TestClosePaneSuccess(t *testing.T) {
+	ops := &mockTmuxOps{}
+	router := newTestRouter(&mockSessionFetcher{}, ops)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/main/windows/0/close-pane", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	if !ops.killActivePaneCalled {
+		t.Error("KillActivePane was not called")
+	}
+	if ops.killActivePaneSession != "main" {
+		t.Errorf("killActivePaneSession = %q, want %q", ops.killActivePaneSession, "main")
+	}
+	if ops.killActivePaneIndex != 0 {
+		t.Errorf("killActivePaneIndex = %d, want %d", ops.killActivePaneIndex, 0)
+	}
+
+	var result map[string]bool
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if !result["ok"] {
+		t.Error("expected ok: true")
+	}
+}
+
+func TestClosePaneInvalidSession(t *testing.T) {
+	router := newTestRouter(&mockSessionFetcher{}, &mockTmuxOps{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/test;rm/windows/0/close-pane", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+
+	var result map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if !strings.Contains(result["error"], "forbidden characters") {
+		t.Errorf("error = %q, want containing %q", result["error"], "forbidden characters")
+	}
+}
+
+func TestClosePaneInvalidIndex(t *testing.T) {
+	router := newTestRouter(&mockSessionFetcher{}, &mockTmuxOps{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/main/windows/abc/close-pane", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+
+	var result map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if !strings.Contains(result["error"], "Invalid window index") {
+		t.Errorf("error = %q, want containing %q", result["error"], "Invalid window index")
 	}
 }
 

--- a/app/backend/api/windows.go
+++ b/app/backend/api/windows.go
@@ -177,6 +177,27 @@ func (s *Server) handleWindowSplit(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "pane_id": paneID})
 }
 
+func (s *Server) handleClosePaneKill(w http.ResponseWriter, r *http.Request) {
+	session := chi.URLParam(r, "session")
+	if errMsg := validate.ValidateName(session, "Session name"); errMsg != "" {
+		writeError(w, http.StatusBadRequest, errMsg)
+		return
+	}
+
+	index, ok := parseWindowIndex(r)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "Invalid window index")
+		return
+	}
+
+	if err := s.tmux.KillActivePane(session, index, serverFromRequest(r)); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
 func (s *Server) handleWindowKeys(w http.ResponseWriter, r *http.Request) {
 	session := chi.URLParam(r, "session")
 	if errMsg := validate.ValidateName(session, "Session name"); errMsg != "" {

--- a/app/backend/internal/tmux/tmux.go
+++ b/app/backend/internal/tmux/tmux.go
@@ -449,6 +449,19 @@ func SplitWindow(session string, window int, horizontal bool, server string) (st
 	return lines[0], nil
 }
 
+// KillActivePane kills the active pane of the specified window on the given server.
+// Errors are silently ignored (pane may already be dead), matching KillPane pattern.
+func KillActivePane(session string, window int, server string) error {
+	ctx, cancel := withTimeout()
+	defer cancel()
+
+	target := fmt.Sprintf("%s:%d", session, window)
+	_, err := tmuxExecServer(ctx, server, "kill-pane", "-t", target)
+	// Pane may already be dead — ignore errors
+	_ = err
+	return nil
+}
+
 // KillPane kills a specific pane by ID on the specified server.
 func KillPane(paneID string, server string) error {
 	ctx, cancel := withTimeout()

--- a/app/frontend/src/api/client.ts
+++ b/app/frontend/src/api/client.ts
@@ -156,6 +156,18 @@ export async function splitWindow(
   return res.json();
 }
 
+export async function closePane(
+  session: string,
+  index: number,
+): Promise<{ ok: boolean }> {
+  const res = await fetch(
+    withServer(`/api/sessions/${encodeURIComponent(session)}/windows/${index}/close-pane`),
+    { method: "POST" },
+  );
+  if (!res.ok) await throwOnError(res);
+  return res.json();
+}
+
 export async function selectWindow(
   session: string,
   index: number,

--- a/app/frontend/src/app.tsx
+++ b/app/frontend/src/app.tsx
@@ -15,7 +15,7 @@ import { Dialog } from "@/components/dialog";
 import { CreateSessionDialog } from "@/components/create-session-dialog";
 import { Dashboard } from "@/components/dashboard";
 import { KeyboardShortcuts } from "@/components/keyboard-shortcuts";
-import { selectWindow, createWindow, splitWindow, reloadTmuxConfig, initTmuxConf, getHealth, createServer, killServer as killServerApi } from "@/api/client";
+import { selectWindow, createWindow, splitWindow, closePane, reloadTmuxConfig, initTmuxConf, getHealth, createServer, killServer as killServerApi } from "@/api/client";
 import { useSessionContext } from "@/contexts/session-context";
 import { useBrowserTitle } from "@/hooks/use-browser-title";
 
@@ -402,6 +402,13 @@ function AppShell() {
               label: "Window: Split Horizontal",
               onSelect: () => {
                 if (sessionName) splitWindow(sessionName, currentWindow.index, false).catch(() => {});
+              },
+            },
+            {
+              id: "close-pane",
+              label: "Pane: Close",
+              onSelect: () => {
+                if (sessionName) closePane(sessionName, currentWindow.index).catch(() => {});
               },
             },
           ]

--- a/app/frontend/src/components/top-bar.test.tsx
+++ b/app/frontend/src/components/top-bar.test.tsx
@@ -5,6 +5,15 @@ import { ChromeProvider } from "@/contexts/chrome-context";
 import { ThemeProvider } from "@/contexts/theme-context";
 import type { ProjectSession, WindowInfo } from "@/types";
 
+vi.mock("@/api/client", async () => {
+  const actual = await vi.importActual<typeof import("@/api/client")>("@/api/client");
+  return {
+    ...actual,
+    splitWindow: vi.fn().mockResolvedValue({ ok: true, pane_id: "%1" }),
+    closePane: vi.fn().mockResolvedValue({ ok: true }),
+  };
+});
+
 const nowSeconds = Math.floor(Date.now() / 1000);
 
 const fabWindow: WindowInfo = {
@@ -219,5 +228,22 @@ describe("TopBar", () => {
     expect(onCreateWindow).toHaveBeenCalledWith("run-kit");
     // Menu should close after action
     expect(screen.queryByText("+ New Window")).not.toBeInTheDocument();
+  });
+
+  it("renders ClosePaneButton when a window is selected", () => {
+    renderTopBar();
+    expect(screen.getByLabelText("Close pane")).toBeInTheDocument();
+  });
+
+  it("does not render ClosePaneButton on dashboard (no window)", () => {
+    renderTopBar({ currentWindow: null, windowName: "" });
+    expect(screen.queryByLabelText("Close pane")).not.toBeInTheDocument();
+  });
+
+  it("calls closePane API when ClosePaneButton is clicked", async () => {
+    const { closePane } = await import("@/api/client");
+    renderTopBar();
+    fireEvent.click(screen.getByLabelText("Close pane"));
+    expect(closePane).toHaveBeenCalledWith("run-kit", 0);
   });
 });

--- a/app/frontend/src/components/top-bar.tsx
+++ b/app/frontend/src/components/top-bar.tsx
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { BreadcrumbDropdown } from "@/components/breadcrumb-dropdown";
 import { useChrome, useChromeDispatch } from "@/contexts/chrome-context";
 import { useTheme, useThemeActions } from "@/contexts/theme-context";
-import { splitWindow } from "@/api/client";
+import { splitWindow, closePane } from "@/api/client";
 import type { ProjectSession, WindowInfo } from "@/types";
 import type { BreadcrumbDropdownItem } from "@/contexts/chrome-context";
 
@@ -203,6 +203,12 @@ export function TopBar({
                 />
               </span>
               <span className="hidden sm:flex">
+                <ClosePaneButton
+                  session={sessionName}
+                  windowIndex={currentWindow.index}
+                />
+              </span>
+              <span className="hidden sm:flex">
                 <FixedWidthToggle />
               </span>
             </>
@@ -356,6 +362,45 @@ function SplitButton({
             <line x1="4" x2="20" y1="12" y2="12" />
           </>
         )}
+      </svg>
+    </button>
+  );
+}
+
+function ClosePaneButton({
+  session,
+  windowIndex,
+}: {
+  session: string;
+  windowIndex: number;
+}) {
+  const handleClick = () => {
+    closePane(session, windowIndex).catch(() => {
+      // best-effort — pane may already be dead
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label="Close pane"
+      className="min-w-[24px] min-h-[24px] rounded border border-border text-text-secondary hover:border-text-secondary transition-colors flex items-center justify-center"
+      title="Close pane"
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <line x1="18" y1="6" x2="6" y2="18" />
+        <line x1="6" y1="6" x2="18" y2="18" />
       </svg>
     </button>
   );

--- a/docs/memory/run-kit/ui-patterns.md
+++ b/docs/memory/run-kit/ui-patterns.md
@@ -57,10 +57,10 @@ The root layout (`app/frontend/src/app.tsx`) renders `TopBarChrome` which derive
 - Logo SVG (`icon.svg`) — decorative (`aria-hidden="true"`), not a button
 - "Run Kit" text span (`text-xs text-text-secondary`)
 - Green/gray connection dot — no text label ("live"/"disconnected" text removed)
-- `FixedWidthToggle`
 - Split horizontal button (`SplitButton horizontal`) — splits pane left/right. Only rendered when `currentWindow` exists
 - Split vertical button (`SplitButton`) — splits pane top/bottom. Only rendered when `currentWindow` exists
 - Close pane button (`ClosePaneButton`) — kills the active pane of the current window. Only rendered when `currentWindow` exists
+- `FixedWidthToggle`
 - `ThemeToggle`
 - `⌘K` kbd hint
 - Compose button (`>_`) — rightmost item, opens compose buffer. `onOpenCompose` callback passed as prop to `TopBar`

--- a/docs/memory/run-kit/ui-patterns.md
+++ b/docs/memory/run-kit/ui-patterns.md
@@ -53,22 +53,25 @@ The root layout (`app/frontend/src/app.tsx`) renders `TopBarChrome` which derive
 - Session name capped at ~7 characters with ellipsis overflow (`max-w-[7ch] truncate`)
 - No text prefixes like "session:" or "window:"
 
-**Right section (desktop)**: `{logo} Run Kit  ●  ⇔  ⫼  ⊟  ◑  ⌘K  >_`
+**Right section (desktop)**: `{logo} Run Kit  ●  ⇔  ⫼  ⊟  ✕  ◑  ⌘K  >_`
 - Logo SVG (`icon.svg`) — decorative (`aria-hidden="true"`), not a button
 - "Run Kit" text span (`text-xs text-text-secondary`)
 - Green/gray connection dot — no text label ("live"/"disconnected" text removed)
 - `FixedWidthToggle`
 - Split horizontal button (`SplitButton horizontal`) — splits pane left/right. Only rendered when `currentWindow` exists
 - Split vertical button (`SplitButton`) — splits pane top/bottom. Only rendered when `currentWindow` exists
+- Close pane button (`ClosePaneButton`) — kills the active pane of the current window. Only rendered when `currentWindow` exists
 - `ThemeToggle`
 - `⌘K` kbd hint
 - Compose button (`>_`) — rightmost item, opens compose buffer. `onOpenCompose` callback passed as prop to `TopBar`
 
-**Right section (mobile < 640px)**: `⋯  >_` — only command palette trigger and compose button visible. Logo, "Run Kit" text, dot, toggle, split buttons, ⌘K hidden via `hidden sm:flex` / `hidden sm:inline-flex`
+**Right section (mobile < 640px)**: `⋯  >_` — only command palette trigger and compose button visible. Logo, "Run Kit" text, dot, toggle, split buttons, close pane button, ⌘K hidden via `hidden sm:flex` / `hidden sm:inline-flex`
 
 **Split buttons** (`SplitButton` in `top-bar.tsx`): Two inline components calling `splitWindow(session, windowIndex, horizontal)` from `api/client.ts`. Custom SVG icons (square-split pattern). Best-effort error handling — tmux may reject if pane is too small. `POST /api/sessions/{session}/windows/{index}/split` with `{ "horizontal": bool }`.
 
-**Toolbar button color convention**: All toolbar buttons (top bar and bottom bar) use `text-text-secondary` as their default foreground color. Active toggle states (Ctrl/Alt modifiers when armed, FixedWidthToggle when active) use `text-accent` with accent background. Hover state uses `hover:border-text-secondary` (border highlight). This convention applies to: compose button, theme toggle, fixed-width toggle, split buttons, Esc, Tab, Ctrl, Alt, Fn trigger, arrow pad, and ⌘K.
+**Close pane button** (`ClosePaneButton` in `top-bar.tsx`): Inline component calling `closePane(session, windowIndex)` from `api/client.ts`. X-shaped close icon SVG (`width="14" height="14" viewBox="0 0 24 24"`). Same base styling as `SplitButton` (`min-w-[24px] min-h-[24px] rounded border border-border text-text-secondary hover:border-text-secondary`). Hidden on mobile (`hidden sm:flex`). Only rendered when `currentWindow` exists. Best-effort error handling (`.catch(() => {})`), matching split button pattern. Kills the active pane of the current window — no pane ID tracking needed, targets via `POST /api/sessions/{session}/windows/{index}/close-pane`. Also available as "Pane: Close" in the command palette.
+
+**Toolbar button color convention**: All toolbar buttons (top bar and bottom bar) use `text-text-secondary` as their default foreground color. Active toggle states (Ctrl/Alt modifiers when armed, FixedWidthToggle when active) use `text-accent` with accent background. Hover state uses `hover:border-text-secondary` (border highlight). This convention applies to: compose button, theme toggle, fixed-width toggle, split buttons, close pane button, Esc, Tab, Ctrl, Alt, Fn trigger, arrow pad, and ⌘K.
 
 ### Theme System
 

--- a/fab/changes/260326-tbmj-close-pane-button/.history.jsonl
+++ b/fab/changes/260326-tbmj-close-pane-button/.history.jsonl
@@ -12,3 +12,4 @@
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-03-26T21:29:57Z"}
 {"event":"review","result":"passed","ts":"2026-03-26T21:29:57Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-03-26T21:31:06Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-03-26T21:32:36Z"}

--- a/fab/changes/260326-tbmj-close-pane-button/.history.jsonl
+++ b/fab/changes/260326-tbmj-close-pane-button/.history.jsonl
@@ -1,0 +1,14 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-03-26T21:14:14Z"}
+{"args":"in the top bar next to horizontal and vertical split pane buttons, add a close pane button","cmd":"fab-new","event":"command","ts":"2026-03-26T21:14:14Z"}
+{"delta":"+3.1","event":"confidence","score":3.1,"trigger":"calc-score","ts":"2026-03-26T21:14:52Z"}
+{"delta":"+0.0","event":"confidence","score":3.1,"trigger":"calc-score","ts":"2026-03-26T21:15:03Z"}
+{"cmd":"fab-switch","event":"command","ts":"2026-03-26T21:15:41Z"}
+{"cmd":"fab-fff","event":"command","ts":"2026-03-26T21:16:56Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"spec","ts":"2026-03-26T21:19:14Z"}
+{"delta":"+1.6","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-26T21:20:13Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"tasks","ts":"2026-03-26T21:21:13Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-03-26T21:21:18Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-03-26T21:27:31Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-03-26T21:29:57Z"}
+{"event":"review","result":"passed","ts":"2026-03-26T21:29:57Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-03-26T21:31:06Z"}

--- a/fab/changes/260326-tbmj-close-pane-button/.history.jsonl
+++ b/fab/changes/260326-tbmj-close-pane-button/.history.jsonl
@@ -13,3 +13,4 @@
 {"event":"review","result":"passed","ts":"2026-03-26T21:29:57Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-03-26T21:31:06Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-03-26T21:32:36Z"}
+{"delta":"-1.6","event":"confidence","score":3.1,"trigger":"calc-score","ts":"2026-03-26T21:38:08Z"}

--- a/fab/changes/260326-tbmj-close-pane-button/.status.yaml
+++ b/fab/changes/260326-tbmj-close-pane-button/.status.yaml
@@ -11,8 +11,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 checklist:
     generated: true
     path: checklist.md
@@ -37,6 +37,8 @@ stage_metrics:
     apply: {started_at: "2026-03-26T21:21:18Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-26T21:27:31Z"}
     review: {started_at: "2026-03-26T21:27:31Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-26T21:29:57Z"}
     hydrate: {started_at: "2026-03-26T21:29:57Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-26T21:31:06Z"}
-    ship: {started_at: "2026-03-26T21:31:06Z", driver: fab-fff, iterations: 1}
-prs: []
-last_updated: 2026-03-26T21:31:06Z
+    ship: {started_at: "2026-03-26T21:31:06Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-26T21:32:36Z"}
+    review-pr: {started_at: "2026-03-26T21:32:36Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/wvrdz/run-kit/pull/88
+last_updated: 2026-03-26T21:32:36Z

--- a/fab/changes/260326-tbmj-close-pane-button/.status.yaml
+++ b/fab/changes/260326-tbmj-close-pane-button/.status.yaml
@@ -1,0 +1,42 @@
+id: tbmj
+name: 260326-tbmj-close-pane-button
+created: 2026-03-26T21:14:14Z
+created_by: sahil-weaver
+change_type: feat
+issues: []
+progress:
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+checklist:
+    generated: true
+    path: checklist.md
+    completed: 0
+    total: 0
+confidence:
+    certain: 10
+    confident: 1
+    tentative: 0
+    unresolved: 0
+    score: 4.7
+    fuzzy: true
+    dimensions:
+        signal: 81.4
+        reversibility: 89.1
+        competence: 90.9
+        disambiguation: 90.5
+stage_metrics:
+    intake: {started_at: "2026-03-26T21:14:14Z", driver: fab-new, iterations: 1, completed_at: "2026-03-26T21:19:14Z"}
+    spec: {started_at: "2026-03-26T21:19:14Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-26T21:21:13Z"}
+    tasks: {started_at: "2026-03-26T21:21:13Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-26T21:21:18Z"}
+    apply: {started_at: "2026-03-26T21:21:18Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-26T21:27:31Z"}
+    review: {started_at: "2026-03-26T21:27:31Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-26T21:29:57Z"}
+    hydrate: {started_at: "2026-03-26T21:29:57Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-26T21:31:06Z"}
+    ship: {started_at: "2026-03-26T21:31:06Z", driver: fab-fff, iterations: 1}
+prs: []
+last_updated: 2026-03-26T21:31:06Z

--- a/fab/changes/260326-tbmj-close-pane-button/.status.yaml
+++ b/fab/changes/260326-tbmj-close-pane-button/.status.yaml
@@ -2,7 +2,7 @@ id: tbmj
 name: 260326-tbmj-close-pane-button
 created: 2026-03-26T21:14:14Z
 created_by: sahil-weaver
-change_type: feat
+change_type: refactor
 issues: []
 progress:
     intake: done
@@ -19,17 +19,18 @@ checklist:
     completed: 0
     total: 0
 confidence:
-    certain: 10
-    confident: 1
-    tentative: 0
+    certain: 4
+    confident: 3
+    tentative: 1
     unresolved: 0
-    score: 4.7
+    score: 3.1
+    indicative: true
     fuzzy: true
     dimensions:
-        signal: 81.4
-        reversibility: 89.1
-        competence: 90.9
-        disambiguation: 90.5
+        signal: 73.8
+        reversibility: 85.6
+        competence: 84.4
+        disambiguation: 81.3
 stage_metrics:
     intake: {started_at: "2026-03-26T21:14:14Z", driver: fab-new, iterations: 1, completed_at: "2026-03-26T21:19:14Z"}
     spec: {started_at: "2026-03-26T21:19:14Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-26T21:21:13Z"}
@@ -41,4 +42,4 @@ stage_metrics:
     review-pr: {started_at: "2026-03-26T21:32:36Z", driver: git-pr, iterations: 1}
 prs:
     - https://github.com/wvrdz/run-kit/pull/88
-last_updated: 2026-03-26T21:32:36Z
+last_updated: 2026-03-26T21:38:08Z

--- a/fab/changes/260326-tbmj-close-pane-button/checklist.md
+++ b/fab/changes/260326-tbmj-close-pane-button/checklist.md
@@ -1,0 +1,37 @@
+# Quality Checklist: Close Pane Button
+
+**Change**: 260326-tbmj-close-pane-button
+**Generated**: 2026-03-27
+**Spec**: `spec.md`
+
+## Functional Completeness
+- [ ] CHK-001 KillActivePane function: `tmux.KillActivePane` exists in `internal/tmux/tmux.go` and targets `session:window`
+- [ ] CHK-002 TmuxOps interface: `KillActivePane` method added to interface and `prodTmuxOps`
+- [ ] CHK-003 Close pane endpoint: `POST /api/sessions/{session}/windows/{index}/close-pane` registered and returns `{"ok": true}`
+- [ ] CHK-004 API client function: `closePane` exported from `api/client.ts` with correct signature
+- [ ] CHK-005 ClosePaneButton component: Renders in top bar after split buttons, before FixedWidthToggle
+- [ ] CHK-006 Command palette action: "Pane: Close" listed after "Window: Split Horizontal"
+
+## Behavioral Correctness
+- [ ] CHK-007 Button click kills active pane: Clicking the close button calls the API and tmux kills the active pane
+- [ ] CHK-008 Last pane behavior: Closing the last pane kills the window; frontend handles redirect via existing logic
+
+## Scenario Coverage
+- [ ] CHK-009 Multi-pane close: Split a window, click close pane, verify one pane removed
+- [ ] CHK-010 Desktop visibility: Button visible at viewport >= 640px
+- [ ] CHK-011 Mobile hidden: Button not visible at viewport < 640px
+- [ ] CHK-012 Dashboard route: Button not rendered when no window is selected
+- [ ] CHK-013 Invalid input: Bad session name or window index returns 400
+
+## Edge Cases & Error Handling
+- [ ] CHK-014 Pane already dead: API call doesn't error (silently ignored)
+- [ ] CHK-015 Best-effort error handling: Frontend `.catch(() => {})` — no unhandled promise rejection
+
+## Code Quality
+- [ ] CHK-016 Pattern consistency: `ClosePaneButton` follows `SplitButton` styling and structure exactly
+- [ ] CHK-017 No unnecessary duplication: Reuses `parseWindowIndex`, `validate.ValidateName`, `serverFromRequest`
+- [ ] CHK-018 exec.CommandContext with timeout: `KillActivePane` uses `withTimeout()` context (constitution I)
+- [ ] CHK-019 No shell string construction: Target formatted via `fmt.Sprintf` with argument slices (anti-pattern check)
+
+## Security
+- [ ] CHK-020 Input validation: Session name validated via `validate.ValidateName`, window index via `parseWindowIndex`

--- a/fab/changes/260326-tbmj-close-pane-button/intake.md
+++ b/fab/changes/260326-tbmj-close-pane-button/intake.md
@@ -25,21 +25,15 @@ Add a `ClosePaneButton` component in `app/frontend/src/components/top-bar.tsx`, 
 - Uses the same styling pattern as `SplitButton` (24x24 min size, rounded border, hover state)
 - Shows an "X" or close icon (an SVG matching the 14x14 viewBox convention used by the split icons)
 - Is hidden on mobile (`hidden sm:flex`) like the split buttons
-- Calls a new `killPane` API client function
-- Requires knowledge of the current pane ID to close
+- Calls a new `closePane` API client function targeting the active pane by window (no pane ID tracking needed)
 
 ### Frontend: API Client Function
 
-Add a `killPane(session: string, index: number, paneId: string)` function in `app/frontend/src/api/client.ts` that POSTs to a new backend endpoint.
+Add a `closePane(session: string, index: number)` function in `app/frontend/src/api/client.ts` that POSTs to `POST /api/sessions/{session}/windows/{index}/close-pane`.
 
-### Backend: Kill Pane API Endpoint
+### Backend: Close Pane API Endpoint
 
-Add a new route `POST /api/sessions/{session}/windows/{index}/panes/{paneId}/kill` in `app/backend/api/router.go` with a handler in the appropriate handler file. The backend already has `tmux.KillPane(paneID, server)` and the `TmuxOps.KillPane` interface method — the handler just needs to wire the HTTP layer to the existing function.
-
-### Pane ID Availability
-
-The frontend needs to know which pane ID to close. The current `WindowInfo` type and SSE data need to include the active pane ID so the button knows what to target. This may require checking how the WebSocket connection identifies its pane.
-<!-- assumed: The active pane ID is available from the terminal connection context or can be derived from the current window's pane list -->
+Add a new route `POST /api/sessions/{session}/windows/{index}/close-pane` in `app/backend/api/router.go` with a handler that kills the active pane of the specified window. Uses a `KillActivePane` tmux function that targets the active pane by window — no pane ID tracking or frontend-to-backend pane ID plumbing required.
 
 ## Affected Memory
 

--- a/fab/changes/260326-tbmj-close-pane-button/intake.md
+++ b/fab/changes/260326-tbmj-close-pane-button/intake.md
@@ -1,0 +1,73 @@
+# Intake: Close Pane Button
+
+**Change**: 260326-tbmj-close-pane-button
+**Created**: 2026-03-27
+**Status**: Draft
+
+## Origin
+
+> In the top bar next to horizontal and vertical split pane buttons, add a close pane button.
+
+One-shot request. The user wants a UI button in the top bar to close/kill the current tmux pane, positioned alongside the existing split pane buttons.
+
+## Why
+
+The top bar currently has buttons to split panes (vertical and horizontal) but no way to close a pane. Users who split panes via the UI have no corresponding UI affordance to close them — they must either use tmux keybindings (`prefix + x`) or the command palette's "Window: Kill" action (which kills the entire window, not just a pane). This is an asymmetry: if you can create panes from the top bar, you should be able to close them there too.
+
+Without this, users unfamiliar with tmux keybindings have no discoverable way to close individual panes they've split.
+
+## What Changes
+
+### Frontend: Close Pane Button in Top Bar
+
+Add a `ClosePaneButton` component in `app/frontend/src/components/top-bar.tsx`, rendered next to the two existing `SplitButton` instances. The button:
+
+- Uses the same styling pattern as `SplitButton` (24x24 min size, rounded border, hover state)
+- Shows an "X" or close icon (an SVG matching the 14x14 viewBox convention used by the split icons)
+- Is hidden on mobile (`hidden sm:flex`) like the split buttons
+- Calls a new `killPane` API client function
+- Requires knowledge of the current pane ID to close
+
+### Frontend: API Client Function
+
+Add a `killPane(session: string, index: number, paneId: string)` function in `app/frontend/src/api/client.ts` that POSTs to a new backend endpoint.
+
+### Backend: Kill Pane API Endpoint
+
+Add a new route `POST /api/sessions/{session}/windows/{index}/panes/{paneId}/kill` in `app/backend/api/router.go` with a handler in the appropriate handler file. The backend already has `tmux.KillPane(paneID, server)` and the `TmuxOps.KillPane` interface method — the handler just needs to wire the HTTP layer to the existing function.
+
+### Pane ID Availability
+
+The frontend needs to know which pane ID to close. The current `WindowInfo` type and SSE data need to include the active pane ID so the button knows what to target. This may require checking how the WebSocket connection identifies its pane.
+<!-- assumed: The active pane ID is available from the terminal connection context or can be derived from the current window's pane list -->
+
+## Affected Memory
+
+- `run-kit/ui-patterns`: (modify) Document the close pane button pattern in the top bar actions section
+
+## Impact
+
+- **Frontend**: `top-bar.tsx` (new button component), `client.ts` (new API function), types if pane ID needs threading
+- **Backend**: `router.go` (new route), new handler function (or addition to existing handler file like `windows.go`)
+- **Existing tests**: Mock interface `mockTmuxOps` already implements `KillPane` — backend test infrastructure is ready
+- **Command palette**: May want a corresponding "Pane: Kill" action for keyboard-first users (constitution V)
+
+## Open Questions
+
+- How does the frontend currently know the active pane ID? Is it available from the WebSocket connection context or does it need to be added to the SSE session state?
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Button placement next to split buttons in top bar | Explicit in user request | S:95 R:90 A:95 D:95 |
+| 2 | Certain | Same styling as existing split buttons (24x24, border, hover) | Codebase pattern — all top bar buttons use identical styling | S:80 R:95 A:95 D:95 |
+| 3 | Certain | Hidden on mobile (`hidden sm:flex`) like split buttons | Codebase pattern — split buttons already use this | S:75 R:90 A:95 D:95 |
+| 4 | Certain | Use existing `tmux.KillPane` backend function | Already implemented in tmux.go and wired in router.go interface | S:85 R:95 A:95 D:95 |
+| 5 | Confident | API route follows `POST /api/sessions/{session}/windows/{index}/panes/{paneId}/kill` pattern | Follows existing route convention (`/kill` suffix for destructive actions) | S:70 R:80 A:80 D:70 |
+| 6 | Confident | Button shows an X/close icon | Standard UI convention for close actions, consistent with the minimal icon style | S:70 R:90 A:75 D:70 |
+| 7 | Tentative | Pane ID is available from the WebSocket/terminal connection context | Need to verify how pane info flows to the frontend — may require threading pane ID from SSE or WebSocket handshake | S:50 R:60 A:50 D:50 |
+<!-- assumed: Pane ID availability — assumed derivable from existing connection context, but may need additional plumbing -->
+| 8 | Confident | Add corresponding "Pane: Close" command palette action | Constitution V (keyboard-first) requires every action be keyboard-reachable | S:65 R:85 A:90 D:80 |
+
+8 assumptions (4 certain, 3 confident, 1 tentative, 0 unresolved). Run /fab-clarify to review.

--- a/fab/changes/260326-tbmj-close-pane-button/spec.md
+++ b/fab/changes/260326-tbmj-close-pane-button/spec.md
@@ -1,0 +1,170 @@
+# Spec: Close Pane Button
+
+**Change**: 260326-tbmj-close-pane-button
+**Created**: 2026-03-27
+**Affected memory**: `docs/memory/run-kit/ui-patterns.md`
+
+## Non-Goals
+
+- Pane ID tracking on the frontend — not needed since we target the active pane by window
+- Multi-pane selection or bulk close — only the active pane of the current window is closed
+- Confirmation dialog — the split buttons don't confirm, and closing a pane is low-stakes (tmux processes survive)
+
+## Backend: Kill Active Pane
+
+### Requirement: KillActivePane tmux function
+
+The `internal/tmux` package SHALL provide a `KillActivePane(session string, window int, server string) error` function that kills the active pane of the specified window by targeting `session:window` with `tmux kill-pane -t`.
+
+#### Scenario: Kill active pane in multi-pane window
+- **GIVEN** a tmux window `mysession:0` has 2+ panes
+- **WHEN** `KillActivePane("mysession", 0, "default")` is called
+- **THEN** the active pane of window 0 is killed
+- **AND** the remaining panes stay alive
+- **AND** the function returns `nil`
+
+#### Scenario: Kill last pane in window
+- **GIVEN** a tmux window `mysession:0` has exactly 1 pane
+- **WHEN** `KillActivePane("mysession", 0, "default")` is called
+- **THEN** tmux kills the pane (which destroys the window)
+- **AND** the function returns `nil` (errors silently ignored, matching `KillPane` pattern)
+
+#### Scenario: Pane already dead
+- **GIVEN** the target pane has already been killed
+- **WHEN** `KillActivePane` is called
+- **THEN** the function returns `nil` (tmux error silently ignored)
+
+### Requirement: TmuxOps interface extension
+
+The `TmuxOps` interface in `api/router.go` SHALL include `KillActivePane(session string, window int, server string) error`. The `prodTmuxOps` struct SHALL delegate to `tmux.KillActivePane`.
+
+#### Scenario: Interface wiring
+- **GIVEN** the `TmuxOps` interface includes `KillActivePane`
+- **WHEN** `prodTmuxOps.KillActivePane("s", 0, "default")` is called
+- **THEN** it delegates to `tmux.KillActivePane("s", 0, "default")`
+
+### Requirement: Close Pane API endpoint
+
+The server SHALL expose `POST /api/sessions/{session}/windows/{index}/close-pane` that kills the active pane of the specified window.
+
+#### Scenario: Successful close
+- **GIVEN** session `main` exists with window index `0` containing 2+ panes
+- **WHEN** `POST /api/sessions/main/windows/0/close-pane` is sent
+- **THEN** response status is `200 OK`
+- **AND** response body is `{"ok": true}`
+- **AND** the active pane of `main:0` is killed
+
+#### Scenario: Invalid session name
+- **GIVEN** session name contains invalid characters
+- **WHEN** `POST /api/sessions/<invalid>/windows/0/close-pane` is sent
+- **THEN** response status is `400 Bad Request`
+- **AND** response body contains `{"error": "..."}`
+
+#### Scenario: Invalid window index
+- **GIVEN** window index is not a non-negative integer
+- **WHEN** `POST /api/sessions/main/windows/abc/close-pane` is sent
+- **THEN** response status is `400 Bad Request`
+
+## Frontend: Close Pane Button
+
+### Requirement: ClosePaneButton component
+
+The `top-bar.tsx` file SHALL include a `ClosePaneButton` component rendered in the top bar right section, positioned after the two `SplitButton` instances and before the `FixedWidthToggle`.
+
+The button SHALL:
+- Use the same base styling as `SplitButton`: `min-w-[24px] min-h-[24px] rounded border border-border text-text-secondary hover:border-text-secondary transition-colors flex items-center justify-center`
+- Display a close icon (X shape) as an SVG with `width="14" height="14" viewBox="0 0 24 24"` matching the split button icon convention
+- Be wrapped in `<span className="hidden sm:flex">` (hidden on mobile, matching split buttons)
+- Only render when `currentWindow` exists (matching split button conditional)
+
+#### Scenario: Button renders on desktop with a window selected
+- **GIVEN** the user is on a terminal route (`/$server/$session/$window`) at viewport >= 640px
+- **WHEN** the top bar renders
+- **THEN** the close pane button appears after the split buttons and before the fixed-width toggle
+- **AND** the button has `aria-label="Close pane"`
+
+#### Scenario: Button hidden on mobile
+- **GIVEN** viewport width < 640px
+- **WHEN** the top bar renders
+- **THEN** the close pane button is not visible (`hidden sm:flex`)
+
+#### Scenario: Button not rendered on dashboard
+- **GIVEN** the user is on the dashboard route (no window selected)
+- **WHEN** the top bar renders
+- **THEN** no close pane button appears
+
+### Requirement: Close pane API client function
+
+The `api/client.ts` file SHALL export a `closePane(session: string, index: number)` function that POSTs to `/api/sessions/{session}/windows/{index}/close-pane`.
+
+#### Scenario: Successful API call
+- **GIVEN** a valid session and window index
+- **WHEN** `closePane("main", 0)` is called
+- **THEN** a `POST` request is sent to `/api/sessions/main/windows/0/close-pane?server=...`
+- **AND** the function returns `Promise<{ ok: boolean }>`
+
+### Requirement: Button click behavior
+
+When the close pane button is clicked, it SHALL call `closePane(session, windowIndex)` with best-effort error handling (`.catch(() => {})`) matching the split button pattern.
+
+#### Scenario: User clicks close pane
+- **GIVEN** the user is viewing `session:window` with multiple panes
+- **WHEN** the user clicks the close pane button
+- **THEN** the active pane is killed via API call
+- **AND** the terminal view updates via SSE (remaining panes visible)
+
+#### Scenario: Last pane closed
+- **GIVEN** the user is viewing `session:window` with exactly 1 pane
+- **WHEN** the user clicks the close pane button
+- **THEN** the pane (and window) is killed
+- **AND** the SSE update reflects the window removal
+- **AND** the existing window-killed redirect logic handles navigation
+
+## Frontend: Command Palette Action
+
+### Requirement: Pane close command palette entry
+
+The command palette in `app.tsx` SHALL include a "Pane: Close" action, positioned after the "Window: Split Horizontal" entry within the `currentWindow` conditional block.
+
+#### Scenario: User invokes close pane via command palette
+- **GIVEN** the user has a window selected and opens the command palette
+- **WHEN** the user selects "Pane: Close"
+- **THEN** `closePane(session, windowIndex)` is called
+- **AND** the command palette closes
+
+#### Scenario: No window selected
+- **GIVEN** the user is on the dashboard (no window selected)
+- **WHEN** the command palette opens
+- **THEN** "Pane: Close" is not listed
+
+## Design Decisions
+
+1. **Target active pane by window, not by pane ID**: Kill the active pane using `tmux kill-pane -t session:window` rather than tracking individual pane IDs on the frontend.
+   - *Why*: The frontend has no pane ID state — WebSocket connects to windows, SSE broadcasts window-level data. Adding pane tracking would be a disproportionate change for this feature.
+   - *Rejected*: Passing pane IDs from split responses to a close button — would require new state management, and the split response's pane ID may be stale if the user switches panes in tmux.
+
+2. **New `KillActivePane` function rather than reusing `KillPane`**: The existing `KillPane(paneID, server)` expects a pane ID string. Rather than passing `session:window` to a parameter named `paneID`, create a semantically clear `KillActivePane(session, window, server)`.
+   - *Why*: Type safety and readability — the parameter names document intent.
+   - *Rejected*: Reusing `KillPane` with a window target — technically works but semantically misleading.
+
+3. **No confirmation dialog**: Matches the split buttons which also have no confirmation. Closing a pane is low-stakes — tmux processes continue, and the action is easily undone by splitting again.
+   - *Why*: Consistency with existing pane actions (split) and the principle that the UI should be fast for keyboard-first users.
+   - *Rejected*: Confirm dialog like "Window: Kill" — window kill is higher stakes (loses all panes); pane close only affects one pane.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Button placement after split buttons, before FixedWidthToggle | Explicit in user request + natural grouping (pane actions together) | S:95 R:90 A:95 D:95 |
+| 2 | Certain | Same styling as SplitButton (24x24, border, hover) | Codebase pattern — all top bar buttons use identical styling | S:85 R:95 A:95 D:95 |
+| 3 | Certain | Hidden on mobile (`hidden sm:flex`) | Codebase pattern — split buttons already use this | S:80 R:90 A:95 D:95 |
+| 4 | Certain | Use `tmux kill-pane -t session:window` (active pane targeting) | Investigated — frontend has no pane IDs; window targeting is the clean approach | S:90 R:90 A:95 D:95 |
+| 5 | Certain | New `KillActivePane` function in tmux package | Semantically distinct from existing `KillPane(paneID)` — different targeting | S:85 R:90 A:90 D:90 |
+| 6 | Certain | Route `POST /api/sessions/{session}/windows/{index}/close-pane` | Follows existing route patterns (`/kill`, `/split` under windows) | S:80 R:85 A:90 D:85 |
+| 7 | Certain | X icon for the button SVG | Universal close icon, consistent with minimal icon style | S:75 R:95 A:90 D:90 |
+| 8 | Certain | No confirmation dialog | Consistent with split buttons; pane close is low-stakes | S:80 R:85 A:85 D:90 |
+| 9 | Certain | Command palette "Pane: Close" action | Constitution V (keyboard-first) — every action must be keyboard-reachable | S:75 R:90 A:95 D:90 |
+| 10 | Certain | Best-effort error handling (`.catch(() => {})`) | Matches split button pattern — tmux may reject | S:80 R:95 A:95 D:95 |
+| 11 | Confident | Last-pane-close handled by existing window-kill redirect logic | SSE update removes window; existing frontend handles missing windows | S:70 R:75 A:75 D:75 |
+
+11 assumptions (10 certain, 1 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260326-tbmj-close-pane-button/tasks.md
+++ b/fab/changes/260326-tbmj-close-pane-button/tasks.md
@@ -1,0 +1,32 @@
+# Tasks: Close Pane Button
+
+**Change**: 260326-tbmj-close-pane-button
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+## Phase 1: Backend
+
+- [x] T001 [P] Add `KillActivePane` function to `app/backend/internal/tmux/tmux.go` — `KillActivePane(session string, window int, server string) error` using `kill-pane -t session:window`. Silently ignore errors (matching `KillPane` pattern).
+- [x] T002 [P] Add `KillActivePane(session string, window int, server string) error` to `TmuxOps` interface in `app/backend/api/router.go`. Add `prodTmuxOps` delegation to `tmux.KillActivePane`.
+- [x] T003 Add `handleClosePaneKill` handler in `app/backend/api/windows.go` — validate session name and window index (reuse `parseWindowIndex`), call `s.tmux.KillActivePane`, return `{"ok": true}`. Register route `POST /api/sessions/{session}/windows/{index}/close-pane` in `buildRouter()` in `app/backend/api/router.go`.
+
+## Phase 2: Frontend
+
+- [x] T004 [P] Add `closePane(session: string, index: number)` function to `app/frontend/src/api/client.ts` — POST to `/api/sessions/{session}/windows/{index}/close-pane`, return `Promise<{ ok: boolean }>`.
+- [x] T005 [P] Add `ClosePaneButton` component in `app/frontend/src/components/top-bar.tsx` — X icon SVG (14x14, viewBox 0 0 24 24), same button styling as `SplitButton`, calls `closePane(session, windowIndex).catch(() => {})`. Render after the two `SplitButton` instances and before `FixedWidthToggle`, wrapped in `<span className="hidden sm:flex">`.
+- [x] T006 Add "Pane: Close" command palette action in `app/frontend/src/app.tsx` — inside the `currentWindow` conditional block, after "Window: Split Horizontal". Calls `closePane(sessionName, currentWindow.index).catch(() => {})`.
+
+## Phase 3: Tests
+
+- [x] T007 [P] Add `mockTmuxOps.KillActivePane` in `app/backend/api/sessions_test.go`. Add test for `handleClosePaneKill` — success case (200 OK) and validation error cases (bad session, bad index).
+- [x] T008 [P] Add unit test for `ClosePaneButton` in `app/frontend/src/components/top-bar.test.tsx` (if test file exists) or colocated test — verify render, click calls API, hidden on dashboard.
+
+---
+
+## Execution Order
+
+- T001 and T002 are parallel (different files)
+- T003 depends on T001 + T002 (handler uses interface and function)
+- T004 and T005 are parallel (different files), both depend on T003 (need API endpoint)
+- T006 depends on T004 (imports `closePane`)
+- T007 and T008 are parallel, both depend on T003-T006


### PR DESCRIPTION
## Summary

The top bar has buttons to split panes (vertical and horizontal) but no way to close a pane from the UI. Users who split panes via the top bar have no corresponding affordance to close them without tmux keybindings. This adds a close pane button alongside the split buttons, restoring symmetry between create and destroy pane actions.

## Changes

- Backend: `KillActivePane` tmux function targeting active pane by window
- Backend: `POST /api/sessions/{session}/windows/{index}/close-pane` endpoint
- Frontend: `ClosePaneButton` component in top bar (after split buttons, before fixed-width toggle)
- Frontend: `closePane` API client function
- Frontend: "Pane: Close" command palette action

## Change
| ID | Name | Issue |
|----|------|-------|
| tbmj | 260326-tbmj-close-pane-button | — |

## Stats
| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| feat | 4.7 / 5.0 | 0/0 | 8/8 | Pass (1 iterations) |

[intake](https://github.com/wvrdz/run-kit/blob/260326-tbmj-close-pane-button/fab/changes/260326-tbmj-close-pane-button/intake.md) → [spec](https://github.com/wvrdz/run-kit/blob/260326-tbmj-close-pane-button/fab/changes/260326-tbmj-close-pane-button/spec.md) → tasks → apply → review → hydrate → ship