### PR TITLE
Add logo to README heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# run-kit
+# <img src="assets/logo.svg" alt="run-kit logo" width="32" height="32"> run-kit
 
 Web-based agent orchestration dashboard. Monitor and interact with tmux sessions from the browser — session overview, live terminal windows, and fab-kit integration for change tracking.
 

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="7 10 50 44" width="64" height="64">
+  <!-- Logo — flat-top hexagon, no transform, pre-computed coordinates -->
+
+  <!-- Border segments — wide contrast range -->
+  <polygon points="44,11.2 56,32 47.5,32 39.5,17.2" fill="#b4b4b4"/>
+  <polygon points="56,32 44,52.8 39.5,46.8 47.5,32" fill="#b4b4b4"/>
+  <polygon points="44,52.8 20,52.8 24.5,46.8 39.5,46.8" fill="#2a2a2a"/>
+  <polygon points="20,52.8 8,32 16.5,32 24.5,46.8" fill="#2a2a2a"/>
+  <polygon points="8,32 20,11.2 24.5,17.2 16.5,32" fill="#2a2a2a"/>
+  <polygon points="20,11.2 44,11.2 39.5,17.2 24.5,17.2" fill="#b4b4b4"/>
+
+  <!-- Inner cube faces — contrasts with adjacent border segments -->
+  <polygon points="24.5,17.2 39.5,17.2 47.5,32 32,32" fill="#888888"/>
+  <polygon points="47.5,32 39.5,46.8 24.5,46.8 32,32" fill="#737373"/>
+  <polygon points="24.5,46.8 16.5,32 24.5,17.2 32,32" fill="#545454"/>
+</svg>


### PR DESCRIPTION
## Summary
- Copies the app icon SVG into `assets/logo.svg`
- Renders it inline next to the `# run-kit` heading in the README