### PR TITLE
refactor: Sidebar polish — active highlight, rename area, spacing

### DIFF
--- a/app/frontend/src/components/sidebar.test.tsx
+++ b/app/frontend/src/components/sidebar.test.tsx
@@ -137,8 +137,7 @@ describe("Sidebar", () => {
   it("highlights selected window", () => {
     renderSidebar();
     const mainBtn = screen.getByText("main").closest("button");
-    expect(mainBtn?.className).toContain("bg-accent/10");
-    expect(mainBtn?.className).toContain("border-accent");
+    expect(mainBtn?.className).toContain("bg-accent/15");
   });
 
   it("calls onSelectWindow when clicking a window", () => {

--- a/app/frontend/src/components/sidebar.tsx
+++ b/app/frontend/src/components/sidebar.tsx
@@ -411,7 +411,7 @@ export function Sidebar({
 
   return (
     <nav aria-label="Sessions" className="flex flex-col h-full pt-2">
-      <div className="flex-1 min-h-0 overflow-y-auto px-3 sm:px-4">
+      <div className="flex-1 min-h-0 overflow-y-auto pl-1 pr-0">
         {sessions.length === 0 ? (
           <div className="text-text-secondary text-xs py-4 text-center flex flex-col items-center gap-2">
             <span>No sessions</span>
@@ -436,7 +436,7 @@ export function Sidebar({
                   onDrop={(e) => handleSessionDrop(e, session.name)}
                   style={sessionDropTarget === session.name ? { border: "2px solid var(--color-accent)", borderRadius: "4px" } : undefined}
                 >
-                  <div className="flex items-center gap-0.5 min-w-0">
+                  <div className="flex items-center gap-0.5 min-w-0 flex-1">
                     <button
                       onClick={() => toggleSession(session.name)}
                       className="text-xs text-text-secondary hover:text-text-primary transition-colors w-5 shrink-0 min-h-[36px] flex items-center justify-center"
@@ -447,7 +447,11 @@ export function Sidebar({
                     </button>
                     <button
                       onClick={() => onSelectWindow(session.name, session.windows[0]?.index ?? 0)}
-                      className="flex items-center gap-1 text-sm text-text-secondary hover:text-text-primary transition-colors py-1 min-h-[36px] min-w-0"
+                      onDoubleClick={(e) => {
+                        e.stopPropagation();
+                        if (editingSession !== session.name) handleStartSessionEditing(session.name);
+                      }}
+                      className="flex items-center gap-1 text-sm text-text-secondary hover:text-text-primary transition-colors py-1 min-h-[36px] min-w-0 flex-1"
                       aria-label={`Navigate to ${session.name}`}
                     >
                       {editingSession === session.name ? (
@@ -464,19 +468,13 @@ export function Sidebar({
                           aria-label="Rename session"
                         />
                       ) : (
-                        <span
-                          className="font-medium truncate"
-                          onDoubleClick={(e) => {
-                            e.stopPropagation();
-                            handleStartSessionEditing(session.name);
-                          }}
-                        >
+                        <span className="font-medium truncate">
                           {session.name}
                         </span>
                       )}
                     </button>
                   </div>
-                  <div className="flex items-center">
+                  <div className="flex items-center pr-2">
                     <button
                       onClick={() => onCreateWindow(session.name)}
                       aria-label={`New window in ${session.name}`}
@@ -529,10 +527,14 @@ export function Sidebar({
                         >
                           <button
                             onClick={() => onSelectWindow(session.name, win.index)}
-                            className={`w-full text-left flex items-center justify-between gap-2 py-1 pl-2 pr-6 text-sm transition-colors min-h-[36px] border-l-2 ${
+                            onDoubleClick={(e) => {
+                              e.stopPropagation();
+                              if (!ghost) handleStartEditing(session.name, win.windowId, win.name);
+                            }}
+                            className={`w-full text-left flex items-center justify-between gap-2 py-1 pl-2 pr-8 text-sm transition-colors min-h-[36px] ${
                               isSelected
-                                ? "bg-accent/10 border-accent text-text-primary font-medium rounded-r"
-                                : "text-text-secondary hover:text-text-primary hover:bg-bg-card/50 border-transparent rounded"
+                                ? "bg-accent/15 text-text-primary font-medium rounded"
+                                : "text-text-secondary hover:text-text-primary hover:bg-bg-card/50 rounded"
                             }`}
                             aria-current={isSelected ? "page" : undefined}
                           >
@@ -559,13 +561,7 @@ export function Sidebar({
                                   aria-label="Rename window"
                                 />
                               ) : (
-                                <span
-                                  className="truncate"
-                                  onDoubleClick={(e) => {
-                                    e.stopPropagation();
-                                    if (!ghost) handleStartEditing(session.name, win.windowId, win.name);
-                                  }}
-                                >{win.name}</span>
+                                <span className="truncate">{win.name}</span>
                               )}
                             </span>
                             <span className="flex items-center gap-1.5 shrink-0">
@@ -601,7 +597,7 @@ export function Sidebar({
                                 });
                               }
                             }}
-                            className="absolute right-0.5 top-1/2 -translate-y-1/2 text-[14px] text-text-secondary hover:text-red-400 transition-opacity cursor-pointer opacity-0 group-hover:opacity-100 coarse:opacity-100 px-1 min-h-[36px] flex items-center justify-center z-10"
+                            className="absolute right-2 top-1/2 -translate-y-1/2 text-[14px] text-text-secondary hover:text-red-400 transition-opacity cursor-pointer opacity-0 group-hover:opacity-100 coarse:opacity-100 px-1 min-h-[36px] flex items-center justify-center z-10"
                           >
                             {"\u2715"}
                           </button>


### PR DESCRIPTION
## Summary
Polish sidebar UX: replace left accent border on active window with background highlight to distinguish from drag indicators, expand double-click rename target to full row for both sessions and windows, and adjust horizontal spacing/padding for better alignment.

## Changes
- Active window uses `bg-accent/15` background instead of `border-l-2 border-accent` left border
- Double-click to rename now works on the full session/window row, not just the text
- Right-side padding adjusted so session and window × buttons align vertically
- Left panel padding set to 4px left, 0 right

## Stats
| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| refactor | — | — | — | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)