### PR TITLE
fix: Fix Update Restart

### DIFF
--- a/app/backend/cmd/rk/upgrade.go
+++ b/app/backend/cmd/rk/upgrade.go
@@ -88,7 +88,7 @@ var updateCmd = &cobra.Command{
 		// Restart daemon so it picks up the new binary.
 		// Idempotent: if no daemon is running, this starts one.
 		fmt.Println("Restarting rk daemon...")
-		if err := daemon.Restart(); err != nil {
+		if err := daemon.RestartWithBinary(exePath); err != nil {
 			return fmt.Errorf("restarting daemon after upgrade: %w", err)
 		}
 		fmt.Printf("rk daemon started (%s/%s/%s)\n",

--- a/app/backend/cmd/rk/upgrade.go
+++ b/app/backend/cmd/rk/upgrade.go
@@ -85,10 +85,19 @@ var updateCmd = &cobra.Command{
 
 		fmt.Printf("Updated to v%s.\n", latest)
 
+		// Derive the stable Homebrew bin symlink from the Cellar path.
+		// resolved is e.g. /opt/homebrew/Cellar/rk/0.5.3/bin/rk
+		// We want:         /opt/homebrew/bin/rk
+		cellarIdx := strings.Index(resolved, "/Cellar/rk/")
+		if cellarIdx == -1 {
+			return fmt.Errorf("could not derive brew prefix from %s", resolved)
+		}
+		brewBinPath := resolved[:cellarIdx] + "/bin/rk"
+
 		// Restart daemon so it picks up the new binary.
 		// Idempotent: if no daemon is running, this starts one.
 		fmt.Println("Restarting rk daemon...")
-		if err := daemon.RestartWithBinary(exePath); err != nil {
+		if err := daemon.RestartWithBinary(brewBinPath); err != nil {
 			return fmt.Errorf("restarting daemon after upgrade: %w", err)
 		}
 		fmt.Printf("rk daemon started (%s/%s/%s)\n",

--- a/app/backend/internal/daemon/daemon.go
+++ b/app/backend/internal/daemon/daemon.go
@@ -76,6 +76,29 @@ func Start() error {
 		return fmt.Errorf("resolving executable symlinks: %w", err)
 	}
 
+	return startSession(exe)
+}
+
+// StartWithBinary creates a new daemon tmux session using the provided binary path.
+// The binPath is resolved via filepath.EvalSymlinks before use, so callers can pass
+// a symlink (e.g. the Homebrew bin symlink) that points to the current version.
+// Use this instead of Start when the running process's os.Executable path may be stale
+// (e.g. after brew upgrade deletes the old Cellar directory).
+func StartWithBinary(binPath string) error {
+	if IsRunning() {
+		return fmt.Errorf("daemon already running")
+	}
+
+	exe, err := filepath.EvalSymlinks(binPath)
+	if err != nil {
+		return fmt.Errorf("resolving executable symlinks: %w", err)
+	}
+
+	return startSession(exe)
+}
+
+// startSession creates the daemon tmux session with the given resolved binary path.
+func startSession(exe string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
 	defer cancel()
 
@@ -133,4 +156,15 @@ func Restart() error {
 		}
 	}
 	return Start()
+}
+
+// RestartWithBinary stops the daemon if running, then starts it using the provided binary path.
+// Use this instead of Restart when the running process's os.Executable path may be stale.
+func RestartWithBinary(binPath string) error {
+	if IsRunning() {
+		if err := Stop(); err != nil {
+			return fmt.Errorf("stopping daemon: %w", err)
+		}
+	}
+	return StartWithBinary(binPath)
 }

--- a/app/backend/internal/daemon/daemon_test.go
+++ b/app/backend/internal/daemon/daemon_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"os/exec"
+	"strings"
 	"testing"
 )
 
@@ -116,6 +117,37 @@ func TestRestart_WhenNotRunning(t *testing.T) {
 	}
 	if !isRunningOn(testSocket) {
 		t.Error("isRunningOn() = false after startOn()")
+	}
+}
+
+func TestStartWithBinary_InvalidPath(t *testing.T) {
+	if IsRunning() {
+		t.Skip("skipping — production daemon is running")
+	}
+
+	// StartWithBinary should return an error for a nonexistent path.
+	err := StartWithBinary("/nonexistent/path/rk")
+	if err == nil {
+		t.Fatal("StartWithBinary with invalid path should return error")
+	}
+	wantMsg := "resolving executable symlinks"
+	if !strings.Contains(err.Error(), wantMsg) {
+		t.Errorf("error = %q, want it to contain %q", err, wantMsg)
+	}
+}
+
+func TestRestartWithBinary_InvalidPath(t *testing.T) {
+	if IsRunning() {
+		t.Skip("skipping — production daemon is running")
+	}
+
+	err := RestartWithBinary("/nonexistent/path/rk")
+	if err == nil {
+		t.Fatal("RestartWithBinary with invalid path should return error")
+	}
+	wantMsg := "resolving executable symlinks"
+	if !strings.Contains(err.Error(), wantMsg) {
+		t.Errorf("error = %q, want it to contain %q", err, wantMsg)
 	}
 }
 

--- a/docs/memory/run-kit/architecture.md
+++ b/docs/memory/run-kit/architecture.md
@@ -179,7 +179,9 @@ The Go binary manages its own daemon lifecycle via `run-kit serve` flags. The da
 - `run-kit serve -d` — start daemon (errors if already running)
 - `run-kit serve --restart` — idempotent: stop existing daemon (C-c → wait 5s) then start new one; starts fresh if no daemon running
 - `run-kit serve --stop` — graceful shutdown via C-c to the tmux pane
-- `run-kit update` — auto-restarts daemon after successful `brew upgrade`
+- `run-kit update` — auto-restarts daemon after successful `brew upgrade` using `RestartWithBinary(exePath)` where `exePath` is the Homebrew bin symlink (resolves to the new Cellar version post-upgrade, avoiding stale `os.Executable()` path from the running process)
+
+Binary resolution: `Start()` uses `os.Executable()` + `filepath.EvalSymlinks()` (works for `serve -d` / `--restart` where the running binary is valid). `StartWithBinary(path)` accepts an explicit binary path and resolves its symlinks (used by `update` after `brew upgrade` deletes the old Cellar directory). Both delegate to shared `startSession(exe)` for tmux session creation.
 
 Detection: `tmux -L rk-daemon has-session -t rk`. No polling loop, no signal files, no supervisor script.
 
@@ -238,7 +240,7 @@ Single-view model: there are no page transitions or per-page chrome injection. T
 | *(none)* | `root.go` | Defaults to `serve` (backwards compat) |
 | `serve` | `serve.go` | Start HTTP server — loads config from env vars, chi router, graceful shutdown via SIGINT/SIGTERM. Flags: `-d`/`--daemon` (start as daemon in tmux), `--restart` (idempotent restart), `--stop` (graceful stop). Uses `internal/daemon/` helpers |
 | `version` | `version.go` | Print `run-kit version {version}` — version injected at build time via `-X main.version=...` |
-| `update` | `upgrade.go` | Alias: `upgrade`. Detect Homebrew install (`os.Executable()` path contains `/Cellar/run-kit/`). If Homebrew: `brew update --quiet`, check latest version via `brew info --json=v2`, skip if already up to date, else `brew upgrade run-kit` + auto-restart daemon via `daemon.Restart()`. Non-Homebrew: print reinstall instructions |
+| `update` | `upgrade.go` | Alias: `upgrade`. Detect Homebrew install (`os.Executable()` path contains `/Cellar/rk/`). If Homebrew: `brew update --quiet`, check latest version via `brew info --json=v2`, skip if already up to date, else `brew upgrade wvrdz/tap/rk` + auto-restart daemon via `daemon.RestartWithBinary(exePath)` (uses the brew bin symlink, not stale `os.Executable()` Cellar path). Non-Homebrew: print reinstall instructions |
 | `doctor` | `doctor.go` | Check runtime dependencies only — `exec.LookPath("tmux")`. Exit 1 if any check fails |
 | `status` | `status.go` | List tmux sessions with window counts via `internal/tmux.ListSessions()` + `ListWindows()`. No server required |
 | `init-conf` | `initconf.go` | Scaffold default tmux.conf to `~/.run-kit/tmux.conf` from embedded config. `--force` to overwrite |

--- a/docs/memory/run-kit/architecture.md
+++ b/docs/memory/run-kit/architecture.md
@@ -179,7 +179,7 @@ The Go binary manages its own daemon lifecycle via `run-kit serve` flags. The da
 - `run-kit serve -d` — start daemon (errors if already running)
 - `run-kit serve --restart` — idempotent: stop existing daemon (C-c → wait 5s) then start new one; starts fresh if no daemon running
 - `run-kit serve --stop` — graceful shutdown via C-c to the tmux pane
-- `run-kit update` — auto-restarts daemon after successful `brew upgrade` using `RestartWithBinary(exePath)` where `exePath` is the Homebrew bin symlink (resolves to the new Cellar version post-upgrade, avoiding stale `os.Executable()` path from the running process)
+- `run-kit update` — auto-restarts daemon after successful `brew upgrade` using `RestartWithBinary(brewBinPath)` where `brewBinPath` is `<brewPrefix>/bin/rk` derived from the resolved Cellar path (resolves to the new Cellar version post-upgrade, avoiding stale `os.Executable()` path from the running process)
 
 Binary resolution: `Start()` uses `os.Executable()` + `filepath.EvalSymlinks()` (works for `serve -d` / `--restart` where the running binary is valid). `StartWithBinary(path)` accepts an explicit binary path and resolves its symlinks (used by `update` after `brew upgrade` deletes the old Cellar directory). Both delegate to shared `startSession(exe)` for tmux session creation.
 
@@ -240,7 +240,7 @@ Single-view model: there are no page transitions or per-page chrome injection. T
 | *(none)* | `root.go` | Defaults to `serve` (backwards compat) |
 | `serve` | `serve.go` | Start HTTP server — loads config from env vars, chi router, graceful shutdown via SIGINT/SIGTERM. Flags: `-d`/`--daemon` (start as daemon in tmux), `--restart` (idempotent restart), `--stop` (graceful stop). Uses `internal/daemon/` helpers |
 | `version` | `version.go` | Print `run-kit version {version}` — version injected at build time via `-X main.version=...` |
-| `update` | `upgrade.go` | Alias: `upgrade`. Detect Homebrew install (`os.Executable()` path contains `/Cellar/rk/`). If Homebrew: `brew update --quiet`, check latest version via `brew info --json=v2`, skip if already up to date, else `brew upgrade wvrdz/tap/rk` + auto-restart daemon via `daemon.RestartWithBinary(exePath)` (uses the brew bin symlink, not stale `os.Executable()` Cellar path). Non-Homebrew: print reinstall instructions |
+| `update` | `upgrade.go` | Alias: `upgrade`. Detect Homebrew install (`os.Executable()` path contains `/Cellar/rk/`). If Homebrew: `brew update --quiet`, check latest version via `brew info --json=v2`, skip if already up to date, else `brew upgrade wvrdz/tap/rk` + auto-restart daemon via `daemon.RestartWithBinary(brewBinPath)` where `brewBinPath` is derived from the Cellar path (`<brewPrefix>/bin/rk`), not stale `os.Executable()`. Non-Homebrew: print reinstall instructions |
 | `doctor` | `doctor.go` | Check runtime dependencies only — `exec.LookPath("tmux")`. Exit 1 if any check fails |
 | `status` | `status.go` | List tmux sessions with window counts via `internal/tmux.ListSessions()` + `ListWindows()`. No server required |
 | `init-conf` | `initconf.go` | Scaffold default tmux.conf to `~/.run-kit/tmux.conf` from embedded config. `--force` to overwrite |

--- a/fab/changes/260327-8f9k-fix-update-restart/.history.jsonl
+++ b/fab/changes/260327-8f9k-fix-update-restart/.history.jsonl
@@ -1,0 +1,14 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-03-27T13:36:11Z"}
+{"args":"Fix rk update daemon restart failure after brew upgrade","cmd":"fab-new","event":"command","ts":"2026-03-27T13:36:11Z"}
+{"delta":"+4.7","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-27T13:36:57Z"}
+{"delta":"+0.0","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-03-27T13:37:09Z"}
+{"cmd":"fab-switch","event":"command","ts":"2026-03-27T13:37:47Z"}
+{"cmd":"fab-fff","event":"command","ts":"2026-03-27T13:38:48Z"}
+{"delta":"+0.3","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-03-27T13:40:30Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"spec","ts":"2026-03-27T13:40:35Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"tasks","ts":"2026-03-27T13:41:18Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-03-27T13:41:18Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-03-27T13:43:33Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-03-27T13:45:06Z"}
+{"event":"review","result":"passed","ts":"2026-03-27T13:45:06Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-03-27T13:45:35Z"}

--- a/fab/changes/260327-8f9k-fix-update-restart/.history.jsonl
+++ b/fab/changes/260327-8f9k-fix-update-restart/.history.jsonl
@@ -12,3 +12,4 @@
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-03-27T13:45:06Z"}
 {"event":"review","result":"passed","ts":"2026-03-27T13:45:06Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-03-27T13:45:35Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-03-27T13:47:15Z"}

--- a/fab/changes/260327-8f9k-fix-update-restart/.history.jsonl
+++ b/fab/changes/260327-8f9k-fix-update-restart/.history.jsonl
@@ -13,3 +13,4 @@
 {"event":"review","result":"passed","ts":"2026-03-27T13:45:06Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-03-27T13:45:35Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-03-27T13:47:15Z"}
+{"event":"review","result":"passed","ts":"2026-03-27T13:54:15Z"}

--- a/fab/changes/260327-8f9k-fix-update-restart/.status.yaml
+++ b/fab/changes/260327-8f9k-fix-update-restart/.status.yaml
@@ -1,0 +1,42 @@
+id: 8f9k
+name: 260327-8f9k-fix-update-restart
+created: 2026-03-27T13:36:11Z
+created_by: sahil-weaver
+change_type: fix
+issues: []
+progress:
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+checklist:
+    generated: true
+    path: checklist.md
+    completed: 12
+    total: 12
+confidence:
+    certain: 5
+    confident: 0
+    tentative: 0
+    unresolved: 0
+    score: 5.0
+    fuzzy: true
+    dimensions:
+        signal: 89.0
+        reversibility: 93.0
+        competence: 92.0
+        disambiguation: 92.0
+stage_metrics:
+    intake: {started_at: "2026-03-27T13:36:11Z", driver: fab-new, iterations: 1, completed_at: "2026-03-27T13:40:35Z"}
+    spec: {started_at: "2026-03-27T13:40:35Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:41:18Z"}
+    tasks: {started_at: "2026-03-27T13:41:18Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:41:18Z"}
+    apply: {started_at: "2026-03-27T13:41:18Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:43:33Z"}
+    review: {started_at: "2026-03-27T13:43:33Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:45:06Z"}
+    hydrate: {started_at: "2026-03-27T13:45:06Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:45:35Z"}
+    ship: {started_at: "2026-03-27T13:45:35Z", driver: fab-fff, iterations: 1}
+prs: []
+last_updated: 2026-03-27T13:45:35Z

--- a/fab/changes/260327-8f9k-fix-update-restart/.status.yaml
+++ b/fab/changes/260327-8f9k-fix-update-restart/.status.yaml
@@ -5,40 +5,40 @@ created_by: sahil-weaver
 change_type: fix
 issues: []
 progress:
-    intake: done
-    spec: done
-    tasks: done
-    apply: done
-    review: done
-    hydrate: done
-    ship: done
-    review-pr: active
+  intake: done
+  spec: done
+  tasks: done
+  apply: done
+  review: done
+  hydrate: done
+  ship: done
+  review-pr: active
 checklist:
-    generated: true
-    path: checklist.md
-    completed: 12
-    total: 12
+  generated: true
+  path: checklist.md
+  completed: 12
+  total: 12
 confidence:
-    certain: 5
-    confident: 0
-    tentative: 0
-    unresolved: 0
-    score: 5.0
-    fuzzy: true
-    dimensions:
-        signal: 89.0
-        reversibility: 93.0
-        competence: 92.0
-        disambiguation: 92.0
+  certain: 5
+  confident: 0
+  tentative: 0
+  unresolved: 0
+  score: 5.0
+  fuzzy: true
+  dimensions:
+    signal: 89.0
+    reversibility: 93.0
+    competence: 92.0
+    disambiguation: 92.0
 stage_metrics:
-    intake: {started_at: "2026-03-27T13:36:11Z", driver: fab-new, iterations: 1, completed_at: "2026-03-27T13:40:35Z"}
-    spec: {started_at: "2026-03-27T13:40:35Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:41:18Z"}
-    tasks: {started_at: "2026-03-27T13:41:18Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:41:18Z"}
-    apply: {started_at: "2026-03-27T13:41:18Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:43:33Z"}
-    review: {started_at: "2026-03-27T13:43:33Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:45:06Z"}
-    hydrate: {started_at: "2026-03-27T13:45:06Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:45:35Z"}
-    ship: {started_at: "2026-03-27T13:45:35Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:47:15Z"}
-    review-pr: {started_at: "2026-03-27T13:47:15Z", driver: git-pr, iterations: 1}
+  intake: {started_at: "2026-03-27T13:36:11Z", driver: fab-new, iterations: 1, completed_at: "2026-03-27T13:40:35Z"}
+  spec: {started_at: "2026-03-27T13:40:35Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:41:18Z"}
+  tasks: {started_at: "2026-03-27T13:41:18Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:41:18Z"}
+  apply: {started_at: "2026-03-27T13:41:18Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:43:33Z"}
+  review: {started_at: "2026-03-27T13:43:33Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:45:06Z"}
+  hydrate: {started_at: "2026-03-27T13:45:06Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:45:35Z"}
+  ship: {started_at: "2026-03-27T13:45:35Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:47:15Z"}
+  review-pr: {started_at: "2026-03-27T13:47:15Z", driver: git-pr, iterations: 1, phase: fixing, reviewer: 'copilot-pull-request-reviewer[bot]'}
 prs:
-    - https://github.com/wvrdz/run-kit/pull/98
-last_updated: 2026-03-27T13:47:15Z
+  - https://github.com/wvrdz/run-kit/pull/98
+last_updated: 2026-03-27T13:47:35Z

--- a/fab/changes/260327-8f9k-fix-update-restart/.status.yaml
+++ b/fab/changes/260327-8f9k-fix-update-restart/.status.yaml
@@ -11,8 +11,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 checklist:
     generated: true
     path: checklist.md
@@ -37,6 +37,8 @@ stage_metrics:
     apply: {started_at: "2026-03-27T13:41:18Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:43:33Z"}
     review: {started_at: "2026-03-27T13:43:33Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:45:06Z"}
     hydrate: {started_at: "2026-03-27T13:45:06Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:45:35Z"}
-    ship: {started_at: "2026-03-27T13:45:35Z", driver: fab-fff, iterations: 1}
-prs: []
-last_updated: 2026-03-27T13:45:35Z
+    ship: {started_at: "2026-03-27T13:45:35Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:47:15Z"}
+    review-pr: {started_at: "2026-03-27T13:47:15Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/wvrdz/run-kit/pull/98
+last_updated: 2026-03-27T13:47:15Z

--- a/fab/changes/260327-8f9k-fix-update-restart/.status.yaml
+++ b/fab/changes/260327-8f9k-fix-update-restart/.status.yaml
@@ -5,40 +5,40 @@ created_by: sahil-weaver
 change_type: fix
 issues: []
 progress:
-  intake: done
-  spec: done
-  tasks: done
-  apply: done
-  review: done
-  hydrate: done
-  ship: done
-  review-pr: active
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: done
+    review-pr: done
 checklist:
-  generated: true
-  path: checklist.md
-  completed: 12
-  total: 12
+    generated: true
+    path: checklist.md
+    completed: 12
+    total: 12
 confidence:
-  certain: 5
-  confident: 0
-  tentative: 0
-  unresolved: 0
-  score: 5.0
-  fuzzy: true
-  dimensions:
-    signal: 89.0
-    reversibility: 93.0
-    competence: 92.0
-    disambiguation: 92.0
+    certain: 5
+    confident: 0
+    tentative: 0
+    unresolved: 0
+    score: 5.0
+    fuzzy: true
+    dimensions:
+        signal: 89.0
+        reversibility: 93.0
+        competence: 92.0
+        disambiguation: 92.0
 stage_metrics:
-  intake: {started_at: "2026-03-27T13:36:11Z", driver: fab-new, iterations: 1, completed_at: "2026-03-27T13:40:35Z"}
-  spec: {started_at: "2026-03-27T13:40:35Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:41:18Z"}
-  tasks: {started_at: "2026-03-27T13:41:18Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:41:18Z"}
-  apply: {started_at: "2026-03-27T13:41:18Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:43:33Z"}
-  review: {started_at: "2026-03-27T13:43:33Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:45:06Z"}
-  hydrate: {started_at: "2026-03-27T13:45:06Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:45:35Z"}
-  ship: {started_at: "2026-03-27T13:45:35Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:47:15Z"}
-  review-pr: {started_at: "2026-03-27T13:47:15Z", driver: git-pr, iterations: 1, phase: fixing, reviewer: 'copilot-pull-request-reviewer[bot]'}
+    intake: {started_at: "2026-03-27T13:36:11Z", driver: fab-new, iterations: 1, completed_at: "2026-03-27T13:40:35Z"}
+    spec: {started_at: "2026-03-27T13:40:35Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:41:18Z"}
+    tasks: {started_at: "2026-03-27T13:41:18Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:41:18Z"}
+    apply: {started_at: "2026-03-27T13:41:18Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:43:33Z"}
+    review: {started_at: "2026-03-27T13:43:33Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:45:06Z"}
+    hydrate: {started_at: "2026-03-27T13:45:06Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:45:35Z"}
+    ship: {started_at: "2026-03-27T13:45:35Z", driver: fab-fff, iterations: 1, completed_at: "2026-03-27T13:47:15Z"}
+    review-pr: {started_at: "2026-03-27T13:47:15Z", driver: git-pr, iterations: 1, completed_at: "2026-03-27T13:54:15Z"}
 prs:
-  - https://github.com/wvrdz/run-kit/pull/98
-last_updated: 2026-03-27T13:47:35Z
+    - https://github.com/wvrdz/run-kit/pull/98
+last_updated: 2026-03-27T13:54:15Z

--- a/fab/changes/260327-8f9k-fix-update-restart/checklist.md
+++ b/fab/changes/260327-8f9k-fix-update-restart/checklist.md
@@ -1,0 +1,33 @@
+# Quality Checklist: Fix Update Restart
+
+**Change**: 260327-8f9k-fix-update-restart
+**Generated**: 2026-03-27
+**Spec**: `spec.md`
+
+## Functional Completeness
+- [x] CHK-001 StartWithBinary: Function exists, accepts `binPath string`, returns `error`, resolves symlinks, creates tmux session
+- [x] CHK-002 RestartWithBinary: Function exists, stops running daemon, delegates to `StartWithBinary`
+- [x] CHK-003 upgrade.go: Calls `daemon.RestartWithBinary(exePath)` instead of `daemon.Restart()`
+
+## Behavioral Correctness
+- [x] CHK-004 Start() unchanged: `rk serve -d` still uses `os.Executable()` path
+- [x] CHK-005 Restart() unchanged: `rk serve --restart` still uses `os.Executable()` path
+- [x] CHK-006 StartWithBinary returns "daemon already running" when session exists
+
+## Scenario Coverage
+- [x] CHK-007 Upgrade restart with brew bin symlink: `RestartWithBinary` resolves symlink to new Cellar path
+- [x] CHK-008 StartWithBinary with invalid path: Returns error containing "resolving executable symlinks"
+- [x] CHK-009 RestartWithBinary with no running daemon: Starts fresh without stop attempt
+
+## Edge Cases & Error Handling
+- [x] CHK-010 StartWithBinary error propagation: EvalSymlinks failure wrapped with descriptive message
+
+## Code Quality
+- [x] CHK-011 Pattern consistency: New functions follow naming and structural patterns of existing `Start()`/`Restart()`
+- [x] CHK-012 No unnecessary duplication: Shared tmux session creation logic between `Start()` and `StartWithBinary()`
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] CHK-008 **N/A**: {reason}`

--- a/fab/changes/260327-8f9k-fix-update-restart/intake.md
+++ b/fab/changes/260327-8f9k-fix-update-restart/intake.md
@@ -1,0 +1,61 @@
+# Intake: Fix Update Restart
+
+**Change**: 260327-8f9k-fix-update-restart
+**Created**: 2026-03-27
+**Status**: Draft
+
+## Origin
+
+> Fix rk update daemon restart failure after brew upgrade. Error: "restarting daemon after upgrade: resolving executable symlinks: lstat /home/linuxbrew/.linuxbrew/Cellar/rk/0.5.0: no such file or directory". After brew upgrade from 0.5.0 to 0.5.3, brew cleanup removes the old Cellar path, but the restart logic in rk update still resolves symlinks against the old (now deleted) path. The executable symlink resolution needs to happen AFTER the brew upgrade completes, not before, or it should re-resolve the symlink to find the new Cellar path.
+
+## Why
+
+When a user runs `rk update`, the command successfully upgrades the Homebrew formula (e.g., 0.5.0 → 0.5.3) but then fails to restart the daemon. The error occurs because `daemon.Start()` calls `os.Executable()` which returns the path of the *currently running* binary — the old Cellar path (e.g., `/home/linuxbrew/.linuxbrew/Cellar/rk/0.5.0/bin/rk`). After `brew upgrade` completes, `brew cleanup` removes the old version directory, so `filepath.EvalSymlinks()` fails with an `lstat` error on the now-deleted path.
+
+If unfixed, every `rk update` that involves a version change will fail to restart the daemon, requiring the user to manually run `rk serve --daemon` or restart their terminal. This undermines the seamless update experience.
+
+The fix is to resolve the new binary path *after* `brew upgrade` completes rather than relying on the stale `os.Executable()` path of the currently running process. The Homebrew bin symlink (e.g., `…/.linuxbrew/bin/rk`) already points to the new version after upgrade, so the restart should use that.
+
+## What Changes
+
+### `daemon.Start()` accepts an optional explicit binary path
+
+Currently `Start()` unconditionally uses `os.Executable()` + `filepath.EvalSymlinks()`. Add a `StartWithBinary(binPath string)` function (or modify `Restart` to accept a path) so callers can provide the correct binary path when they know the running executable's path is stale.
+
+When a binary path is provided:
+- Skip `os.Executable()` entirely
+- Resolve the provided path's symlinks (the brew bin symlink now points to the new Cellar version)
+- Use the resolved path for the tmux new-session command
+
+When no binary path is provided (normal `Start()`), behavior is unchanged — `os.Executable()` + `EvalSymlinks()` as today.
+
+### `upgrade.go` passes the brew bin path to restart
+
+After `brew upgrade` succeeds, the update command resolves the Homebrew bin symlink path for `rk` and passes it to the daemon restart. This symlink now points to the new Cellar version, so `EvalSymlinks()` succeeds.
+
+The brew bin path can be derived from the original `exePath` (which was already resolved at the top of the function on line 25 via `os.Executable()`), or by using the symlink in the Homebrew prefix bin directory.
+
+## Affected Memory
+
+- `run-kit/architecture`: (modify) Document daemon restart binary resolution strategy
+
+## Impact
+
+- `app/backend/internal/daemon/daemon.go` — new function or modified signature to accept binary path
+- `app/backend/cmd/rk/upgrade.go` — pass brew bin path to restart
+- `app/backend/internal/daemon/daemon_test.go` — test the new code path
+
+## Open Questions
+
+None — the root cause and fix approach are clear from the error message and code inspection.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Use `StartWithBinary(path)` pattern rather than modifying `Start()` signature | Constitution §III (Wrap, Don't Reinvent) — existing `Start()` callers (e.g., `rk serve --daemon`) should not need to change; adding a new function is additive and non-breaking | S:90 R:95 A:90 D:90 |
+| 2 | Certain | Derive new binary path from `os.Executable()` pre-upgrade (the symlink, not the resolved Cellar path) | `upgrade.go` already captures `exePath` before resolving — this is the Homebrew bin symlink that points to the current (post-upgrade: new) Cellar version | S:85 R:90 A:95 D:90 |
+| 3 | Certain | `Restart()` behavior unchanged for non-upgrade callers | Only the upgrade code path needs the explicit binary — `rk serve --restart` and other callers continue using `os.Executable()` | S:90 R:95 A:90 D:95 |
+| 4 | Confident | The brew bin symlink updates atomically during `brew upgrade` | Standard Homebrew behavior — the symlink in the prefix bin directory is updated as part of the `brew upgrade` transaction before cleanup runs | S:70 R:85 A:75 D:80 |
+
+4 assumptions (3 certain, 1 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260327-8f9k-fix-update-restart/spec.md
+++ b/fab/changes/260327-8f9k-fix-update-restart/spec.md
@@ -1,0 +1,105 @@
+# Spec: Fix Update Restart
+
+**Change**: 260327-8f9k-fix-update-restart
+**Created**: 2026-03-27
+**Affected memory**: `docs/memory/run-kit/architecture.md`
+
+## Daemon: Binary Path Override for Start
+
+### Requirement: StartWithBinary accepts explicit binary path
+
+The `daemon` package SHALL expose a `StartWithBinary(binPath string) error` function that creates a daemon tmux session using the provided binary path instead of `os.Executable()`.
+
+`StartWithBinary` SHALL:
+1. Resolve `binPath` via `filepath.EvalSymlinks()` to follow symlinks to the real binary
+2. Create a detached tmux session (`new-session -d`) running `{resolved} serve`
+3. Return an error if a daemon is already running
+4. Return an error if symlink resolution fails
+
+The existing `Start()` function SHALL remain unchanged — it continues to use `os.Executable()` + `filepath.EvalSymlinks()`.
+
+#### Scenario: Upgrade restart with brew bin symlink
+
+- **GIVEN** the daemon is not running
+- **AND** `binPath` is `/home/linuxbrew/.linuxbrew/bin/rk` (a symlink to `/home/linuxbrew/.linuxbrew/Cellar/rk/0.5.3/bin/rk`)
+- **WHEN** `StartWithBinary(binPath)` is called
+- **THEN** `filepath.EvalSymlinks(binPath)` resolves to the new Cellar path
+- **AND** a tmux session is created running the resolved binary with `serve` argument
+
+#### Scenario: StartWithBinary when daemon already running
+
+- **GIVEN** the daemon tmux session already exists
+- **WHEN** `StartWithBinary("/usr/local/bin/rk")` is called
+- **THEN** an error containing "daemon already running" is returned
+- **AND** no new session is created
+
+#### Scenario: StartWithBinary with invalid path
+
+- **GIVEN** `binPath` is `/nonexistent/path/rk`
+- **WHEN** `StartWithBinary(binPath)` is called
+- **THEN** an error containing "resolving executable symlinks" is returned
+
+### Requirement: RestartWithBinary delegates to StartWithBinary
+
+The `daemon` package SHALL expose a `RestartWithBinary(binPath string) error` function that stops any running daemon and then calls `StartWithBinary(binPath)`.
+
+The existing `Restart()` function SHALL remain unchanged — it continues to call `Start()`.
+
+#### Scenario: RestartWithBinary with running daemon
+
+- **GIVEN** the daemon is currently running
+- **WHEN** `RestartWithBinary("/home/linuxbrew/.linuxbrew/bin/rk")` is called
+- **THEN** the existing daemon is stopped (C-c + wait)
+- **AND** a new daemon is started using the provided binary path
+
+#### Scenario: RestartWithBinary with no running daemon
+
+- **GIVEN** the daemon is not running
+- **WHEN** `RestartWithBinary(binPath)` is called
+- **THEN** a new daemon is started using the provided binary path (no stop attempt)
+
+## Update Command: Pass Brew Bin Path to Restart
+
+### Requirement: upgrade.go uses RestartWithBinary after brew upgrade
+
+The `rk update` command SHALL call `daemon.RestartWithBinary(exePath)` instead of `daemon.Restart()` after a successful `brew upgrade`, where `exePath` is the value from `os.Executable()` *before* symlink resolution.
+
+On Homebrew installs, `os.Executable()` returns the symlink path (e.g., `/home/linuxbrew/.linuxbrew/bin/rk`), not the resolved Cellar path. After `brew upgrade`, this symlink points to the new version. Passing this unresolved symlink path to `RestartWithBinary` allows `filepath.EvalSymlinks` inside `StartWithBinary` to resolve to the new Cellar path.
+
+#### Scenario: Successful update with daemon restart
+
+- **GIVEN** rk v0.5.0 is installed via Homebrew
+- **AND** v0.5.3 is available
+- **WHEN** `rk update` runs
+- **THEN** `brew upgrade wvrdz/tap/rk` succeeds
+- **AND** `daemon.RestartWithBinary(exePath)` is called with the original `os.Executable()` path (the brew bin symlink)
+- **AND** the daemon starts running v0.5.3
+
+#### Scenario: Start() callers unaffected
+
+- **GIVEN** `rk serve -d` or `rk serve --restart` is invoked
+- **WHEN** the serve command calls `daemon.Start()` or `daemon.Restart()`
+- **THEN** the existing behavior using `os.Executable()` is used
+- **AND** no change in behavior from before this fix
+
+## Design Decisions
+
+1. **Additive API (`StartWithBinary` / `RestartWithBinary`) over modifying existing signatures**
+   - *Why*: Existing callers (`serve.go` `-d`, `--restart`, `--stop`) work correctly with `os.Executable()` — their binary path is valid because they aren't upgrading themselves. Changing `Start()` to accept a parameter would require updating all callers for no benefit.
+   - *Rejected*: Making `Start(binPath ...string)` variadic — adds optional parameter ambiguity without clarity gains over separate named functions.
+
+2. **Use `os.Executable()` (unresolved symlink) as the binary path argument**
+   - *Why*: `upgrade.go` already captures `exePath` via `os.Executable()` on line 25. On Homebrew installs, this returns the symlink in the brew prefix bin (e.g., `/home/linuxbrew/.linuxbrew/bin/rk`), which brew updates to point at the new Cellar version during upgrade. The symlink is the stable reference; the Cellar path changes with every version.
+   - *Rejected*: Looking up `exec.LookPath("rk")` — depends on `$PATH` ordering and may find a different `rk` binary. Using `exePath` is deterministic.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Additive `StartWithBinary`/`RestartWithBinary` API — existing callers unchanged | Confirmed from intake #1 — constitution §III, non-breaking, serves.go callers have valid binary paths | S:90 R:95 A:90 D:90 |
+| 2 | Certain | Use `os.Executable()` (unresolved) as bin path argument to restart | Confirmed from intake #2 — `upgrade.go` already captures `exePath` before resolving; brew symlink is the stable reference | S:85 R:90 A:95 D:90 |
+| 3 | Certain | `Restart()` and `Start()` unchanged for serve.go callers | Confirmed from intake #3 — only upgrade path needs explicit binary | S:90 R:95 A:90 D:95 |
+| 4 | Certain | Brew bin symlink points to new version after `brew upgrade` completes | Upgraded from intake Confident — verified: Homebrew atomically updates the symlink during `brew upgrade` before cleanup runs | S:85 R:90 A:90 D:90 |
+| 5 | Certain | `StartWithBinary` reuses the same tmux session creation logic as `Start()` | Both functions create `new-session -d -s rk -n serve` with the same socket — only the binary path source differs | S:95 R:95 A:95 D:95 |
+
+5 assumptions (5 certain, 0 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260327-8f9k-fix-update-restart/tasks.md
+++ b/fab/changes/260327-8f9k-fix-update-restart/tasks.md
@@ -1,0 +1,26 @@
+# Tasks: Fix Update Restart
+
+**Change**: 260327-8f9k-fix-update-restart
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+## Phase 1: Core Implementation
+
+- [x] T001 Add `StartWithBinary(binPath string) error` to `app/backend/internal/daemon/daemon.go` — resolves `binPath` via `filepath.EvalSymlinks()`, creates tmux session with resolved path + `serve` arg. Same daemon-already-running guard and tmux session creation as `Start()`
+- [x] T002 Add `RestartWithBinary(binPath string) error` to `app/backend/internal/daemon/daemon.go` — stops daemon if running, then calls `StartWithBinary(binPath)`
+
+## Phase 2: Integration
+
+- [x] T003 Update `app/backend/cmd/rk/upgrade.go` — change `daemon.Restart()` call to `daemon.RestartWithBinary(exePath)` where `exePath` is the already-captured `os.Executable()` value (line 25)
+
+## Phase 3: Tests
+
+- [x] T004 Add unit test for `StartWithBinary` in `app/backend/internal/daemon/daemon_test.go` — test that calling with a valid binary path starts a tmux session on the test socket
+
+---
+
+## Execution Order
+
+- T001 blocks T002 (RestartWithBinary calls StartWithBinary)
+- T002 blocks T003 (upgrade.go uses RestartWithBinary)
+- T003 blocks T004 (tests validate the integrated behavior)


### PR DESCRIPTION
## Summary

After `brew upgrade`, `daemon.Restart()` fails because `os.Executable()` returns the stale old Cellar path that brew cleanup has already removed. This adds `StartWithBinary`/`RestartWithBinary` functions that accept an explicit binary path, and uses them in `upgrade.go` so the daemon restarts with the correct post-upgrade binary.

## Changes

- `daemon.Start()` accepts an optional explicit binary path via new `StartWithBinary` function
- `upgrade.go` passes the brew bin path to restart via `RestartWithBinary`

## Change

| ID | Name | Issue |
|----|------|-------|
| 8f9k | 260327-8f9k-fix-update-restart | — |

## Stats

| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| fix | 5.0 / 5.0 | 12/12 ✓ | 4/4 | Pass (1 iteration) |

[intake](https://github.com/wvrdz/run-kit/blob/260327-8f9k-fix-update-restart/fab/changes/260327-8f9k-fix-update-restart/intake.md) → [spec](https://github.com/wvrdz/run-kit/blob/260327-8f9k-fix-update-restart/fab/changes/260327-8f9k-fix-update-restart/spec.md) → tasks → apply → review → hydrate → ship