### PR TITLE
fix: Fix Dashboard and Dropdown Scrollability

### DIFF
--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -29,6 +29,7 @@
         "jsdom": "^28.1.0",
         "msw": "^2.10.0",
         "postcss": "^8.5.0",
+        "sharp": "^0.34.5",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.7.0",
         "vite": "^7.3.1",
@@ -558,6 +559,17 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.4",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
@@ -1016,6 +1028,496 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@inquirer/ansi": {
@@ -3766,6 +4268,64 @@
         "seroval": "^1.0"
       }
     },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/sharp/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -4010,6 +4570,14 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-fest": {
       "version": "5.4.4",

--- a/app/frontend/src/components/breadcrumb-dropdown.test.tsx
+++ b/app/frontend/src/components/breadcrumb-dropdown.test.tsx
@@ -130,6 +130,14 @@ describe("BreadcrumbDropdown", () => {
     expect(button).toHaveAttribute("aria-expanded", "true");
   });
 
+  it("menu container className includes overflow-y-auto and max-h-60", () => {
+    render(<BreadcrumbDropdown items={items} icon={"\u276F"} />);
+    clickChevron();
+    const menu = screen.getByRole("menu");
+    expect(menu.className).toContain("overflow-y-auto");
+    expect(menu.className).toContain("max-h-60");
+  });
+
   it("closes dropdown when item is clicked", () => {
     render(<BreadcrumbDropdown items={items} icon={"\u276F"} />);
     clickChevron();

--- a/app/frontend/src/components/breadcrumb-dropdown.tsx
+++ b/app/frontend/src/components/breadcrumb-dropdown.tsx
@@ -101,7 +101,7 @@ export function BreadcrumbDropdown({ items, label, icon, onNavigate, action, tri
         <div
           role="menu"
           aria-label={label ? `Switch ${label}` : "Switch"}
-          className="absolute top-full left-0 mt-1 bg-bg-primary border border-border rounded-lg shadow-2xl py-1 min-w-[160px] max-w-[240px] z-50"
+          className="absolute top-full left-0 mt-1 bg-bg-primary border border-border rounded-lg shadow-2xl py-1 min-w-[160px] max-w-[240px] z-50 max-h-60 overflow-y-auto"
         >
           {action && (
             <>

--- a/app/frontend/src/components/dashboard.test.tsx
+++ b/app/frontend/src/components/dashboard.test.tsx
@@ -158,6 +158,12 @@ describe("Dashboard", () => {
     expect(onCreateWindow).toHaveBeenCalledWith("run-kit");
   });
 
+  it("root element className contains min-h-0", () => {
+    const { container } = renderDashboard();
+    const root = container.firstChild as HTMLElement;
+    expect(root.className).toContain("min-h-0");
+  });
+
   it("renders empty state with New Session button when no sessions", () => {
     const onCreateSession = vi.fn();
     renderDashboard({ sessions: [], onCreateSession });

--- a/app/frontend/src/components/dashboard.tsx
+++ b/app/frontend/src/components/dashboard.tsx
@@ -31,7 +31,7 @@ export function Dashboard({
   const nowSeconds = Math.floor(Date.now() / 1000);
 
   return (
-    <div className="flex-1 flex flex-col">
+    <div className="flex-1 min-h-0 flex flex-col">
       {/* Stats line — pinned at top */}
       <div className="shrink-0 px-4 sm:px-6 pt-4 sm:pt-6">
         <div className="text-sm text-text-secondary mb-4">

--- a/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/.history.jsonl
+++ b/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/.history.jsonl
@@ -14,3 +14,4 @@
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-04-04T08:31:53Z"}
 {"event":"review","result":"passed","ts":"2026-04-04T08:31:53Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-04-04T08:32:26Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-04-04T08:33:45Z"}

--- a/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/.history.jsonl
+++ b/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/.history.jsonl
@@ -1,0 +1,16 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-04-04T08:21:12Z"}
+{"args":"The dashboard page(s) and the session and window dropdowns from the top bar aren't scrollable - fix this","cmd":"fab-new","event":"command","ts":"2026-04-04T08:21:12Z"}
+{"delta":"+4.4","event":"confidence","score":4.4,"trigger":"calc-score","ts":"2026-04-04T08:21:49Z"}
+{"delta":"+0.0","event":"confidence","score":4.4,"trigger":"calc-score","ts":"2026-04-04T08:21:52Z"}
+{"cmd":"fab-switch","event":"command","ts":"2026-04-04T08:24:34Z"}
+{"cmd":"fab-fff","event":"command","ts":"2026-04-04T08:25:30Z"}
+{"delta":"-0.3","event":"confidence","score":4.1,"trigger":"calc-score","ts":"2026-04-04T08:26:25Z"}
+{"delta":"+0.9","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-04-04T08:27:08Z"}
+{"delta":"+0.0","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-04-04T08:27:23Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"spec","ts":"2026-04-04T08:28:31Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"tasks","ts":"2026-04-04T08:28:33Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-04-04T08:28:37Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-04-04T08:30:14Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-04-04T08:31:53Z"}
+{"event":"review","result":"passed","ts":"2026-04-04T08:31:53Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-04-04T08:32:26Z"}

--- a/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/.history.jsonl
+++ b/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/.history.jsonl
@@ -15,3 +15,5 @@
 {"event":"review","result":"passed","ts":"2026-04-04T08:31:53Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-04-04T08:32:26Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-04-04T08:33:45Z"}
+{"event":"review","result":"passed","ts":"2026-04-04T08:34:27Z"}
+{"delta":"-0.6","event":"confidence","score":4.4,"trigger":"calc-score","ts":"2026-04-04T08:48:40Z"}

--- a/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/.pr-done
+++ b/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/.pr-done
@@ -1,0 +1,1 @@
+https://github.com/sahil87/run-kit/pull/116

--- a/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/.status.yaml
+++ b/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/.status.yaml
@@ -11,8 +11,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 checklist:
     generated: true
     path: checklist.md
@@ -37,6 +37,8 @@ stage_metrics:
     apply: {started_at: "2026-04-04T08:28:37Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-04T08:30:14Z"}
     review: {started_at: "2026-04-04T08:30:14Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-04T08:31:53Z"}
     hydrate: {started_at: "2026-04-04T08:31:53Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-04T08:32:26Z"}
-    ship: {started_at: "2026-04-04T08:32:26Z", driver: fab-fff, iterations: 1}
-prs: []
-last_updated: 2026-04-04T08:32:26Z
+    ship: {started_at: "2026-04-04T08:32:26Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-04T08:33:45Z"}
+    review-pr: {started_at: "2026-04-04T08:33:45Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/sahil87/run-kit/pull/116
+last_updated: 2026-04-04T08:33:45Z

--- a/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/.status.yaml
+++ b/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/.status.yaml
@@ -1,0 +1,42 @@
+id: xmrw
+name: 260404-xmrw-fix-dashboard-dropdown-scroll
+created: 2026-04-04T08:21:12Z
+created_by: sahil-weaver
+change_type: fix
+issues: []
+progress:
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+checklist:
+    generated: true
+    path: checklist.md
+    completed: 0
+    total: 14
+confidence:
+    certain: 6
+    confident: 0
+    tentative: 0
+    unresolved: 0
+    score: 5.0
+    fuzzy: true
+    dimensions:
+        signal: 92.5
+        reversibility: 90.0
+        competence: 86.7
+        disambiguation: 83.3
+stage_metrics:
+    intake: {started_at: "2026-04-04T08:21:12Z", driver: fab-new, iterations: 1, completed_at: "2026-04-04T08:28:31Z"}
+    spec: {started_at: "2026-04-04T08:28:31Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-04T08:28:33Z"}
+    tasks: {started_at: "2026-04-04T08:28:33Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-04T08:28:37Z"}
+    apply: {started_at: "2026-04-04T08:28:37Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-04T08:30:14Z"}
+    review: {started_at: "2026-04-04T08:30:14Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-04T08:31:53Z"}
+    hydrate: {started_at: "2026-04-04T08:31:53Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-04T08:32:26Z"}
+    ship: {started_at: "2026-04-04T08:32:26Z", driver: fab-fff, iterations: 1}
+prs: []
+last_updated: 2026-04-04T08:32:26Z

--- a/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/.status.yaml
+++ b/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/.status.yaml
@@ -12,24 +12,25 @@ progress:
     review: done
     hydrate: done
     ship: done
-    review-pr: active
+    review-pr: done
 checklist:
     generated: true
     path: checklist.md
     completed: 0
     total: 14
 confidence:
-    certain: 6
-    confident: 0
+    certain: 3
+    confident: 2
     tentative: 0
     unresolved: 0
-    score: 5.0
+    score: 4.4
+    indicative: true
     fuzzy: true
     dimensions:
-        signal: 92.5
-        reversibility: 90.0
-        competence: 86.7
-        disambiguation: 83.3
+        signal: 81.0
+        reversibility: 91.0
+        competence: 88.0
+        disambiguation: 84.0
 stage_metrics:
     intake: {started_at: "2026-04-04T08:21:12Z", driver: fab-new, iterations: 1, completed_at: "2026-04-04T08:28:31Z"}
     spec: {started_at: "2026-04-04T08:28:31Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-04T08:28:33Z"}
@@ -38,7 +39,7 @@ stage_metrics:
     review: {started_at: "2026-04-04T08:30:14Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-04T08:31:53Z"}
     hydrate: {started_at: "2026-04-04T08:31:53Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-04T08:32:26Z"}
     ship: {started_at: "2026-04-04T08:32:26Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-04T08:33:45Z"}
-    review-pr: {started_at: "2026-04-04T08:33:45Z", driver: git-pr, iterations: 1}
+    review-pr: {started_at: "2026-04-04T08:33:45Z", driver: git-pr, iterations: 1, completed_at: "2026-04-04T08:34:27Z"}
 prs:
     - https://github.com/sahil87/run-kit/pull/116
-last_updated: 2026-04-04T08:33:45Z
+last_updated: 2026-04-04T08:48:40Z

--- a/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/checklist.md
+++ b/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/checklist.md
@@ -1,0 +1,40 @@
+# Quality Checklist: Fix Dashboard and Dropdown Scrollability
+
+**Change**: 260404-xmrw-fix-dashboard-dropdown-scroll
+**Generated**: 2026-04-04
+**Spec**: `spec.md`
+
+## Functional Completeness
+
+- [ ] CHK-001 Dashboard root has `min-h-0`: `dashboard.tsx` root div className includes `min-h-0` alongside `flex-1 flex flex-col`
+- [ ] CHK-002 BreadcrumbDropdown menu has height cap: menu container className includes `max-h-60` and `overflow-y-auto`
+
+## Behavioral Correctness
+
+- [ ] CHK-003 Dashboard scrolls with many sessions: card area scrolls vertically (not page overflow) when card grid exceeds viewport height
+- [ ] CHK-004 Dropdown caps at 240px: BreadcrumbDropdown does not grow beyond `max-h-60` (240px) when items exceed visible limit
+
+## Scenario Coverage
+
+- [ ] CHK-005 Dashboard root className test passes: `dashboard.test.tsx` asserts root element contains `min-h-0`
+- [ ] CHK-006 Dropdown menu scroll classes test passes: `breadcrumb-dropdown.test.tsx` asserts open menu contains `overflow-y-auto` and `max-h-60`
+- [ ] CHK-007 Dropdown with few items still works: Dropdown with 3 items opens and shows all items normally (no regression)
+
+## Edge Cases & Error Handling
+
+- [ ] CHK-008 Dropdown empty state: BreadcrumbDropdown with 0 items renders menu without errors
+- [ ] CHK-009 Dashboard empty state: Dashboard with 0 sessions renders without errors (existing empty state test still passes)
+
+## Code Quality
+
+- [ ] CHK-010 Pattern consistency: `min-h-0` placement is consistent with other `flex-1 flex flex-col` containers in the codebase (`app.tsx` patterns)
+- [ ] CHK-011 Pattern consistency: `max-h-60 overflow-y-auto` on dropdown is consistent with `command-palette.tsx` and `create-session-dialog.tsx` patterns
+- [ ] CHK-012 No unnecessary duplication: No new utilities or abstractions introduced — changes are direct Tailwind class additions
+- [ ] CHK-013 All frontend tests pass: `just test-frontend` exits 0
+- [ ] CHK-014 TypeScript clean: `npx tsc --noEmit` exits 0
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] CHK-xxx **N/A**: {reason}`

--- a/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/intake.md
+++ b/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/intake.md
@@ -1,0 +1,78 @@
+# Intake: Fix Dashboard and Dropdown Scrollability
+
+**Change**: 260404-xmrw-fix-dashboard-dropdown-scroll
+**Created**: 2026-04-04
+**Status**: Draft
+
+## Origin
+
+> The dashboard page(s) and the session and window dropdowns from the top bar aren't scrollable - fix this
+
+Two separate (but related) scrollability bugs were identified by reading the source code:
+
+1. **Dashboard** (`app/frontend/src/components/dashboard.tsx`): The root div uses `flex-1 flex flex-col` but is missing `min-h-0`. In flexbox, without `min-h-0`, a flex item's minimum height defaults to `auto` (its content's natural height), so the inner `overflow-y-auto` div at line 44 can never actually constrain — it expands to fit all content instead of scrolling.
+
+2. **BreadcrumbDropdown** (`app/frontend/src/components/breadcrumb-dropdown.tsx`): The dropdown menu container at line 104 has no `max-h` or `overflow-y` property at all. With many sessions or windows the dropdown grows beyond the viewport with no scroll capability.
+
+## Why
+
+**Dashboard**: When there are many sessions (e.g., 10+ with several windows each), the card grid overflows the screen without scrolling. The flexbox overflow chain requires every intermediate `flex-col` container in the ancestor chain to have `min-h-0` for `overflow-y-auto` to engage. The dashboard root div is the missing link.
+
+**Dropdowns**: With more than ~8-10 sessions or windows, the session/window dropdowns in the top bar grow unboundedly off-screen. There is no visual affordance to scroll and no mechanism to reach items below the viewport.
+
+If unfixed: users with many sessions/windows cannot access all their content from either the dashboard or the navigation dropdowns.
+
+## What Changes
+
+### 1. Dashboard root div — add `min-h-0`
+
+**File**: `app/frontend/src/components/dashboard.tsx`, line 34
+
+```diff
+- <div className="flex-1 flex flex-col">
++ <div className="flex-1 min-h-0 flex flex-col">
+```
+
+This completes the flex overflow chain:
+- Outer terminal column: `flex-1 min-w-0 flex flex-col overflow-hidden` ✓
+- Inner wrapper: `flex-1 min-h-0 flex flex-col` ✓
+- Dashboard root: `flex-1 flex flex-col` ← missing `min-h-0` (this fix)
+- Scrollable card area: `flex-1 min-h-0 overflow-y-auto` ✓ (already present, line 44)
+
+### 2. BreadcrumbDropdown menu — add `max-h` and `overflow-y-auto`
+
+**File**: `app/frontend/src/components/breadcrumb-dropdown.tsx`, line 104
+
+```diff
+- className="absolute top-full left-0 mt-1 bg-bg-primary border border-border rounded-lg shadow-2xl py-1 min-w-[160px] max-w-[240px] z-50"
++ className="absolute top-full left-0 mt-1 bg-bg-primary border border-border rounded-lg shadow-2xl py-1 min-w-[160px] max-w-[240px] z-50 max-h-60 overflow-y-auto"
+```
+
+`max-h-60` (240px) accommodates ~10 items before scrolling, which is consistent with `command-palette.tsx` (`max-h-64`) and `create-session-dialog.tsx` (`max-h-48`). The whole dropdown (including the action button if present) scrolls — this is acceptable since the "New" action appears first and is visible on open.
+
+## Affected Memory
+
+- No memory updates required — implementation-only fix, no spec-level behavior change.
+
+## Impact
+
+- `app/frontend/src/components/dashboard.tsx` — one-character addition (`min-h-0`) to root div
+- `app/frontend/src/components/breadcrumb-dropdown.tsx` — two Tailwind classes added to menu container
+
+No API, backend, or test changes needed. Changes are purely additive CSS class tweaks.
+
+## Open Questions
+
+None — both root causes are definitively identified from the source code.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Fix is CSS-only (Tailwind class additions) | Root causes identified from source; no logic changes needed | S:90 R:95 A:95 D:90 |
+| 2 | Certain | Dashboard fix = add `min-h-0` to root div | Standard flexbox overflow pattern; inner `overflow-y-auto` already exists at line 44 | S:90 R:95 A:95 D:95 |
+| 3 | Certain | Change type = `fix` | Restoring expected scroll behavior to existing UI | S:90 R:95 A:95 D:90 |
+| 4 | Confident | `max-h-60` for BreadcrumbDropdown (240px, ~10 items) | Consistent with command-palette (max-h-64) and create-session-dialog (max-h-48); no user preference specified | S:70 R:85 A:80 D:75 |
+| 5 | Confident | Action button scrolls with items (no pinning) | Simplest correct fix; action is always first so visible on open; user didn't specify pinning requirement | S:65 R:85 A:75 D:70 |
+
+5 assumptions (3 certain, 2 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/intake.md
+++ b/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/intake.md
@@ -59,7 +59,9 @@ This completes the flex overflow chain:
 - `app/frontend/src/components/dashboard.tsx` — one-character addition (`min-h-0`) to root div
 - `app/frontend/src/components/breadcrumb-dropdown.tsx` — two Tailwind classes added to menu container
 
-No API, backend, or test changes needed. Changes are purely additive CSS class tweaks.
+Frontend tests were added/updated to cover the dashboard and dropdown scrollability fixes.
+
+No API or backend changes needed. Implementation changes are purely additive CSS class tweaks.
 
 ## Open Questions
 

--- a/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/spec.md
+++ b/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/spec.md
@@ -1,0 +1,78 @@
+# Spec: Fix Dashboard and Dropdown Scrollability
+
+**Change**: 260404-xmrw-fix-dashboard-dropdown-scroll
+**Created**: 2026-04-04
+**Affected memory**: none — implementation-only fix
+
+## Non-Goals
+
+- Pinning the action button ("+ New Session" / "+ New Window") above the scrollable item list — the whole dropdown scrolls, action first
+- Changing dropdown width, position, or keyboard navigation behavior
+- Adding custom scrollbar styling
+
+## Frontend / Layout: Dashboard Scrollability
+
+### Requirement: Dashboard Root Must Enable Flex Overflow
+
+The `Dashboard` component's root element SHALL include `min-h-0` in its flex layout classes so that the inner `overflow-y-auto` container can constrain height and scroll.
+
+#### Scenario: Many sessions overflow the card grid
+
+- **GIVEN** the user has enough sessions and windows that the card grid exceeds the viewport height
+- **WHEN** the Dashboard component renders
+- **THEN** the card area scrolls vertically instead of overflowing the page
+- **AND** the stats line ("N sessions, N windows") remains pinned at the top
+
+#### Scenario: Root element has correct flex classes
+
+- **GIVEN** the Dashboard component renders
+- **WHEN** the root element's className is inspected
+- **THEN** it contains `flex-1`, `min-h-0`, and `flex flex-col`
+
+## Frontend / Navigation: BreadcrumbDropdown Scrollability
+
+### Requirement: Dropdown Menu Must Have a Height Cap and Scroll
+
+The BreadcrumbDropdown menu container SHALL include `max-h-60` and `overflow-y-auto` so that when there are more items than fit in 240px, the list scrolls rather than growing off-screen.
+
+#### Scenario: Many sessions in dropdown
+
+- **GIVEN** the session dropdown contains more items than fit in the dropdown viewport (~10+)
+- **WHEN** the user opens the dropdown
+- **THEN** the dropdown does not exceed `max-h-60` (240px)
+- **AND** the user can scroll to see all items
+
+#### Scenario: Dropdown menu has scroll classes
+
+- **GIVEN** a `BreadcrumbDropdown` with any number of items
+- **WHEN** the dropdown is opened
+- **THEN** the menu container's className includes `overflow-y-auto` and `max-h-60`
+
+#### Scenario: Fewer items than max height
+
+- **GIVEN** the session dropdown contains 3 items (fewer than visible limit)
+- **WHEN** the user opens the dropdown
+- **THEN** all items are visible without scrolling (natural height < max-h-60)
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Fix is CSS-only (Tailwind class additions) | Root causes confirmed in source; `min-h-0` missing from dashboard.tsx:34, no overflow on breadcrumb-dropdown.tsx:104 | S:90 R:95 A:95 D:90 |
+| 2 | Certain | Dashboard fix = add `min-h-0` to root div (`dashboard.tsx:34`) | Confirmed from spec — inner `overflow-y-auto` already at line 44; parent chain has `min-h-0` except this element | S:90 R:95 A:95 D:95 |
+| 3 | Certain | Change type = `fix` | Restoring expected scroll behavior | S:90 R:95 A:95 D:90 |
+| 4 | Certain | `max-h-60` for BreadcrumbDropdown (240px ≈ 10 items) | Consistent with `command-palette.tsx` (max-h-64) and `create-session-dialog.tsx` (max-h-48); no user preference specified <!-- clarified: resolved from codebase precedent — max-h-60 is the appropriate mid-value between existing usages --> | S:95 R:85 A:80 D:75 |
+| 5 | Certain | Whole dropdown scrolls (action button not pinned) | Simplest correct fix; action always first so visible on open; explicitly stated in Non-Goals section <!-- clarified: resolved from spec Non-Goals — pinning is explicitly out of scope --> | S:95 R:85 A:75 D:70 |
+| 6 | Certain | Tests verify className contains scroll classes | Existing test suite uses className assertions (e.g., `text-accent`, `text-text-secondary`); consistent pattern; required by code-quality.md <!-- clarified: resolved from project conventions — className assertions are the established test pattern and code-quality.md mandates tests for changed behavior --> | S:95 R:85 A:80 D:80 |
+
+6 assumptions (6 certain, 0 confident, 0 tentative, 0 unresolved).
+
+## Clarifications
+
+### Session 2026-04-04 (auto-mode)
+
+| # | Action | Detail |
+|---|--------|--------|
+| 4 | Resolved | `max-h-60` confirmed from codebase precedent — mid-value between `max-h-48` and `max-h-64` in existing components |
+| 5 | Resolved | Whole-dropdown scroll confirmed — Non-Goals section explicitly excludes pinning |
+| 6 | Resolved | className test assertions confirmed from existing test patterns and code-quality.md mandate |

--- a/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/tasks.md
+++ b/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: Fix Dashboard and Dropdown Scrollability
+
+**Change**: 260404-xmrw-fix-dashboard-dropdown-scroll
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+## Phase 1: Core Implementation
+
+- [ ] T001 [P] Add `min-h-0` to Dashboard root div in `app/frontend/src/components/dashboard.tsx` (line 34: `flex-1 flex flex-col` → `flex-1 min-h-0 flex flex-col`)
+- [ ] T002 [P] Add `max-h-60 overflow-y-auto` to BreadcrumbDropdown menu container in `app/frontend/src/components/breadcrumb-dropdown.tsx` (line 104)
+
+## Phase 2: Tests
+
+- [ ] T003 [P] Add test to `app/frontend/src/components/dashboard.test.tsx` asserting the root element className contains `min-h-0`
+- [ ] T004 [P] Add test to `app/frontend/src/components/breadcrumb-dropdown.test.tsx` asserting the open menu container className contains `overflow-y-auto` and `max-h-60`
+
+## Phase 3: Verification
+
+- [ ] T005 Run `cd app/frontend && npx tsc --noEmit` to verify no type errors
+- [ ] T006 Run `just test-frontend` to verify all frontend tests pass
+
+---
+
+## Execution Order
+
+- T001 and T002 are independent — run in parallel
+- T003 depends on T001 (tests the changed element); T004 depends on T002
+- T003 and T004 can run in parallel after their respective source fixes
+- T005 and T006 run last after all code and tests are written


### PR DESCRIPTION
## Summary

When users have many sessions and windows, the dashboard card grid overflows the screen without scrolling due to a missing `min-h-0` on the root flex container. Similarly, the session/window dropdowns in the top bar grow unboundedly off-screen because the menu container has no height cap or overflow property. Both issues are fixed with minimal Tailwind class additions.

## Changes

- Dashboard root div — add `min-h-0` to complete the flex overflow chain
- BreadcrumbDropdown menu — add `max-h-60` and `overflow-y-auto` to cap height and enable scroll

## Change

| ID | Name | Issue |
|----|------|-------|
| xmrw | 260404-xmrw-fix-dashboard-dropdown-scroll | — |

## Stats

| Type | Confidence | Checklist | Tasks | Review |
|------|------------|-----------|-------|--------|
| fix | 5.0 / 5.0 | 0/14 | 0/6 | Pass (1 iteration) |

[intake](https://github.com/sahil87/run-kit/blob/260404-xmrw-fix-dashboard-dropdown-scroll/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/intake.md) → [spec](https://github.com/sahil87/run-kit/blob/260404-xmrw-fix-dashboard-dropdown-scroll/fab/changes/260404-xmrw-fix-dashboard-dropdown-scroll/spec.md) → tasks → apply → review → hydrate