### PR TITLE
fix: Sidebar Kill Hides Extra Window

### DIFF
--- a/app/frontend/src/components/sidebar.test.tsx
+++ b/app/frontend/src/components/sidebar.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent, cleanup, act } from "@testing-library/react";
 import { Sidebar } from "./sidebar";
-import { OptimisticProvider } from "@/contexts/optimistic-context";
+import { OptimisticProvider, useOptimisticContext } from "@/contexts/optimistic-context";
 import { ToastProvider } from "@/components/toast";
 import type { ProjectSession } from "@/types";
 
@@ -9,6 +9,8 @@ vi.mock("@/api/client", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/api/client")>();
   return {
     ...actual,
+    killWindow: vi.fn().mockResolvedValue({ ok: true }),
+    killSession: vi.fn().mockResolvedValue({ ok: true }),
     renameWindow: vi.fn().mockResolvedValue({ ok: true }),
     moveWindow: vi.fn().mockResolvedValue({ ok: true }),
     moveWindowToSession: vi.fn().mockResolvedValue({ ok: true }),
@@ -531,6 +533,53 @@ describe("Sidebar", () => {
       });
 
       expect(moveWindowMock).toHaveBeenCalledWith("run-kit", 0, 1);
+    });
+  });
+
+  describe("window kill clears optimistic state on success", () => {
+    it("Ctrl+click kill: killed entry is removed after API call resolves", async () => {
+      const { killWindow: killWindowMock } = await import("@/api/client");
+      vi.mocked(killWindowMock).mockResolvedValue({ ok: true });
+
+      let killedCount = -1;
+
+      function KilledCountDisplay() {
+        const ctx = useOptimisticContext();
+        killedCount = ctx.killed.length;
+        return <span data-testid="killed-count">{ctx.killed.length}</span>;
+      }
+
+      render(
+        <ToastProvider>
+          <OptimisticProvider>
+            <KilledCountDisplay />
+            <Sidebar
+              sessions={sessions}
+              currentSession="run-kit"
+              currentWindowIndex="0"
+              onSelectWindow={vi.fn()}
+              onCreateWindow={vi.fn()}
+              onCreateSession={vi.fn()}
+              server="runkit"
+              servers={["runkit"]}
+              onSwitchServer={vi.fn()}
+              onCreateServer={vi.fn()}
+              onRefreshServers={vi.fn()}
+              onMoveWindowToSession={vi.fn()}
+            />
+          </OptimisticProvider>
+        </ToastProvider>,
+      );
+
+      // Ctrl+click the X button for "scratch" window (index 1)
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText("Kill window scratch"), { ctrlKey: true });
+      });
+
+      // API was called
+      expect(killWindowMock).toHaveBeenCalledWith("run-kit", 1);
+      // After the API call resolves, the killed entry must be removed (unmarkKilled called)
+      expect(killedCount).toBe(0);
     });
   });
 

--- a/app/frontend/src/components/sidebar.tsx
+++ b/app/frontend/src/components/sidebar.tsx
@@ -93,6 +93,10 @@ export function Sidebar({
     onRollback: () => {
       if (lastKillWindowRef.current) unmarkKilled(lastKillWindowRef.current);
     },
+    onSettled: () => {
+      if (lastKillWindowRef.current) unmarkKilled(lastKillWindowRef.current);
+      lastKillWindowRef.current = null;
+    },
     onError: (err) => {
       addToast(err.message || "Failed to kill window");
     },
@@ -117,6 +121,15 @@ export function Sidebar({
       }
     },
     onRollback: () => {
+      const target = killTargetRef.current;
+      if (!target) return;
+      if (target.type === "window" && target.windowIndex != null) {
+        unmarkKilled(`${target.session}:${target.windowIndex}`);
+      } else {
+        unmarkKilled(target.session);
+      }
+    },
+    onSettled: () => {
       const target = killTargetRef.current;
       if (!target) return;
       if (target.type === "window" && target.windowIndex != null) {

--- a/app/frontend/src/contexts/optimistic-context.test.tsx
+++ b/app/frontend/src/contexts/optimistic-context.test.tsx
@@ -378,6 +378,89 @@ describe("OptimisticProvider", () => {
     expect(() => render(<Orphan />)).toThrow("useOptimisticContext must be used within OptimisticProvider");
   });
 
+  it("renumbered window appears in merged output once killed entry is cleared", () => {
+    // Scenario: dev session has windows [0, 1, 2]. Window 1 is killed.
+    // After tmux renumbers, index 2 becomes index 1.
+    // Once unmarkKilled("dev:1") fires, the new window at index 1 should be visible.
+
+    // TestConsumer already exposes a kill-window button for "dev:0".
+    // We need a custom consumer that targets "dev:1" specifically.
+    function KillWindowConsumer({ realSessions }: { realSessions: ProjectSession[] }) {
+      const ctx = useOptimisticContext();
+      const merged = useMergedSessions(realSessions);
+      return (
+        <div>
+          <span data-testid="kw-windows">
+            {merged.flatMap((s) => s.windows.map((w) => `${s.name}:${w.index}:${w.name}`)).join(",")}
+          </span>
+          <span data-testid="kw-killed-count">{ctx.killed.length}</span>
+          <button data-testid="kw-mark-killed" onClick={() => ctx.markKilled("window", "dev:1")}>
+            Mark Killed
+          </button>
+          <button data-testid="kw-unmark-killed" onClick={() => ctx.unmarkKilled("dev:1")}>
+            Unmark Killed
+          </button>
+        </div>
+      );
+    }
+
+    const threeWindowSessions: ProjectSession[] = [
+      {
+        name: "dev",
+        windows: [
+          { index: 0, name: "zsh", worktreePath: "/tmp", activity: "active", isActiveWindow: true, activityTimestamp: 0 },
+          { index: 1, name: "build", worktreePath: "/tmp", activity: "idle", isActiveWindow: false, activityTimestamp: 0 },
+          { index: 2, name: "logs", worktreePath: "/tmp", activity: "idle", isActiveWindow: false, activityTimestamp: 0 },
+        ],
+      },
+    ];
+
+    const renumberedSessions: ProjectSession[] = [
+      {
+        name: "dev",
+        windows: [
+          { index: 0, name: "zsh", worktreePath: "/tmp", activity: "active", isActiveWindow: true, activityTimestamp: 0 },
+          // After killing index 1 ("build"), tmux renumbers "logs" from index 2 to index 1
+          { index: 1, name: "logs", worktreePath: "/tmp", activity: "idle", isActiveWindow: false, activityTimestamp: 0 },
+        ],
+      },
+    ];
+
+    const { rerender } = render(
+      <OptimisticProvider>
+        <KillWindowConsumer realSessions={threeWindowSessions} />
+      </OptimisticProvider>,
+    );
+
+    // Step 1: mark window 1 as killed (optimistic hide)
+    act(() => {
+      screen.getByTestId("kw-mark-killed").click();
+    });
+
+    // Window 1 ("build") is hidden; windows 0 and 2 still visible
+    expect(screen.getByTestId("kw-windows").textContent).toBe("dev:0:zsh,dev:2:logs");
+    expect(screen.getByTestId("kw-killed-count").textContent).toBe("1");
+
+    // Step 2: SSE delivers renumbered session (window 2 "logs" is now at index 1)
+    rerender(
+      <OptimisticProvider>
+        <KillWindowConsumer realSessions={renumberedSessions} />
+      </OptimisticProvider>,
+    );
+
+    // Killed entry for "dev:1" still hides the renumbered window
+    expect(screen.getByTestId("kw-windows").textContent).toBe("dev:0:zsh");
+
+    // Step 3: onSettled fires — unmarkKilled clears the killed entry
+    act(() => {
+      screen.getByTestId("kw-unmark-killed").click();
+    });
+
+    // Renumbered window (index 1 "logs") is now visible
+    expect(screen.getByTestId("kw-windows").textContent).toBe("dev:0:zsh,dev:1:logs");
+    expect(screen.getByTestId("kw-killed-count").textContent).toBe("0");
+  });
+
   it("ghost entry lifecycle: add ghost → SSE update matching ghost → ghost cleared", async () => {
     const { rerender } = render(
       <OptimisticProvider>

--- a/app/frontend/src/hooks/use-dialog-state.ts
+++ b/app/frontend/src/hooks/use-dialog-state.ts
@@ -143,6 +143,7 @@ export function useDialogState({ sessionName, windowIndex, onKillComplete, onSes
       addToast(err.message || "Failed to kill window");
     },
     onSettled: () => {
+      if (lastKillWindowRef.current) unmarkKilled(lastKillWindowRef.current);
       lastKillWindowRef.current = null;
     },
   });

--- a/docs/memory/run-kit/ui-patterns.md
+++ b/docs/memory/run-kit/ui-patterns.md
@@ -414,6 +414,26 @@ All mutating API calls use the `useOptimisticAction` hook (`app/frontend/src/hoo
 
 **Type guard**: `isGhostWindow(win)` exported from `optimistic-context.tsx` — narrows `WindowInfo | MergedWindow` to `MergedWindow & { optimistic: true }`. Used in sidebar and dashboard instead of `as` casts.
 
+### Window Kill: `onSettled` Cleanup Requirement
+
+After a window kill API call **succeeds**, `unmarkKilled` MUST be called to remove the stale optimistic killed entry. Without this, tmux's automatic window renumbering causes an index collision: when window N is killed, tmux renumbers window N+1 → N. The next SSE update delivers a real window at index N, but the stale `killed["session:N"]` entry in `OptimisticProvider` filters it out, making it appear as though two windows were removed.
+
+The `onRollback` path already calls `unmarkKilled` on API failure. The `onSettled` callback (which fires on success only — see `use-optimistic-action.ts` line ~42) handles the success case. These two hooks together cover all terminal states without double-invoking.
+
+**Three `useOptimisticAction` instances** must implement this pattern:
+
+| Instance | File | Kill path |
+|----------|------|-----------|
+| `executeKillWindow` | `app/frontend/src/components/sidebar.tsx` | Ctrl+Click direct kill |
+| `executeKillFromDialog` | `app/frontend/src/components/sidebar.tsx` | Confirmation dialog kill |
+| `executeKillWindow` | `app/frontend/src/hooks/use-dialog-state.ts` | Command palette kill |
+
+**Null guard**: `executeKillFromDialog`'s `onSettled` must check `killTargetRef.current` before calling `unmarkKilled` — the ref may be null if the component unmounts before the API call settles.
+
+**Session kills are exempt**: Session names are stable across kills (tmux never renumbers sessions). The index-collision mechanism is window-specific only.
+
+**Micro-flash trade-off**: If the HTTP response arrives before SSE, `unmarkKilled` fires first and the old window slot may briefly reappear (~sub-100ms) before SSE confirms the kill. This is accepted — permanently hiding a window is far worse than a sub-perceptible flash.
+
 ## Changelog
 
 | Date | Change | Reference |
@@ -461,3 +481,4 @@ All mutating API calls use the `useOptimisticAction` hook (`app/frontend/src/hoo
 | 2026-04-03 | Optimistic UI feedback — `useOptimisticAction` hook replacing all `.catch(() => {})` mutation patterns, `OptimisticProvider` context for ghost entries (create) and optimistic removal (kill) with SSE reconciliation, `ToastProvider` + `Toast` for error/info notifications (auto-dismiss 4s), button loading states (split/close pane spinners), inline progress (upload badge, directory autocomplete spinner, server refresh spinner), `isGhostWindow` type guard | `260403-32la-optimistic-ui-feedback` |
 | 2026-04-04 | Window move & reorder — CmdK "Window: Move Left/Right" actions (boundary-excluded, navigate after swap), sidebar drag-and-drop window reordering via native HTML5 DnD (same-session only, accent drop indicator, no external library) | `260404-29qz-window-move-reorder` |
 | 2026-04-04 | Cross-session window move — CmdK "Window: Move to {name}" actions (one per other session, flat list), cross-session drag-and-drop to session headers (accent border feedback), `moveWindowToSession` API client function, post-move navigation to `/$server` (server dashboard) | `260404-dq70-move-window-between-sessions` |
+| 2026-04-04 | Fix sidebar kill hides extra window — `onSettled` callbacks added to all three `useOptimisticAction` kill instances (`executeKillWindow` in sidebar, `executeKillFromDialog` in sidebar, `executeKillWindow` in use-dialog-state) to call `unmarkKilled` after success, preventing tmux index-renumbering from causing index collision on next SSE update | `260404-dsq9-sidebar-kill-hides-extra-window` |

--- a/fab/changes/260404-dsq9-sidebar-kill-hides-extra-window/.history.jsonl
+++ b/fab/changes/260404-dsq9-sidebar-kill-hides-extra-window/.history.jsonl
@@ -14,3 +14,4 @@
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-04-04T14:05:41Z"}
 {"event":"review","result":"passed","ts":"2026-04-04T14:05:41Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-04-04T14:06:54Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-04-04T14:08:34Z"}

--- a/fab/changes/260404-dsq9-sidebar-kill-hides-extra-window/.history.jsonl
+++ b/fab/changes/260404-dsq9-sidebar-kill-hides-extra-window/.history.jsonl
@@ -1,0 +1,16 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-04-04T13:53:19Z"}
+{"args":"Clicking on x in the left panel ends up killing two windows at a time","cmd":"fab-new","event":"command","ts":"2026-04-04T13:53:19Z"}
+{"delta":"+3.4","event":"confidence","score":3.4,"trigger":"calc-score","ts":"2026-04-04T13:53:59Z"}
+{"delta":"+0.0","event":"confidence","score":3.4,"trigger":"calc-score","ts":"2026-04-04T13:54:02Z"}
+{"cmd":"fab-switch","event":"command","ts":"2026-04-04T13:55:58Z"}
+{"delta":"+0.0","event":"confidence","score":3.4,"trigger":"calc-score","ts":"2026-04-04T13:58:02Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"spec","ts":"2026-04-04T13:58:05Z"}
+{"delta":"+0.0","event":"confidence","score":3.4,"trigger":"calc-score","ts":"2026-04-04T13:58:58Z"}
+{"delta":"+0.7","event":"confidence","score":4.1,"trigger":"calc-score","ts":"2026-04-04T13:59:03Z"}
+{"delta":"+0.0","event":"confidence","score":4.1,"trigger":"calc-score","ts":"2026-04-04T13:59:06Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"tasks","ts":"2026-04-04T14:00:57Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-04-04T14:01:02Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-04-04T14:04:13Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-04-04T14:05:41Z"}
+{"event":"review","result":"passed","ts":"2026-04-04T14:05:41Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-04-04T14:06:54Z"}

--- a/fab/changes/260404-dsq9-sidebar-kill-hides-extra-window/.status.yaml
+++ b/fab/changes/260404-dsq9-sidebar-kill-hides-extra-window/.status.yaml
@@ -11,8 +11,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 checklist:
     generated: true
     path: checklist.md
@@ -37,6 +37,8 @@ stage_metrics:
     apply: {started_at: "2026-04-04T14:01:02Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-04T14:04:13Z"}
     review: {started_at: "2026-04-04T14:04:13Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-04T14:05:41Z"}
     hydrate: {started_at: "2026-04-04T14:05:41Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-04T14:06:54Z"}
-    ship: {started_at: "2026-04-04T14:06:54Z", driver: fab-fff, iterations: 1}
-prs: []
-last_updated: 2026-04-04T14:06:54Z
+    ship: {started_at: "2026-04-04T14:06:54Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-04T14:08:34Z"}
+    review-pr: {started_at: "2026-04-04T14:08:34Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/sahil87/run-kit/pull/120
+last_updated: 2026-04-04T14:08:34Z

--- a/fab/changes/260404-dsq9-sidebar-kill-hides-extra-window/.status.yaml
+++ b/fab/changes/260404-dsq9-sidebar-kill-hides-extra-window/.status.yaml
@@ -1,0 +1,42 @@
+id: dsq9
+name: 260404-dsq9-sidebar-kill-hides-extra-window
+created: 2026-04-04T13:53:19Z
+created_by: sahil-weaver
+change_type: fix
+issues: []
+progress:
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+checklist:
+    generated: true
+    path: checklist.md
+    completed: 0
+    total: 0
+confidence:
+    certain: 4
+    confident: 3
+    tentative: 0
+    unresolved: 0
+    score: 4.1
+    fuzzy: true
+    dimensions:
+        signal: 87.9
+        reversibility: 88.6
+        competence: 89.3
+        disambiguation: 85.0
+stage_metrics:
+    intake: {started_at: "2026-04-04T13:53:19Z", driver: fab-new, iterations: 1, completed_at: "2026-04-04T13:58:05Z"}
+    spec: {started_at: "2026-04-04T13:58:05Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-04T14:00:57Z"}
+    tasks: {started_at: "2026-04-04T14:00:57Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-04T14:01:02Z"}
+    apply: {started_at: "2026-04-04T14:01:02Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-04T14:04:13Z"}
+    review: {started_at: "2026-04-04T14:04:13Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-04T14:05:41Z"}
+    hydrate: {started_at: "2026-04-04T14:05:41Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-04T14:06:54Z"}
+    ship: {started_at: "2026-04-04T14:06:54Z", driver: fab-fff, iterations: 1}
+prs: []
+last_updated: 2026-04-04T14:06:54Z

--- a/fab/changes/260404-dsq9-sidebar-kill-hides-extra-window/checklist.md
+++ b/fab/changes/260404-dsq9-sidebar-kill-hides-extra-window/checklist.md
@@ -1,0 +1,40 @@
+# Quality Checklist: Sidebar Kill Hides Extra Window
+
+**Change**: 260404-dsq9-sidebar-kill-hides-extra-window
+**Generated**: 2026-04-04
+**Spec**: `spec.md`
+
+## Functional Completeness
+
+- [ ] CHK-001 `executeKillWindow` (sidebar Ctrl+Click): `onSettled` added and calls `unmarkKilled(lastKillWindowRef.current)` when ref is non-null
+- [ ] CHK-002 `executeKillFromDialog` (sidebar dialog): `onSettled` added and calls `unmarkKilled` using `killTargetRef.current`, with null guard
+- [ ] CHK-003 `executeKillWindow` (use-dialog-state command palette): existing `onSettled` extended to call `unmarkKilled(lastKillWindowRef.current)` before nulling the ref
+
+## Behavioral Correctness
+
+- [ ] CHK-004 After a successful window kill, the killed entry is removed from `OptimisticContext.killed[]` so the next SSE update renders the renumbered window correctly
+- [ ] CHK-005 On kill failure, `onRollback` still fires and `unmarkKilled` is called (no regression to existing rollback behaviour)
+
+## Scenario Coverage
+
+- [ ] CHK-006 Direct kill scenario: killing window N in a multi-window session does not hide the window that gets renumbered to index N
+- [ ] CHK-007 Dialog kill scenario: same scenario via the confirmation dialog path
+- [ ] CHK-008 Command palette kill scenario: same scenario via `use-dialog-state` path
+- [ ] CHK-009 Null guard scenario: `executeKillFromDialog` `onSettled` does not throw when `killTargetRef.current` is null
+
+## Edge Cases & Error Handling
+
+- [ ] CHK-010 Single-window session: killing the only window (index 0) does not cause a phantom window to appear after `unmarkKilled` fires
+- [ ] CHK-011 `onSettled` is not called on failure — failure path calls `onRollback` + `onError` only (verified from `use-optimistic-action.ts` inspection)
+
+## Code Quality
+
+- [ ] CHK-012 Pattern consistency: `onSettled` callbacks follow the same pattern as `onRollback` callbacks in the same `useOptimisticAction` instances (guard → unmark → null ref)
+- [ ] CHK-013 No unnecessary duplication: no new utilities introduced — `unmarkKilled` is already available via `useOptimisticContext()` in each affected file
+- [ ] CHK-014 Type narrowing: all `onSettled` closures use `if` guards rather than non-null assertions to access refs
+- [ ] CHK-015 Tests added: `sidebar.test.tsx` and/or `optimistic-context.test.tsx` cover the new `onSettled` behaviour
+
+## Notes
+
+- All items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] CHK-NNN **N/A**: {reason}`

--- a/fab/changes/260404-dsq9-sidebar-kill-hides-extra-window/intake.md
+++ b/fab/changes/260404-dsq9-sidebar-kill-hides-extra-window/intake.md
@@ -1,0 +1,94 @@
+# Intake: Sidebar Kill Hides Extra Window
+
+**Change**: 260404-dsq9-sidebar-kill-hides-extra-window
+**Created**: 2026-04-04
+**Status**: Draft
+
+## Origin
+
+> Clicking on x in the left panel ends up killing two windows at a time
+
+One-shot natural language report. No prior conversation.
+
+## Why
+
+When a user clicks the X (kill) button on a window in the left panel sidebar, two windows visually disappear instead of one. The root cause is a stale optimistic kill state that is never cleared on success.
+
+Optimistic updates mark a window as killed using `markKilled("window", "session:index")`. This correctly hides the targeted window immediately. However, `unmarkKilled` is never called after a successful kill API response — only after a failure (rollback). When tmux kills window N, it renumbers all subsequent windows: the window that was at N+1 becomes N. When the next SSE update arrives, the new window at index N is filtered out by the stale killed entry (`session:N`), making it look like two windows were removed.
+
+If not fixed, any session with more than one window will lose a visible window every time any window is killed — a confusing and persistent UI regression.
+
+## What Changes
+
+### Clearing stale optimistic kill state on success
+
+All three `useOptimisticAction` instances that call `markKilled("window", ...)` need an `onSettled` callback that calls `unmarkKilled` to clear the optimistic filter after the API call completes (success or failure is handled separately via `onRollback`).
+
+**`app/frontend/src/components/sidebar.tsx`** — two instances:
+
+1. `executeKillWindow` (Ctrl+Click direct kill, lines 86–99): add `onSettled`:
+   ```ts
+   onSettled: () => {
+     if (lastKillWindowRef.current) unmarkKilled(lastKillWindowRef.current);
+   },
+   ```
+
+2. `executeKillFromDialog` (confirmation dialog kill, lines 105–131): currently no `onSettled`. Add it using `killTargetRef`:
+   ```ts
+   onSettled: () => {
+     const target = killTargetRef.current;
+     if (!target) return;
+     if (target.type === "window" && target.windowIndex != null) {
+       unmarkKilled(`${target.session}:${target.windowIndex}`);
+     } else {
+       unmarkKilled(target.session);
+     }
+   },
+   ```
+
+**`app/frontend/src/hooks/use-dialog-state.ts`** — one instance:
+
+3. `executeKillWindow` (lines 132–148): already has `onSettled` but it only nulls the ref. Extend it to also call `unmarkKilled`:
+   ```ts
+   onSettled: () => {
+     if (lastKillWindowRef.current) {
+       unmarkKilled(lastKillWindowRef.current);
+     }
+     lastKillWindowRef.current = null;
+   },
+   ```
+
+### Timing behaviour after fix
+
+After a successful kill:
+- If SSE arrives **before** the HTTP response: the stale killed state still filters the renumbered window until `onSettled` fires and calls `unmarkKilled`, after which the renumbered window appears correctly. No flash.
+- If SSE arrives **after** the HTTP response: `unmarkKilled` fires first, the old window at that index may briefly reappear for the milliseconds before SSE clears it. This micro-flash is acceptable — it is far better than permanently losing a window.
+
+Session kills (`killSession`) share the same pattern but are not affected by index renumbering since tmux session names are stable. No fix needed there for this specific bug, though the same `onSettled` cleanup is defensively correct.
+
+## Affected Memory
+
+- `ui/optimistic-state.md`: (modify) document that killed window entries must be cleared on success to avoid index collision after tmux renumbering
+
+## Impact
+
+- `app/frontend/src/components/sidebar.tsx` — two `useOptimisticAction` instances get `onSettled` callbacks
+- `app/frontend/src/hooks/use-dialog-state.ts` — one `useOptimisticAction` instance gets extended `onSettled`
+- `app/frontend/src/contexts/optimistic-context.tsx` — no changes needed; the `unmarkKilled` API is already correct
+- No backend changes required
+
+## Open Questions
+
+- Should `killSession` entries also be cleaned up in `onSettled` for consistency, or is the index-collision risk specific enough to windows only that it should stay out of scope?
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Root cause is stale optimistic kill state in `killed[]` — `unmarkKilled` is never called on success | Code inspection: `onRollback` calls `unmarkKilled`, but no `onSettled` does. tmux renumbering confirmed by tmux kill-window behaviour. | S:95 R:95 A:90 D:90 |
+| 2 | Certain | Fix scope is frontend only — `handleWindowKill` in backend correctly kills exactly one window | Backend handler at `windows.go:82` is a single `tmux kill-window` call with no side effects | S:90 R:95 A:95 D:90 |
+| 3 | Confident | `onSettled` is the right hook (not a separate reconciliation in `useMergedSessions`) | `onSettled` is already in the `useOptimisticAction` API and used in rename flows; adding it to kill flows is consistent. Reconciliation in `useMergedSessions` would require storing window name in killed entries to distinguish old vs renumbered — unnecessary complexity. | S:80 R:85 A:85 D:75 |
+| 4 | Confident | Session kill entries don't need the same fix in this change — session names don't shift on kill | tmux session names are user-chosen strings; killing one session never renames another. The index-collision mechanism is window-specific. | S:85 R:80 A:85 D:80 |
+| 5 | Tentative | Brief reappearance flash (HTTP settles before SSE) is acceptable UX trade-off | The flash is sub-100ms in practice. The alternative (permanent hidden window) is far worse. No user preference gathered. <!-- assumed: flash acceptable — far better than permanent loss; can always revisit with SSE-gated unmark if needed --> | S:60 R:70 A:65 D:65 |
+
+5 assumptions (2 certain, 2 confident, 1 tentative, 0 unresolved). Run /fab-clarify to review.

--- a/fab/changes/260404-dsq9-sidebar-kill-hides-extra-window/spec.md
+++ b/fab/changes/260404-dsq9-sidebar-kill-hides-extra-window/spec.md
@@ -1,0 +1,102 @@
+# Spec: Sidebar Kill Hides Extra Window
+
+**Change**: 260404-dsq9-sidebar-kill-hides-extra-window
+**Created**: 2026-04-04
+**Affected memory**: `docs/memory/run-kit/ui-patterns.md`
+
+## Non-Goals
+
+- Fixing the same stale-state pattern for `killSession` entries — session names never shift on kill, so the index-collision mechanism does not apply to sessions
+- Changing the optimistic kill architecture (killed-by-id approach) — `onSettled` cleanup is the minimal correct fix within the existing model
+
+## Frontend: Optimistic Kill State Lifecycle
+
+### Requirement: Window Kill Must Clear Optimistic State on Settled
+
+After a window kill API call settles (success or failure), the optimistic killed entry for that window MUST be removed from the `killed[]` state via `unmarkKilled`. The existing `onRollback` path already handles the failure case; an `onSettled` callback MUST be added to handle the success case.
+
+This requirement applies to all three `useOptimisticAction` instances that call `markKilled("window", ...)`:
+1. `executeKillWindow` in `sidebar.tsx` (Ctrl+Click direct kill path)
+2. `executeKillFromDialog` in `sidebar.tsx` (confirmation dialog kill path)
+3. `executeKillWindow` in `use-dialog-state.ts` (command palette kill path)
+
+#### Scenario: Direct kill clears state on success
+
+- **GIVEN** a session has windows at indices [0, 1, 2]
+- **WHEN** the user Ctrl+Clicks the X button on window at index 1
+- **THEN** `markKilled("window", "session:1")` is called optimistically, hiding window 1
+- **AND** the kill API call is dispatched
+- **AND** when the API call resolves (success), `unmarkKilled("session:1")` is called
+- **AND** the next SSE update showing windows [0, 1 (renumbered from 2)] renders correctly with both windows visible
+
+#### Scenario: Dialog kill clears state on success
+
+- **GIVEN** a session has windows at indices [0, 1, 2]
+- **WHEN** the user clicks the X button on window at index 1 and confirms in the dialog
+- **THEN** `markKilled("window", "session:1")` is called optimistically
+- **AND** when the kill API call resolves (success), `unmarkKilled("session:1")` is called
+- **AND** the renumbered window (old index 2, now index 1) appears in the sidebar after SSE update
+
+#### Scenario: Rollback still removes optimistic state on failure
+
+- **GIVEN** a window kill is in flight with optimistic state applied
+- **WHEN** the kill API call fails (network error, tmux error)
+- **THEN** `onRollback` fires and `unmarkKilled` removes the killed entry (existing behaviour preserved)
+- **AND** the window reappears in the sidebar
+
+#### Scenario: No double-kill appearance for last window in session
+
+- **GIVEN** a session has exactly one window (index 0)
+- **WHEN** the user kills window at index 0
+- **THEN** the window disappears optimistically
+- **AND** the session itself eventually disappears via SSE (no renumbering occurs)
+- **AND** no phantom window appears after `unmarkKilled` fires (there is no next window to unhide)
+
+### Requirement: `onSettled` Must Not Double-Invoke `unmarkKilled`
+
+The `onSettled` callback for `executeKillFromDialog` in `sidebar.tsx` MUST guard against the case where `killTargetRef.current` is null before calling `unmarkKilled`. The ref is set via the component's state sync and may be null if the component unmounts before the API call settles.
+
+#### Scenario: Dialog unmounts before API settles
+
+- **GIVEN** a kill API call is in flight via `executeKillFromDialog`
+- **WHEN** the sidebar component unmounts before the API call resolves
+- **THEN** `onSettled` fires but `killTargetRef.current` is null
+- **AND** `unmarkKilled` is NOT called (null guard prevents the call)
+- **AND** no runtime error is thrown
+
+### Requirement: `use-dialog-state.ts` `onSettled` Must Clear Both Ref and Killed State
+
+The existing `onSettled` in `use-dialog-state.ts` `executeKillWindow` only nulls `lastKillWindowRef.current`. It MUST be extended to also call `unmarkKilled(lastKillWindowRef.current)` before nulling the ref.
+
+#### Scenario: Command palette kill clears stale state
+
+- **GIVEN** a session has windows at indices [0, 1, 2] and the user navigates to window 1
+- **WHEN** the user opens the command palette and selects "Window: Kill"
+- **THEN** a kill confirm dialog appears
+- **AND** on confirm, `markKilled("window", "session:1")` is called
+- **AND** when the API call settles (success), `unmarkKilled("session:1")` is called
+- **AND** `lastKillWindowRef.current` is nulled after unmarkKilled
+
+## Design Decisions
+
+1. **`onSettled` over SSE reconciliation in `useMergedSessions`**: Add `unmarkKilled` call in `onSettled` rather than auto-reconciling killed entries in the merge function.
+   - *Why*: `useMergedSessions` can only detect that a killed window no longer appears in real SSE data, but cannot distinguish between "kill confirmed, index now occupied by renumbered window" vs "SSE update hasn't arrived yet". The `onSettled` hook fires after the API call completes, which is the definitive signal that the kill was processed. Reconciliation in `useMergedSessions` would require storing the window name in killed entries — unnecessary complexity for this fix.
+   - *Rejected*: Adding a `windowName` field to `KilledEntry` and clearing in `useMergedSessions` when the real window at that index has a different name. Too complex and introduces a new failure mode (name-match false positive).
+
+2. **Accepting micro-flash UX trade-off**: When the HTTP response arrives before the SSE update, `unmarkKilled` fires first and the old window slot may briefly reappear before SSE removes it.
+   - *Why*: The flash is sub-100ms in practice and imperceptible. The alternative — permanently hiding a window — is a significant data-loss UX bug. The flash is strictly better.
+   - *Rejected*: Delaying `unmarkKilled` until after SSE reconciliation via a flag in `.status.yaml` — overly complex, introduces coupling between SSE and the optimistic action hook.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Root cause: `unmarkKilled` is never called on success — only on rollback | Confirmed from intake #1. `onRollback` calls `unmarkKilled`; no `onSettled` does. tmux renumbering creates index collision for the next window. | S:95 R:95 A:90 D:90 |
+| 2 | Certain | Fix is frontend-only — backend kills exactly one window, no side effects | Confirmed from intake #2. `handleWindowKill` at `windows.go:82` issues a single `tmux kill-window` call. | S:90 R:95 A:95 D:90 |
+| 3 | Certain | Three `useOptimisticAction` instances need `onSettled`: `executeKillWindow` (sidebar), `executeKillFromDialog` (sidebar), `executeKillWindow` (use-dialog-state) | Confirmed by code review of all kill paths. No fourth path exists. | S:90 R:90 A:95 D:90 |
+| 4 | Certain | `onSettled` fires on success only in `useOptimisticAction` — failure path calls `onRollback` then `onError`, never `onSettled` | <!-- clarified: codebase inspection of use-optimistic-action.ts confirms onSettled is only called in the .then() success branch (line 42); the rejection handler (lines 45-51) calls onRollback+onError but NOT onSettled. The original assumption was wrong. This means: onRollback handles the failure unmark, and onSettled handles the success unmark — no double-invoke risk at all. --> Verified from `app/frontend/src/hooks/use-optimistic-action.ts`: success branch calls `onSettled?.()` before `setIsPending(false)`; error branch calls `onRollback?.()` then `onError?.(error)` — no `onSettled` call. | S:95 R:95 A:95 D:95 |
+| 5 | Confident | `onSettled` is the right hook — `useMergedSessions` reconciliation is unnecessary complexity | Confirmed from intake #3. API surface already exists; no structural changes needed. | S:80 R:85 A:85 D:75 |
+| 6 | Confident | Session kill entries don't need same fix — session names are stable across kills | Confirmed from intake #4. | S:85 R:80 A:85 D:80 |
+| 7 | Confident | Micro-flash UX (HTTP before SSE) is acceptable | Confirmed from intake #5. Sub-100ms flash preferred over permanent data loss. <!-- clarified: design decision #2 in this spec documents and explicitly accepts this trade-off with rationale; no user input needed to validate the acceptability. --> | S:80 R:80 A:80 D:75 |
+
+7 assumptions (4 certain, 3 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260404-dsq9-sidebar-kill-hides-extra-window/tasks.md
+++ b/fab/changes/260404-dsq9-sidebar-kill-hides-extra-window/tasks.md
@@ -1,0 +1,26 @@
+# Tasks: Sidebar Kill Hides Extra Window
+
+**Change**: 260404-dsq9-sidebar-kill-hides-extra-window
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+## Phase 1: Core Implementation
+
+<!-- All three changes are independent — different instances in different files. -->
+
+- [x] T001 [P] In `app/frontend/src/components/sidebar.tsx`, add `onSettled` to `executeKillWindow` (lines ~86–99) to call `unmarkKilled(lastKillWindowRef.current)` after a successful direct kill (Ctrl+Click path)
+- [x] T002 [P] In `app/frontend/src/components/sidebar.tsx`, add `onSettled` to `executeKillFromDialog` (lines ~105–131) to call `unmarkKilled` for the targeted window/session using `killTargetRef.current`, guarded against null
+- [x] T003 [P] In `app/frontend/src/hooks/use-dialog-state.ts`, extend the existing `onSettled` on `executeKillWindow` (lines ~132–148) to also call `unmarkKilled(lastKillWindowRef.current)` before nulling the ref
+
+## Phase 2: Tests
+
+- [x] T004 [P] Add a test to `app/frontend/src/components/sidebar.test.tsx` verifying that after a window kill succeeds, the killed entry is removed from the optimistic context (i.e., `unmarkKilled` is called on success)
+- [x] T005 [P] Add a test to `app/frontend/src/contexts/optimistic-context.test.tsx` (or a new test file if needed) verifying that `useMergedSessions` renders the renumbered window correctly once the killed entry is cleared
+
+---
+
+## Execution Order
+
+- T001, T002, T003 are independent and can run in parallel (different file locations)
+- T004, T005 depend on T001–T003 being done (tests verify the fixed behaviour)
+- T004 and T005 are independent of each other


### PR DESCRIPTION
## Summary

When a user clicks the X (kill) button on a window in the left panel sidebar, two windows visually disappear instead of one. The root cause is a stale optimistic kill state (`markKilled`) that is never cleared on success — only on rollback. After tmux kills window N and renumbers subsequent windows, the next SSE update's window at index N gets filtered out by the stale killed entry, making it appear as if two windows were removed.

## Changes

- Clearing stale optimistic kill state on success — all three `useOptimisticAction` kill instances get `onSettled` callbacks
- Tests verifying renumbered windows render correctly after kill succeeds

## Change

| ID | Name | Issue |
|----|------|-------|
| dsq9 | 260404-dsq9-sidebar-kill-hides-extra-window | — |

## Stats

| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| fix | 4.1 / 5.0 | — | 5/5 ✓ | — |

[intake](https://github.com/sahil87/run-kit/blob/260404-dsq9-sidebar-kill-hides-extra-window/fab/changes/260404-dsq9-sidebar-kill-hides-extra-window/intake.md) → [spec](https://github.com/sahil87/run-kit/blob/260404-dsq9-sidebar-kill-hides-extra-window/fab/changes/260404-dsq9-sidebar-kill-hides-extra-window/spec.md) → tasks → apply → review → hydrate → ship