### PR TITLE
fix: SSE heartbeat and window kill navigation

### DIFF
--- a/app/backend/api/sse.go
+++ b/app/backend/api/sse.go
@@ -13,9 +13,10 @@ import (
 )
 
 const (
-	ssePollInterval = 2500 * time.Millisecond
-	sseCacheTTL     = 500 * time.Millisecond
-	maxLifetime     = 30 * time.Minute
+	ssePollInterval    = 2500 * time.Millisecond
+	sseCacheTTL        = 500 * time.Millisecond
+	sseHeartbeatTicks  = 6 // send heartbeat every 6 ticks (~15s)
+	maxLifetime        = 30 * time.Minute
 )
 
 // cachedResult holds a cached FetchSessions result with a timestamp.
@@ -89,6 +90,8 @@ func (h *sseHub) removeClient(c *sseClient) {
 }
 
 func (h *sseHub) poll() {
+	ticksSinceHeartbeat := 0
+
 	for {
 		// Read-only check: count clients and collect server keys
 		h.mu.RLock()
@@ -120,6 +123,7 @@ func (h *sseHub) poll() {
 		h.mu.RUnlock()
 
 		// Poll each server and broadcast to its clients
+		dataChanged := false
 		for _, server := range servers {
 			// Check session fetch cache (500ms TTL)
 			var result []sessions.ProjectSession
@@ -157,8 +161,29 @@ func (h *sseHub) poll() {
 						}
 					}
 				}
+				dataChanged = true
 			}
 			h.mu.Unlock()
+		}
+
+		// Send heartbeat to all clients periodically to keep connections
+		// alive through proxies and detect dead connections early.
+		ticksSinceHeartbeat++
+		if dataChanged {
+			ticksSinceHeartbeat = 0
+		} else if ticksSinceHeartbeat >= sseHeartbeatTicks {
+			ticksSinceHeartbeat = 0
+			heartbeat := []byte(": heartbeat\n\n")
+			h.mu.RLock()
+			for _, cs := range h.clients {
+				for _, c := range cs {
+					select {
+					case c.ch <- heartbeat:
+					default:
+					}
+				}
+			}
+			h.mu.RUnlock()
 		}
 
 		time.Sleep(ssePollInterval)

--- a/app/frontend/src/app.tsx
+++ b/app/frontend/src/app.tsx
@@ -227,8 +227,25 @@ function AppShell() {
   // Redirect when the current session/window no longer exists (e.g. window/session killed)
   useEffect(() => {
     if (!sessionName || !isConnected) return;
-    if (!currentSession || (currentSession && windowIndex && !currentWindow)) {
+    if (!currentSession) {
       navigate({ to: "/$server", params: { server }, replace: true });
+    } else if (windowIndex && !currentWindow) {
+      // Window killed — navigate to nearest sibling in the same session
+      const siblings = currentSession.windows;
+      if (siblings.length > 0) {
+        const killedIdx = Number(windowIndex);
+        // Prefer the previous window, fall back to the next
+        const target = siblings.reduce((best, w) =>
+          Math.abs(w.index - killedIdx) < Math.abs(best.index - killedIdx) ? w : best,
+        );
+        navigate({
+          to: "/$server/$session/$window",
+          params: { server, session: sessionName, window: String(target.index) },
+          replace: true,
+        });
+      } else {
+        navigate({ to: "/$server", params: { server }, replace: true });
+      }
     }
   }, [sessionName, windowIndex, sessions, currentSession, currentWindow, isConnected, navigate, server]);
 

--- a/app/frontend/src/app.tsx
+++ b/app/frontend/src/app.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useEffect, useRef, useMemo, useState, useCallback } from "react";
 import { useNavigate, useMatches, Outlet } from "@tanstack/react-router";
 import { ChromeProvider, useChromeState, useChromeDispatch } from "@/contexts/chrome-context";
+import { computeKillRedirect } from "@/lib/navigation";
 import { ThemeProvider, useTheme, useThemeActions } from "@/contexts/theme-context";
 import { SessionProvider } from "@/contexts/session-context";
 import { ToastProvider } from "@/components/toast";
@@ -226,26 +227,22 @@ function AppShell() {
 
   // Redirect when the current session/window no longer exists (e.g. window/session killed)
   useEffect(() => {
-    if (!sessionName || !isConnected) return;
-    if (!currentSession) {
+    const target = computeKillRedirect({
+      sessionName,
+      windowIndex,
+      currentSessionWindows: currentSession?.windows ?? null,
+      currentWindowExists: !!currentWindow,
+      isConnected,
+    });
+    if (!target) return;
+    if (target.to === "window") {
+      navigate({
+        to: "/$server/$session/$window",
+        params: { server, session: target.session, window: String(target.windowIndex) },
+        replace: true,
+      });
+    } else {
       navigate({ to: "/$server", params: { server }, replace: true });
-    } else if (windowIndex && !currentWindow) {
-      // Window killed — navigate to nearest sibling in the same session
-      const siblings = currentSession.windows;
-      if (siblings.length > 0) {
-        const killedIdx = Number(windowIndex);
-        // Prefer the previous window, fall back to the next
-        const target = siblings.reduce((best, w) =>
-          Math.abs(w.index - killedIdx) < Math.abs(best.index - killedIdx) ? w : best,
-        );
-        navigate({
-          to: "/$server/$session/$window",
-          params: { server, session: sessionName, window: String(target.index) },
-          replace: true,
-        });
-      } else {
-        navigate({ to: "/$server", params: { server }, replace: true });
-      }
     }
   }, [sessionName, windowIndex, sessions, currentSession, currentWindow, isConnected, navigate, server]);
 

--- a/app/frontend/src/lib/navigation.test.ts
+++ b/app/frontend/src/lib/navigation.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import { computeKillRedirect } from "./navigation";
+
+describe("computeKillRedirect", () => {
+  const windows = [
+    { index: 0 },
+    { index: 1 },
+    { index: 2 },
+    { index: 3 },
+  ];
+
+  it("returns null when not connected", () => {
+    expect(
+      computeKillRedirect({
+        sessionName: "sess",
+        windowIndex: "1",
+        currentSessionWindows: windows,
+        currentWindowExists: false,
+        isConnected: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when no session name", () => {
+    expect(
+      computeKillRedirect({
+        sessionName: undefined,
+        windowIndex: "1",
+        currentSessionWindows: windows,
+        currentWindowExists: false,
+        isConnected: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when current window still exists", () => {
+    expect(
+      computeKillRedirect({
+        sessionName: "sess",
+        windowIndex: "1",
+        currentSessionWindows: windows,
+        currentWindowExists: true,
+        isConnected: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns dashboard when session is gone", () => {
+    expect(
+      computeKillRedirect({
+        sessionName: "sess",
+        windowIndex: "1",
+        currentSessionWindows: null,
+        currentWindowExists: false,
+        isConnected: true,
+      }),
+    ).toEqual({ to: "dashboard" });
+  });
+
+  it("returns dashboard when window killed and no siblings remain", () => {
+    expect(
+      computeKillRedirect({
+        sessionName: "sess",
+        windowIndex: "0",
+        currentSessionWindows: [],
+        currentWindowExists: false,
+        isConnected: true,
+      }),
+    ).toEqual({ to: "dashboard" });
+  });
+
+  it("navigates to nearest sibling when middle window killed", () => {
+    // Kill window 2 — siblings [0, 1, 3], nearest is 1 or 3 (both distance 1)
+    const siblings = [{ index: 0 }, { index: 1 }, { index: 3 }];
+    const result = computeKillRedirect({
+      sessionName: "sess",
+      windowIndex: "2",
+      currentSessionWindows: siblings,
+      currentWindowExists: false,
+      isConnected: true,
+    });
+    expect(result).toEqual({ to: "window", session: "sess", windowIndex: 1 });
+  });
+
+  it("navigates to next window when first window killed", () => {
+    const siblings = [{ index: 1 }, { index: 2 }, { index: 3 }];
+    const result = computeKillRedirect({
+      sessionName: "sess",
+      windowIndex: "0",
+      currentSessionWindows: siblings,
+      currentWindowExists: false,
+      isConnected: true,
+    });
+    expect(result).toEqual({ to: "window", session: "sess", windowIndex: 1 });
+  });
+
+  it("navigates to previous window when last window killed", () => {
+    const siblings = [{ index: 0 }, { index: 1 }, { index: 2 }];
+    const result = computeKillRedirect({
+      sessionName: "sess",
+      windowIndex: "3",
+      currentSessionWindows: siblings,
+      currentWindowExists: false,
+      isConnected: true,
+    });
+    expect(result).toEqual({ to: "window", session: "sess", windowIndex: 2 });
+  });
+
+  it("navigates to only remaining sibling", () => {
+    const siblings = [{ index: 5 }];
+    const result = computeKillRedirect({
+      sessionName: "my-session",
+      windowIndex: "0",
+      currentSessionWindows: siblings,
+      currentWindowExists: false,
+      isConnected: true,
+    });
+    expect(result).toEqual({ to: "window", session: "my-session", windowIndex: 5 });
+  });
+});

--- a/app/frontend/src/lib/navigation.ts
+++ b/app/frontend/src/lib/navigation.ts
@@ -1,0 +1,36 @@
+/**
+ * Compute where to redirect when the current session or window no longer exists.
+ * Returns null when no redirect is needed.
+ */
+export type RedirectTarget =
+  | { to: "dashboard" }
+  | { to: "window"; session: string; windowIndex: number };
+
+export function computeKillRedirect(params: {
+  sessionName: string | undefined;
+  windowIndex: string | undefined;
+  currentSessionWindows: { index: number }[] | null;
+  currentWindowExists: boolean;
+  isConnected: boolean;
+}): RedirectTarget | null {
+  const { sessionName, windowIndex, currentSessionWindows, currentWindowExists, isConnected } = params;
+
+  if (!sessionName || !isConnected) return null;
+
+  // Session gone entirely
+  if (!currentSessionWindows) return { to: "dashboard" };
+
+  // Window gone — find nearest sibling
+  if (windowIndex && !currentWindowExists) {
+    if (currentSessionWindows.length > 0) {
+      const killedIdx = Number(windowIndex);
+      const target = currentSessionWindows.reduce((best, w) =>
+        Math.abs(w.index - killedIdx) < Math.abs(best.index - killedIdx) ? w : best,
+      );
+      return { to: "window", session: sessionName, windowIndex: target.index };
+    }
+    return { to: "dashboard" };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
Fixes two regressions: SSE connections silently dying through proxies (causing the sidebar to stop updating until page refresh), and window kill navigating to dashboard instead of the nearest sibling window.

## Changes
- Add periodic SSE heartbeat comments (~15s) to keep connections alive through proxies and detect dead connections early
- Navigate to nearest sibling window on kill instead of falling back to dashboard

## Stats
| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| fix | — | — | — | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)