### PR TITLE
fix: Align tests with implementation and fix SSE race condition

### DIFF
--- a/app/frontend/src/components/theme-selector.test.tsx
+++ b/app/frontend/src/components/theme-selector.test.tsx
@@ -141,8 +141,8 @@ describe("ThemeSelector", () => {
     fireEvent.keyDown(input, { key: "ArrowDown" });
     fireEvent.keyDown(input, { key: "Enter" });
 
-    // Should persist Dracula as per-mode dark pref (preference stays system)
-    expect(localStorage.getItem("runkit-theme")).toBe("system");
+    // Preference is the theme ID, per-mode dark slot also updated
+    expect(localStorage.getItem("runkit-theme")).toBe("dracula");
     expect(localStorage.getItem("runkit-theme-dark")).toBe("dracula");
     expect(screen.queryByPlaceholderText("Search themes...")).not.toBeInTheDocument();
   });
@@ -156,9 +156,12 @@ describe("ThemeSelector", () => {
     fireEvent.keyDown(input, { key: "ArrowUp" });
     fireEvent.keyDown(input, { key: "Enter" });
 
-    // Last theme wraps around — persist as per-mode pref based on its category
-    const lastTheme = THEMES[THEMES.length - 1];
-    expect(localStorage.getItem("runkit-theme")).toBe("system");
+    // Last theme in flat list (dark + light) — preference is the theme ID
+    const darkThemes = THEMES.filter((t) => t.category === "dark");
+    const lightThemes = THEMES.filter((t) => t.category === "light");
+    const flatThemes = [...darkThemes, ...lightThemes];
+    const lastTheme = flatThemes[flatThemes.length - 1];
+    expect(localStorage.getItem("runkit-theme")).toBe(lastTheme.id);
     const storageKey = lastTheme.category === "dark" ? "runkit-theme-dark" : "runkit-theme-light";
     expect(localStorage.getItem(storageKey)).toBe(lastTheme.id);
   });

--- a/app/frontend/src/components/tmux-commands-dialog.test.tsx
+++ b/app/frontend/src/components/tmux-commands-dialog.test.tsx
@@ -5,7 +5,7 @@ import { TmuxCommandsDialog } from "./tmux-commands-dialog";
 afterEach(cleanup);
 
 describe("TmuxCommandsDialog", () => {
-  it("renders three command rows with correct labels", () => {
+  it("renders two command rows plus static detach hint", () => {
     render(
       <TmuxCommandsDialog
         server="runkit"
@@ -16,8 +16,8 @@ describe("TmuxCommandsDialog", () => {
     );
 
     expect(screen.getByText("Attach")).toBeInTheDocument();
-    expect(screen.getByText("New window")).toBeInTheDocument();
-    expect(screen.getByText("Detach")).toBeInTheDocument();
+    expect(screen.getByText("Send keys")).toBeInTheDocument();
+    expect(screen.getByText(/Detach/)).toBeInTheDocument();
   });
 
   it("includes -L flag for named servers", () => {
@@ -31,8 +31,7 @@ describe("TmuxCommandsDialog", () => {
     );
 
     expect(screen.getByText("tmux -L runkit attach-session -t devshell:editor")).toBeInTheDocument();
-    expect(screen.getByText("tmux -L runkit new-window -t devshell")).toBeInTheDocument();
-    expect(screen.getByText("tmux -L runkit detach-client -t devshell")).toBeInTheDocument();
+    expect(screen.getByText(/tmux -L runkit send-keys -t devshell:editor/)).toBeInTheDocument();
   });
 
   it("omits -L flag for default server", () => {
@@ -46,8 +45,7 @@ describe("TmuxCommandsDialog", () => {
     );
 
     expect(screen.getByText("tmux attach-session -t devshell:editor")).toBeInTheDocument();
-    expect(screen.getByText("tmux new-window -t devshell")).toBeInTheDocument();
-    expect(screen.getByText("tmux detach-client -t devshell")).toBeInTheDocument();
+    expect(screen.getByText(/tmux send-keys -t devshell:editor/)).toBeInTheDocument();
   });
 
   it("copy button calls navigator.clipboard.writeText with correct command", () => {
@@ -73,7 +71,7 @@ describe("TmuxCommandsDialog", () => {
     expect(writeText).toHaveBeenCalledWith("tmux -L runkit attach-session -t devshell:editor");
   });
 
-  it("each row has a copy button", () => {
+  it("each command row has a copy button", () => {
     render(
       <TmuxCommandsDialog
         server="default"
@@ -84,6 +82,6 @@ describe("TmuxCommandsDialog", () => {
     );
 
     const copyButtons = screen.getAllByRole("button", { name: /copy .+ command/i });
-    expect(copyButtons).toHaveLength(3);
+    expect(copyButtons).toHaveLength(2);
   });
 });

--- a/app/frontend/src/components/top-bar.test.tsx
+++ b/app/frontend/src/components/top-bar.test.tsx
@@ -169,18 +169,6 @@ describe("TopBar", () => {
     expect(lines[2].style.transform).toContain("rotate(40deg)");
   });
 
-  it("renders compose button in top bar", () => {
-    renderTopBar();
-    expect(screen.getByLabelText("Compose text")).toBeInTheDocument();
-  });
-
-  it("calls onOpenCompose when compose button is clicked", () => {
-    const onOpenCompose = vi.fn();
-    renderTopBar({ onOpenCompose });
-    fireEvent.click(screen.getByLabelText("Compose text"));
-    expect(onOpenCompose).toHaveBeenCalledTimes(1);
-  });
-
   it("renders 'Run Kit' branding text", () => {
     renderTopBar();
     expect(screen.getByText("Run Kit")).toBeInTheDocument();

--- a/app/frontend/src/contexts/session-context.tsx
+++ b/app/frontend/src/contexts/session-context.tsx
@@ -92,10 +92,12 @@ export function SessionProvider({ children, server }: SessionProviderProps) {
         }
         prevSseDataRef.current = e.data;
         const data = JSON.parse(e.data) as ProjectSession[];
+        // Batch sessions + connected in the same transition so consumers
+        // never see isConnected=true with stale/empty sessions.
         startTransition(() => {
           setSessions(data);
+          markConnected();
         });
-        markConnected();
       } catch {
         // Malformed event — skip
       }
@@ -108,7 +110,9 @@ export function SessionProvider({ children, server }: SessionProviderProps) {
     };
 
     es.onopen = () => {
-      markConnected();
+      // Don't markConnected() here — wait for the first "sessions" event
+      // so consumers see isConnected=true only when session data is available.
+      // This prevents redirect races in AppShell.
     };
 
     return () => {

--- a/app/frontend/src/contexts/session-context.tsx
+++ b/app/frontend/src/contexts/session-context.tsx
@@ -63,8 +63,11 @@ export function SessionProvider({ children, server }: SessionProviderProps) {
   const prevSseDataRef = useRef("");
 
   useEffect(() => {
-    // Reset diff cache so the first event from a new server always applies
+    // Reset state so stale data from the previous server never leaks through
     prevSseDataRef.current = "";
+    setSessions([]);
+    setIsConnected(false);
+    setChromeConnected(false);
 
     const es = new EventSource(`/api/sessions/stream?server=${encodeURIComponent(server)}`);
 

--- a/app/frontend/src/contexts/theme-context.test.tsx
+++ b/app/frontend/src/contexts/theme-context.test.tsx
@@ -157,7 +157,7 @@ describe("ThemeProvider", () => {
     expect(screen.getByTestId("preference").textContent).toBe("system");
   });
 
-  it("setTheme persists per-mode pref and stays in system mode", () => {
+  it("setTheme persists theme ID as preference", () => {
     render(
       <ThemeProvider>
         <TestConsumer />
@@ -166,10 +166,10 @@ describe("ThemeProvider", () => {
     act(() => {
       screen.getByText("Set Light").click();
     });
-    // Preference stays system, themeLight is updated
-    expect(localStorage.getItem("runkit-theme")).toBe("system");
+    // Preference is the theme ID, per-mode slot is also updated
+    expect(localStorage.getItem("runkit-theme")).toBe("default-light");
     expect(localStorage.getItem("runkit-theme-light")).toBe("default-light");
-    expect(screen.getByTestId("preference").textContent).toBe("system");
+    expect(screen.getByTestId("preference").textContent).toBe("default-light");
     expect(screen.getByTestId("theme-light").textContent).toBe("default-light");
     expect(screen.getByTestId("resolved").textContent).toBe("light");
     expect(screen.getByTestId("theme-id").textContent).toBe("default-light");
@@ -338,8 +338,8 @@ describe("ThemeProvider", () => {
       });
 
       expect(screen.getByTestId("theme-id").textContent).toBe("dracula");
-      // Preference stays system, per-mode dark is updated
-      expect(localStorage.getItem("runkit-theme")).toBe("system");
+      // Preference is the theme ID, per-mode dark is also updated
+      expect(localStorage.getItem("runkit-theme")).toBe("dracula");
       expect(localStorage.getItem("runkit-theme-dark")).toBe("dracula");
     });
   });
@@ -437,7 +437,7 @@ describe("ThemeProvider", () => {
   });
 
   describe("API persistence", () => {
-    it("setTheme calls setThemePreference fire-and-forget with per-mode pref", async () => {
+    it("setTheme calls setThemePreference fire-and-forget with theme ID", async () => {
       const { setThemePreference } = await import("@/api/client");
       vi.mocked(setThemePreference).mockClear();
 
@@ -452,7 +452,7 @@ describe("ThemeProvider", () => {
       });
 
       expect(setThemePreference).toHaveBeenCalledWith({
-        theme: "system",
+        theme: "dracula",
         themeDark: "dracula",
       });
     });

--- a/app/frontend/src/themes.test.ts
+++ b/app/frontend/src/themes.test.ts
@@ -13,15 +13,15 @@ import type { Theme, ThemePalette, UIColors } from "./themes";
 const HEX_RE = /^#[0-9a-fA-F]{6}$/;
 
 describe("themes", () => {
-  it("exports exactly 20 themes", () => {
-    expect(THEMES).toHaveLength(20);
+  it("exports exactly 70 themes", () => {
+    expect(THEMES).toHaveLength(70);
   });
 
-  it("has 14 dark themes and 6 light themes", () => {
+  it("has 56 dark themes and 14 light themes", () => {
     const dark = THEMES.filter((t) => t.category === "dark");
     const light = THEMES.filter((t) => t.category === "light");
-    expect(dark).toHaveLength(14);
-    expect(light).toHaveLength(6);
+    expect(dark).toHaveLength(56);
+    expect(light).toHaveLength(14);
   });
 
   it("every theme has unique id", () => {

--- a/app/frontend/tests/e2e/api-integration.spec.ts
+++ b/app/frontend/tests/e2e/api-integration.spec.ts
@@ -38,7 +38,7 @@ test.describe("API Integration", () => {
   test("create session via sidebar, verify it appears, then kill it", async ({
     page,
   }) => {
-    await page.goto(`/?server=${TMUX_SERVER}`);
+    await page.goto(`/${TMUX_SERVER}`);
 
     // Wait for SSE to connect and dashboard to populate
     await expect(

--- a/app/frontend/tests/e2e/mobile-layout.spec.ts
+++ b/app/frontend/tests/e2e/mobile-layout.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "@playwright/test";
 
+const TMUX_SERVER = process.env.E2E_TMUX_SERVER ?? "rk-e2e";
 // iPhone 14 viewport
 const MOBILE_VIEWPORT = { width: 375, height: 812 };
 
@@ -9,51 +10,50 @@ test.describe("Mobile layout", () => {
   });
 
   test("page does not overflow horizontally", async ({ page }) => {
-    await page.goto("/");
+    await page.goto(`/${TMUX_SERVER}`);
     // The document should not be wider than the viewport
     const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
     expect(bodyWidth).toBeLessThanOrEqual(MOBILE_VIEWPORT.width);
   });
 
   test("top bar line 2 is hidden on mobile", async ({ page }) => {
-    await page.goto("/");
-    // Fixed-width toggle should not be visible on mobile
+    await page.goto(`/${TMUX_SERVER}`);
+    // Theme toggle should not be visible on mobile (hidden sm:flex)
     await expect(
-      page.getByRole("button", { name: "Toggle fixed terminal width" }),
+      page.getByRole("button", { name: /theme/i }),
     ).not.toBeVisible();
-    // Action buttons should not be visible
-    await expect(page.getByText("+ Session")).not.toBeVisible();
   });
 
   test("top bar line 2 is visible on desktop", async ({ page }) => {
     await page.setViewportSize({ width: 1024, height: 768 });
-    await page.goto("/");
+    await page.goto(`/${TMUX_SERVER}`);
+    // Theme toggle is always rendered on desktop (hidden sm:flex, visible at >=640px)
     await expect(
-      page.getByRole("button", { name: "Toggle fixed terminal width" }),
+      page.getByRole("button", { name: /theme/i }),
     ).toBeVisible();
   });
 
   test("mobile drawer opens below top bar", async ({ page }) => {
-    await page.goto("/");
-    const logo = page.getByRole("button", { name: "Toggle navigation" });
+    await page.goto(`/${TMUX_SERVER}`);
+    const toggle = page.getByRole("button", { name: "Toggle navigation" });
 
     // Open drawer
-    await logo.click();
+    await toggle.click();
 
     // The sidebar navigation should be visible
     const sidebar = page.getByRole("navigation", { name: "Sessions" });
     await expect(sidebar).toBeVisible();
 
-    // Logo button should still be visible (not covered by drawer)
-    await expect(logo).toBeVisible();
+    // Toggle button should still be visible (not covered by drawer)
+    await expect(toggle).toBeVisible();
 
     // The sidebar should be below the top bar — its top should be > 0
     const sidebarBox = await sidebar.boundingBox();
     expect(sidebarBox).toBeTruthy();
     expect(sidebarBox!.y).toBeGreaterThan(0);
 
-    // Clicking logo again should close the drawer
-    await logo.click();
+    // Clicking toggle again should close the drawer
+    await toggle.click();
     await expect(sidebar).not.toBeVisible();
   });
 });

--- a/app/frontend/tests/e2e/sse-connection.spec.ts
+++ b/app/frontend/tests/e2e/sse-connection.spec.ts
@@ -29,7 +29,7 @@ test.describe("SSE Connection", () => {
   test("SSE delivers session data and connection status shows connected", async ({
     page,
   }) => {
-    await page.goto(`/?server=${TMUX_SERVER}`);
+    await page.goto(`/${TMUX_SERVER}`);
 
     // Wait for the connection status dot to show "Connected"
     const status = page.locator("[aria-label='Connected']");

--- a/justfile
+++ b/justfile
@@ -12,8 +12,12 @@ doctor:
 
 # ─── Setup & Development ──────────────────────────────────────────────
 
+# Ensure tmux.conf exists for Go embed (canonical source: configs/tmux/default.conf)
+_ensure-tmux-conf:
+    cp configs/tmux/default.conf app/backend/build/tmux.conf
+
 # Copy default config files for local development
-setup:
+setup: _ensure-tmux-conf
     cd app/frontend && pnpm install
     [ -f .env.local ] || cp .env .env.local
     cd app/frontend && pnpm exec playwright install --with-deps chromium
@@ -70,7 +74,7 @@ restart:
 test: test-backend test-frontend test-e2e
 
 # Run Go tests
-test-backend:
+test-backend: _ensure-tmux-conf
     cd app/backend && go test ./...
 
 # Run Vitest unit tests


### PR DESCRIPTION
## Summary
Tests were out of sync with the current implementation across multiple fronts: theme count changes, routing restructure to server-picker, removed compose button, and tmux dialog command updates. Additionally, a race condition in the SSE session provider caused terminal pages to redirect to dashboard before session data arrived.

## Changes
- Add `_ensure-tmux-conf` justfile recipe as dependency for `setup` and `test-backend`
- Update unit test assertions to match current theme count (70), `setTheme` behavior, dialog commands, and removed UI elements
- Fix e2e test navigation URLs for server-picker routing (`/` → `/${TMUX_SERVER}`)
- Fix SSE race condition: batch `setSessions` and `markConnected` inside `startTransition` so consumers never see `isConnected=true` with empty sessions

## Stats
| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| fix | — | — | — | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)