### PR TITLE
feat: Mobile Bar Keyboard Toggle

### DIFF
--- a/app/frontend/src/app.tsx
+++ b/app/frontend/src/app.tsx
@@ -96,6 +96,7 @@ function AppShell() {
   const navigate = useNavigate();
   const matches = useMatches();
   const wsRef = useRef<WebSocket | null>(null);
+  const focusTerminalRef = useRef<(() => void) | null>(null);
 
   // Extract params -- the route may be /$server (no session/window) or /$server/$session/$window
   const lastMatch = matches[matches.length - 1];
@@ -597,11 +598,12 @@ function AppShell() {
                     composeOpen={composeOpen}
                     setComposeOpen={setComposeOpen}
                     onSessionNotFound={() => navigate({ to: "/$server", params: { server }, replace: true })}
+                    focusRef={focusTerminalRef}
                   />
                 </div>
                 {/* Bottom Bar — only on terminal pages */}
                 <div className="shrink-0 border-t border-border px-1.5 h-[48px]">
-                  <BottomBar wsRef={wsRef} hostname={hostname} onOpenCompose={() => setComposeOpen((v) => !v)} />
+                  <BottomBar wsRef={wsRef} hostname={hostname} onOpenCompose={() => setComposeOpen((v) => !v)} onFocusTerminal={() => focusTerminalRef.current?.()} />
                 </div>
               </>
             ) : (

--- a/app/frontend/src/components/bottom-bar.tsx
+++ b/app/frontend/src/components/bottom-bar.tsx
@@ -6,6 +6,7 @@ type BottomBarProps = {
   wsRef: React.RefObject<WebSocket | null>;
   hostname?: string;
   onOpenCompose?: () => void;
+  onFocusTerminal?: () => void;
 };
 
 /** xterm modifier parameter: 1 + (alt?2:0) + (ctrl?4:0) */
@@ -55,7 +56,7 @@ const MODIFIER_LABELS: Record<string, string> = {
 /** Prevent mousedown from stealing focus away from the terminal. */
 const preventFocusSteal = (e: React.MouseEvent) => e.preventDefault();
 
-export function BottomBar({ wsRef, hostname, onOpenCompose }: BottomBarProps) {
+export function BottomBar({ wsRef, hostname, onOpenCompose, onFocusTerminal }: BottomBarProps) {
   const mods = useModifierState();
   const [fnOpen, setFnOpen] = useState(false);
   const fnRef = useRef<HTMLDivElement>(null);
@@ -153,9 +154,6 @@ export function BottomBar({ wsRef, hostname, onOpenCompose }: BottomBarProps) {
 
   return (
     <div className="flex items-center gap-1 py-1.5 flex-wrap" role="toolbar" aria-label="Terminal keys">
-      <button aria-label="Escape" className={`${KBD_CLASS} text-text-secondary`} onMouseDown={preventFocusSteal} onClick={() => sendSpecial("\x1b")}>
-        <kbd aria-hidden="true">{"\u238B"}</kbd>
-      </button>
       <button aria-label="Tab" className={`${KBD_CLASS} text-text-secondary`} onMouseDown={preventFocusSteal} onClick={() => sendSpecial("\t")}>
         <kbd aria-hidden="true">{"\u21E5"}</kbd>
       </button>
@@ -206,6 +204,15 @@ export function BottomBar({ wsRef, hostname, onOpenCompose }: BottomBarProps) {
             </div>
             <div className="border-t border-border my-1" />
             <div className="grid grid-cols-3 gap-0.5">
+              <button
+                role="menuitem"
+                aria-label="Escape"
+                className="px-2 py-1 min-h-[36px] flex items-center justify-center text-xs text-text-secondary hover:text-text-primary hover:bg-bg-card rounded focus-visible:outline-2 focus-visible:outline-accent"
+                onMouseDown={preventFocusSteal}
+                onClick={() => { sendSpecial("\x1b"); setFnOpen(false); }}
+              >
+                Esc
+              </button>
               {EXT_KEYS.map((ek) => (
                 <button
                   key={ek.label}
@@ -250,19 +257,21 @@ export function BottomBar({ wsRef, hostname, onOpenCompose }: BottomBarProps) {
         <span className="hidden sm:inline ml-auto min-w-0 text-xs text-text-secondary truncate">{hostname}</span>
       )}
 
-      {/* Dismiss keyboard — visible only on touch devices */}
+      {/* Keyboard toggle — visible only on touch devices */}
       <button
         type="button"
-        aria-label="Dismiss keyboard"
+        aria-label={document.activeElement instanceof HTMLElement && document.activeElement.closest(".xterm") ? "Hide keyboard" : "Show keyboard"}
         className={`${KBD_CLASS} hidden coarse:inline-flex ml-auto text-text-secondary`}
         onMouseDown={preventFocusSteal}
         onClick={() => {
-          if (document.activeElement instanceof HTMLElement) {
+          if (document.activeElement instanceof HTMLElement && document.activeElement.closest(".xterm")) {
             document.activeElement.blur();
+          } else {
+            onFocusTerminal?.();
           }
         }}
       >
-        <kbd aria-hidden="true">{"\u2304"}</kbd>
+        <kbd aria-hidden="true">{"\u2328"}</kbd>
       </button>
     </div>
   );

--- a/app/frontend/src/components/bottom-bar.tsx
+++ b/app/frontend/src/components/bottom-bar.tsx
@@ -118,6 +118,27 @@ export function BottomBar({ wsRef, hostname, onOpenCompose, onFocusTerminal }: B
     return () => document.removeEventListener("keydown", handleKeyDown, { capture: true });
   }, [mods, wsRef]);
 
+  const [termFocused, setTermFocused] = useState(false);
+
+  useEffect(() => {
+    function onFocusIn(e: FocusEvent) {
+      if (e.target instanceof HTMLElement && e.target.closest(".xterm")) {
+        setTermFocused(true);
+      }
+    }
+    function onFocusOut(e: FocusEvent) {
+      if (e.target instanceof HTMLElement && e.target.closest(".xterm")) {
+        setTermFocused(false);
+      }
+    }
+    document.addEventListener("focusin", onFocusIn);
+    document.addEventListener("focusout", onFocusOut);
+    return () => {
+      document.removeEventListener("focusin", onFocusIn);
+      document.removeEventListener("focusout", onFocusOut);
+    };
+  }, []);
+
   const send = useCallback(
     (data: string) => {
       if (wsRef.current?.readyState === WebSocket.OPEN) {
@@ -253,26 +274,28 @@ export function BottomBar({ wsRef, hostname, onOpenCompose, onFocusTerminal }: B
         <kbd aria-hidden="true">{"\u2318K"}</kbd>
       </button>
 
-      {hostname && (
-        <span className="hidden sm:inline ml-auto min-w-0 text-xs text-text-secondary truncate">{hostname}</span>
-      )}
+      <div className="ml-auto flex items-center gap-1">
+        {hostname && (
+          <span className="hidden sm:inline min-w-0 text-xs text-text-secondary truncate">{hostname}</span>
+        )}
 
-      {/* Keyboard toggle — visible only on touch devices */}
-      <button
-        type="button"
-        aria-label={document.activeElement instanceof HTMLElement && document.activeElement.closest(".xterm") ? "Hide keyboard" : "Show keyboard"}
-        className={`${KBD_CLASS} hidden coarse:inline-flex ml-auto text-text-secondary`}
-        onMouseDown={preventFocusSteal}
-        onClick={() => {
-          if (document.activeElement instanceof HTMLElement && document.activeElement.closest(".xterm")) {
-            document.activeElement.blur();
-          } else {
-            onFocusTerminal?.();
-          }
-        }}
-      >
-        <kbd aria-hidden="true">{"\u2328"}</kbd>
-      </button>
+        {/* Keyboard toggle — visible only on touch devices */}
+        <button
+          type="button"
+          aria-label={termFocused ? "Hide keyboard" : "Show keyboard"}
+          className={`${KBD_CLASS} hidden coarse:inline-flex text-text-secondary`}
+          onMouseDown={preventFocusSteal}
+          onClick={() => {
+            if (termFocused && document.activeElement instanceof HTMLElement) {
+              document.activeElement.blur();
+            } else {
+              onFocusTerminal?.();
+            }
+          }}
+        >
+          <kbd aria-hidden="true">{"\u2328"}</kbd>
+        </button>
+      </div>
     </div>
   );
 }

--- a/app/frontend/src/components/terminal-client.tsx
+++ b/app/frontend/src/components/terminal-client.tsx
@@ -57,6 +57,7 @@ type TerminalClientProps = {
   composeOpen: boolean;
   setComposeOpen: (open: boolean | ((prev: boolean) => boolean)) => void;
   onSessionNotFound?: () => void;
+  focusRef?: React.MutableRefObject<(() => void) | null>;
 };
 
 export function TerminalClient({
@@ -67,6 +68,7 @@ export function TerminalClient({
   composeOpen,
   setComposeOpen,
   onSessionNotFound,
+  focusRef,
 }: TerminalClientProps) {
   const terminalRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<import("@xterm/xterm").Terminal | null>(null);
@@ -235,6 +237,7 @@ export function TerminalClient({
       }
 
       resizeObserver.observe(terminalRef.current);
+      if (focusRef) focusRef.current = () => xtermRef.current?.focus();
       setTerminalReady(true);
     }
 
@@ -249,12 +252,13 @@ export function TerminalClient({
         wsRef.current.close();
         wsRef.current = null;
       }
+      if (focusRef) focusRef.current = null;
       xtermRef.current = null;
       fitAddonRef.current = null;
       try { terminal?.dispose(); } catch { /* WebGL addon may throw during teardown */ }
       setTerminalReady(false);
     };
-  }, [wsRef]);
+  }, [wsRef, focusRef]);
 
   // Mobile touch-to-scroll: translate vertical swipe gestures into SGR mouse
   // wheel escape sequences sent to tmux via WebSocket.

--- a/docs/memory/run-kit/ui-patterns.md
+++ b/docs/memory/run-kit/ui-patterns.md
@@ -151,7 +151,7 @@ Popover state managed via `popoverKey` state in `Sidebar`, keyed by `session:win
 
 ## Bottom Bar (Terminal Pages Only, Inside Terminal Column)
 
-Single row of `<kbd>` styled buttons, rendered only on terminal pages (`/:session/:window`). Hidden on the Dashboard route (`/`) — there is no terminal to send keys to. Rendered inside the terminal column (not root-level), so its width tracks the terminal width, not the full viewport. Styled with `border-t border-border` and `py-1.5` padding. Layout: `Esc Tab | Ctrl Alt | Fn▴ ArrowPad`. Compose button (`>_`) moved to top bar right section.
+Single row of `<kbd>` styled buttons, rendered only on terminal pages (`/:session/:window`). Hidden on the Dashboard route (`/`) — there is no terminal to send keys to. Rendered inside the terminal column (not root-level), so its width tracks the terminal width, not the full viewport. Styled with `border-t border-border` and `py-1.5` padding. Layout: `Tab Ctrl Alt Fn▴ ArrowPad | >_ ⌘K [hostname] ⌨`. Escape moved to the Function key dropdown's extended-keys section. Compose button (`>_`) conditionally rendered when `onOpenCompose` is provided.
 
 **Modifier toggles** (Ctrl, Alt): Sticky armed state with visual indicator (`accent` bg). Click to arm, auto-clears after next key is sent. Click again while armed to disarm. Multiple modifiers can be armed simultaneously. Cmd (`⌘`) removed — on desktop users hold the real Cmd key; on mobile Cmd combos aren't used in terminal workflows.
 
@@ -159,9 +159,9 @@ Single row of `<kbd>` styled buttons, rendered only on terminal pages (`/:sessio
 
 **ArrowPad** (`arrow-pad.tsx`): Combined directional pad replacing individual arrow buttons. Sends ANSI escape sequences (`[A/B/C/D`). With modifiers, use xterm parameter encoding (`[1;{mod}X`). Modifier parameter: 1 + (alt?2:0) + (ctrl?4:0).
 
-**Function key dropdown** (F▴): Opens a combined popup above the button. Top section: F1-F12 in a 4-column grid. Divider (`border-t border-border`). Bottom section: PgUp, PgDn, Home, End, Ins, Del in a 3-column grid. Closes after each selection, on outside click, or on Escape.
+**Function key dropdown** (F▴): Opens a combined popup above the button. Top section: F1-F12 in a 4-column grid. Divider (`border-t border-border`). Bottom section: Esc, PgUp, PgDn, Home, End, Ins, Del in a 3-column grid (3x3, 7 items). Escape uses `sendSpecial` (preserves Ctrl re-arm semantics); other extended keys use `sendWithMods`. Closes after each selection, on outside click, or on Escape.
 
-**Special keys** (Esc, Tab): Direct send. Ctrl is not consumed for Esc/Tab (Esc IS Ctrl+[, Tab IS Ctrl+I in terminal semantics) — Ctrl stays armed for the next key. Alt prefix with ESC (Meta convention).
+**Special keys** (Tab in bottom bar, Esc in Fn menu): Direct send via `sendSpecial`. Ctrl is not consumed for Esc/Tab (Esc IS Ctrl+[, Tab IS Ctrl+I in terminal semantics) — Ctrl stays armed for the next key. Alt prefix with ESC (Meta convention).
 
 **All buttons**: 36px minimum height/width on desktop (`min-h-[36px] min-w-[36px]`), 44px height / 36px width on touch devices (`coarse:min-h-[44px] coarse:min-w-[36px]`). `text-xs`, `<kbd>` element styling.
 
@@ -193,6 +193,8 @@ After upload: file path auto-inserted into compose buffer (opens compose if clos
 ### iOS Keyboard Support
 
 `useVisualViewport` hook (`app/frontend/src/hooks/use-visual-viewport.ts`) manages all viewport-related CSS side effects: adds the `fullbleed` class to `<html>` on mount (removed on cleanup), and listens to both `resize` and `scroll` events on `window.visualViewport`, setting `--app-height` CSS custom property from `visualViewport.height`. The `scroll` listener catches iOS Safari viewport panning that doesn't trigger `resize`. In fullbleed mode, `globals.css` applies `position: fixed` to the `.app-shell` container with `inset: 0` and `height: var(--app-height, 100vh)`, pinning it to the viewport regardless of document scroll. When the iOS keyboard appears, the bottom bar stays pinned above it, the terminal shrinks, and xterm refits via the existing `ResizeObserver`. The `fullbleed` class is also present in `index.html` as a static default (FOUC prevention); the hook takes over lifecycle management at runtime.
+
+**Keyboard toggle** (`⌨` U+2328): Right-aligned button in the bottom bar, visible only on touch devices (`hidden coarse:inline-flex`). Bidirectional toggle: when terminal is focused (detected via `document.activeElement.closest(".xterm")`), tapping blurs to dismiss the keyboard; when not focused, tapping calls `onFocusTerminal` callback which chains through `app.tsx` → `TerminalClient.focusRef` → `xtermRef.current.focus()` to summon the keyboard. Dynamic `aria-label`: "Hide keyboard" / "Show keyboard". Uses `preventFocusSteal` to avoid stealing focus on the dismiss path.
 
 ### Terminal Touch Scroll
 

--- a/fab/changes/260327-bkm8-mobile-bar-keyboard-toggle/.history.jsonl
+++ b/fab/changes/260327-bkm8-mobile-bar-keyboard-toggle/.history.jsonl
@@ -1,0 +1,14 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-03-27T11:14:10Z"}
+{"args":"Move the escape button from the bottom bar into the Function button menu. Only tab, ctrl, alt, fn, arrow inputs remain in the bottom bar, then console (text input) and Cmd K buttons. Also a right-aligned down caret in mobile view. Change the down caret icon to a keyboard icon and make it toggle instead of just keyboard-down — in mobile I should also be able to bring the keyboard up with its help.","cmd":"fab-new","event":"command","ts":"2026-03-27T11:14:10Z"}
+{"delta":"+4.1","event":"confidence","score":4.1,"trigger":"calc-score","ts":"2026-03-27T11:15:39Z"}
+{"delta":"+0.0","event":"confidence","score":4.1,"trigger":"calc-score","ts":"2026-03-27T11:16:14Z"}
+{"cmd":"fab-switch","event":"command","ts":"2026-03-27T11:18:28Z"}
+{"cmd":"fab-fff","event":"command","ts":"2026-03-27T11:19:42Z"}
+{"delta":"+0.0","event":"confidence","score":4.1,"trigger":"calc-score","ts":"2026-03-27T11:21:15Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"spec","ts":"2026-03-27T11:21:19Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"tasks","ts":"2026-03-27T11:22:21Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-03-27T11:22:21Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-03-27T11:26:34Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-03-27T11:29:34Z"}
+{"event":"review","result":"passed","ts":"2026-03-27T11:29:34Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-03-27T11:30:51Z"}

--- a/fab/changes/260327-bkm8-mobile-bar-keyboard-toggle/.history.jsonl
+++ b/fab/changes/260327-bkm8-mobile-bar-keyboard-toggle/.history.jsonl
@@ -12,3 +12,4 @@
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-03-27T11:29:34Z"}
 {"event":"review","result":"passed","ts":"2026-03-27T11:29:34Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-03-27T11:30:51Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review-pr","ts":"2026-03-27T11:34:29Z"}

--- a/fab/changes/260327-bkm8-mobile-bar-keyboard-toggle/.status.yaml
+++ b/fab/changes/260327-bkm8-mobile-bar-keyboard-toggle/.status.yaml
@@ -1,0 +1,42 @@
+id: bkm8
+name: 260327-bkm8-mobile-bar-keyboard-toggle
+created: 2026-03-27T11:14:10Z
+created_by: sahil-weaver
+change_type: feat
+issues: []
+progress:
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+checklist:
+    generated: true
+    path: checklist.md
+    completed: 0
+    total: 0
+confidence:
+    certain: 6
+    confident: 3
+    tentative: 0
+    unresolved: 0
+    score: 4.1
+    fuzzy: true
+    dimensions:
+        signal: 82.8
+        reversibility: 90.6
+        competence: 87.8
+        disambiguation: 86.7
+stage_metrics:
+    intake: {started_at: "2026-03-27T11:14:10Z", driver: fab-new, iterations: 1, completed_at: "2026-03-27T11:21:19Z"}
+    spec: {started_at: "2026-03-27T11:21:19Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T11:22:21Z"}
+    tasks: {started_at: "2026-03-27T11:22:21Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T11:22:21Z"}
+    apply: {started_at: "2026-03-27T11:22:21Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T11:26:34Z"}
+    review: {started_at: "2026-03-27T11:26:34Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T11:29:34Z"}
+    hydrate: {started_at: "2026-03-27T11:29:34Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T11:30:51Z"}
+    ship: {started_at: "2026-03-27T11:30:51Z", driver: fab-fff, iterations: 1}
+prs: []
+last_updated: 2026-03-27T11:30:51Z

--- a/fab/changes/260327-bkm8-mobile-bar-keyboard-toggle/.status.yaml
+++ b/fab/changes/260327-bkm8-mobile-bar-keyboard-toggle/.status.yaml
@@ -11,8 +11,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 checklist:
     generated: true
     path: checklist.md
@@ -37,6 +37,8 @@ stage_metrics:
     apply: {started_at: "2026-03-27T11:22:21Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T11:26:34Z"}
     review: {started_at: "2026-03-27T11:26:34Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T11:29:34Z"}
     hydrate: {started_at: "2026-03-27T11:29:34Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T11:30:51Z"}
-    ship: {started_at: "2026-03-27T11:30:51Z", driver: fab-fff, iterations: 1}
-prs: []
-last_updated: 2026-03-27T11:30:51Z
+    ship: {started_at: "2026-03-27T11:30:51Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T11:34:29Z"}
+    review-pr: {started_at: "2026-03-27T11:34:29Z", driver: fab-fff, iterations: 1}
+prs:
+    - https://github.com/wvrdz/run-kit/pull/97
+last_updated: 2026-03-27T11:34:29Z

--- a/fab/changes/260327-bkm8-mobile-bar-keyboard-toggle/checklist.md
+++ b/fab/changes/260327-bkm8-mobile-bar-keyboard-toggle/checklist.md
@@ -1,0 +1,40 @@
+# Quality Checklist: Mobile Bar Keyboard Toggle
+
+**Change**: 260327-bkm8-mobile-bar-keyboard-toggle
+**Generated**: 2026-03-27
+**Spec**: `spec.md`
+
+## Functional Completeness
+- [ ] CHK-001 Escape in Fn menu: Escape button appears in extended-keys section of Fn dropdown, sends `\x1b` on click
+- [ ] CHK-002 Escape removed from main row: No standalone Escape button in the bottom bar
+- [ ] CHK-003 Keyboard toggle renders: `⌨` button visible on touch devices, hidden on desktop
+- [ ] CHK-004 Keyboard dismiss works: Tapping toggle when terminal focused blurs active element
+- [ ] CHK-005 Keyboard summon works: Tapping toggle when terminal not focused calls `onFocusTerminal`
+- [ ] CHK-006 Bottom bar layout: Tab, Ctrl, Alt, Fn, ArrowPad, divider, Compose, ⌘K, hostname, keyboard toggle — in order
+
+## Behavioral Correctness
+- [ ] CHK-007 Escape modifier bridging: Alt+Esc sends `\x1b\x1b`, Ctrl stays armed after Esc
+- [ ] CHK-008 Fn menu closes after Escape tap: Dropdown dismisses after Escape key selection
+- [ ] CHK-009 Focus preservation: `preventFocusSteal` on keyboard toggle prevents focus theft on dismiss
+
+## Scenario Coverage
+- [ ] CHK-010 Scenario: dismiss keyboard when terminal focused — active element blurs
+- [ ] CHK-011 Scenario: summon keyboard when not focused — terminal regains focus
+- [ ] CHK-012 Scenario: Escape via Fn menu with Alt modifier — correct escape sequence sent
+- [ ] CHK-013 Scenario: bottom bar at 375px — no wrapping, all buttons visible
+
+## Edge Cases & Error Handling
+- [ ] CHK-014 No `onFocusTerminal` callback: Toggle in summon mode is a graceful no-op
+- [ ] CHK-015 No `onOpenCompose` callback: Compose button absent, layout unaffected
+
+## Code Quality
+- [ ] CHK-016 Pattern consistency: New code follows naming and structural patterns of surrounding bottom-bar code
+- [ ] CHK-017 No unnecessary duplication: Escape in Fn menu reuses existing key-send patterns
+- [ ] CHK-018 No inline tmux command construction: N/A (frontend-only change)
+- [ ] CHK-019 Type safety: No `as` type assertions — proper narrowing and discriminated unions
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] CHK-008 **N/A**: {reason}`

--- a/fab/changes/260327-bkm8-mobile-bar-keyboard-toggle/intake.md
+++ b/fab/changes/260327-bkm8-mobile-bar-keyboard-toggle/intake.md
@@ -1,0 +1,90 @@
+# Intake: Mobile Bar Keyboard Toggle
+
+**Change**: 260327-bkm8-mobile-bar-keyboard-toggle
+**Created**: 2026-03-27
+**Status**: Draft
+
+## Origin
+
+> Move the escape button from the bottom bar into the Function button menu. Only tab, ctrl, alt, fn, arrow inputs remain in the bottom bar, then console (text input) and Cmd K buttons. Also a right-aligned down caret in mobile view. Change the down caret icon to a keyboard icon and make it toggle instead of just keyboard-down — in mobile I should also be able to bring the keyboard up with its help.
+
+One-shot request. User wants to declutter the bottom bar by relocating the Escape button into the existing Fn dropdown menu, and to convert the mobile keyboard-dismiss button from a one-way dismiss into a bidirectional toggle that can also summon the keyboard.
+
+## Why
+
+The bottom bar on mobile is space-constrained at 375px. The Escape button occupies a slot that could be freed — Escape is infrequently tapped compared to Tab/Ctrl/Alt, and it fits naturally alongside the other special keys already in the Fn menu (PgUp, PgDn, Home, End, Ins, Del).
+
+The current keyboard-dismiss button (down caret `⌄`) is one-way: it calls `document.activeElement.blur()` to hide the virtual keyboard, but there's no way to bring it back without tapping into the terminal area. This is a usability gap on mobile — if the user accidentally dismisses the keyboard, recovery requires knowing to tap the terminal canvas to refocus xterm's hidden textarea. A toggle button that can both dismiss and summon the keyboard solves this.
+
+Changing the icon from a down caret to a keyboard icon also improves discoverability — the caret's meaning ("dismiss keyboard") is ambiguous without context.
+
+## What Changes
+
+### 1. Move Escape to Function Menu
+
+Remove the standalone `Esc` (`⎋`) button from the bottom bar's main row. Add it as the first item in the Fn dropdown menu's bottom section (the extended-keys grid that currently has PgUp, PgDn, Home, End, Ins, Del).
+
+**Fn menu new bottom section layout** (3-column grid → 3x3):
+```
+Esc    PgUp   PgDn
+Home   End    Ins
+Del
+```
+
+Escape in the Fn menu sends `\x1b` exactly as the standalone button does today. It respects the same modifier bridging (Alt prefix, Ctrl stays armed).
+
+### 2. Simplify Bottom Bar Layout
+
+After removing Escape, the bottom bar main row becomes:
+
+```
+Tab  Ctrl  Alt  Fn▴  ArrowPad  |  >_  ⌘K  [hostname]  ⌨
+```
+
+- `Tab`, `Ctrl`, `Alt`, `Fn▴`, `ArrowPad` — unchanged
+- Vertical divider — unchanged
+- `>_` (Compose) — unchanged (only renders when `onOpenCompose` is provided)
+- `⌘K` (Command Palette) — unchanged
+- `[hostname]` — unchanged (hidden on small screens)
+- `⌨` (Keyboard Toggle) — replaces the old down-caret `⌄`, right-aligned, touch-only (`hidden coarse:inline-flex`)
+
+### 3. Keyboard Toggle Button
+
+Replace the current keyboard-dismiss button (down caret `⌄`, `hidden coarse:inline-flex`) with a keyboard icon (`⌨` U+2328 or an SVG keyboard icon) that **toggles** the virtual keyboard:
+
+- **When keyboard is visible** (xterm textarea is focused): tapping the button calls `document.activeElement?.blur()` to dismiss the keyboard — same as current behavior.
+- **When keyboard is hidden** (nothing focused / xterm textarea lost focus): tapping the button focuses xterm's hidden textarea to summon the virtual keyboard. The xterm terminal instance exposes a `.focus()` method, and the component already has access to the terminal ref via `termRef`.
+
+**Implementation approach**: The toggle needs to detect whether the keyboard is currently visible. The most reliable signal is whether `document.activeElement` is the xterm hidden textarea (or any input/textarea element within the terminal container). If active element is inside the terminal → blur (dismiss). Otherwise → call `termRef.current?.focus()` (summon).
+
+The button's icon should visually indicate its toggle nature. A keyboard icon (`⌨`) is appropriate — it communicates "keyboard control" regardless of direction. The icon does NOT need to change between states (no animate between keyboard-up/keyboard-down).
+
+## Affected Memory
+
+- `run-kit/ui-patterns`: (modify) Update Bottom Bar section to reflect new layout (Escape removed from main row), Fn menu section to include Escape, and keyboard toggle behavior replacing dismiss-only caret.
+
+## Impact
+
+- **`app/frontend/src/components/bottom-bar.tsx`** — Primary file. Remove Esc button from main row, add Esc to Fn menu grid, replace dismiss button with toggle button.
+- **No backend changes** — purely frontend.
+- **No new dependencies** — uses existing xterm `.focus()` API.
+- **No API changes** — no new routes or WebSocket messages.
+- **Accessibility** — `aria-label` on the keyboard toggle should describe current action ("Show keyboard" / "Hide keyboard").
+
+## Open Questions
+
+None — the scope is well-defined and all implementation details are clear from the existing codebase.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Escape goes into Fn menu bottom section, not top (F-key) section | Escape is a special/extended key like PgUp/Del, not a function key | S:90 R:90 A:95 D:95 |
+| 2 | Certain | Keyboard toggle uses xterm's `.focus()` to summon keyboard | Codebase already has `termRef` access; `.focus()` is the standard xterm.js API for this | S:85 R:90 A:95 D:90 |
+| 3 | Confident | Use Unicode `⌨` (U+2328) for the keyboard icon rather than a custom SVG | Consistent with existing bottom bar style (Esc uses `⎋`, Tab uses `⇥`); simpler than adding SVG | S:70 R:90 A:75 D:70 |
+| 4 | Certain | Toggle detection uses `document.activeElement` comparison | Standard DOM API; no need for a separate "keyboard visible" state variable | S:85 R:95 A:90 D:90 |
+| 5 | Confident | Fn menu bottom section becomes 3x3 grid (was 2x3) to accommodate Escape | 7 items in a 3-column grid = 3 rows; natural extension of existing layout | S:75 R:85 A:80 D:75 |
+| 6 | Certain | No changes needed to modifier bridging — Escape in Fn menu uses same `sendKey` path | Fn menu keys already go through the same send mechanism with modifier support | S:90 R:95 A:90 D:95 |
+| 7 | Confident | `aria-label` toggles between "Show keyboard" and "Hide keyboard" | Best practice for toggle buttons; the active state is derivable from `document.activeElement` | S:70 R:95 A:80 D:85 |
+
+7 assumptions (4 certain, 3 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260327-bkm8-mobile-bar-keyboard-toggle/spec.md
+++ b/fab/changes/260327-bkm8-mobile-bar-keyboard-toggle/spec.md
@@ -1,0 +1,159 @@
+# Spec: Mobile Bar Keyboard Toggle
+
+**Change**: 260327-bkm8-mobile-bar-keyboard-toggle
+**Created**: 2026-03-27
+**Affected memory**: `docs/memory/run-kit/ui-patterns.md`
+
+## Bottom Bar: Escape Relocation
+
+### Requirement: Escape Button in Function Menu
+
+The standalone Escape button (`⎋`) SHALL be removed from the bottom bar's main row. Escape SHALL be added as the first item in the Fn dropdown menu's bottom section (extended-keys grid), before PgUp.
+
+The extended-keys grid SHALL contain 7 items in a 3-column layout:
+```
+Esc    PgUp   PgDn
+Home   End    Ins
+Del
+```
+
+Escape in the Fn menu SHALL send `\x1b` via WebSocket, identical to the current standalone button. Modifier bridging (Alt prefix, Ctrl stays armed) SHALL apply to Escape in the Fn menu via the existing `sendSpecial` path.
+
+#### Scenario: User sends Escape via Fn menu
+- **GIVEN** the Fn dropdown is open
+- **WHEN** the user taps the Escape button in the extended-keys section
+- **THEN** `\x1b` is sent via WebSocket
+- **AND** the Fn dropdown closes
+
+#### Scenario: Escape with Alt modifier via Fn menu
+- **GIVEN** the Alt modifier is armed
+- **AND** the Fn dropdown is open
+- **WHEN** the user taps Escape in the extended-keys section
+- **THEN** `\x1b\x1b` (ESC prefix + ESC) is sent via WebSocket
+- **AND** the Alt modifier is consumed
+
+#### Scenario: Escape with Ctrl modifier via Fn menu
+- **GIVEN** the Ctrl modifier is armed
+- **AND** the Fn dropdown is open
+- **WHEN** the user taps Escape in the extended-keys section
+- **THEN** `\x1b` is sent (Ctrl stays armed — Esc IS Ctrl+[)
+- **AND** the Fn dropdown closes
+- **AND** the Ctrl modifier remains armed
+
+### Requirement: Simplified Bottom Bar Layout
+
+After Escape removal, the bottom bar main row SHALL contain these elements in order:
+1. Tab (`⇥`)
+2. Ctrl (`^`)
+3. Alt (`⌥`)
+4. Fn (`F▴`) with dropdown
+5. ArrowPad
+6. Vertical divider
+7. Compose (`>_`) — conditional on `onOpenCompose` prop
+8. Command palette (`⌘K`)
+9. Hostname — right-aligned, hidden on small screens (`hidden sm:inline`)
+10. Keyboard toggle (`⌨`) — right-aligned, touch-only (`hidden coarse:inline-flex`)
+
+No other changes to existing button behavior, styling, or sizing.
+
+#### Scenario: Bottom bar renders on 375px mobile viewport
+- **GIVEN** a terminal page on a 375px-wide touch device
+- **WHEN** the bottom bar renders
+- **THEN** all buttons fit in a single row without wrapping
+- **AND** the Escape button is not present in the main row
+- **AND** the keyboard toggle button is visible (right-aligned)
+
+## Bottom Bar: Keyboard Toggle
+
+### Requirement: Bidirectional Keyboard Toggle
+
+The current keyboard-dismiss button (down caret `⌄`) SHALL be replaced with a keyboard toggle button using the `⌨` (U+2328) icon.
+
+The button SHALL be visible only on touch/coarse-pointer devices (`hidden coarse:inline-flex`), right-aligned via `ml-auto`.
+
+The button SHALL toggle the virtual keyboard:
+- **Dismiss**: When `document.activeElement` is an element inside the terminal container (xterm's hidden textarea), tapping SHALL call `document.activeElement.blur()`.
+- **Summon**: When `document.activeElement` is NOT inside the terminal container, tapping SHALL focus the terminal to bring up the virtual keyboard.
+
+#### Scenario: Dismiss keyboard when terminal is focused
+- **GIVEN** the terminal's hidden textarea is focused (keyboard visible)
+- **WHEN** the user taps the keyboard toggle button
+- **THEN** `document.activeElement.blur()` is called
+- **AND** the virtual keyboard dismisses
+
+#### Scenario: Summon keyboard when terminal is not focused
+- **GIVEN** no element is focused (keyboard hidden, e.g., after previous dismiss)
+- **WHEN** the user taps the keyboard toggle button
+- **THEN** the terminal is focused
+- **AND** the virtual keyboard appears
+
+#### Scenario: Summon keyboard after accidental dismiss
+- **GIVEN** the user previously dismissed the keyboard via the toggle button
+- **WHEN** the user taps the keyboard toggle button again
+- **THEN** the terminal regains focus
+- **AND** the virtual keyboard reappears
+
+### Requirement: Focus Terminal Callback
+
+`BottomBar` SHALL accept an optional `onFocusTerminal` callback prop (`() => void`). When the keyboard toggle detects that the terminal is not focused, it SHALL call `onFocusTerminal()` to summon the keyboard.
+
+The parent (`app.tsx`) SHALL pass a callback that focuses the terminal. The `TerminalClient` component SHALL expose a mechanism (imperative handle or callback) for the parent to trigger `.focus()` on the xterm instance.
+
+#### Scenario: Parent wires focus callback
+- **GIVEN** `BottomBar` receives an `onFocusTerminal` callback
+- **WHEN** the keyboard toggle fires in "summon" mode
+- **THEN** the callback is invoked
+- **AND** the terminal gains focus
+
+#### Scenario: No focus callback provided
+- **GIVEN** `BottomBar` does not receive `onFocusTerminal`
+- **WHEN** the keyboard toggle fires in "summon" mode
+- **THEN** no error occurs (graceful no-op)
+
+### Requirement: Accessibility Labels
+
+The keyboard toggle button SHALL have a dynamic `aria-label`:
+- `"Hide keyboard"` when the terminal is focused (dismiss mode)
+- `"Show keyboard"` when the terminal is not focused (summon mode)
+
+The button SHALL use `preventFocusSteal` (`onMouseDown={e => e.preventDefault()}`) to avoid stealing focus from the terminal when tapping to dismiss.
+
+#### Scenario: Screen reader announces toggle state
+- **GIVEN** the terminal is focused
+- **WHEN** the screen reader reads the keyboard toggle button
+- **THEN** it announces "Hide keyboard"
+
+#### Scenario: Screen reader announces summon state
+- **GIVEN** the terminal is not focused
+- **WHEN** the screen reader reads the keyboard toggle button
+- **THEN** it announces "Show keyboard"
+
+## Design Decisions
+
+1. **Callback prop vs DOM query for terminal focus**: Callback prop (`onFocusTerminal`)
+   - *Why*: `xtermRef` is internal to `TerminalClient`; querying `.xterm-helper-textarea` is fragile and depends on xterm.js internals. A callback through the parent is clean and testable.
+   - *Rejected*: Direct DOM query — couples to xterm.js internal class names that may change across versions.
+
+2. **Escape in extended-keys section (not F-keys section)**: Bottom grid
+   - *Why*: Escape is semantically a special/navigation key, not a function key (F1-F12). It belongs with PgUp, Home, Del, etc.
+   - *Rejected*: Adding to the F-keys 4-column grid — would break the grid alignment and confuse users expecting only F1-F12 there.
+
+3. **Static icon (no state-dependent icon change)**: Single `⌨` icon
+   - *Why*: The button's behavior is a toggle; the icon represents "keyboard control." Animating between up/down states adds visual complexity without improving discoverability.
+   - *Rejected*: Dual-icon approach (keyboard-up/keyboard-down) — more complex, less consistent with other bottom bar buttons that use static icons.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Escape goes in Fn bottom section (extended keys), not F-key grid | Confirmed from intake #1 — Escape is a special key, not F1-F12 | S:90 R:90 A:95 D:95 |
+| 2 | Certain | Keyboard toggle uses callback prop to focus terminal | Spec-level analysis: `xtermRef` is internal to `TerminalClient`; callback is the clean pattern | S:90 R:85 A:95 D:90 |
+| 3 | Confident | Unicode `⌨` (U+2328) for icon | Confirmed from intake #3 — consistent with `⎋`, `⇥` style | S:70 R:90 A:75 D:70 |
+| 4 | Certain | Toggle detection via `document.activeElement` | Confirmed from intake #4 — standard DOM API, no extra state needed | S:85 R:95 A:90 D:90 |
+| 5 | Confident | Fn extended-keys grid becomes 3x3 (7 items) | Confirmed from intake #5 — natural extension of existing 3-column grid | S:75 R:85 A:80 D:75 |
+| 6 | Certain | No modifier bridging changes — Escape uses existing `sendSpecial` | Confirmed from intake #6 — `sendSpecial` handles Alt prefix and Ctrl re-arm already | S:90 R:95 A:90 D:95 |
+| 7 | Confident | Dynamic `aria-label` ("Show keyboard" / "Hide keyboard") | Confirmed from intake #7 — best practice for toggle buttons | S:70 R:95 A:80 D:85 |
+| 8 | Certain | `TerminalClient` exposes focus via imperative handle or callback | Codebase uses `useRef` for xterm; `useImperativeHandle` or lifted callback are standard React patterns | S:85 R:85 A:90 D:85 |
+| 9 | Certain | `preventFocusSteal` on toggle button (dismiss mode) | Required by existing pattern — all bottom bar buttons that interact with terminal use this | S:90 R:95 A:95 D:95 |
+
+9 assumptions (6 certain, 3 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260327-bkm8-mobile-bar-keyboard-toggle/tasks.md
+++ b/fab/changes/260327-bkm8-mobile-bar-keyboard-toggle/tasks.md
@@ -1,0 +1,37 @@
+# Tasks: Mobile Bar Keyboard Toggle
+
+**Change**: 260327-bkm8-mobile-bar-keyboard-toggle
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+## Phase 1: Setup
+
+- [x] T001 Add Escape to `EXT_KEYS` array in `app/frontend/src/components/bottom-bar.tsx` — insert `{ label: "Esc", ... }` as the first element before PgUp. Use `sendSpecial("\x1b")` path (not `sendWithMods`) to preserve Ctrl re-arm behavior.
+
+## Phase 2: Core Implementation
+
+- [x] T002 Remove standalone Escape button from the bottom bar main row in `app/frontend/src/components/bottom-bar.tsx` — delete the `<button aria-label="Escape">` element (lines ~156-158).
+- [x] T003 Wire Escape in Fn menu to use `sendSpecial` instead of `sendWithMods` — the extended-keys grid currently uses `sendWithMods` for all items, but Escape needs `sendSpecial` to preserve Ctrl-stays-armed semantics. Handle Escape as a special case in the `onClick` handler for the extended-keys grid.
+- [x] T004 Add `onFocusTerminal` optional callback prop to `BottomBarProps` in `app/frontend/src/components/bottom-bar.tsx`.
+- [x] T005 Replace keyboard-dismiss button with keyboard toggle in `app/frontend/src/components/bottom-bar.tsx` — change icon from `⌄` (U+2304) to `⌨` (U+2328), change `onClick` to toggle logic: if `document.activeElement` is inside terminal → blur, else → call `onFocusTerminal?.()`.
+- [x] T006 Expose terminal focus from `TerminalClient` in `app/frontend/src/components/terminal-client.tsx` — add a `focusRef` callback prop (`React.RefObject<(() => void) | null>`) that the parent can call to invoke `xtermRef.current?.focus()`.
+- [x] T007 Wire `onFocusTerminal` in `app/frontend/src/app.tsx` — create a ref for the focus callback, pass it to `TerminalClient` as `focusRef` and to `BottomBar` as `onFocusTerminal`.
+
+## Phase 3: Integration & Edge Cases
+
+- [x] T008 Add dynamic `aria-label` to keyboard toggle button — "Hide keyboard" when terminal is focused, "Show keyboard" otherwise. Use state derived from a `focuschange`-like listener or compute on click.
+- [x] T009 Verify `preventFocusSteal` on keyboard toggle button — ensure `onMouseDown={preventFocusSteal}` is present so dismiss mode doesn't steal focus before blur fires.
+- [x] T010 Run `cd app/frontend && npx tsc --noEmit` to verify TypeScript compiles cleanly.
+- [x] T011 Run `just test-frontend` to verify existing tests pass.
+
+---
+
+## Execution Order
+
+- T001 is independent (data change only)
+- T002 depends on T001 (remove old button after Escape is in Fn menu)
+- T003 depends on T001 (Escape must be in EXT_KEYS first)
+- T004, T005, T006 can proceed in parallel after T002
+- T007 depends on T004 + T005 + T006 (wires everything together)
+- T008, T009 depend on T005 (toggle button must exist)
+- T010, T011 are final gates


### PR DESCRIPTION
## Summary

The bottom bar on mobile is space-constrained. The Escape button occupies a slot that could be freed — it is infrequently tapped compared to Tab/Ctrl/Alt, and fits naturally in the Fn menu alongside PgUp, PgDn, Home, End, Ins, Del. The keyboard-dismiss button (down caret) was also one-way — there was no way to bring the keyboard back without tapping the terminal canvas. This change fixes both issues.

## Changes

- Move Escape to Function Menu
- Simplify Bottom Bar Layout
- Keyboard Toggle Button (bidirectional show/hide)

## Change
| ID | Name | Issue |
|----|------|-------|
| bkm8 | 260327-bkm8-mobile-bar-keyboard-toggle | — |

## Stats
| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| feat | 4.1 / 5.0 | 0/0 | 11/11 | Pass (1 iterations) |

[intake](https://github.com/wvrdz/run-kit/blob/260327-bkm8-mobile-bar-keyboard-toggle/fab/changes/260327-bkm8-mobile-bar-keyboard-toggle/intake.md) → [spec](https://github.com/wvrdz/run-kit/blob/260327-bkm8-mobile-bar-keyboard-toggle/fab/changes/260327-bkm8-mobile-bar-keyboard-toggle/spec.md) → tasks → apply → review → hydrate → ship