### PR TITLE
feat: ctrl+click force kill window/session

### DIFF
--- a/app/frontend/src/components/sidebar.tsx
+++ b/app/frontend/src/components/sidebar.tsx
@@ -175,13 +175,17 @@ export function Sidebar({
                       +
                     </button>
                     <button
-                      onClick={() =>
+                      onClick={(e) => {
+                        if (e.ctrlKey || e.metaKey) {
+                          killSessionApi(session.name).catch(() => {});
+                          return;
+                        }
                         setKillTarget({
                           type: "session",
                           session: session.name,
                           windowCount: session.windows.length,
-                        })
-                      }
+                        });
+                      }}
                       aria-label={`Kill session ${session.name}`}
                       className="text-text-secondary hover:text-red-400 transition-colors text-[16px] px-1 min-h-[36px] flex items-center justify-center"
                     >
@@ -262,6 +266,10 @@ export function Sidebar({
                             aria-label={`Kill window ${win.name}`}
                             onClick={(e) => {
                               e.stopPropagation();
+                              if (e.ctrlKey || e.metaKey) {
+                                killWindowApi(session.name, win.index).catch(() => {});
+                                return;
+                              }
                               setKillTarget({
                                 type: "window",
                                 session: session.name,

--- a/docs/memory/run-kit/ui-patterns.md
+++ b/docs/memory/run-kit/ui-patterns.md
@@ -113,7 +113,10 @@ Connection indicator: green/gray dot only (no text label), driven by `isConnecte
 
 ### Sidebar Kill Controls
 
-- **Session row ✕**: Always-visible ✕ button on session rows with red hover. Click opens confirmation dialog: "Kill session **{name}** and all {N} windows?"
+- **Session row ✕**: Always-visible ✕ button on session rows with red hover. Normal click opens confirmation dialog: "Kill session **{name}** and all {N} windows?" **Ctrl+Click / Cmd+Click** bypasses the confirmation dialog and kills immediately (best-effort `.catch(() => {})`).
+- **Window row ✕**: Hover-reveal ✕ button on window rows (always visible on touch devices via `coarse:opacity-100`). Normal click opens confirmation dialog: "Kill window in **{session}**?" **Ctrl+Click / Cmd+Click** bypasses the confirmation dialog and kills immediately (best-effort `.catch(() => {})`).
+
+The Ctrl+Click force-kill pattern matches the established "modifier = power action" convention: ThemeToggle uses Ctrl+Click to open the theme selector instead of cycling. Modifier detection uses `e.ctrlKey || e.metaKey` (Ctrl on Linux/Windows, Cmd on macOS).
 
 ## Sidebar
 

--- a/fab/changes/260403-d3i1-ctrl-click-force-kill-window/.history.jsonl
+++ b/fab/changes/260403-d3i1-ctrl-click-force-kill-window/.history.jsonl
@@ -1,0 +1,13 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-04-03T13:20:24Z"}
+{"args":"Right now when you close a window by clicking on the x mark next to it, there is a pop-up which says Are you sure you want to close or Are you sure you want to kill this window Kill/Cancel. Now if the user is pressing control while clicking on the x mark, we should not have a pop-up like this. We should force kill the window or the session.","cmd":"fab-new","event":"command","ts":"2026-04-03T13:20:24Z"}
+{"delta":"+4.4","event":"confidence","score":4.4,"trigger":"calc-score","ts":"2026-04-03T13:21:05Z"}
+{"delta":"+0.0","event":"confidence","score":4.4,"trigger":"calc-score","ts":"2026-04-03T13:21:14Z"}
+{"cmd":"fab-fff","event":"command","ts":"2026-04-03T13:22:43Z"}
+{"delta":"-1.3","event":"confidence","score":3.1,"trigger":"calc-score","ts":"2026-04-03T13:23:25Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"spec","ts":"2026-04-03T13:23:29Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"tasks","ts":"2026-04-03T13:24:05Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-04-03T13:24:05Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-04-03T13:25:35Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-04-03T13:26:00Z"}
+{"event":"review","result":"passed","ts":"2026-04-03T13:26:00Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-04-03T13:26:31Z"}

--- a/fab/changes/260403-d3i1-ctrl-click-force-kill-window/.status.yaml
+++ b/fab/changes/260403-d3i1-ctrl-click-force-kill-window/.status.yaml
@@ -1,0 +1,42 @@
+id: d3i1
+name: 260403-d3i1-ctrl-click-force-kill-window
+created: 2026-04-03T13:20:24Z
+created_by: sahil-weaver
+change_type: feat
+issues: []
+progress:
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+checklist:
+    generated: true
+    path: checklist.md
+    completed: 13
+    total: 13
+confidence:
+    certain: 3
+    confident: 2
+    tentative: 0
+    unresolved: 0
+    score: 3.1
+    fuzzy: true
+    dimensions:
+        signal: 81.3
+        reversibility: 91.3
+        competence: 88.8
+        disambiguation: 88.8
+stage_metrics:
+    intake: {started_at: "2026-04-03T13:20:24Z", driver: fab-new, iterations: 1, completed_at: "2026-04-03T13:23:29Z"}
+    spec: {started_at: "2026-04-03T13:23:29Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-03T13:24:05Z"}
+    tasks: {started_at: "2026-04-03T13:24:05Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-03T13:24:05Z"}
+    apply: {started_at: "2026-04-03T13:24:05Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-03T13:25:35Z"}
+    review: {started_at: "2026-04-03T13:25:35Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-03T13:26:00Z"}
+    hydrate: {started_at: "2026-04-03T13:26:00Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-03T13:26:31Z"}
+    ship: {started_at: "2026-04-03T13:26:31Z", driver: fab-fff, iterations: 1}
+prs: []
+last_updated: 2026-04-03T13:26:31Z

--- a/fab/changes/260403-d3i1-ctrl-click-force-kill-window/checklist.md
+++ b/fab/changes/260403-d3i1-ctrl-click-force-kill-window/checklist.md
@@ -1,0 +1,39 @@
+# Quality Checklist: Ctrl+Click Force Kill Window
+
+**Change**: 260403-d3i1-ctrl-click-force-kill-window
+**Generated**: 2026-04-03
+**Spec**: `spec.md`
+
+## Functional Completeness
+
+- [x] CHK-001 Window kill button Ctrl+Click bypass: Ctrl/Cmd+clicking window × calls `killWindowApi` directly without confirmation dialog
+- [x] CHK-002 Session kill button Ctrl+Click bypass: Ctrl/Cmd+clicking session × calls `killSessionApi` directly without confirmation dialog
+- [x] CHK-003 No backend changes: Kill API endpoints are unmodified
+- [x] CHK-004 No top bar changes: `ClosePaneButton` is unmodified
+
+## Behavioral Correctness
+
+- [x] CHK-005 Normal click preserved (window): Clicking window × without modifier still shows confirmation dialog
+- [x] CHK-006 Normal click preserved (session): Clicking session × without modifier still shows confirmation dialog
+
+## Scenario Coverage
+
+- [x] CHK-007 Ctrl+Click kills window immediately: Verify no dialog appears and kill API is invoked
+- [x] CHK-008 Ctrl+Click kills session immediately: Verify no dialog appears and kill API is invoked
+- [x] CHK-009 Normal click shows confirmation: Verify dialog appears for both session and window × buttons
+
+## Edge Cases & Error Handling
+
+- [x] CHK-010 Best-effort error handling: Force kill uses `.catch(() => {})` — API errors don't surface to user (SSE reflects actual state)
+- [x] CHK-011 Event propagation: Window × Ctrl+Click does not trigger window selection (parent button click)
+
+## Code Quality
+
+- [x] CHK-012 Pattern consistency: Modifier detection uses `e.ctrlKey || e.metaKey` matching ThemeToggle pattern
+- [x] CHK-013 No unnecessary duplication: Reuses existing `killWindowApi` and `killSessionApi` imports
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] CHK-008 **N/A**: {reason}`

--- a/fab/changes/260403-d3i1-ctrl-click-force-kill-window/intake.md
+++ b/fab/changes/260403-d3i1-ctrl-click-force-kill-window/intake.md
@@ -1,0 +1,83 @@
+# Intake: Ctrl+Click Force Kill Window
+
+**Change**: 260403-d3i1-ctrl-click-force-kill-window
+**Created**: 2026-04-03
+**Status**: Draft
+
+## Origin
+
+> Right now when you close a window by clicking on the x mark next to it, there is a pop-up which says "Are you sure you want to close" or "Are you sure you want to kill this window? Kill/Cancel". Now if the user is pressing control while clicking on the x mark, we should not have a pop-up like this. We should force kill the window or the session.
+
+One-shot request. No prior conversation or design discussion.
+
+## Why
+
+The sidebar kill buttons (× next to sessions and windows) always show a confirmation dialog before killing. This is a safety feature that prevents accidental destruction, but it adds friction for users who are confident about what they want to kill. Power users who hold Ctrl while clicking are signaling explicit intent — they want the action to happen immediately without interruption.
+
+This follows the same modifier-key pattern already established in the codebase: the ThemeToggle uses Ctrl+Click/Cmd+Click to open the theme selector instead of cycling themes. Extending this convention to kill buttons creates a consistent "Ctrl+Click = power action" mental model.
+
+Without this change, users must always click twice (× then "Kill") to destroy a session or window from the sidebar, even when they're certain about the action.
+
+## What Changes
+
+### Sidebar × Buttons — Bypass Confirmation on Ctrl+Click
+
+The two × buttons in the sidebar (`sidebar.tsx`) currently set a `killTarget` state that triggers a confirmation dialog. When the user holds Ctrl (or Cmd on macOS) while clicking:
+
+1. **Window × button** (line ~260-275 in `sidebar.tsx`): Instead of setting `killTarget`, directly call `killWindowApi(sessionName, windowIndex)` and return. No dialog shown.
+
+2. **Session × button** (line ~177-189 in `sidebar.tsx`): Instead of setting `killTarget`, directly call `killSessionApi(sessionName)` and return. No dialog shown.
+
+The detection is straightforward — check `event.ctrlKey || event.metaKey` in the click handler before setting `killTarget`. If the modifier is held, execute the kill immediately; otherwise, fall through to the existing confirmation flow.
+
+### Implementation Pattern
+
+```tsx
+// Window kill button click handler
+onClick={(e) => {
+  if (e.ctrlKey || e.metaKey) {
+    // Force kill — no confirmation
+    killWindowApi(session.name, window.index)
+    return
+  }
+  // Existing behavior — show confirmation dialog
+  setKillTarget({ type: 'window', session: session.name, index: window.index, windowCount: session.windows.length })
+}}
+```
+
+Same pattern for the session × button, calling `killSessionApi(session.name)` instead.
+
+### No Backend Changes
+
+The backend `handleWindowKill()` and `handleClosePaneKill()` endpoints already perform the kill unconditionally — the confirmation is purely a frontend concern. No API changes needed.
+
+### No Top Bar Changes
+
+The `ClosePaneButton` in the top bar already kills without confirmation (best-effort, `.catch(() => {})`). This change only affects the sidebar × buttons that currently show the confirmation dialog.
+
+## Affected Memory
+
+- `run-kit/ui-patterns`: (modify) Document the Ctrl+Click force-kill behavior on sidebar × buttons and the broader "Ctrl+Click = power action" convention.
+
+## Impact
+
+- **Frontend only**: `app/frontend/src/components/sidebar.tsx` — modify click handlers for session and window × buttons
+- **No backend changes**: existing kill APIs are unchanged
+- **No new dependencies**: uses native `MouseEvent.ctrlKey` / `MouseEvent.metaKey`
+- **Risk**: Low — additive behavior; default (non-modifier) click flow is unchanged
+
+## Open Questions
+
+None — the scope is clear and the implementation pattern is established.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Use `ctrlKey \|\| metaKey` for modifier detection | Matches existing ThemeToggle pattern in the codebase (top-bar.tsx line ~258-273) | S:90 R:95 A:95 D:95 |
+| 2 | Certain | No backend changes needed | Kill endpoints already execute unconditionally; confirmation is frontend-only | S:85 R:95 A:95 D:95 |
+| 3 | Certain | No top bar ClosePaneButton changes | It already kills without confirmation — out of scope | S:90 R:95 A:95 D:95 |
+| 4 | Confident | Best-effort error handling on force kill (`.catch(() => {})`) | Matches existing patterns (ClosePaneButton, split buttons) — SSE reflects actual state | S:70 R:90 A:85 D:80 |
+| 5 | Confident | Apply to both session × and window × buttons | User said "window or session" — both sidebar × buttons get the same treatment | S:80 R:85 A:80 D:85 |
+
+5 assumptions (3 certain, 2 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260403-d3i1-ctrl-click-force-kill-window/spec.md
+++ b/fab/changes/260403-d3i1-ctrl-click-force-kill-window/spec.md
@@ -1,0 +1,74 @@
+# Spec: Ctrl+Click Force Kill Window
+
+**Change**: 260403-d3i1-ctrl-click-force-kill-window
+**Created**: 2026-04-03
+**Affected memory**: `docs/memory/run-kit/ui-patterns.md`
+
+## Sidebar: Ctrl+Click Force Kill
+
+### Requirement: Window Kill Button Ctrl+Click Bypass
+
+The sidebar window × button (`sidebar.tsx`, positioned as an absolute overlay on each window row) SHALL check for `ctrlKey || metaKey` on the click event. When a modifier is held, the button SHALL call `killWindowApi(session, windowIndex)` directly with best-effort error handling (`.catch(() => {})`), stop event propagation, and return — bypassing the `setKillTarget` confirmation flow entirely.
+
+When no modifier is held, the existing behavior SHALL be preserved: `setKillTarget` is called, which opens the kill confirmation dialog.
+
+#### Scenario: Ctrl+Click kills window immediately
+- **GIVEN** a sidebar with a visible window × button
+- **WHEN** the user Ctrl+clicks (or Cmd+clicks on macOS) the × button
+- **THEN** `killWindowApi` is called immediately with the session name and window index
+- **AND** no confirmation dialog is shown
+- **AND** the click event does not propagate to the parent window-select button
+
+#### Scenario: Normal click shows confirmation
+- **GIVEN** a sidebar with a visible window × button
+- **WHEN** the user clicks the × button without holding Ctrl/Cmd
+- **THEN** the existing kill confirmation dialog is shown
+- **AND** no API call is made until the user confirms
+
+### Requirement: Session Kill Button Ctrl+Click Bypass
+
+The sidebar session × button (`sidebar.tsx`, inline in the session row header) SHALL check for `ctrlKey || metaKey` on the click event. When a modifier is held, the button SHALL call `killSessionApi(session)` directly with best-effort error handling (`.catch(() => {})`), and return — bypassing the `setKillTarget` confirmation flow entirely.
+
+When no modifier is held, the existing behavior SHALL be preserved.
+
+#### Scenario: Ctrl+Click kills session immediately
+- **GIVEN** a sidebar with a visible session × button
+- **WHEN** the user Ctrl+clicks (or Cmd+clicks on macOS) the × button
+- **THEN** `killSessionApi` is called immediately with the session name
+- **AND** no confirmation dialog is shown
+
+#### Scenario: Normal click shows confirmation
+- **GIVEN** a sidebar with a visible session × button
+- **WHEN** the user clicks the × button without holding Ctrl/Cmd
+- **THEN** the existing kill confirmation dialog is shown
+
+### Requirement: No Backend Changes
+
+The backend kill endpoints (`handleWindowKill`, `handleClosePaneKill`) SHALL NOT be modified. The confirmation bypass is purely a frontend concern — the kill APIs already execute unconditionally.
+
+#### Scenario: API contract unchanged
+- **GIVEN** the existing kill window and kill session API endpoints
+- **WHEN** this change is applied
+- **THEN** the API request/response format remains identical
+- **AND** no new endpoints are added
+
+### Requirement: No Top Bar Changes
+
+The `ClosePaneButton` in `top-bar.tsx` SHALL NOT be modified. It already kills without confirmation.
+
+#### Scenario: Top bar close pane unaffected
+- **GIVEN** the ClosePaneButton in the top bar
+- **WHEN** this change is applied
+- **THEN** the button's click behavior remains unchanged (immediate kill, no confirmation)
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Use `ctrlKey \|\| metaKey` for modifier detection | Confirmed from intake #1 — matches ThemeToggle pattern in top-bar.tsx | S:90 R:95 A:95 D:95 |
+| 2 | Certain | No backend changes needed | Confirmed from intake #2 — kill endpoints execute unconditionally | S:85 R:95 A:95 D:95 |
+| 3 | Certain | No top bar ClosePaneButton changes | Confirmed from intake #3 — already kills without confirmation | S:90 R:95 A:95 D:95 |
+| 4 | Confident | Best-effort error handling on force kill (`.catch(() => {})`) | Confirmed from intake #4 — matches ClosePaneButton and SplitButton patterns; SSE reflects actual state | S:70 R:90 A:85 D:80 |
+| 5 | Confident | Apply to both session × and window × buttons | Confirmed from intake #5 — user explicitly said "window or session" | S:80 R:85 A:80 D:85 |
+
+5 assumptions (3 certain, 2 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260403-d3i1-ctrl-click-force-kill-window/tasks.md
+++ b/fab/changes/260403-d3i1-ctrl-click-force-kill-window/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: Ctrl+Click Force Kill Window
+
+**Change**: 260403-d3i1-ctrl-click-force-kill-window
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+## Phase 1: Core Implementation
+
+- [x] T001 Add Ctrl/Cmd modifier check to session × button click handler in `app/frontend/src/components/sidebar.tsx` (line ~177-189). When `e.ctrlKey || e.metaKey`, call `killSessionApi(session.name).catch(() => {})` directly and return, bypassing `setKillTarget`.
+- [x] T002 Add Ctrl/Cmd modifier check to window × button click handler in `app/frontend/src/components/sidebar.tsx` (line ~260-271). When `e.ctrlKey || e.metaKey`, call `killWindowApi(session.name, win.index).catch(() => {})` directly, stop propagation, and return, bypassing `setKillTarget`.
+
+## Phase 2: Verification
+
+- [x] T003 Run frontend type check (`cd app/frontend && npx tsc --noEmit`) to verify no type errors introduced.
+- [x] T004 Run frontend tests (`just test-frontend`) to verify no regressions (pre-existing failures in themes/top-bar/tmux-commands-dialog — none related to sidebar changes).
+
+---
+
+## Execution Order
+
+- T001 and T002 are independent ([P] — different click handlers in the same file)
+- T003 and T004 depend on T001+T002 completion

--- a/fab/changes/260403-xnq5-new-pane-inherit-cwd/.history.jsonl
+++ b/fab/changes/260403-xnq5-new-pane-inherit-cwd/.history.jsonl
@@ -1,0 +1,11 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-04-03T13:19:52Z"}
+{"args":"New pane should start in current working directory of previously active pane, not project root","cmd":"fab-new","event":"command","ts":"2026-04-03T13:19:52Z"}
+{"delta":"+4.7","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-04-03T13:20:27Z"}
+{"delta":"+0.0","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-04-03T13:20:36Z"}
+{"cmd":"fab-switch","event":"command","ts":"2026-04-03T13:21:38Z"}
+{"cmd":"fab-fff","event":"command","ts":"2026-04-03T13:23:23Z"}
+{"delta":"+0.3","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-04-03T13:24:07Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"spec","ts":"2026-04-03T13:24:10Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"tasks","ts":"2026-04-03T13:24:30Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-04-03T13:24:30Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-04-03T13:25:34Z"}

--- a/fab/changes/260403-xnq5-new-pane-inherit-cwd/.status.yaml
+++ b/fab/changes/260403-xnq5-new-pane-inherit-cwd/.status.yaml
@@ -1,0 +1,40 @@
+id: xnq5
+name: 260403-xnq5-new-pane-inherit-cwd
+created: 2026-04-03T13:19:52Z
+created_by: sahil-weaver
+change_type: fix
+issues: []
+progress:
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: active
+    hydrate: pending
+    ship: pending
+    review-pr: pending
+checklist:
+    generated: true
+    path: checklist.md
+    completed: 0
+    total: 8
+confidence:
+    certain: 5
+    confident: 0
+    tentative: 0
+    unresolved: 0
+    score: 5.0
+    fuzzy: true
+    dimensions:
+        signal: 91.0
+        reversibility: 90.0
+        competence: 93.0
+        disambiguation: 93.0
+stage_metrics:
+    intake: {started_at: "2026-04-03T13:19:52Z", driver: fab-new, iterations: 1, completed_at: "2026-04-03T13:24:10Z"}
+    spec: {started_at: "2026-04-03T13:24:10Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-03T13:24:30Z"}
+    tasks: {started_at: "2026-04-03T13:24:30Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-03T13:24:30Z"}
+    apply: {started_at: "2026-04-03T13:24:30Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-03T13:25:34Z"}
+    review: {started_at: "2026-04-03T13:25:34Z", driver: fab-fff, iterations: 1}
+prs: []
+last_updated: 2026-04-03T13:27:07Z


### PR DESCRIPTION
## Summary
- Sidebar × buttons (session and window) now bypass the kill confirmation dialog when Ctrl+Click (or Cmd+Click on macOS) is held
- Matches the existing "modifier = power action" convention (ThemeToggle uses Ctrl+Click to open theme selector)
- Frontend-only change — no backend modifications

## Test plan
- [ ] Ctrl+Click session × — kills session immediately, no dialog
- [ ] Ctrl+Click window × — kills window immediately, no dialog
- [ ] Normal click session × — shows confirmation dialog (unchanged)
- [ ] Normal click window × — shows confirmation dialog (unchanged)
- [ ] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)