### PR TITLE
feat: Add + and × buttons to tmux server line in sidebar

### DIFF
--- a/app/frontend/src/app.tsx
+++ b/app/frontend/src/app.tsx
@@ -824,6 +824,7 @@ function AppShell() {
                 servers={servers}
                 onSwitchServer={handleSwitchServer}
                 onCreateServer={() => setShowCreateServerDialog(true)}
+                onKillServer={() => setShowKillServerConfirm(true)}
                 onRefreshServers={refreshServers}
                 onMoveWindowToSession={handleMoveWindowToSession}
               />
@@ -901,6 +902,7 @@ function AppShell() {
                 servers={servers}
                 onSwitchServer={handleSwitchServer}
                 onCreateServer={() => setShowCreateServerDialog(true)}
+                onKillServer={() => setShowKillServerConfirm(true)}
                 onRefreshServers={refreshServers}
                 onMoveWindowToSession={handleMoveWindowToSession}
               />

--- a/app/frontend/src/components/sidebar.test.tsx
+++ b/app/frontend/src/components/sidebar.test.tsx
@@ -83,6 +83,7 @@ function renderSidebar(overrides: Partial<React.ComponentProps<typeof Sidebar>> 
           servers={["runkit"]}
           onSwitchServer={vi.fn()}
           onCreateServer={vi.fn()}
+          onKillServer={vi.fn()}
           onRefreshServers={vi.fn()}
           onMoveWindowToSession={vi.fn()}
           {...overrides}
@@ -727,6 +728,7 @@ describe("Sidebar", () => {
               servers={["runkit"]}
               onSwitchServer={vi.fn()}
               onCreateServer={vi.fn()}
+              onKillServer={vi.fn()}
               onRefreshServers={vi.fn()}
               onMoveWindowToSession={vi.fn()}
             />

--- a/app/frontend/src/components/sidebar/index.tsx
+++ b/app/frontend/src/components/sidebar/index.tsx
@@ -24,6 +24,7 @@ export type SidebarProps = {
   servers: string[];
   onSwitchServer: (name: string) => void;
   onCreateServer: () => void;
+  onKillServer: () => void;
   onRefreshServers: () => void;
   onMoveWindowToSession: (srcSession: string, srcIndex: number, dstSession: string) => void;
 };
@@ -39,6 +40,7 @@ export function Sidebar({
   servers,
   onSwitchServer,
   onCreateServer,
+  onKillServer,
   onRefreshServers,
   onMoveWindowToSession,
 }: SidebarProps) {
@@ -409,6 +411,8 @@ export function Sidebar({
         servers={servers}
         onSwitchServer={onSwitchServer}
         onCreateServer={onCreateServer}
+        onCreateSession={onCreateSession}
+        onKillServer={onKillServer}
         onRefreshServers={onRefreshServers}
       />
 

--- a/app/frontend/src/components/sidebar/server-selector.tsx
+++ b/app/frontend/src/components/sidebar/server-selector.tsx
@@ -6,6 +6,8 @@ type ServerSelectorProps = {
   servers: string[];
   onSwitchServer: (name: string) => void;
   onCreateServer: () => void;
+  onCreateSession: () => void;
+  onKillServer: () => void;
   onRefreshServers: () => void;
 };
 
@@ -14,6 +16,8 @@ export function ServerSelector({
   servers,
   onSwitchServer,
   onCreateServer,
+  onCreateSession,
+  onKillServer,
   onRefreshServers,
 }: ServerSelectorProps) {
   const [serverDropdownOpen, setServerDropdownOpen] = useState(false);
@@ -32,7 +36,7 @@ export function ServerSelector({
   }, [serverDropdownOpen]);
 
   return (
-    <div className="shrink-0 border-b border-border px-3 sm:px-4 flex items-center h-[48px]" ref={serverDropdownRef}>
+    <div className="shrink-0 border-b border-border px-3 sm:px-4 flex items-center justify-between h-[48px]" ref={serverDropdownRef}>
       <div className="flex items-center gap-1.5 relative">
         <span className="text-xs text-text-secondary">tmux server:</span>
         <button
@@ -89,6 +93,22 @@ export function ServerSelector({
             )}
           </div>
         )}
+      </div>
+      <div className="flex items-center">
+        <button
+          onClick={onCreateSession}
+          aria-label="New session"
+          className="text-text-secondary hover:text-text-primary transition-colors text-[16px] px-1 min-h-[36px] flex items-center justify-center"
+        >
+          +
+        </button>
+        <button
+          onClick={onKillServer}
+          aria-label={`Kill server ${server}`}
+          className="text-text-secondary hover:text-red-400 transition-colors text-[16px] px-1 min-h-[36px] flex items-center justify-center"
+        >
+          {"\u2715"}
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Adds inline + (create session) and × (kill server) action buttons to the tmux server selector row in the sidebar, matching the existing pattern used on session rows.

## Changes

- Added `onCreateSession` and `onKillServer` props to `ServerSelector` component
- Added + and × buttons to the server selector row with same styling as session row buttons
- Threaded new callbacks through `Sidebar` → `ServerSelector` from `app.tsx`
- + button triggers instant session creation (auto-selects CWD from active window)
- × button opens the existing kill server confirmation dialog

## Stats
| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| feat | — | — | — | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)