### PR TITLE
refactor: SSE Infrastructure Performance

### DIFF
--- a/app/backend/api/relay.go
+++ b/app/backend/api/relay.go
@@ -144,6 +144,9 @@ func (s *Server) handleRelay(w http.ResponseWriter, r *http.Request) {
 			if cmd.Process != nil {
 				cmd.Process.Kill()
 			}
+			// Set a short read deadline to unblock the main goroutine's
+			// conn.ReadMessage() when the PTY dies while the client is idle.
+			conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
 			slog.Debug("relay cleanup", "session", session, "window", windowIndex)
 		})
 	}

--- a/app/backend/api/relay.go
+++ b/app/backend/api/relay.go
@@ -158,7 +158,7 @@ func (s *Server) handleRelay(w http.ResponseWriter, r *http.Request) {
 				if err != io.EOF {
 					slog.Debug("pty read error", "err", err)
 				}
-				conn.Close()
+				cleanup()
 				return
 			}
 			if err := conn.WriteMessage(websocket.BinaryMessage, buf[:n]); err != nil {

--- a/app/backend/api/sse.go
+++ b/app/backend/api/sse.go
@@ -25,14 +25,15 @@ type cachedResult struct {
 }
 
 type sseClient struct {
-	ch     chan []byte
-	server string
+	ch      chan []byte
+	server  string
+	dropped bool
 }
 
 type sseHub struct {
 	mu           sync.RWMutex
-	clients      map[*sseClient]struct{}
-	previousJSON map[string]string // per-server JSON dedup cache
+	clients      map[string][]*sseClient
+	previousJSON map[string]string                // per-server JSON dedup cache
 	cache        map[string]*cachedResult // per-server session fetch cache (500ms TTL)
 	polling      bool
 	fetcher      SessionFetcher
@@ -40,7 +41,7 @@ type sseHub struct {
 
 func newSSEHub(fetcher SessionFetcher) *sseHub {
 	return &sseHub{
-		clients:      make(map[*sseClient]struct{}),
+		clients:      make(map[string][]*sseClient),
 		previousJSON: make(map[string]string),
 		cache:        make(map[string]*cachedResult),
 		fetcher:      fetcher,
@@ -51,7 +52,7 @@ func (h *sseHub) addClient(c *sseClient) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	h.clients[c] = struct{}{}
+	h.clients[c.server] = append(h.clients[c.server], c)
 
 	// Send cached snapshot immediately
 	if prev, ok := h.previousJSON[c.server]; ok && prev != "" {
@@ -71,27 +72,55 @@ func (h *sseHub) removeClient(c *sseClient) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	delete(h.clients, c)
+	cs := h.clients[c.server]
+	for i, cl := range cs {
+		if cl == c {
+			cs[i] = cs[len(cs)-1]
+			cs[len(cs)-1] = nil // avoid leak
+			cs = cs[:len(cs)-1]
+			break
+		}
+	}
+	if len(cs) == 0 {
+		delete(h.clients, c.server)
+	} else {
+		h.clients[c.server] = cs
+	}
 }
 
 func (h *sseHub) poll() {
 	for {
-		h.mu.Lock()
-		if len(h.clients) == 0 {
-			h.polling = false
+		// Read-only check: count clients and collect server keys
+		h.mu.RLock()
+		total := 0
+		for _, cs := range h.clients {
+			total += len(cs)
+		}
+		if total == 0 {
+			h.mu.RUnlock()
+			// Upgrade to write lock to set polling = false
+			h.mu.Lock()
+			// Re-check under write lock — a client may have been added
+			recheck := 0
+			for _, cs := range h.clients {
+				recheck += len(cs)
+			}
+			if recheck == 0 {
+				h.polling = false
+				h.mu.Unlock()
+				return
+			}
 			h.mu.Unlock()
-			return
+			continue
 		}
-
-		// Collect distinct servers that have active clients
-		serverSet := make(map[string]struct{})
-		for c := range h.clients {
-			serverSet[c.server] = struct{}{}
+		servers := make([]string, 0, len(h.clients))
+		for server := range h.clients {
+			servers = append(servers, server)
 		}
-		h.mu.Unlock()
+		h.mu.RUnlock()
 
-		// Poll each server and broadcast to matching clients
-		for server := range serverSet {
+		// Poll each server and broadcast to its clients
+		for _, server := range servers {
 			// Check session fetch cache (500ms TTL)
 			var result []sessions.ProjectSession
 			if cached, ok := h.cache[server]; ok && time.Since(cached.fetchedAt) < sseCacheTTL {
@@ -117,12 +146,14 @@ func (h *sseHub) poll() {
 				h.previousJSON[server] = jsonStr
 				event := []byte(fmt.Sprintf("event: sessions\ndata: %s\n\n", jsonStr))
 
-				for c := range h.clients {
-					if c.server == server {
-						select {
-						case c.ch <- event:
-						default:
-							// Client buffer full — skip
+				for _, c := range h.clients[server] {
+					select {
+					case c.ch <- event:
+						c.dropped = false
+					default:
+						if !c.dropped {
+							slog.Warn("SSE event dropped", "server", server)
+							c.dropped = true
 						}
 					}
 				}
@@ -146,7 +177,7 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Connection", "keep-alive")
 
 	client := &sseClient{
-		ch:     make(chan []byte, 8),
+		ch:     make(chan []byte, 32),
 		server: serverFromRequest(r),
 	}
 

--- a/app/backend/api/sse_test.go
+++ b/app/backend/api/sse_test.go
@@ -221,3 +221,211 @@ func TestSSEHubDropLogging(t *testing.T) {
 		t.Error("expected client.dropped to be reset to false after successful send")
 	}
 }
+
+// perServerSessionFetcher returns different data per server so we can verify isolation.
+type perServerSessionFetcher struct {
+	mu   sync.Mutex
+	data map[string][]sessions.ProjectSession
+}
+
+func (f *perServerSessionFetcher) FetchSessions(ctx context.Context, server string) ([]sessions.ProjectSession, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.data[server], nil
+}
+
+func TestSSEHubMultiServerIsolation(t *testing.T) {
+	sf := &perServerSessionFetcher{
+		data: map[string][]sessions.ProjectSession{
+			"runkit":  {{Name: "rk-session", Windows: []tmux.WindowInfo{}}},
+			"default": {{Name: "default-session", Windows: []tmux.WindowInfo{}}},
+		},
+	}
+
+	hub := newSSEHub(sf)
+	rkClient := &sseClient{ch: make(chan []byte, 16), server: "runkit"}
+	dfClient := &sseClient{ch: make(chan []byte, 16), server: "default"}
+
+	hub.addClient(rkClient)
+	hub.addClient(dfClient)
+	defer hub.removeClient(rkClient)
+	defer hub.removeClient(dfClient)
+
+	// Wait for at least one poll cycle
+	time.Sleep(ssePollInterval + 500*time.Millisecond)
+
+	// Drain both channels and check content
+	var rkEvents, dfEvents []string
+	for len(rkClient.ch) > 0 {
+		rkEvents = append(rkEvents, string(<-rkClient.ch))
+	}
+	for len(dfClient.ch) > 0 {
+		dfEvents = append(dfEvents, string(<-dfClient.ch))
+	}
+
+	if len(rkEvents) == 0 {
+		t.Fatal("runkit client received no events")
+	}
+	if len(dfEvents) == 0 {
+		t.Fatal("default client received no events")
+	}
+
+	// Verify isolation: runkit client only sees rk-session, default only sees default-session
+	for _, ev := range rkEvents {
+		if strings.Contains(ev, "default-session") {
+			t.Errorf("runkit client received default server data: %s", ev)
+		}
+		if !strings.Contains(ev, "rk-session") {
+			t.Errorf("runkit client event missing rk-session: %s", ev)
+		}
+	}
+	for _, ev := range dfEvents {
+		if strings.Contains(ev, "rk-session") {
+			t.Errorf("default client received runkit server data: %s", ev)
+		}
+		if !strings.Contains(ev, "default-session") {
+			t.Errorf("default client event missing default-session: %s", ev)
+		}
+	}
+}
+
+func TestSSEHubRemoveClientSwapDelete(t *testing.T) {
+	sf := &slowSessionFetcher{result: []sessions.ProjectSession{}}
+	hub := newSSEHub(sf)
+
+	c1 := &sseClient{ch: make(chan []byte, 8), server: "runkit"}
+	c2 := &sseClient{ch: make(chan []byte, 8), server: "runkit"}
+	c3 := &sseClient{ch: make(chan []byte, 8), server: "runkit"}
+
+	hub.addClient(c1)
+	hub.addClient(c2)
+	hub.addClient(c3)
+
+	hub.mu.RLock()
+	if len(hub.clients["runkit"]) != 3 {
+		t.Fatalf("expected 3 clients, got %d", len(hub.clients["runkit"]))
+	}
+	hub.mu.RUnlock()
+
+	// Remove the middle client
+	hub.removeClient(c2)
+
+	hub.mu.RLock()
+	remaining := hub.clients["runkit"]
+	hub.mu.RUnlock()
+
+	if len(remaining) != 2 {
+		t.Fatalf("expected 2 clients after remove, got %d", len(remaining))
+	}
+
+	// c1 and c3 should still be present (order may differ due to swap-delete)
+	found1, found3 := false, false
+	for _, c := range remaining {
+		if c == c1 {
+			found1 = true
+		}
+		if c == c3 {
+			found3 = true
+		}
+	}
+	if !found1 {
+		t.Error("c1 should still be in the slice after removing c2")
+	}
+	if !found3 {
+		t.Error("c3 should still be in the slice after removing c2")
+	}
+}
+
+func TestSSEHubRemoveLastClientDeletesKey(t *testing.T) {
+	sf := &slowSessionFetcher{result: []sessions.ProjectSession{}}
+	hub := newSSEHub(sf)
+
+	c1 := &sseClient{ch: make(chan []byte, 8), server: "runkit"}
+	c2 := &sseClient{ch: make(chan []byte, 8), server: "default"}
+
+	hub.addClient(c1)
+	hub.addClient(c2)
+
+	hub.mu.RLock()
+	if len(hub.clients) != 2 {
+		t.Fatalf("expected 2 server keys, got %d", len(hub.clients))
+	}
+	hub.mu.RUnlock()
+
+	// Remove the only runkit client
+	hub.removeClient(c1)
+
+	hub.mu.RLock()
+	_, exists := hub.clients["runkit"]
+	defaultLen := len(hub.clients["default"])
+	hub.mu.RUnlock()
+
+	if exists {
+		t.Error("runkit key should be deleted after removing its last client")
+	}
+	if defaultLen != 1 {
+		t.Errorf("default slice should still have 1 client, got %d", defaultLen)
+	}
+}
+
+func TestSSEHubConcurrentAddRemove(t *testing.T) {
+	sf := &slowSessionFetcher{
+		result: []sessions.ProjectSession{
+			{Name: "s", Windows: []tmux.WindowInfo{}},
+		},
+	}
+
+	hub := newSSEHub(sf)
+
+	// Seed one client to start polling
+	seed := &sseClient{ch: make(chan []byte, 32), server: "default"}
+	hub.addClient(seed)
+
+	var wg sync.WaitGroup
+	const n = 20
+
+	// Concurrently add and remove clients while polling is active
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c := &sseClient{ch: make(chan []byte, 32), server: "default"}
+			hub.addClient(c)
+			time.Sleep(10 * time.Millisecond)
+			hub.removeClient(c)
+		}()
+	}
+
+	// Also add clients on a different server concurrently
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c := &sseClient{ch: make(chan []byte, 32), server: "runkit"}
+			hub.addClient(c)
+			time.Sleep(10 * time.Millisecond)
+			hub.removeClient(c)
+		}()
+	}
+
+	wg.Wait()
+	hub.removeClient(seed)
+
+	// Wait for polling to stop
+	time.Sleep(ssePollInterval + 500*time.Millisecond)
+
+	hub.mu.RLock()
+	totalClients := 0
+	for _, cs := range hub.clients {
+		totalClients += len(cs)
+	}
+	isPolling := hub.polling
+	hub.mu.RUnlock()
+
+	if totalClients != 0 {
+		t.Errorf("expected 0 clients after all removed, got %d", totalClients)
+	}
+	if isPolling {
+		t.Error("hub should have stopped polling after all clients removed")
+	}
+}

--- a/app/backend/api/sse_test.go
+++ b/app/backend/api/sse_test.go
@@ -3,9 +3,11 @@ package api
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -100,7 +102,7 @@ func TestSSEHubDeduplication(t *testing.T) {
 	}
 
 	hub := newSSEHub(sf)
-	client := &sseClient{ch: make(chan []byte, 16)}
+	client := &sseClient{ch: make(chan []byte, 16), server: "default"}
 
 	hub.addClient(client)
 	defer hub.removeClient(client)
@@ -141,7 +143,7 @@ func TestSSEHubStopsPollingWhenNoClients(t *testing.T) {
 	}
 
 	hub := newSSEHub(sf)
-	client := &sseClient{ch: make(chan []byte, 8)}
+	client := &sseClient{ch: make(chan []byte, 8), server: "default"}
 
 	hub.addClient(client)
 
@@ -165,5 +167,57 @@ func TestSSEHubStopsPollingWhenNoClients(t *testing.T) {
 	hub.mu.RUnlock()
 	if isPolling {
 		t.Error("hub should stop polling when no clients")
+	}
+}
+
+// countingSessionFetcher returns incrementing data so each poll produces a new event.
+type countingSessionFetcher struct {
+	mu    sync.Mutex
+	count int
+}
+
+func (f *countingSessionFetcher) FetchSessions(ctx context.Context, server string) ([]sessions.ProjectSession, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.count++
+	return []sessions.ProjectSession{
+		{Name: fmt.Sprintf("session-%d", f.count), Windows: []tmux.WindowInfo{}},
+	}, nil
+}
+
+func TestSSEHubDropLogging(t *testing.T) {
+	sf := &countingSessionFetcher{}
+	hub := newSSEHub(sf)
+
+	// Use a buffer of 1 so it fills immediately
+	client := &sseClient{ch: make(chan []byte, 1), server: "default"}
+	hub.addClient(client)
+	defer hub.removeClient(client)
+
+	// Wait for at least two poll cycles to fill the tiny buffer and trigger drops
+	time.Sleep(ssePollInterval*3 + 500*time.Millisecond)
+
+	hub.mu.RLock()
+	dropped := client.dropped
+	hub.mu.RUnlock()
+
+	if !dropped {
+		t.Error("expected client.dropped to be true after buffer overflow")
+	}
+
+	// Drain the channel to simulate recovery
+	for len(client.ch) > 0 {
+		<-client.ch
+	}
+
+	// Wait for another poll cycle — successful send should reset dropped
+	time.Sleep(ssePollInterval + 500*time.Millisecond)
+
+	hub.mu.RLock()
+	dropped = client.dropped
+	hub.mu.RUnlock()
+
+	if dropped {
+		t.Error("expected client.dropped to be reset to false after successful send")
 	}
 }

--- a/docs/memory/run-kit/architecture.md
+++ b/docs/memory/run-kit/architecture.md
@@ -120,7 +120,7 @@ All endpoints served by the single Go binary on one port. POST-only mutations wi
 | `/api/sessions/:session/windows/:index/keys` | POST | Send keys — JSON body `{"keys":"..."}` (non-empty after trim). Returns `200 {"ok":true}` |
 | `/api/directories` | GET | Server-side directory listing for autocomplete — `?prefix=~/code/wvr` returns matching dirs under `$HOME` |
 | `/api/sessions/:session/upload` | POST | File upload — session from URL path (not form field). Multipart with `file` field, optional `window` field (defaults to `"0"`). Resolves project root via `ListWindows`, writes to `.uploads/{timestamp}-{name}`, auto-manages `.gitignore`. 50MB limit. Returns `200 {"ok":true,"path":"..."}` |
-| `/api/sessions/stream` | GET | SSE — hub singleton polls tmux every 2.5s, fans out full snapshots to all connected clients on change. Deduplicates polling across browser tabs. 30-minute lifetime cap per connection |
+| `/api/sessions/stream` | GET | SSE — hub singleton polls tmux every 2.5s, fans out full snapshots to all connected clients on change. Deduplicates polling across browser tabs. 30-minute lifetime cap per connection. Hub clients map is `map[string][]*sseClient` keyed by server name for O(1) server-scoped broadcast. `sync.RWMutex` — `RLock()` for read-only operations in `poll()` (collecting server keys, counting clients), `Lock()` for writes (broadcasting, updating `previousJSON`). Channel buffer 32. Drop logging via `slog.Warn` with per-client boolean debounce (resets on successful send) |
 | `/api/tmux/reload-config` | POST | Reload tmux config — server from `?server=` param (default `"default"`). Runs `source-file` on the specified server. Returns `200 {"status":"ok"}` |
 | `/api/servers` | GET | List available tmux servers — scans socket dir, returns JSON array of names |
 | `/api/servers` | POST | Create tmux server — JSON body `{"name":"..."}`. Creates session "0" in `$HOME`. Returns `201 {"ok":true}` |
@@ -168,7 +168,7 @@ Per connection:
 2. Spawns `tmux [-L runkit] attach-session -t <session>` via `creack/pty` for real terminal I/O (runkit server includes `-L runkit` and `-f` flags; default server uses plain `tmux`)
 3. Relays I/O between WebSocket and pty (goroutine for pty→WS, main loop for WS→pty)
 4. Handles resize messages (JSON `{"type":"resize","cols":N,"rows":N}`) via `pty.Setsize`
-5. On disconnect: kills pty + pane via `sync.Once` cleanup (no orphaned panes)
+5. On disconnect: `sync.Once` cleanup cancels context, closes PTY, kills process. PTY reader goroutine calls `cleanup()` (not `conn.Close()`) on read failure — eliminates concurrent WebSocket close race. WebSocket connection closed only by `defer conn.Close()` on the main goroutine
 
 Client-side WebSocket reconnection: exponential backoff (1s, 2s, 4s, 8s, 16s, max 30s) on unexpected close. Shows `[reconnecting...]` in terminal. Re-sends resize on successful reconnect. Skips reconnect on component unmount. On close code `4004` (session/window not found): shows `[session not found]` and navigates to `/` instead of reconnecting. Terminal page connects via `ws://${location.host}/relay/{session}/{window}?server={runkit|default}` — same host, server param from session metadata.
 
@@ -315,7 +315,7 @@ Install flow: `brew tap wvrdz/tap git@github.com:wvrdz/homebrew-tap.git && brew 
 - **TanStack Router over React Router** — type-safe params and search params, built-in loader pattern. Single route `/:session/:window` in the new frontend
 - **Vite proxy in dev (not CORS)** — single browser URL, no CORS config needed. WebSocket upgrade works transparently. Go includes chi CORS middleware for production/non-browser clients
 - **SPA fallback in Go** — Go serves standalone; TLS termination handled externally via Tailscale Serve when needed
-- **SSE (not WebSocket) for session state** — simpler, server-push only, naturally resilient. Module-level hub deduplicates polling across tabs (one `FetchSessions()` per interval regardless of client count). SSE data includes `isActiveWindow` per window, enabling UI sync when users switch tmux/byobu windows via terminal shortcuts
+- **SSE (not WebSocket) for session state** — simpler, server-push only, naturally resilient. Module-level hub deduplicates polling across tabs (one `FetchSessions()` per server per interval). Clients indexed by server name (`map[string][]*sseClient`) — broadcast iterates only the target server's slice. `sync.RWMutex` with `RLock` for read-only poll operations, `Lock` for writes. SSE data includes `isActiveWindow` per window, enabling UI sync when users switch tmux/byobu windows via terminal shortcuts
 - **Full snapshots (not diffs)** — small payload (<100 sessions), simple client logic
 - **Independent panes per browser client** — no cursor fights, agent pane untouched. The relay pty follows tmux window switches natively (runs `tmux -L runkit attach-session`)
 - **Every tmux session is a project** — no config, no "Other" bucket. Project root derived from window 0's `pane_current_path`

--- a/fab/changes/260327-5mlg-sse-infrastructure-perf/.history.jsonl
+++ b/fab/changes/260327-5mlg-sse-infrastructure-perf/.history.jsonl
@@ -12,3 +12,4 @@
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-03-27T10:55:54Z"}
 {"event":"review","result":"passed","ts":"2026-03-27T10:55:54Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-03-27T10:56:57Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-03-27T10:58:25Z"}

--- a/fab/changes/260327-5mlg-sse-infrastructure-perf/.history.jsonl
+++ b/fab/changes/260327-5mlg-sse-infrastructure-perf/.history.jsonl
@@ -1,0 +1,14 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-03-27T10:35:01Z"}
+{"args":"Performance Phase 2 — SSE Infrastructure: (1) Upgrade SSE hub mutex to sync.RWMutex + index clients by server in api/sse.go, (2) Increase SSE client channel buffer to 32 + add slog.Warn on first drop per client (debounced) in api/sse.go, (3) Fix relay goroutine race on close — remove conn.Close() from reader goroutine, use context cancellation in api/relay.go","cmd":"fab-new","event":"command","ts":"2026-03-27T10:35:01Z"}
+{"delta":"+4.4","event":"confidence","score":4.4,"trigger":"calc-score","ts":"2026-03-27T10:36:07Z"}
+{"delta":"+0.0","event":"confidence","score":4.4,"trigger":"calc-score","ts":"2026-03-27T10:36:11Z"}
+{"cmd":"fab-switch","event":"command","ts":"2026-03-27T10:39:23Z"}
+{"cmd":"fab-fff","event":"command","ts":"2026-03-27T10:40:31Z"}
+{"delta":"+0.0","event":"confidence","score":4.4,"trigger":"calc-score","ts":"2026-03-27T10:41:57Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"spec","ts":"2026-03-27T10:42:01Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"tasks","ts":"2026-03-27T10:47:46Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-03-27T10:47:46Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-03-27T10:52:53Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-03-27T10:55:54Z"}
+{"event":"review","result":"passed","ts":"2026-03-27T10:55:54Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-03-27T10:56:57Z"}

--- a/fab/changes/260327-5mlg-sse-infrastructure-perf/.status.yaml
+++ b/fab/changes/260327-5mlg-sse-infrastructure-perf/.status.yaml
@@ -1,0 +1,42 @@
+id: 5mlg
+name: 260327-5mlg-sse-infrastructure-perf
+created: 2026-03-27T10:35:01Z
+created_by: sahil-weaver
+change_type: refactor
+issues: []
+progress:
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+checklist:
+    generated: true
+    path: checklist.md
+    completed: 0
+    total: 22
+confidence:
+    certain: 7
+    confident: 2
+    tentative: 0
+    unresolved: 0
+    score: 4.4
+    fuzzy: true
+    dimensions:
+        signal: 86.7
+        reversibility: 87.8
+        competence: 89.4
+        disambiguation: 87.8
+stage_metrics:
+    intake: {started_at: "2026-03-27T10:35:01Z", driver: fab-new, iterations: 1, completed_at: "2026-03-27T10:42:01Z"}
+    spec: {started_at: "2026-03-27T10:42:01Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T10:47:46Z"}
+    tasks: {started_at: "2026-03-27T10:47:46Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T10:47:46Z"}
+    apply: {started_at: "2026-03-27T10:47:46Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T10:52:53Z"}
+    review: {started_at: "2026-03-27T10:52:53Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T10:55:54Z"}
+    hydrate: {started_at: "2026-03-27T10:55:54Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T10:56:57Z"}
+    ship: {started_at: "2026-03-27T10:56:57Z", driver: fab-fff, iterations: 1}
+prs: []
+last_updated: 2026-03-27T10:56:57Z

--- a/fab/changes/260327-5mlg-sse-infrastructure-perf/.status.yaml
+++ b/fab/changes/260327-5mlg-sse-infrastructure-perf/.status.yaml
@@ -11,8 +11,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 checklist:
     generated: true
     path: checklist.md
@@ -37,6 +37,8 @@ stage_metrics:
     apply: {started_at: "2026-03-27T10:47:46Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T10:52:53Z"}
     review: {started_at: "2026-03-27T10:52:53Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T10:55:54Z"}
     hydrate: {started_at: "2026-03-27T10:55:54Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T10:56:57Z"}
-    ship: {started_at: "2026-03-27T10:56:57Z", driver: fab-fff, iterations: 1}
-prs: []
-last_updated: 2026-03-27T10:56:57Z
+    ship: {started_at: "2026-03-27T10:56:57Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T10:58:25Z"}
+    review-pr: {started_at: "2026-03-27T10:58:25Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/wvrdz/run-kit/pull/96
+last_updated: 2026-03-27T10:58:25Z

--- a/fab/changes/260327-5mlg-sse-infrastructure-perf/checklist.md
+++ b/fab/changes/260327-5mlg-sse-infrastructure-perf/checklist.md
@@ -1,0 +1,43 @@
+# Quality Checklist: SSE Infrastructure Performance
+
+**Change**: 260327-5mlg-sse-infrastructure-perf
+**Generated**: 2026-03-27
+**Spec**: `spec.md`
+
+## Functional Completeness
+- [x] CHK-001 Server-indexed client map: `sseHub.clients` is `map[string][]*sseClient`
+- [x] CHK-002 RLock for reads: `poll()` uses `RLock()` for server-key collection and client-count check
+- [x] CHK-003 Lock for writes: `poll()` uses `Lock()` for broadcast and `previousJSON` update
+- [x] CHK-004 Channel buffer 32: `handleSSE` creates client with `make(chan []byte, 32)`
+- [x] CHK-005 Drop logging: `slog.Warn("SSE event dropped")` emitted on first buffer-full per client
+- [x] CHK-006 Drop debounce: `dropped` boolean prevents spam; reset on successful send
+- [x] CHK-007 Relay race fix: reader goroutine calls `cleanup()` not `conn.Close()`
+
+## Behavioral Correctness
+- [x] CHK-008 addClient appends to server slice and sends cached snapshot
+- [x] CHK-009 removeClient uses swap-delete; deletes map key when slice empty
+- [x] CHK-010 poll() stops when total clients across all slices is 0
+- [x] CHK-011 SSE event format unchanged (external behavior preserved)
+
+## Scenario Coverage
+- [x] CHK-012 Adding clients to different servers creates separate slices
+- [x] CHK-013 Removing last client for a server deletes the key
+- [x] CHK-014 PTY read failure triggers cleanup(), not conn.Close()
+- [x] CHK-015 Main goroutine exits cleanly after reader cleanup
+
+## Edge Cases & Error Handling
+- [x] CHK-016 Concurrent add/remove during poll does not race
+- [x] CHK-017 Empty hub (no clients) stops polling gracefully
+- [x] CHK-018 Both goroutines exiting simultaneously handled by sync.Once
+
+## Code Quality
+- [x] CHK-019 Pattern consistency: new code follows existing Go patterns in api/ package
+- [x] CHK-020 No unnecessary duplication: reuses existing cleanup() pattern
+- [x] CHK-021 All subprocess calls use exec.CommandContext with timeouts (constitution)
+- [x] CHK-022 No shell string construction (constitution)
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] CHK-008 **N/A**: {reason}`

--- a/fab/changes/260327-5mlg-sse-infrastructure-perf/intake.md
+++ b/fab/changes/260327-5mlg-sse-infrastructure-perf/intake.md
@@ -1,0 +1,103 @@
+# Intake: SSE Infrastructure Performance
+
+**Change**: 260327-5mlg-sse-infrastructure-perf
+**Created**: 2026-03-27
+**Status**: Draft
+
+## Origin
+
+> Performance Phase 2 — SSE Infrastructure: (1) Upgrade SSE hub mutex to sync.RWMutex + index clients by server in api/sse.go, (2) Increase SSE client channel buffer to 32 + add slog.Warn on first drop per client (debounced) in api/sse.go, (3) Fix relay goroutine race on close — remove conn.Close() from reader goroutine, use context cancellation in api/relay.go. See fab/plans/performance-improvements.md Phase 2 for full details.
+
+One-shot invocation with detailed description referencing the performance improvements plan.
+
+## Why
+
+The SSE hub and WebSocket relay in `app/backend/api/` have three scalability and correctness issues:
+
+1. **Lock contention in SSE hub**: The hub's `poll()` function takes an exclusive `Lock()` for every broadcast, even though most operations (checking client count, iterating clients) are read-only. Additionally, it iterates *all* clients to find those matching a given server — O(N) per server per tick. With multiple concurrent SSE clients across multiple servers, this creates unnecessary contention.
+
+2. **Silent event drops**: The SSE client channel buffer is 8. Under burst conditions (e.g., rapid session creation/deletion), the buffer fills and events are silently dropped (lines 102-106 in `sse.go`). There is no logging or observability when drops occur, making it impossible to diagnose missed UI updates.
+
+3. **Relay goroutine race on close**: In `relay.go`, the PTY reader goroutine calls `conn.Close()` (line 161) when PTY read fails. Meanwhile, the main goroutine may be blocked in `conn.ReadMessage()` (line 172). This is a data race on the WebSocket connection — the gorilla/websocket docs explicitly state that connections are not safe for concurrent read/write after close.
+
+If unfixed, issue 1 limits scalability under concurrent clients, issue 2 causes invisible UI staleness, and issue 3 causes rare but real panics or undefined behavior on connection teardown.
+
+## What Changes
+
+### 2.1 Use RLock for read-only operations + index clients by server
+
+**File**: `app/backend/api/sse.go`
+
+The `sseHub.mu` field is already declared as `sync.RWMutex` (line 23), but the code only ever calls `Lock()`/`Unlock()` — never `RLock()`/`RUnlock()`. Fix by using `RLock()` where appropriate.
+
+Restructure the `clients` map from:
+```go
+clients map[*sseClient]struct{}
+```
+to:
+```go
+clients map[string][]*sseClient  // keyed by server name
+```
+
+Changes to `poll()`:
+- Collecting distinct servers: use `RLock()` + read the map keys directly (no iteration over all clients)
+- Broadcasting: acquire `Lock()` only for the target server's slice (write lock needed since we're sending to channels)
+- The check for `len(h.clients) == 0` should count total clients across all server slices
+
+Changes to `addClient()` / `removeClient()`:
+- `addClient`: append to the server's slice
+- `removeClient`: remove from the server's slice (swap-delete for O(1)); if slice becomes empty, delete the map key
+
+Changes to `newSSEHub()`:
+- Initialize with `make(map[string][]*sseClient)`
+
+### 2.2 Increase SSE client channel buffer to 32 + log drops
+
+**File**: `app/backend/api/sse.go`
+
+- Change `make(chan []byte, 8)` to `make(chan []byte, 32)` in `handleSSE`
+- Add a `dropped` boolean field to `sseClient` for debounce tracking
+- In the broadcast loop's `default` case (buffer full), check `!c.dropped`, and if so, emit `slog.Warn("SSE event dropped", "server", server)` and set `c.dropped = true`
+- Reset `c.dropped = false` on successful send (so the next drop after a recovery also logs)
+
+### 2.3 Fix relay goroutine race on close
+
+**File**: `app/backend/api/relay.go`
+
+Remove `conn.Close()` (line 161) from the PTY reader goroutine. Instead, call `cleanup()` which already handles cancellation and resource teardown via `sync.Once`. The `cleanup()` function cancels the context, closes the PTY, and kills the process. The main goroutine's `conn.ReadMessage()` will unblock when `defer conn.Close()` (line 73) fires on function return.
+
+Specifically:
+- Replace `conn.Close()` on line 161 with `cleanup()` — this cancels the context and closes the PTY
+- The main goroutine loop (`for { conn.ReadMessage() }`) will see a read error when the PTY writer encounters an error (since cleanup closes ptmx), and will break out naturally
+- `defer cleanup()` on line 150 ensures all resources are freed regardless of which goroutine exits first
+- `defer conn.Close()` on line 73 ensures the WebSocket connection is closed after function return
+
+## Affected Memory
+
+- `run-kit/architecture`: (modify) Update SSE hub internal structure description (client indexing, lock strategy)
+
+## Impact
+
+- **`app/backend/api/sse.go`**: SSE hub data structure change (clients map), locking strategy change, buffer size increase, drop logging
+- **`app/backend/api/relay.go`**: Reader goroutine cleanup path change
+- **Existing tests**: Any tests that directly construct `sseClient` or `sseHub` will need updating for the new map type
+- **No API changes**: External behavior (SSE event format, endpoints) is unchanged
+- **No frontend changes**: This is purely backend infrastructure
+
+## Open Questions
+
+None — the performance plan specifies exact changes and the source code confirms the issues exist as described.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Channel buffer size is 32 | Explicitly specified in the performance plan and user description | S:95 R:90 A:95 D:95 |
+| 2 | Certain | Client map keyed by server name (string) | Performance plan specifies `map[string][]*sseClient` | S:95 R:85 A:95 D:95 |
+| 3 | Certain | Remove conn.Close() from reader goroutine, use cleanup() | Explicitly specified — only safe teardown path | S:95 R:80 A:90 D:95 |
+| 4 | Certain | Drop logging uses slog.Warn with per-client debounce | Specified in plan: "slog.Warn on first drop per client (debounced)" | S:90 R:90 A:90 D:90 |
+| 5 | Confident | Use boolean field on sseClient for drop debounce | Simplest debounce mechanism; reset on successful send so next burst also logs. Alternative: atomic counter or time-based debounce — boolean is sufficient for "first drop" semantics | S:75 R:90 A:80 D:70 |
+| 6 | Confident | Broadcast still acquires write Lock() (not RLock) | Sending to channels is a write-path operation; RLock is only for read-only map iteration. The plan says "write lock only for the target server's slice" | S:80 R:85 A:80 D:75 |
+| 7 | Certain | poll() client-count check counts across all server slices | Must check total clients == 0 to stop polling, not just one server's slice | S:85 R:85 A:90 D:90 |
+
+7 assumptions (5 certain, 2 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260327-5mlg-sse-infrastructure-perf/spec.md
+++ b/fab/changes/260327-5mlg-sse-infrastructure-perf/spec.md
@@ -1,0 +1,158 @@
+# Spec: SSE Infrastructure Performance
+
+**Change**: 260327-5mlg-sse-infrastructure-perf
+**Created**: 2026-03-27
+**Affected memory**: `docs/memory/run-kit/architecture.md`
+
+## Non-Goals
+
+- Changing the SSE poll interval or event format — external behavior is unchanged
+- Adding per-server locking granularity (single hub mutex is sufficient at current scale)
+- Modifying the WebSocket relay I/O relay logic beyond the goroutine race fix
+
+## SSE Hub: Server-Indexed Client Map
+
+### Requirement: Client map keyed by server name
+
+The `sseHub.clients` field SHALL be `map[string][]*sseClient` keyed by tmux server name. Each server key maps to a slice of clients subscribed to that server.
+
+#### Scenario: Adding a client to the hub
+- **GIVEN** a hub with no clients for server "runkit"
+- **WHEN** `addClient()` is called with a client whose `server` field is "runkit"
+- **THEN** `h.clients["runkit"]` contains that client
+- **AND** the client slice has length 1
+
+#### Scenario: Adding multiple clients to different servers
+- **GIVEN** a hub with one client for server "runkit"
+- **WHEN** `addClient()` is called with a client for server "default"
+- **THEN** `h.clients["runkit"]` has 1 client and `h.clients["default"]` has 1 client
+
+#### Scenario: Removing a client
+- **GIVEN** a hub with two clients for server "runkit"
+- **WHEN** `removeClient()` is called for one of them
+- **THEN** `h.clients["runkit"]` has 1 client remaining
+- **AND** the remaining client is the one that was not removed
+
+#### Scenario: Removing the last client for a server
+- **GIVEN** a hub with one client for server "runkit"
+- **WHEN** `removeClient()` is called for that client
+- **THEN** the key "runkit" is deleted from `h.clients`
+
+### Requirement: Hub initialization with new map type
+
+`newSSEHub()` SHALL initialize `clients` as `make(map[string][]*sseClient)`.
+
+#### Scenario: Fresh hub creation
+- **GIVEN** a new `SessionFetcher`
+- **WHEN** `newSSEHub(fetcher)` is called
+- **THEN** the returned hub has an empty `clients` map of type `map[string][]*sseClient`
+
+## SSE Hub: Read-Write Lock Usage
+
+### Requirement: RLock for read-only operations in poll()
+
+The `poll()` function SHALL use `RLock()` when only reading from `h.clients` (collecting server keys and checking client count). It SHALL use `Lock()` when writing (updating `previousJSON` and sending to client channels).
+
+#### Scenario: Collecting active servers
+- **GIVEN** a hub with clients on multiple servers
+- **WHEN** `poll()` collects the set of active servers
+- **THEN** it acquires `RLock()` (not exclusive `Lock()`)
+- **AND** reads the keys of `h.clients` directly without iterating all clients
+
+#### Scenario: Broadcasting to a server's clients
+- **GIVEN** a hub with clients on server "runkit" and new data from `FetchSessions`
+- **WHEN** `poll()` broadcasts the data
+- **THEN** it acquires `Lock()` for the write path (updating `previousJSON` and sending to channels)
+- **AND** only iterates clients in `h.clients["runkit"]`, not all clients
+
+#### Scenario: Checking if hub should stop polling
+- **GIVEN** a hub with no clients in any server slice
+- **WHEN** `poll()` checks client count at the top of its loop
+- **THEN** it acquires `RLock()` and checks the total count across all server slices
+- **AND** sets `h.polling = false` (upgrading to `Lock()` to write) and returns
+
+### Requirement: addClient and removeClient use exclusive Lock
+
+`addClient()` and `removeClient()` SHALL continue to use exclusive `Lock()` since they mutate the clients map.
+
+#### Scenario: Concurrent add and poll
+- **GIVEN** a hub that is actively polling
+- **WHEN** `addClient()` is called concurrently
+- **THEN** `addClient()` acquires `Lock()` and `poll()` waits for the lock release before proceeding
+
+## SSE Hub: Increased Channel Buffer
+
+### Requirement: Client channel buffer size of 32
+
+The `sseClient` channel SHALL be created with a buffer size of 32 (previously 8) in `handleSSE`.
+
+#### Scenario: Client channel creation
+- **GIVEN** a new SSE connection request
+- **WHEN** `handleSSE` creates the `sseClient`
+- **THEN** `client.ch` is `make(chan []byte, 32)`
+
+## SSE Hub: Drop Logging
+
+### Requirement: Log first drop per client with debounce
+
+The `sseClient` struct SHALL have a `dropped bool` field. When the broadcast loop's `default` case fires (buffer full), and `c.dropped` is `false`, the hub SHALL emit `slog.Warn("SSE event dropped", "server", server)` and set `c.dropped = true`. On successful send, `c.dropped` SHALL be reset to `false`.
+
+#### Scenario: First event drop for a client
+- **GIVEN** a client whose channel buffer is full and `dropped` is `false`
+- **WHEN** the broadcast loop attempts to send and hits the `default` case
+- **THEN** `slog.Warn("SSE event dropped", "server", server)` is emitted
+- **AND** `c.dropped` is set to `true`
+
+#### Scenario: Consecutive drops (debounced)
+- **GIVEN** a client whose `dropped` is already `true`
+- **WHEN** the broadcast loop hits the `default` case again
+- **THEN** no log is emitted
+
+#### Scenario: Recovery resets debounce
+- **GIVEN** a client whose `dropped` is `true` (from a previous drop)
+- **WHEN** a subsequent event is successfully sent to the channel
+- **THEN** `c.dropped` is reset to `false`
+- **AND** the next drop will trigger a new `slog.Warn`
+
+## Relay: Goroutine Race Fix
+
+### Requirement: No conn.Close() in reader goroutine
+
+The PTY reader goroutine in `handleRelay` SHALL NOT call `conn.Close()`. Instead, it SHALL call `cleanup()` when the PTY read fails or reaches EOF. The `cleanup()` function (guarded by `sync.Once`) cancels the context, closes the PTY, and kills the process. The WebSocket connection is closed only by `defer conn.Close()` on line 73.
+
+#### Scenario: PTY read failure triggers cleanup
+- **GIVEN** a relay connection with an active PTY reader goroutine
+- **WHEN** `ptmx.Read()` returns an error (including EOF)
+- **THEN** the reader goroutine calls `cleanup()`
+- **AND** `cleanup()` cancels the context and closes the PTY
+- **AND** the reader goroutine returns
+
+#### Scenario: Main goroutine exits after reader cleanup
+- **GIVEN** the reader goroutine has called `cleanup()` (PTY closed)
+- **WHEN** the main goroutine attempts `conn.ReadMessage()`
+- **THEN** the read eventually fails (when `defer conn.Close()` fires or the connection is closed externally)
+- **AND** the main goroutine breaks out of its loop
+- **AND** `defer cleanup()` runs (no-op via `sync.Once`)
+
+#### Scenario: Main goroutine exits first
+- **GIVEN** an active relay connection
+- **WHEN** the WebSocket client disconnects (main goroutine's `conn.ReadMessage()` returns error)
+- **THEN** the main goroutine breaks and `defer cleanup()` fires
+- **AND** the reader goroutine's next `ptmx.Read()` or `conn.WriteMessage()` fails and it returns
+- **AND** no concurrent `conn.Close()` race occurs
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Channel buffer size is 32 | Confirmed from intake #1 — explicitly specified in performance plan | S:95 R:90 A:95 D:95 |
+| 2 | Certain | Client map keyed by server name (string) | Confirmed from intake #2 — `map[string][]*sseClient` | S:95 R:85 A:95 D:95 |
+| 3 | Certain | Remove conn.Close() from reader goroutine, use cleanup() | Confirmed from intake #3 — only safe teardown path per gorilla/websocket docs | S:95 R:80 A:90 D:95 |
+| 4 | Certain | Drop logging uses slog.Warn with per-client debounce | Confirmed from intake #4 — "slog.Warn on first drop per client (debounced)" | S:90 R:90 A:90 D:90 |
+| 5 | Confident | Use boolean field on sseClient for drop debounce, reset on successful send | Confirmed from intake #5 — simplest debounce; reset enables re-logging after recovery | S:75 R:90 A:80 D:70 |
+| 6 | Confident | Broadcast acquires exclusive Lock() for write path | Confirmed from intake #6 — sending to channels + updating previousJSON is a write operation | S:80 R:85 A:80 D:75 |
+| 7 | Certain | poll() checks total clients across all server slices to decide stop | Confirmed from intake #7 — must count all slices, not just one key | S:85 R:85 A:90 D:90 |
+| 8 | Certain | removeClient uses swap-delete for O(1) removal from slice | Codebase convention: standard Go slice removal pattern, no ordering dependency in client slice | S:80 R:95 A:90 D:90 |
+| 9 | Certain | poll() upgrades from RLock to Lock when stopping (needs to write h.polling) | Cannot write `h.polling = false` under RLock — must release RLock and acquire Lock | S:85 R:90 A:95 D:90 |
+
+9 assumptions (7 certain, 2 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260327-5mlg-sse-infrastructure-perf/tasks.md
+++ b/fab/changes/260327-5mlg-sse-infrastructure-perf/tasks.md
@@ -1,0 +1,34 @@
+# Tasks: SSE Infrastructure Performance
+
+**Change**: 260327-5mlg-sse-infrastructure-perf
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+## Phase 1: Core SSE Hub Restructure
+
+- [x] T001 Restructure `sseClient` and `sseHub` types in `app/backend/api/sse.go`: add `dropped bool` field to `sseClient`, change `clients` from `map[*sseClient]struct{}` to `map[string][]*sseClient`, update `newSSEHub()` initializer
+- [x] T002 Update `addClient()` in `app/backend/api/sse.go`: append client to `h.clients[c.server]` slice, send cached snapshot, start polling if needed
+- [x] T003 Update `removeClient()` in `app/backend/api/sse.go`: swap-delete from server's slice, delete map key if slice becomes empty
+
+## Phase 2: Poll Loop + Buffer + Drop Logging
+
+- [x] T004 Rewrite `poll()` in `app/backend/api/sse.go`: use `RLock()` for client-count check and server-key collection, `Lock()` for broadcast; iterate only the target server's client slice; add drop logging with debounce; reset `dropped` on successful send
+- [x] T005 [P] Increase channel buffer from 8 to 32 in `handleSSE` in `app/backend/api/sse.go`
+
+## Phase 3: Relay Race Fix
+
+- [x] T006 [P] Fix reader goroutine in `app/backend/api/relay.go`: replace `conn.Close()` with `cleanup()` call in the PTY reader goroutine
+
+## Phase 4: Tests
+
+- [x] T007 Update `app/backend/api/sse_test.go`: fix `TestSSEHubDeduplication` and `TestSSEHubStopsPollingWhenNoClients` for new `map[string][]*sseClient` type — `sseClient` construction must include `server` field; add test for drop logging behavior
+
+---
+
+## Execution Order
+
+- T001 blocks T002, T003, T004
+- T002, T003 block T004
+- T005 is independent (single line change)
+- T006 is independent (different file)
+- T007 depends on T001-T006


### PR DESCRIPTION
## Summary

The SSE hub and WebSocket relay in `app/backend/api/` have lock contention, silent event drops, and a goroutine race on close. This change restructures the hub to use server-indexed client maps with proper RWMutex usage, increases the channel buffer to 32 with drop logging, and fixes the relay reader goroutine race.

## Changes

- SSE hub: server-indexed client map (`map[string][]*sseClient`), RLock for read-only operations, Lock for broadcasts
- SSE hub: channel buffer increased from 8 to 32, slog.Warn on first drop per client with debounce reset on successful send
- Relay: reader goroutine calls `cleanup()` instead of `conn.Close()` to eliminate WebSocket concurrent access race

## Change
| ID | Name | Issue |
|----|------|-------|
| 5mlg | 260327-5mlg-sse-infrastructure-perf | — |

## Stats
| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| refactor | 4.4 / 5.0 | 0/22 | 7/7 | Pass (1 iterations) |

[intake](https://github.com/wvrdz/run-kit/blob/260327-5mlg-sse-infrastructure-perf/fab/changes/260327-5mlg-sse-infrastructure-perf/intake.md) → [spec](https://github.com/wvrdz/run-kit/blob/260327-5mlg-sse-infrastructure-perf/fab/changes/260327-5mlg-sse-infrastructure-perf/spec.md) → tasks → apply → review → hydrate → ship