### PR TITLE
refactor: Sidebar Component Decomposition

### DIFF
--- a/app/frontend/src/components/sidebar/index.tsx
+++ b/app/frontend/src/components/sidebar/index.tsx
@@ -1,8 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from "react";
-import { killSession as killSessionApi, killWindow as killWindowApi, renameWindow, renameSession, moveWindow, moveWindowToSession } from "@/api/client";
-import { Dialog } from "@/components/dialog";
-import { LogoSpinner } from "@/components/logo-spinner";
-import { getWindowDuration } from "@/lib/format";
+import { killSession as killSessionApi, killWindow as killWindowApi, renameWindow, renameSession, moveWindow } from "@/api/client";
 import { useOptimisticAction } from "@/hooks/use-optimistic-action";
 import { useOptimisticContext } from "@/contexts/optimistic-context";
 import { useToast } from "@/components/toast";
@@ -10,8 +7,12 @@ import type { ProjectSession } from "@/types";
 import { isGhostWindow } from "@/contexts/optimistic-context";
 import type { MergedSession } from "@/contexts/optimistic-context";
 import { useWindowStore } from "@/store/window-store";
+import { KillDialog } from "./kill-dialog";
+import { ServerSelector } from "./server-selector";
+import { SessionRow } from "./session-row";
+import { WindowRow } from "./window-row";
 
-type SidebarProps = {
+export type SidebarProps = {
   sessions: (ProjectSession | MergedSession)[];
   currentSession: string | null;
   currentWindowIndex: string | null;
@@ -65,10 +66,6 @@ export function Sidebar({
   const [dragSource, setDragSource] = useState<{ session: string; index: number } | null>(null);
   const [dropTarget, setDropTarget] = useState<{ session: string; index: number } | null>(null);
   const [sessionDropTarget, setSessionDropTarget] = useState<string | null>(null);
-
-  const [serverDropdownOpen, setServerDropdownOpen] = useState(false);
-  const [refreshingServers, setRefreshingServers] = useState(false);
-  const serverDropdownRef = useRef<HTMLDivElement>(null);
 
   const { markKilled, unmarkKilled, markRenamed, unmarkRenamed } = useOptimisticContext();
   const { addToast } = useToast();
@@ -206,18 +203,6 @@ export function Sidebar({
       lastRenameWindowRef.current = null;
     },
   });
-
-  // Close server dropdown on outside click
-  useEffect(() => {
-    if (!serverDropdownOpen) return;
-    function handleClick(e: MouseEvent) {
-      if (serverDropdownRef.current && !serverDropdownRef.current.contains(e.target as Node)) {
-        setServerDropdownOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [serverDropdownOpen]);
 
   useEffect(() => {
     if (editingWindow && inputRef.current) {
@@ -429,78 +414,35 @@ export function Sidebar({
             return (
               <div key={session.name} className={`mb-2${isGhostSession ? " opacity-50 animate-pulse" : ""}`}>
                 {/* Session row */}
-                <div
-                  className="flex items-center justify-between group"
+                <SessionRow
+                  session={session}
+                  isCollapsed={isCollapsed}
+                  isSessionDropTarget={sessionDropTarget === session.name}
+                  editingSession={editingSession}
+                  editingSessionName={editingSessionName}
+                  sessionInputRef={sessionInputRef}
+                  onToggleCollapse={() => toggleSession(session.name)}
+                  onSelectFirstWindow={() => onSelectWindow(session.name, session.windows[0]?.index ?? 0)}
+                  onCreateWindow={() => onCreateWindow(session.name)}
+                  onKillClick={(e) => {
+                    if (e.ctrlKey || e.metaKey) {
+                      executeKillSession(session.name);
+                      return;
+                    }
+                    setKillTarget({
+                      type: "session",
+                      session: session.name,
+                      windowCount: session.windows.length,
+                    });
+                  }}
+                  onDoubleClickName={() => handleStartSessionEditing(session.name)}
+                  onSessionNameChange={setEditingSessionName}
+                  onSessionRenameKeyDown={handleSessionRenameKeyDown}
+                  onSessionRenameBlur={handleSessionRenameBlur}
                   onDragOver={(e) => handleSessionDragOver(e, session.name)}
                   onDragLeave={(e) => handleSessionDragLeave(e, session.name)}
                   onDrop={(e) => handleSessionDrop(e, session.name)}
-                  style={sessionDropTarget === session.name ? { border: "2px solid var(--color-accent)", borderRadius: "4px" } : undefined}
-                >
-                  <div className="flex items-center gap-0.5 min-w-0 flex-1">
-                    <button
-                      onClick={() => toggleSession(session.name)}
-                      className="text-xs text-text-secondary hover:text-text-primary transition-colors w-5 shrink-0 min-h-[36px] flex items-center justify-center"
-                      aria-expanded={!isCollapsed}
-                      aria-label={`${isCollapsed ? "Expand" : "Collapse"} ${session.name}`}
-                    >
-                      {isCollapsed ? "\u25B6" : "\u25BC"}
-                    </button>
-                    <button
-                      onClick={() => onSelectWindow(session.name, session.windows[0]?.index ?? 0)}
-                      onDoubleClick={(e) => {
-                        e.stopPropagation();
-                        if (editingSession !== session.name) handleStartSessionEditing(session.name);
-                      }}
-                      className="flex items-center gap-1 text-sm text-text-secondary hover:text-text-primary transition-colors py-1 min-h-[36px] min-w-0 flex-1"
-                      aria-label={`Navigate to ${session.name}`}
-                    >
-                      {editingSession === session.name ? (
-                        <input
-                          ref={sessionInputRef}
-                          type="text"
-                          value={editingSessionName}
-                          onChange={(e) => setEditingSessionName(e.target.value)}
-                          onKeyDown={handleSessionRenameKeyDown}
-                          onBlur={handleSessionRenameBlur}
-                          onClick={(e) => e.stopPropagation()}
-                          onMouseDown={(e) => e.stopPropagation()}
-                          className="text-sm font-medium bg-transparent border border-accent rounded px-0.5 outline-none truncate w-full"
-                          aria-label="Rename session"
-                        />
-                      ) : (
-                        <span className="font-medium truncate">
-                          {session.name}
-                        </span>
-                      )}
-                    </button>
-                  </div>
-                  <div className="flex items-center pr-2">
-                    <button
-                      onClick={() => onCreateWindow(session.name)}
-                      aria-label={`New window in ${session.name}`}
-                      className="text-text-secondary hover:text-text-primary transition-colors text-[16px] px-1 min-h-[36px] flex items-center justify-center"
-                    >
-                      +
-                    </button>
-                    <button
-                      onClick={(e) => {
-                        if (e.ctrlKey || e.metaKey) {
-                          executeKillSession(session.name);
-                          return;
-                        }
-                        setKillTarget({
-                          type: "session",
-                          session: session.name,
-                          windowCount: session.windows.length,
-                        });
-                      }}
-                      aria-label={`Kill session ${session.name}`}
-                      className="text-text-secondary hover:text-red-400 transition-colors text-[16px] px-1 min-h-[36px] flex items-center justify-center"
-                    >
-                      {"\u2715"}
-                    </button>
-                  </div>
-                </div>
+                />
 
                 {/* Window rows */}
                 {!isCollapsed && (
@@ -509,99 +451,46 @@ export function Sidebar({
                       const isSelected =
                         currentSession === session.name &&
                         currentWindowIndex === String(win.index);
-                      const duration = getWindowDuration(win, nowSeconds);
                       const ghost = isGhostWindow(win);
-
                       const isDragOver = dropTarget?.session === session.name && dropTarget?.index === win.index && dragSource?.index !== win.index;
 
                       return (
-                        <div
+                        <WindowRow
                           key={ghost ? `ghost-${win.optimisticId}` : win.windowId}
-                          className={`relative group${ghost ? " opacity-50 animate-pulse" : ""}`}
-                          draggable={!ghost}
+                          win={win}
+                          session={session.name}
+                          isSelected={isSelected}
+                          isDragOver={isDragOver}
+                          nowSeconds={nowSeconds}
+                          editingWindow={editingWindow}
+                          editingName={editingName}
+                          inputRef={inputRef}
+                          onSelectWindow={() => onSelectWindow(session.name, win.index)}
+                          onDoubleClickName={() => handleStartEditing(session.name, win.windowId, win.name)}
+                          onWindowNameChange={setEditingName}
+                          onRenameKeyDown={handleRenameKeyDown}
+                          onRenameBlur={handleRenameBlur}
+                          onKillClick={(e) => {
+                            e.stopPropagation();
+                            if (e.ctrlKey || e.metaKey) {
+                              if (!ghost) executeKillWindow(session.name, win.windowId, win.index);
+                              return;
+                            }
+                            if (!ghost) {
+                              setKillTarget({
+                                type: "window",
+                                session: session.name,
+                                windowId: win.windowId,
+                                windowIndex: win.index,
+                                windowCount: 1,
+                              });
+                            }
+                          }}
                           onDragStart={(e) => handleDragStart(e, session.name, win.index)}
                           onDragOver={(e) => handleDragOver(e, session.name, win.index)}
                           onDrop={(e) => handleDrop(e, session.name, win.index)}
                           onDragEnd={handleDragEnd}
-                          style={isDragOver ? { borderTop: "2px solid var(--color-accent)" } : undefined}
-                        >
-                          <button
-                            onClick={() => onSelectWindow(session.name, win.index)}
-                            onDoubleClick={(e) => {
-                              e.stopPropagation();
-                              if (!ghost) handleStartEditing(session.name, win.windowId, win.name);
-                            }}
-                            className={`w-full text-left flex items-center justify-between gap-2 py-1 pl-2 pr-8 text-sm transition-colors min-h-[36px] ${
-                              isSelected
-                                ? "bg-accent/15 text-text-primary font-medium rounded-l-lg rounded-r-none"
-                                : "text-text-secondary hover:text-text-primary hover:bg-bg-card/50 rounded-l-lg rounded-r-none"
-                            }`}
-                            aria-current={isSelected ? "page" : undefined}
-                          >
-                            <span className="flex items-center gap-1.5 truncate min-w-0">
-                              <span
-                                className={`w-1.5 h-1.5 rounded-full shrink-0 ${
-                                  win.activity === "active"
-                                    ? "bg-accent-green"
-                                    : "bg-text-secondary/40"
-                                }`}
-                                aria-label={win.activity}
-                              />
-                              {editingWindow?.session === session.name && editingWindow.windowId === win.windowId ? (
-                                <input
-                                  ref={inputRef}
-                                  type="text"
-                                  value={editingName}
-                                  onChange={(e) => setEditingName(e.target.value)}
-                                  onKeyDown={handleRenameKeyDown}
-                                  onBlur={handleRenameBlur}
-                                  onClick={(e) => e.stopPropagation()}
-                                  onMouseDown={(e) => e.stopPropagation()}
-                                  className="text-sm bg-transparent border border-accent rounded px-0.5 outline-none truncate w-full"
-                                  aria-label="Rename window"
-                                />
-                              ) : (
-                                <span className="truncate">{win.name}</span>
-                              )}
-                            </span>
-                            <span className="flex items-center gap-1.5 shrink-0">
-                              {win.fabStage && (
-                                <span className="text-xs text-text-secondary">
-                                  {win.fabStage}
-                                </span>
-                              )}
-                              {duration && (
-                                <span className="text-xs text-text-secondary">
-                                  {duration}
-                                </span>
-                              )}
-                            </span>
-                          </button>
-                          {/* Kill window button: hover-reveal on desktop, always visible on mobile */}
-                          <button
-                            type="button"
-                            aria-label={`Kill window ${win.name}`}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              if (e.ctrlKey || e.metaKey) {
-                                if (!ghost) executeKillWindow(session.name, win.windowId, win.index);
-                                return;
-                              }
-                              if (!ghost) {
-                                setKillTarget({
-                                  type: "window",
-                                  session: session.name,
-                                  windowId: win.windowId,
-                                  windowIndex: win.index,
-                                  windowCount: 1,
-                                });
-                              }
-                            }}
-                            className="absolute right-2 top-1/2 -translate-y-1/2 text-[14px] text-text-secondary hover:text-red-400 transition-opacity cursor-pointer opacity-0 group-hover:opacity-100 coarse:opacity-100 px-1 min-h-[36px] flex items-center justify-center z-10"
-                          >
-                            {"\u2715"}
-                          </button>
-                        </div>
+                        />
                       );
                     })}
                   </div>
@@ -613,96 +502,21 @@ export function Sidebar({
       </div>
 
       {/* Server selector — pinned at bottom */}
-      <div className="shrink-0 border-t border-border px-3 sm:px-4 flex items-center h-[48px]" ref={serverDropdownRef}>
-        <div className="flex items-center gap-1.5 relative">
-          <span className="text-xs text-text-secondary">tmux server:</span>
-          <button
-            onClick={() => setServerDropdownOpen((v) => {
-              if (!v) {
-                setRefreshingServers(true);
-                Promise.resolve(onRefreshServers()).finally(() => setRefreshingServers(false));
-              }
-              return !v;
-            })}
-            className="text-xs text-text-primary font-medium hover:text-accent transition-colors min-h-[36px] flex items-center gap-1"
-            aria-haspopup="listbox"
-            aria-expanded={serverDropdownOpen}
-          >
-            {server}
-            {refreshingServers ? (
-              <LogoSpinner size={10} />
-            ) : (
-              <span className="text-text-secondary text-[10px]">{serverDropdownOpen ? "\u25B4" : "\u25BE"}</span>
-            )}
-          </button>
-          {serverDropdownOpen && (
-            <div role="menu" className="absolute bottom-full left-0 mb-1 bg-bg-primary border border-border rounded shadow-2xl z-50 min-w-[140px] py-1">
-              <button
-                role="menuitem"
-                onClick={() => {
-                  setServerDropdownOpen(false);
-                  onCreateServer();
-                }}
-                className="w-full text-left text-sm px-3 py-2 text-text-primary hover:bg-bg-card transition-colors"
-              >
-                + tmux server
-              </button>
-              <div className="border-t border-border" />
-              {servers.length === 0 ? (
-                <div className="text-sm text-text-secondary px-3 py-2">No servers</div>
-              ) : (
-                servers.map((s) => (
-                  <button
-                    key={s}
-                    onClick={() => {
-                      onSwitchServer(s);
-                      setServerDropdownOpen(false);
-                    }}
-                    className={`w-full text-left text-sm px-3 py-2 hover:bg-bg-card transition-colors ${
-                      s === server ? "text-accent font-medium" : "text-text-primary"
-                    }`}
-                    role="menuitem"
-                    aria-current={s === server ? "true" : undefined}
-                  >
-                    {s}
-                  </button>
-                ))
-              )}
-            </div>
-          )}
-        </div>
-      </div>
+      <ServerSelector
+        server={server}
+        servers={servers}
+        onSwitchServer={onSwitchServer}
+        onCreateServer={onCreateServer}
+        onRefreshServers={onRefreshServers}
+      />
 
       {/* Kill confirmation */}
       {killTarget && (
-        <Dialog
-          title={killTarget.type === "window" ? "Kill window?" : "Kill session?"}
-          onClose={() => setKillTarget(null)}
-        >
-          <p className="text-sm text-text-secondary mb-3">
-            {killTarget.type === "window" ? (
-              <>Kill this window in <strong>{killTarget.session}</strong>?</>
-            ) : (
-              <>Kill session <strong>{killTarget.session}</strong> and all{" "}
-              {killTarget.windowCount} window
-              {killTarget.windowCount !== 1 ? "s" : ""}?</>
-            )}
-          </p>
-          <div className="flex gap-2">
-            <button
-              onClick={() => setKillTarget(null)}
-              className="flex-1 text-sm py-1.5 border border-border rounded hover:border-text-secondary"
-            >
-              Cancel
-            </button>
-            <button
-              onClick={handleKill}
-              className="flex-1 text-sm py-1.5 bg-red-900/30 border border-red-900 rounded hover:bg-red-900/50"
-            >
-              Kill
-            </button>
-          </div>
-        </Dialog>
+        <KillDialog
+          killTarget={killTarget}
+          onConfirm={handleKill}
+          onCancel={() => setKillTarget(null)}
+        />
       )}
     </nav>
   );

--- a/app/frontend/src/components/sidebar/kill-dialog.tsx
+++ b/app/frontend/src/components/sidebar/kill-dialog.tsx
@@ -1,0 +1,46 @@
+import { Dialog } from "@/components/dialog";
+
+type KillDialogProps = {
+  killTarget: {
+    type: "session" | "window";
+    session: string;
+    windowId?: string;
+    windowIndex?: number;
+    windowCount: number;
+  };
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export function KillDialog({ killTarget, onConfirm, onCancel }: KillDialogProps) {
+  return (
+    <Dialog
+      title={killTarget.type === "window" ? "Kill window?" : "Kill session?"}
+      onClose={onCancel}
+    >
+      <p className="text-sm text-text-secondary mb-3">
+        {killTarget.type === "window" ? (
+          <>Kill this window in <strong>{killTarget.session}</strong>?</>
+        ) : (
+          <>Kill session <strong>{killTarget.session}</strong> and all{" "}
+          {killTarget.windowCount} window
+          {killTarget.windowCount !== 1 ? "s" : ""}?</>
+        )}
+      </p>
+      <div className="flex gap-2">
+        <button
+          onClick={onCancel}
+          className="flex-1 text-sm py-1.5 border border-border rounded hover:border-text-secondary"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={onConfirm}
+          className="flex-1 text-sm py-1.5 bg-red-900/30 border border-red-900 rounded hover:bg-red-900/50"
+        >
+          Kill
+        </button>
+      </div>
+    </Dialog>
+  );
+}

--- a/app/frontend/src/components/sidebar/server-selector.tsx
+++ b/app/frontend/src/components/sidebar/server-selector.tsx
@@ -1,0 +1,95 @@
+import { useState, useRef, useEffect } from "react";
+import { LogoSpinner } from "@/components/logo-spinner";
+
+type ServerSelectorProps = {
+  server: string;
+  servers: string[];
+  onSwitchServer: (name: string) => void;
+  onCreateServer: () => void;
+  onRefreshServers: () => void;
+};
+
+export function ServerSelector({
+  server,
+  servers,
+  onSwitchServer,
+  onCreateServer,
+  onRefreshServers,
+}: ServerSelectorProps) {
+  const [serverDropdownOpen, setServerDropdownOpen] = useState(false);
+  const [refreshingServers, setRefreshingServers] = useState(false);
+  const serverDropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!serverDropdownOpen) return;
+    function handleClick(e: MouseEvent) {
+      if (serverDropdownRef.current && !serverDropdownRef.current.contains(e.target as Node)) {
+        setServerDropdownOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [serverDropdownOpen]);
+
+  return (
+    <div className="shrink-0 border-t border-border px-3 sm:px-4 flex items-center h-[48px]" ref={serverDropdownRef}>
+      <div className="flex items-center gap-1.5 relative">
+        <span className="text-xs text-text-secondary">tmux server:</span>
+        <button
+          onClick={() => setServerDropdownOpen((v) => {
+            if (!v) {
+              setRefreshingServers(true);
+              Promise.resolve(onRefreshServers()).finally(() => setRefreshingServers(false));
+            }
+            return !v;
+          })}
+          className="text-xs text-text-primary font-medium hover:text-accent transition-colors min-h-[36px] flex items-center gap-1"
+          aria-haspopup="listbox"
+          aria-expanded={serverDropdownOpen}
+        >
+          {server}
+          {refreshingServers ? (
+            <LogoSpinner size={10} />
+          ) : (
+            <span className="text-text-secondary text-[10px]">{serverDropdownOpen ? "\u25B4" : "\u25BE"}</span>
+          )}
+        </button>
+        {serverDropdownOpen && (
+          <div role="menu" className="absolute bottom-full left-0 mb-1 bg-bg-primary border border-border rounded shadow-2xl z-50 min-w-[140px] py-1">
+            <button
+              role="menuitem"
+              onClick={() => {
+                setServerDropdownOpen(false);
+                onCreateServer();
+              }}
+              className="w-full text-left text-sm px-3 py-2 text-text-primary hover:bg-bg-card transition-colors"
+            >
+              + tmux server
+            </button>
+            <div className="border-t border-border" />
+            {servers.length === 0 ? (
+              <div className="text-sm text-text-secondary px-3 py-2">No servers</div>
+            ) : (
+              servers.map((s) => (
+                <button
+                  key={s}
+                  onClick={() => {
+                    onSwitchServer(s);
+                    setServerDropdownOpen(false);
+                  }}
+                  className={`w-full text-left text-sm px-3 py-2 hover:bg-bg-card transition-colors ${
+                    s === server ? "text-accent font-medium" : "text-text-primary"
+                  }`}
+                  role="menuitem"
+                  aria-current={s === server ? "true" : undefined}
+                >
+                  {s}
+                </button>
+              ))
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/src/components/sidebar/session-row.tsx
+++ b/app/frontend/src/components/sidebar/session-row.tsx
@@ -1,0 +1,107 @@
+import type { ProjectSession } from "@/types";
+import type { MergedSession } from "@/contexts/optimistic-context";
+
+type SessionRowProps = {
+  session: ProjectSession | MergedSession;
+  isCollapsed: boolean;
+  isSessionDropTarget: boolean;
+  editingSession: string | null;
+  editingSessionName: string;
+  sessionInputRef: React.RefObject<HTMLInputElement | null>;
+  onToggleCollapse: () => void;
+  onSelectFirstWindow: () => void;
+  onCreateWindow: () => void;
+  onKillClick: (e: React.MouseEvent) => void;
+  onDoubleClickName: () => void;
+  onSessionNameChange: (value: string) => void;
+  onSessionRenameKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  onSessionRenameBlur: () => void;
+  onDragOver: (e: React.DragEvent) => void;
+  onDragLeave: (e: React.DragEvent) => void;
+  onDrop: (e: React.DragEvent) => void;
+};
+
+export function SessionRow({
+  session,
+  isCollapsed,
+  isSessionDropTarget,
+  editingSession,
+  editingSessionName,
+  sessionInputRef,
+  onToggleCollapse,
+  onSelectFirstWindow,
+  onCreateWindow,
+  onKillClick,
+  onDoubleClickName,
+  onSessionNameChange,
+  onSessionRenameKeyDown,
+  onSessionRenameBlur,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+}: SessionRowProps) {
+  return (
+    <div
+      className="flex items-center justify-between group"
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+      style={isSessionDropTarget ? { border: "2px solid var(--color-accent)", borderRadius: "4px" } : undefined}
+    >
+      <div className="flex items-center gap-0.5 min-w-0 flex-1">
+        <button
+          onClick={onToggleCollapse}
+          className="text-xs text-text-secondary hover:text-text-primary transition-colors w-5 shrink-0 min-h-[36px] flex items-center justify-center"
+          aria-expanded={!isCollapsed}
+          aria-label={`${isCollapsed ? "Expand" : "Collapse"} ${session.name}`}
+        >
+          {isCollapsed ? "\u25B6" : "\u25BC"}
+        </button>
+        <button
+          onClick={onSelectFirstWindow}
+          onDoubleClick={(e) => {
+            e.stopPropagation();
+            if (editingSession !== session.name) onDoubleClickName();
+          }}
+          className="flex items-center gap-1 text-sm text-text-secondary hover:text-text-primary transition-colors py-1 min-h-[36px] min-w-0 flex-1"
+          aria-label={`Navigate to ${session.name}`}
+        >
+          {editingSession === session.name ? (
+            <input
+              ref={sessionInputRef}
+              type="text"
+              value={editingSessionName}
+              onChange={(e) => onSessionNameChange(e.target.value)}
+              onKeyDown={onSessionRenameKeyDown}
+              onBlur={onSessionRenameBlur}
+              onClick={(e) => e.stopPropagation()}
+              onMouseDown={(e) => e.stopPropagation()}
+              className="text-sm font-medium bg-transparent border border-accent rounded px-0.5 outline-none truncate w-full"
+              aria-label="Rename session"
+            />
+          ) : (
+            <span className="font-medium truncate">
+              {session.name}
+            </span>
+          )}
+        </button>
+      </div>
+      <div className="flex items-center pr-2">
+        <button
+          onClick={onCreateWindow}
+          aria-label={`New window in ${session.name}`}
+          className="text-text-secondary hover:text-text-primary transition-colors text-[16px] px-1 min-h-[36px] flex items-center justify-center"
+        >
+          +
+        </button>
+        <button
+          onClick={onKillClick}
+          aria-label={`Kill session ${session.name}`}
+          className="text-text-secondary hover:text-red-400 transition-colors text-[16px] px-1 min-h-[36px] flex items-center justify-center"
+        >
+          {"\u2715"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/src/components/sidebar/window-row.tsx
+++ b/app/frontend/src/components/sidebar/window-row.tsx
@@ -1,0 +1,128 @@
+import { isGhostWindow } from "@/contexts/optimistic-context";
+import { getWindowDuration } from "@/lib/format";
+import type { ProjectSession } from "@/types";
+import type { MergedSession } from "@/contexts/optimistic-context";
+
+type ProjectWindow = ProjectSession["windows"][number];
+type GhostWindow = MergedSession["windows"][number];
+
+type WindowRowProps = {
+  win: ProjectWindow | GhostWindow;
+  session: string;
+  isSelected: boolean;
+  isDragOver: boolean;
+  nowSeconds: number;
+  editingWindow: { session: string; windowId: string } | null;
+  editingName: string;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  onSelectWindow: () => void;
+  onDoubleClickName: () => void;
+  onWindowNameChange: (value: string) => void;
+  onRenameKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  onRenameBlur: () => void;
+  onKillClick: (e: React.MouseEvent) => void;
+  onDragStart: (e: React.DragEvent) => void;
+  onDragOver: (e: React.DragEvent) => void;
+  onDrop: (e: React.DragEvent) => void;
+  onDragEnd: () => void;
+};
+
+export function WindowRow({
+  win,
+  session,
+  isSelected,
+  isDragOver,
+  nowSeconds,
+  editingWindow,
+  editingName,
+  inputRef,
+  onSelectWindow,
+  onDoubleClickName,
+  onWindowNameChange,
+  onRenameKeyDown,
+  onRenameBlur,
+  onKillClick,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  onDragEnd,
+}: WindowRowProps) {
+  const ghost = isGhostWindow(win);
+  const duration = getWindowDuration(win, nowSeconds);
+  const isEditing = editingWindow?.session === session && editingWindow.windowId === win.windowId;
+
+  return (
+    <div
+      key={ghost ? `ghost-${win.optimisticId}` : win.windowId}
+      className={`relative group${ghost ? " opacity-50 animate-pulse" : ""}`}
+      draggable={!ghost}
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      onDragEnd={onDragEnd}
+      style={isDragOver ? { borderTop: "2px solid var(--color-accent)" } : undefined}
+    >
+      <button
+        onClick={onSelectWindow}
+        onDoubleClick={(e) => {
+          e.stopPropagation();
+          if (!ghost) onDoubleClickName();
+        }}
+        className={`w-full text-left flex items-center justify-between gap-2 py-1 pl-2 pr-8 text-sm transition-colors min-h-[36px] ${
+          isSelected
+            ? "bg-accent/15 text-text-primary font-medium rounded-l-lg rounded-r-none"
+            : "text-text-secondary hover:text-text-primary hover:bg-bg-card/50 rounded-l-lg rounded-r-none"
+        }`}
+        aria-current={isSelected ? "page" : undefined}
+      >
+        <span className="flex items-center gap-1.5 truncate min-w-0">
+          <span
+            className={`w-1.5 h-1.5 rounded-full shrink-0 ${
+              win.activity === "active"
+                ? "bg-accent-green"
+                : "bg-text-secondary/40"
+            }`}
+            aria-label={win.activity}
+          />
+          {isEditing ? (
+            <input
+              ref={inputRef}
+              type="text"
+              value={editingName}
+              onChange={(e) => onWindowNameChange(e.target.value)}
+              onKeyDown={onRenameKeyDown}
+              onBlur={onRenameBlur}
+              onClick={(e) => e.stopPropagation()}
+              onMouseDown={(e) => e.stopPropagation()}
+              className="text-sm bg-transparent border border-accent rounded px-0.5 outline-none truncate w-full"
+              aria-label="Rename window"
+            />
+          ) : (
+            <span className="truncate">{win.name}</span>
+          )}
+        </span>
+        <span className="flex items-center gap-1.5 shrink-0">
+          {win.fabStage && (
+            <span className="text-xs text-text-secondary">
+              {win.fabStage}
+            </span>
+          )}
+          {duration && (
+            <span className="text-xs text-text-secondary">
+              {duration}
+            </span>
+          )}
+        </span>
+      </button>
+      {/* Kill window button: hover-reveal on desktop, always visible on mobile */}
+      <button
+        type="button"
+        aria-label={`Kill window ${win.name}`}
+        onClick={onKillClick}
+        className="absolute right-2 top-1/2 -translate-y-1/2 text-[14px] text-text-secondary hover:text-red-400 transition-opacity cursor-pointer opacity-0 group-hover:opacity-100 coarse:opacity-100 px-1 min-h-[36px] flex items-center justify-center z-10"
+      >
+        {"\u2715"}
+      </button>
+    </div>
+  );
+}

--- a/docs/memory/run-kit/ui-patterns.md
+++ b/docs/memory/run-kit/ui-patterns.md
@@ -120,7 +120,15 @@ The Ctrl+Click force-kill pattern matches the established "modifier = power acti
 
 ## Sidebar
 
-`app/frontend/src/components/sidebar.tsx` — session/window tree navigation.
+`app/frontend/src/components/sidebar/` — session/window tree navigation. The sidebar is decomposed into an orchestrator and four sub-components:
+
+- `index.tsx` — `Sidebar` orchestrator; owns all state (`collapsed`, `killTarget`, `editingWindow`, `editingSession`, `dragSource`, `dropTarget`, `sessionDropTarget`) and all `useOptimisticAction` hooks; public `SidebarProps` API unchanged
+- `session-row.tsx` — `SessionRow`; pure presentational; renders the session header row (chevron, name, + button, ✕ button); handles cross-session drag-over styling; all event handlers passed as props
+- `window-row.tsx` — `WindowRow`; pure presentational; renders a single window row (activity dot, name, fab stage, duration, kill button); handles drag-and-drop and inline rename display; all event handlers passed as props
+- `server-selector.tsx` — `ServerSelector`; owns its own dropdown state (`serverDropdownOpen`, `refreshingServers`, `serverDropdownRef`); pinned-bottom server dropdown with outside-click dismiss
+- `kill-dialog.tsx` — `KillDialog`; stateless; renders the kill confirmation dialog for sessions and windows using `<Dialog>`
+
+Consumers import `@/components/sidebar` as before — Vite resolves directory imports to `sidebar/index.tsx` automatically.
 
 **Desktop** (>= 768px): Drag-resizable panel, default 220px width. Width persisted to `localStorage` key `runkit-sidebar-width`. Constraints: min 160px, max 400px. Drag handle (4-6px) on right edge with `col-resize` cursor, supports mouse and touch events. Collapsible via logo button in top bar.
 

--- a/fab/changes/260405-f8p9-sidebar-component-decomposition/.history.jsonl
+++ b/fab/changes/260405-f8p9-sidebar-component-decomposition/.history.jsonl
@@ -2,3 +2,13 @@
 {"args":"Sidebar component decomposition — Extract the ~700-line sidebar into sub-components: SessionRow, WindowRow, ServerSelector, KillDialog, and any other logical pieces.","cmd":"fab-new","event":"command","ts":"2026-04-05T18:41:18Z"}
 {"delta":"+4.1","event":"confidence","score":4.1,"trigger":"calc-score","ts":"2026-04-05T18:42:19Z"}
 {"delta":"+0.0","event":"confidence","score":4.1,"trigger":"calc-score","ts":"2026-04-05T18:42:30Z"}
+{"cmd":"fab-switch","event":"command","ts":"2026-04-05T19:02:06Z"}
+{"cmd":"fab-fff","event":"command","ts":"2026-04-05T19:02:49Z"}
+{"delta":"-0.3","event":"confidence","score":3.8,"trigger":"calc-score","ts":"2026-04-05T19:04:42Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"spec","ts":"2026-04-05T19:04:57Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"tasks","ts":"2026-04-05T19:05:49Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-04-05T19:05:49Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-04-05T19:10:15Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-04-05T19:13:57Z"}
+{"event":"review","result":"passed","ts":"2026-04-05T19:13:57Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-04-05T19:14:52Z"}

--- a/fab/changes/260405-f8p9-sidebar-component-decomposition/.history.jsonl
+++ b/fab/changes/260405-f8p9-sidebar-component-decomposition/.history.jsonl
@@ -12,3 +12,4 @@
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-04-05T19:13:57Z"}
 {"event":"review","result":"passed","ts":"2026-04-05T19:13:57Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-04-05T19:14:52Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-04-05T19:16:13Z"}

--- a/fab/changes/260405-f8p9-sidebar-component-decomposition/.status.yaml
+++ b/fab/changes/260405-f8p9-sidebar-component-decomposition/.status.yaml
@@ -5,33 +5,38 @@ created_by: sahil-weaver
 change_type: refactor
 issues: []
 progress:
-    intake: ready
-    spec: pending
-    tasks: pending
-    apply: pending
-    review: pending
-    hydrate: pending
-    ship: pending
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
     review-pr: pending
 checklist:
-    generated: false
+    generated: true
     path: checklist.md
     completed: 0
     total: 0
 confidence:
-    certain: 4
-    confident: 3
+    certain: 5
+    confident: 4
     tentative: 0
     unresolved: 0
-    score: 4.1
-    indicative: true
+    score: 3.8
     fuzzy: true
     dimensions:
-        signal: 82.9
-        reversibility: 87.1
-        competence: 85.0
-        disambiguation: 84.3
+        signal: 83.9
+        reversibility: 87.8
+        competence: 87.8
+        disambiguation: 86.1
 stage_metrics:
-    intake: {started_at: "2026-04-05T18:41:18Z", driver: fab-new, iterations: 1}
+    intake: {started_at: "2026-04-05T18:41:18Z", driver: fab-new, iterations: 1, completed_at: "2026-04-05T19:04:57Z"}
+    spec: {started_at: "2026-04-05T19:04:57Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-05T19:05:49Z"}
+    tasks: {started_at: "2026-04-05T19:05:49Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-05T19:05:49Z"}
+    apply: {started_at: "2026-04-05T19:05:49Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-05T19:10:15Z"}
+    review: {started_at: "2026-04-05T19:10:15Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-05T19:13:57Z"}
+    hydrate: {started_at: "2026-04-05T19:13:57Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-05T19:14:52Z"}
+    ship: {started_at: "2026-04-05T19:14:52Z", driver: fab-fff, iterations: 1}
 prs: []
-last_updated: 2026-04-05T18:42:33Z
+last_updated: 2026-04-05T19:14:52Z

--- a/fab/changes/260405-f8p9-sidebar-component-decomposition/.status.yaml
+++ b/fab/changes/260405-f8p9-sidebar-component-decomposition/.status.yaml
@@ -11,8 +11,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 checklist:
     generated: true
     path: checklist.md
@@ -37,6 +37,8 @@ stage_metrics:
     apply: {started_at: "2026-04-05T19:05:49Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-05T19:10:15Z"}
     review: {started_at: "2026-04-05T19:10:15Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-05T19:13:57Z"}
     hydrate: {started_at: "2026-04-05T19:13:57Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-05T19:14:52Z"}
-    ship: {started_at: "2026-04-05T19:14:52Z", driver: fab-fff, iterations: 1}
-prs: []
-last_updated: 2026-04-05T19:14:52Z
+    ship: {started_at: "2026-04-05T19:14:52Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-05T19:16:13Z"}
+    review-pr: {started_at: "2026-04-05T19:16:13Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/sahil87/run-kit/pull/126
+last_updated: 2026-04-05T19:16:13Z

--- a/fab/changes/260405-f8p9-sidebar-component-decomposition/checklist.md
+++ b/fab/changes/260405-f8p9-sidebar-component-decomposition/checklist.md
@@ -1,0 +1,59 @@
+# Quality Checklist: Sidebar Component Decomposition
+
+**Change**: 260405-f8p9-sidebar-component-decomposition
+**Generated**: 2026-04-06
+**Spec**: `spec.md`
+
+## Functional Completeness
+
+- [ ] CHK-001 Directory layout: `sidebar/` directory exists with `index.tsx`, `session-row.tsx`, `window-row.tsx`, `server-selector.tsx`, `kill-dialog.tsx`; old `sidebar.tsx` deleted
+- [ ] CHK-002 Public API preserved: `SidebarProps` type is identical to original; `Sidebar` export present in `sidebar/index.tsx`
+- [ ] CHK-003 KillDialog: component accepts `killTarget`, `onConfirm`, `onCancel` props; renders session vs window variants correctly; uses `<Dialog>` component
+- [ ] CHK-004 ServerSelector: owns dropdown state (`serverDropdownOpen`, `refreshingServers`, ref, outside-click `useEffect`); accepts `server`, `servers`, `onSwitchServer`, `onCreateServer`, `onRefreshServers` props
+- [ ] CHK-005 SessionRow: pure presentational; accepts all required props for collapse, inline rename, drag, kill; no hook imports for optimistic/store logic
+- [ ] CHK-006 WindowRow: pure presentational; accepts all required props for selection, drag-and-drop, inline rename, kill; no hook imports for optimistic/store logic
+- [ ] CHK-007 Orchestrator owns all state: `collapsed`, `killTarget`, `editingWindow`, `editingSession`, `dragSource`, `dropTarget`, `sessionDropTarget`, all refs, all `useOptimisticAction` hooks, all handler functions in `index.tsx`
+
+## Behavioral Correctness
+
+- [ ] CHK-008 Import resolution: `@/components/sidebar` resolves to `sidebar/index.tsx` — `app.tsx` requires no changes
+- [ ] CHK-009 No behavioral changes: all interactions (click, double-click, Ctrl+click, drag, drop, rename) function identically to pre-refactor
+
+## Removal Verification
+
+- [ ] CHK-010 Original `sidebar.tsx` deleted: no dead code; no leftover monolithic file at `app/frontend/src/components/sidebar.tsx`
+
+## Scenario Coverage
+
+- [ ] CHK-011 Session kill dialog: "Kill session?" title with window count renders for session targets
+- [ ] CHK-012 Window kill dialog: "Kill window?" title with session name renders for window targets
+- [ ] CHK-013 ServerSelector outside-click dismiss: clicking outside the selector closes the dropdown
+- [ ] CHK-014 SessionRow collapsed/expanded chevron: `▶`/`▼` and `aria-expanded` toggle correctly
+- [ ] CHK-015 SessionRow cross-session drag-over: accent border style applied when `isSessionDropTarget === true`
+- [ ] CHK-016 WindowRow selected styling: `bg-accent/15` applied when `isSelected === true`
+- [ ] CHK-017 WindowRow drag-over indicator: `borderTop: "2px solid var(--color-accent)"` when `isDragOver === true`
+- [ ] CHK-018 WindowRow ghost: `draggable={false}`, kill button is no-op, opacity+pulse styling applied
+- [ ] CHK-019 Inline rename — window: double-click shows input; Enter commits; Escape cancels; blur commits unless cancelled
+- [ ] CHK-020 Inline rename — session: double-click shows input; Enter commits; Escape cancels; cross-cancellation works
+- [ ] CHK-021 All existing `sidebar.test.tsx` tests pass with `just test-frontend`
+
+## Edge Cases & Error Handling
+
+- [ ] CHK-022 Ghost window: kill button click is guarded by `!ghost` check in `WindowRow`
+- [ ] CHK-023 Ghost session: row has `opacity-50 animate-pulse` class; kill and rename interactions behave as in original
+- [ ] CHK-024 Empty sessions state: "No sessions" text + "+ New Session" button renders when `sessions.length === 0`
+- [ ] CHK-025 Cross-cancellation: starting window rename cancels active session rename (and vice versa) without committing
+
+## Code Quality
+
+- [ ] CHK-026 Pattern consistency: kebab-case filenames, prop type definitions co-located with component, existing import aliases (`@/`) used throughout
+- [ ] CHK-027 No unnecessary duplication: `getWindowDuration` and `isGhostWindow` imported from existing modules, not reimplemented
+- [ ] CHK-028 Readability: sub-components are < 200 lines each; no god functions > 50 lines without clear reason
+- [ ] CHK-029 Type safety: no `as` casts introduced; props typed with explicit TypeScript interfaces; `tsc --noEmit` passes
+- [ ] CHK-030 No anti-patterns: no polling, no inline tmux construction, no new dependencies, no new routes
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] CHK-NNN **N/A**: {reason}`

--- a/fab/changes/260405-f8p9-sidebar-component-decomposition/spec.md
+++ b/fab/changes/260405-f8p9-sidebar-component-decomposition/spec.md
@@ -1,0 +1,312 @@
+# Spec: Sidebar Component Decomposition
+
+**Change**: 260405-f8p9-sidebar-component-decomposition
+**Created**: 2026-04-06
+**Affected memory**: `docs/memory/run-kit/ui-patterns.md`
+
+## Non-Goals
+
+- New unit tests for individual sub-components — out of scope for this refactor
+- Any behavioral changes to sidebar interactions
+- New React contexts, new dependencies, or new API calls
+- Changes to the backend or any non-sidebar frontend components
+
+## Frontend: Sidebar Component Structure
+
+### Requirement: Directory Layout
+
+The monolithic `app/frontend/src/components/sidebar.tsx` (709 lines) SHALL be replaced by a `sidebar/` directory with an `index.tsx` orchestrator and four sub-component files:
+
+```
+app/frontend/src/components/
+  sidebar/
+    index.tsx            # Orchestrator — Sidebar component and re-export
+    session-row.tsx      # SessionRow sub-component
+    window-row.tsx       # WindowRow sub-component
+    server-selector.tsx  # ServerSelector sub-component
+    kill-dialog.tsx      # KillDialog sub-component
+  sidebar.test.tsx       # Existing tests — import paths updated if needed
+```
+
+The old `sidebar.tsx` file SHALL be deleted. Vite resolves `@/components/sidebar` to `sidebar/index.tsx` automatically — no consumer (`app.tsx`) changes required.
+
+#### Scenario: Import resolution unchanged
+- **GIVEN** a consumer imports `@/components/sidebar`
+- **WHEN** the sidebar directory exists with `index.tsx`
+- **THEN** Vite and Vitest resolve the import to `sidebar/index.tsx` without any changes to the importing file
+
+### Requirement: Public API Preserved
+
+The `SidebarProps` type and the `Sidebar` component export SHALL remain identical to the current `sidebar.tsx`. Zero changes to `app.tsx` or any other consumer.
+
+#### Scenario: App shell compiles after refactor
+- **GIVEN** `app.tsx` imports `{ Sidebar }` from `@/components/sidebar`
+- **WHEN** the refactor replaces `sidebar.tsx` with `sidebar/index.tsx`
+- **THEN** `tsc --noEmit` passes without errors
+
+### Requirement: KillDialog Sub-Component
+
+A `KillDialog` component SHALL be extracted to `app/frontend/src/components/sidebar/kill-dialog.tsx`. It encapsulates the kill confirmation dialog for both sessions and windows.
+
+Props:
+```typescript
+type KillDialogProps = {
+  killTarget: {
+    type: "session" | "window";
+    session: string;
+    windowId?: string;
+    windowIndex?: number;
+    windowCount: number;
+  };
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+```
+
+It SHALL use the existing `<Dialog>` component from `@/components/dialog`.
+
+#### Scenario: Session kill confirmation dialog renders
+- **GIVEN** `killTarget.type === "session"` with `windowCount: 3`
+- **WHEN** `KillDialog` is rendered
+- **THEN** the dialog title is "Kill session?" and body reads "Kill session **{name}** and all 3 windows?"
+
+#### Scenario: Window kill confirmation dialog renders
+- **GIVEN** `killTarget.type === "window"`
+- **WHEN** `KillDialog` is rendered
+- **THEN** the dialog title is "Kill window?" and body reads "Kill this window in **{session}**?"
+
+#### Scenario: Confirm triggers onConfirm callback
+- **GIVEN** `KillDialog` is rendered with `onConfirm` and `onCancel`
+- **WHEN** the user clicks the "Kill" button
+- **THEN** `onConfirm` is called
+
+#### Scenario: Cancel triggers onCancel callback
+- **GIVEN** `KillDialog` is rendered
+- **WHEN** the user clicks the "Cancel" button or the Dialog's onClose
+- **THEN** `onCancel` is called
+
+### Requirement: ServerSelector Sub-Component
+
+A `ServerSelector` component SHALL be extracted to `app/frontend/src/components/sidebar/server-selector.tsx`. It encapsulates the pinned-bottom server dropdown.
+
+Props:
+```typescript
+type ServerSelectorProps = {
+  server: string;
+  servers: string[];
+  onSwitchServer: (name: string) => void;
+  onCreateServer: () => void;
+  onRefreshServers: () => void;
+};
+```
+
+The `serverDropdownOpen`, `refreshingServers` state, the `serverDropdownRef`, and the outside-click `useEffect` SHALL all live inside `ServerSelector`. No state for server dropdown is needed in the orchestrator.
+
+#### Scenario: Dropdown opens on click and refreshes servers
+- **GIVEN** the server selector button is visible
+- **WHEN** the user clicks the button
+- **THEN** `onRefreshServers` is called and the dropdown list renders
+
+#### Scenario: Outside click closes dropdown
+- **GIVEN** the server dropdown is open
+- **WHEN** a mousedown event fires outside the selector container
+- **THEN** the dropdown closes
+
+#### Scenario: Current server highlighted
+- **GIVEN** the dropdown is open with `server === "default"` and `servers === ["default", "work"]`
+- **WHEN** the list renders
+- **THEN** "default" has `text-accent` styling and "work" has `text-text-primary` styling
+
+#### Scenario: Create server action
+- **GIVEN** the dropdown is open
+- **WHEN** the user clicks "+ tmux server"
+- **THEN** `onCreateServer` is called and the dropdown closes
+
+### Requirement: SessionRow Sub-Component
+
+A `SessionRow` component SHALL be extracted to `app/frontend/src/components/sidebar/session-row.tsx`. It renders one session header row.
+
+Props:
+```typescript
+type SessionRowProps = {
+  session: ProjectSession | MergedSession;
+  isCollapsed: boolean;
+  isSessionDropTarget: boolean;
+  editingSession: string | null;
+  editingSessionName: string;
+  sessionInputRef: React.RefObject<HTMLInputElement | null>;
+  onToggleCollapse: () => void;
+  onSelectFirstWindow: () => void;
+  onCreateWindow: () => void;
+  onKillClick: (e: React.MouseEvent) => void;
+  onDoubleClickName: () => void;
+  onSessionNameChange: (value: string) => void;
+  onSessionRenameKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  onSessionRenameBlur: () => void;
+  onDragOver: (e: React.DragEvent) => void;
+  onDragLeave: (e: React.DragEvent) => void;
+  onDrop: (e: React.DragEvent) => void;
+};
+```
+
+`SessionRow` SHALL be a pure presentational component — all state (collapsed map, editingSession, drag targets) lives in the orchestrator `index.tsx`. All event handlers are passed as props.
+
+#### Scenario: Collapsed state renders expand chevron
+- **GIVEN** `isCollapsed === true`
+- **WHEN** `SessionRow` renders
+- **THEN** the chevron button shows `▶` and has `aria-expanded={false}`
+
+#### Scenario: Expanded state renders collapse chevron
+- **GIVEN** `isCollapsed === false`
+- **WHEN** `SessionRow` renders
+- **THEN** the chevron button shows `▼` and has `aria-expanded={true}`
+
+#### Scenario: Cross-session drag-over shows accent border
+- **GIVEN** `isSessionDropTarget === true`
+- **WHEN** `SessionRow` renders
+- **THEN** the row container has accent border styling (`border: "2px solid var(--color-accent)"`)
+
+#### Scenario: Double-click on session name triggers inline rename
+- **GIVEN** `editingSession !== session.name`
+- **WHEN** the user double-clicks the session name button
+- **THEN** `onDoubleClickName` is called
+
+#### Scenario: Ctrl+click kill bypasses dialog
+- **GIVEN** `e.ctrlKey === true` or `e.metaKey === true`
+- **WHEN** the user clicks the ✕ kill button on the session row
+- **THEN** `onKillClick` is called with the event (orchestrator handles force-kill)
+
+### Requirement: WindowRow Sub-Component
+
+A `WindowRow` component SHALL be extracted to `app/frontend/src/components/sidebar/window-row.tsx`. It renders one window row with all its interactions.
+
+Props:
+```typescript
+type WindowRowProps = {
+  win: ProjectWindow | GhostWindow;  // window from session.windows
+  session: string;
+  isSelected: boolean;
+  isDragOver: boolean;
+  nowSeconds: number;
+  editingWindow: { session: string; windowId: string } | null;
+  editingName: string;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  onSelectWindow: () => void;
+  onDoubleClickName: () => void;
+  onWindowNameChange: (value: string) => void;
+  onRenameKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  onRenameBlur: () => void;
+  onKillClick: (e: React.MouseEvent) => void;
+  onDragStart: (e: React.DragEvent) => void;
+  onDragOver: (e: React.DragEvent) => void;
+  onDrop: (e: React.DragEvent) => void;
+  onDragEnd: () => void;
+};
+```
+
+`WindowRow` SHALL be a pure presentational component. Ghost window detection (`isGhostWindow`) can be called inside `WindowRow` using the passed `win` prop (it's a pure predicate with no side effects), or the `ghost` boolean can be passed as a prop — either is acceptable as long as the behavior is identical.
+
+#### Scenario: Selected window has accent styling
+- **GIVEN** `isSelected === true`
+- **WHEN** `WindowRow` renders
+- **THEN** the button has `bg-accent/15 text-text-primary font-medium` classes
+
+#### Scenario: Active window shows green dot
+- **GIVEN** `win.activity === "active"`
+- **WHEN** `WindowRow` renders
+- **THEN** the activity dot has `bg-accent-green` class
+
+#### Scenario: Drag-over shows top border indicator
+- **GIVEN** `isDragOver === true`
+- **WHEN** `WindowRow` renders
+- **THEN** the container has `borderTop: "2px solid var(--color-accent)"` style
+
+#### Scenario: Kill button hidden on desktop, visible on touch
+- **GIVEN** a non-ghost window
+- **WHEN** `WindowRow` renders
+- **THEN** the kill button has `opacity-0 group-hover:opacity-100 coarse:opacity-100` classes
+
+#### Scenario: Ghost window is not draggable and kill is no-op
+- **GIVEN** `isGhostWindow(win) === true`
+- **WHEN** `WindowRow` renders
+- **THEN** `draggable` is `false` and clicking kill does nothing
+
+#### Scenario: Inline rename input shown when editing this window
+- **GIVEN** `editingWindow.session === session` and `editingWindow.windowId === win.windowId`
+- **WHEN** `WindowRow` renders
+- **THEN** a text input is shown pre-filled with `editingName` instead of the name span
+
+### Requirement: Orchestrator Owns All State
+
+`sidebar/index.tsx` SHALL contain all state and hook wiring currently in `sidebar.tsx`:
+
+- `collapsed`, `killTarget`, `editingWindow`, `editingName`, `editingSession`, `editingSessionName`, `dragSource`, `dropTarget`, `sessionDropTarget`
+- All `useRef` instances (`inputRef`, `cancelledRef`, `originalNameRef`, `sessionInputRef`, `sessionCancelledRef`, `sessionOriginalNameRef`, `lastKillSessionRef`, `lastKillWindowRef`, `killTargetRef`, `lastRenameSessionRef`, `lastRenameWindowRef`)
+- All `useOptimisticAction` hooks (`executeKillSession`, `executeKillWindow`, `executeKillFromDialog`, `executeRenameSession`, `executeRenameWindow`)
+- The `toggleSession` `useCallback`
+- The `handleKill` function and all rename/drag event handler functions
+
+The orchestrator SHALL pass computed props down to each sub-component. No sub-component may import `useOptimisticAction`, `useOptimisticContext`, `useWindowStore`, or `useToast` directly.
+
+#### Scenario: State stays in orchestrator after refactor
+- **GIVEN** the `Sidebar` component is fully refactored
+- **WHEN** `tsc --noEmit` is run
+- **THEN** no TypeScript errors are reported and sub-components have no direct hook imports for optimistic/store logic
+
+### Requirement: Existing Tests Pass Unmodified (or with import-only changes)
+
+The existing `app/frontend/src/components/sidebar.test.tsx` (810 lines) SHALL continue to pass. Import paths in the test file MAY be updated if needed (e.g., if any type is re-exported from a sub-component file), but no test logic SHALL change.
+
+#### Scenario: All existing sidebar tests pass after refactor
+- **GIVEN** the refactor is complete
+- **WHEN** `just test-frontend` is run
+- **THEN** all tests in `sidebar.test.tsx` pass with exit code 0
+
+### Requirement: No Behavioral Changes
+
+Every interaction currently supported by `sidebar.tsx` SHALL behave identically after the refactor:
+- Single-click session name → navigate to first window
+- Double-click session name → inline rename
+- Single-click window row → navigate to window
+- Double-click window name → inline rename
+- Ctrl/Cmd+click session ✕ → force-kill session
+- Ctrl/Cmd+click window ✕ → force-kill window
+- Normal click ✕ (session or window) → open kill dialog
+- Drag window within session → reorder
+- Drag window onto different session header → cross-session move
+- Ghost window/session opacity and non-interactivity
+
+#### Scenario: Full behavioral parity
+- **GIVEN** the refactored sidebar is rendered with identical props
+- **WHEN** any interaction is performed
+- **THEN** the behavior, visual output, and side effects are identical to the pre-refactor sidebar
+
+## Design Decisions
+
+1. **Pure presentational sub-components with all state in orchestrator**
+   - *Why*: Keeps sub-components prop-driven and independently testable without hook mocking. Avoids splitting optimistic action logic across files, which would create tangled rollback/commit paths.
+   - *Rejected*: Moving some state into sub-components (e.g., `serverDropdownOpen` into `ServerSelector`) — accepted for `ServerSelector` only because its state is fully self-contained (no cross-component interactions).
+
+2. **`ServerSelector` owns its own dropdown state**
+   - *Why*: `serverDropdownOpen`, `refreshingServers`, and the outside-click `useEffect` are entirely local to the server selector. Moving them into `ServerSelector` reduces orchestrator complexity without creating any coupling.
+   - *Rejected*: Keeping server dropdown state in orchestrator — would mean orchestrator passes 3 extra props for state that it never needs to read.
+
+3. **Passing `sessionInputRef` and `inputRef` as props to sub-components**
+   - *Why*: The `useEffect` for auto-focus lives in the orchestrator and depends on these refs. Keeping refs in the orchestrator and threading them as props is the minimal change.
+   - *Rejected*: Moving auto-focus `useEffect` into sub-components — would require sub-components to own more state/refs, complicating the refactor scope.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Use `sidebar/` directory with `index.tsx` barrel | Vite resolves directory imports to `index.tsx` — confirmed standard pattern in this codebase (`command-palette.tsx` etc.) | S:90 R:95 A:95 D:95 |
+| 2 | Certain | Keep `SidebarProps` type unchanged | Description explicitly: "no user-facing changes" and "existing consumers (`app.tsx`) require zero changes" | S:95 R:90 A:90 D:95 |
+| 3 | Certain | Use kebab-case filenames (`session-row.tsx`) | Confirmed from intake #3 — codebase convention: `logo-spinner.tsx`, `command-palette.tsx` | S:85 R:95 A:95 D:95 |
+| 4 | Certain | No new React contexts | Confirmed from intake #6 — constitution IV (minimal surface), code-quality (no context for one-level nesting) | S:85 R:85 A:90 D:90 |
+| 5 | Confident | State and optimistic hooks stay in orchestrator `index.tsx` | Confirmed from spec analysis — sub-components are purely presentational. Exception: `ServerSelector` owns its own self-contained state | S:85 R:80 A:80 D:75 |
+| 6 | Confident | Existing `sidebar.test.tsx` stays as integration tests, no new unit tests | Confirmed from intake #5 — scope is "pure refactor", new tests are explicitly out of scope | S:80 R:85 A:75 D:80 |
+| 7 | Confident | Drag-and-drop handlers split between `SessionRow` and `WindowRow` | Confirmed from code analysis — `handleSessionDragOver/Leave/Drop` scoped to session header; `handleDragStart/Over/Drop/End` scoped to window items | S:75 R:80 A:85 D:75 |
+| 8 | Confident | `ServerSelector` owns its dropdown state internally | Self-contained state — `serverDropdownOpen`, `refreshingServers`, `serverDropdownRef`. No cross-component reads from orchestrator needed | S:80 R:85 A:85 D:80 |
+| 9 | Certain | `isGhostWindow` import used in `WindowRow` or passed as a `ghost` boolean prop | Pure predicate, no side effects — can be called anywhere. Implementation choice is free | S:80 R:95 A:95 D:90 |
+
+9 assumptions (5 certain, 4 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260405-f8p9-sidebar-component-decomposition/tasks.md
+++ b/fab/changes/260405-f8p9-sidebar-component-decomposition/tasks.md
@@ -1,0 +1,36 @@
+# Tasks: Sidebar Component Decomposition
+
+**Change**: 260405-f8p9-sidebar-component-decomposition
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+## Phase 1: Setup
+
+- [x] T001 Create `app/frontend/src/components/sidebar/` directory (empty) to establish the new module root
+
+## Phase 2: Core Implementation
+
+- [x] T002 Extract `KillDialog` to `app/frontend/src/components/sidebar/kill-dialog.tsx` — standalone presentational component using `<Dialog>` from `@/components/dialog`; accepts `killTarget`, `onConfirm`, `onCancel` props
+- [x] T003 [P] Extract `ServerSelector` to `app/frontend/src/components/sidebar/server-selector.tsx` — owns `serverDropdownOpen`, `refreshingServers`, `serverDropdownRef`, and outside-click `useEffect` internally; accepts `server`, `servers`, `onSwitchServer`, `onCreateServer`, `onRefreshServers` props
+- [x] T004 [P] Extract `WindowRow` to `app/frontend/src/components/sidebar/window-row.tsx` — pure presentational; accepts all window rendering, drag-and-drop, inline rename, and kill props; calls `isGhostWindow` and `getWindowDuration` internally
+- [x] T005 Extract `SessionRow` to `app/frontend/src/components/sidebar/session-row.tsx` — pure presentational; accepts session data, collapsed/drag/editing state, and all event handler props; renders chevron, session name (with inline rename input), +window, and ✕kill buttons
+- [x] T006 Create `app/frontend/src/components/sidebar/index.tsx` — orchestrator; contains all state (`collapsed`, `killTarget`, `editingWindow`, `editingSession`, `dragSource`, `dropTarget`, `sessionDropTarget`), all refs, all `useOptimisticAction` hooks, and all handler functions; composes `SessionRow`, `WindowRow`, `ServerSelector`, `KillDialog`; exports `Sidebar` and `SidebarProps`
+
+## Phase 3: Integration & Edge Cases
+
+- [x] T007 Delete `app/frontend/src/components/sidebar.tsx` — remove the original monolithic file after `sidebar/index.tsx` is verified
+- [x] T008 Verify `app/frontend/src/components/sidebar.test.tsx` — check if any import paths need updating (e.g., type imports for `SidebarProps`); update import paths only if needed, no test logic changes
+- [x] T009 Run `cd app/frontend && npx tsc --noEmit` — confirm zero TypeScript errors across all sidebar sub-components and consumers
+- [x] T010 Run `just test-frontend` — confirm all tests in `sidebar.test.tsx` pass with no regressions
+
+---
+
+## Execution Order
+
+- T002, T003, T004 are parallelizable (independent files, no shared dependencies)
+- T005 has no dependency on T002/T003/T004 but SessionRow renders no sub-components itself — can run in parallel
+- T006 depends on T002, T003, T004, T005 all being complete (it imports all four)
+- T007 depends on T006 (delete original only after orchestrator is complete)
+- T008 depends on T007 (check test imports only after original file is removed)
+- T009 depends on T008
+- T010 depends on T009


### PR DESCRIPTION
## Summary

The sidebar component (`app/frontend/src/components/sidebar.tsx`) was 713 lines in a single monolithic file, making it difficult to iterate on new features (inline output peek, activity previews), test in isolation, and review. This refactor extracts it into an orchestrator and four pure presentational sub-components with zero behavioral changes.

## Changes

- Sub-Component Extraction: `SessionRow`, `WindowRow`, `ServerSelector`, `KillDialog`
- Orchestrator: `sidebar/index.tsx` owns all state, hooks, and optimistic action wiring
- File structure replaced: `sidebar.tsx` → `sidebar/` directory with `index.tsx` barrel
- Memory updated: `docs/memory/run-kit/ui-patterns.md` documents new sidebar structure
- All existing tests pass unmodified; TypeScript clean

## Change

| ID | Name | Issue |
|----|------|-------|
| f8p9 | 260405-f8p9-sidebar-component-decomposition | — |

## Stats

| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| refactor | 3.8 / 5.0 | — | 10/10 | Pass (1 iterations) |

[intake](https://github.com/sahil87/run-kit/blob/260405-f8p9-sidebar-component-decomposition/fab/changes/260405-f8p9-sidebar-component-decomposition/intake.md) → [spec](https://github.com/sahil87/run-kit/blob/260405-f8p9-sidebar-component-decomposition/fab/changes/260405-f8p9-sidebar-component-decomposition/spec.md) → tasks → apply → review → hydrate → ship