### PR TITLE
fix: window drag-drop insert-before semantics + optimistic render

### DIFF
--- a/app/backend/api/router.go
+++ b/app/backend/api/router.go
@@ -30,7 +30,7 @@ type TmuxOps interface {
 	RenameSession(session, name, server string) error
 	CreateWindow(session, name, cwd, server string) error
 	KillWindow(session string, index int, server string) error
-	SwapWindow(session string, srcIndex int, dstIndex int, server string) error
+	MoveWindow(session string, srcIndex int, dstIndex int, server string) error
 	MoveWindowToSession(srcSession string, srcIndex int, dstSession string, server string) error
 	RenameWindow(session string, index int, name, server string) error
 	SendKeys(session string, window int, keys, server string) error
@@ -100,8 +100,8 @@ func (p *prodTmuxOps) CreateWindow(session, name, cwd, server string) error {
 func (p *prodTmuxOps) KillWindow(session string, index int, server string) error {
 	return tmux.KillWindow(session, index, server)
 }
-func (p *prodTmuxOps) SwapWindow(session string, srcIndex int, dstIndex int, server string) error {
-	return tmux.SwapWindow(session, srcIndex, dstIndex, server)
+func (p *prodTmuxOps) MoveWindow(session string, srcIndex int, dstIndex int, server string) error {
+	return tmux.MoveWindow(session, srcIndex, dstIndex, server)
 }
 func (p *prodTmuxOps) MoveWindowToSession(srcSession string, srcIndex int, dstSession string, server string) error {
 	return tmux.MoveWindowToSession(srcSession, srcIndex, dstSession, server)

--- a/app/backend/api/sessions_test.go
+++ b/app/backend/api/sessions_test.go
@@ -108,7 +108,7 @@ func (m *mockTmuxOps) KillWindow(session string, index int, server string) error
 	m.killWindowIndex = index
 	return m.err
 }
-func (m *mockTmuxOps) SwapWindow(session string, srcIndex int, dstIndex int, server string) error {
+func (m *mockTmuxOps) MoveWindow(session string, srcIndex int, dstIndex int, server string) error {
 	m.swapWindowCalled = true
 	m.swapWindowSession = session
 	m.swapWindowSrcIndex = srcIndex

--- a/app/backend/api/windows.go
+++ b/app/backend/api/windows.go
@@ -251,7 +251,7 @@ func (s *Server) handleWindowMove(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.tmux.SwapWindow(session, index, *body.TargetIndex, serverFromRequest(r)); err != nil {
+	if err := s.tmux.MoveWindow(session, index, *body.TargetIndex, serverFromRequest(r)); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/app/backend/api/windows_test.go
+++ b/app/backend/api/windows_test.go
@@ -299,7 +299,7 @@ func TestWindowMoveSuccess(t *testing.T) {
 	}
 
 	if !ops.swapWindowCalled {
-		t.Error("SwapWindow was not called")
+		t.Error("MoveWindow was not called")
 	}
 	if ops.swapWindowSession != "run-kit" {
 		t.Errorf("session = %q, want %q", ops.swapWindowSession, "run-kit")

--- a/app/backend/internal/tmux/tmux.go
+++ b/app/backend/internal/tmux/tmux.go
@@ -483,15 +483,68 @@ func KillSession(session string, server string) error {
 	return err
 }
 
-// SwapWindow swaps two windows within the same session on the specified server.
-func SwapWindow(session string, srcIndex int, dstIndex int, server string) error {
+// MoveWindow moves a window from srcIndex to before dstIndex within the same session,
+// shifting intermediate windows via adjacent swaps. This gives "insert before" semantics
+// (e.g., moving index 0 to index 2 in [a b c d] produces [b a c d]).
+func MoveWindow(session string, srcIndex int, dstIndex int, server string) error {
+	if srcIndex == dstIndex {
+		return nil
+	}
+
+	// Get sorted window indices so we can bubble via adjacent swaps
 	ctx, cancel := withTimeout()
 	defer cancel()
+	out, err := tmuxExecServer(ctx, server, "list-windows", "-t", session, "-F", "#{window_index}")
+	if err != nil {
+		return fmt.Errorf("list windows: %w", err)
+	}
 
-	src := fmt.Sprintf("%s:%d", session, srcIndex)
-	dst := fmt.Sprintf("%s:%d", session, dstIndex)
-	_, err := tmuxExecServer(ctx, server, "swap-window", "-s", src, "-t", dst)
-	return err
+	var indices []int
+	for _, line := range out {
+		if idx, err := strconv.Atoi(strings.TrimSpace(line)); err == nil {
+			indices = append(indices, idx)
+		}
+	}
+	sort.Ints(indices)
+
+	srcPos, dstPos := -1, -1
+	for i, idx := range indices {
+		if idx == srcIndex {
+			srcPos = i
+		}
+		if idx == dstIndex {
+			dstPos = i
+		}
+	}
+	if srcPos < 0 || dstPos < 0 {
+		return fmt.Errorf("window index not found (src=%d dst=%d)", srcIndex, dstIndex)
+	}
+
+	// "Insert before" semantics: source lands just before the target item.
+	// When moving forward, stop one short (source ends up before dst).
+	// When moving backward, go all the way (source takes dst's slot, dst shifts right).
+	endPos := dstPos
+	if srcPos < dstPos {
+		endPos = dstPos - 1
+	}
+	if srcPos == endPos {
+		return nil
+	}
+	step := 1
+	if srcPos > endPos {
+		step = -1
+	}
+	for pos := srcPos; pos != endPos; pos += step {
+		src := fmt.Sprintf("%s:%d", session, indices[pos])
+		dst := fmt.Sprintf("%s:%d", session, indices[pos+step])
+		ctx2, cancel2 := withTimeout()
+		_, err := tmuxExecServer(ctx2, server, "swap-window", "-s", src, "-t", dst)
+		cancel2()
+		if err != nil {
+			return fmt.Errorf("swap %d↔%d: %w", indices[pos], indices[pos+step], err)
+		}
+	}
+	return nil
 }
 
 // MoveWindowToSession moves a window from one session to another on the specified server.

--- a/app/backend/internal/tmux/tmux.go
+++ b/app/backend/internal/tmux/tmux.go
@@ -516,15 +516,22 @@ func MoveWindow(session string, srcIndex int, dstIndex int, server string) error
 			dstPos = i
 		}
 	}
-	if srcPos < 0 || dstPos < 0 {
-		return fmt.Errorf("window index not found (src=%d dst=%d)", srcIndex, dstIndex)
+	if srcPos < 0 {
+		return fmt.Errorf("source window index %d not found", srcIndex)
+	}
+	// Sentinel index (past the last window) → move source to end.
+	// In this case, use "move to position" (full swaps), not "insert before."
+	sentinel := dstPos < 0
+	if sentinel {
+		dstPos = len(indices) - 1
 	}
 
 	// "Insert before" semantics: source lands just before the target item.
 	// When moving forward, stop one short (source ends up before dst).
 	// When moving backward, go all the way (source takes dst's slot, dst shifts right).
+	// Sentinel overrides: full swaps so source lands AT the end, not before it.
 	endPos := dstPos
-	if srcPos < dstPos {
+	if srcPos < dstPos && !sentinel {
 		endPos = dstPos - 1
 	}
 	if srcPos == endPos {

--- a/app/frontend/src/components/sidebar.test.tsx
+++ b/app/frontend/src/components/sidebar.test.tsx
@@ -55,6 +55,16 @@ const sessions: ProjectSession[] = [
         paneCommand: "zsh",
         activityTimestamp: Math.floor(Date.now() / 1000) - 180,
       },
+      {
+        index: 2,
+        windowId: "@2",
+        name: "logs",
+        worktreePath: "~/code/run-kit",
+        activity: "idle",
+        isActiveWindow: false,
+        paneCommand: "tail",
+        activityTimestamp: Math.floor(Date.now() / 1000) - 300,
+      },
     ],
   },
   {
@@ -62,7 +72,7 @@ const sessions: ProjectSession[] = [
     windows: [
       {
         index: 0,
-        windowId: "@2",
+        windowId: "@3",
         name: "dev",
         worktreePath: "~/code/ao-server",
         activity: "idle",
@@ -178,7 +188,7 @@ describe("Sidebar", () => {
     fireEvent.click(screen.getByLabelText("Kill session run-kit"));
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getByText("Kill session?")).toBeInTheDocument();
-    expect(screen.getByText(/2 window/)).toBeInTheDocument();
+    expect(screen.getByText(/3 window/)).toBeInTheDocument();
   });
 
   it("shows empty state with + New Session button when no sessions", () => {
@@ -810,15 +820,17 @@ describe("Sidebar", () => {
 
   describe("optimistic drag-drop reorder", () => {
     beforeEach(() => {
-      // Seed the window store so swapWindowOrder has entries to operate on
+      // Seed the window store so moveWindowOrder has entries to operate on.
+      // Need 3+ windows to test insert-before semantics (2-item forward move is a no-op).
       useWindowStore.setState({ entries: new Map(), ghosts: [] });
       useWindowStore.getState().setWindowsForSession("run-kit", [
         { windowId: "@0", index: 0, name: "main", worktreePath: "~/code/run-kit", activity: "active", isActiveWindow: true, activityTimestamp: Math.floor(Date.now() / 1000) - 5 },
         { windowId: "@1", index: 1, name: "scratch", worktreePath: "~/code/run-kit", activity: "idle", isActiveWindow: false, activityTimestamp: Math.floor(Date.now() / 1000) - 180 },
+        { windowId: "@2", index: 2, name: "logs", worktreePath: "~/code/run-kit", activity: "idle", isActiveWindow: false, activityTimestamp: Math.floor(Date.now() / 1000) - 300 },
       ]);
     });
 
-    it("optimistic swap updates window store indices synchronously on drop", async () => {
+    it("optimistic move updates window store indices synchronously on drop", async () => {
       const { moveWindow: moveWindowMock } = await import("@/api/client");
       // Use a deferred promise so API stays pending during assertion
       let resolveApi!: () => void;
@@ -827,29 +839,32 @@ describe("Sidebar", () => {
       const onSelectWindow = vi.fn();
       renderSidebar({ onSelectWindow });
 
+      // Drag main(@0, index 0) onto logs(@2, index 2)
+      // Insert-before: [main scratch logs] → [scratch main logs]
       const mainBtn = screen.getAllByText("main")[0].closest("button");
       const mainDraggable = mainBtn?.closest("[draggable]") as HTMLElement;
-      const scratchBtn = screen.getByText("scratch").closest("button");
-      const scratchDraggable = scratchBtn?.closest("[draggable]") as HTMLElement;
+      const logsBtn = screen.getByText("logs").closest("button");
+      const logsDraggable = logsBtn?.closest("[draggable]") as HTMLElement;
 
       const dataTransfer = {
         setData: vi.fn(),
-        getData: vi.fn().mockReturnValue(JSON.stringify({ session: "run-kit", index: 0 })),
+        getData: vi.fn().mockReturnValue(JSON.stringify({ session: "run-kit", index: 0, windowId: "@0", name: "main" })),
         effectAllowed: "",
         dropEffect: "",
       };
 
       fireEvent.dragStart(mainDraggable, { dataTransfer });
-      fireEvent.dragOver(scratchDraggable, { dataTransfer });
-      fireEvent.drop(scratchDraggable, { dataTransfer });
+      fireEvent.dragOver(logsDraggable, { dataTransfer });
+      fireEvent.drop(logsDraggable, { dataTransfer });
 
-      // Synchronous: store indices should already be swapped (before API resolves)
+      // Synchronous: store indices should reflect insert-before (before API resolves)
       const entries = useWindowStore.getState().entries;
-      expect(entries.get("@0")?.index).toBe(1);
-      expect(entries.get("@1")?.index).toBe(0);
+      expect(entries.get("@1")?.index).toBe(0); // scratch shifted left
+      expect(entries.get("@0")?.index).toBe(1); // main inserted before logs
+      expect(entries.get("@2")?.index).toBe(2); // logs unchanged
 
-      // onSelectWindow called immediately
-      expect(onSelectWindow).toHaveBeenCalledWith("run-kit", 1);
+      // onSelectWindow called with the drop target index
+      expect(onSelectWindow).toHaveBeenCalledWith("run-kit", 2);
 
       // Clean up: flush microtask to let action() run (assigns resolveApi), then resolve
       await act(async () => { await Promise.resolve(); });
@@ -862,30 +877,32 @@ describe("Sidebar", () => {
 
       renderSidebar();
 
+      // Drag main(@0, index 0) onto logs(@2, index 2)
       const mainBtn = screen.getAllByText("main")[0].closest("button");
       const mainDraggable = mainBtn?.closest("[draggable]") as HTMLElement;
-      const scratchBtn = screen.getByText("scratch").closest("button");
-      const scratchDraggable = scratchBtn?.closest("[draggable]") as HTMLElement;
+      const logsBtn = screen.getByText("logs").closest("button");
+      const logsDraggable = logsBtn?.closest("[draggable]") as HTMLElement;
 
       const dataTransfer = {
         setData: vi.fn(),
-        getData: vi.fn().mockReturnValue(JSON.stringify({ session: "run-kit", index: 0 })),
+        getData: vi.fn().mockReturnValue(JSON.stringify({ session: "run-kit", index: 0, windowId: "@0", name: "main" })),
         effectAllowed: "",
         dropEffect: "",
       };
 
       fireEvent.dragStart(mainDraggable, { dataTransfer });
-      fireEvent.dragOver(scratchDraggable, { dataTransfer });
+      fireEvent.dragOver(logsDraggable, { dataTransfer });
 
-      // Drop triggers optimistic swap + API call
+      // Drop triggers optimistic move + API call
       await act(async () => {
-        fireEvent.drop(scratchDraggable, { dataTransfer });
+        fireEvent.drop(logsDraggable, { dataTransfer });
       });
 
       // After API rejection settles, indices should be restored
       const entries = useWindowStore.getState().entries;
       expect(entries.get("@0")?.index).toBe(0);
       expect(entries.get("@1")?.index).toBe(1);
+      expect(entries.get("@2")?.index).toBe(2);
     });
   });
 

--- a/app/frontend/src/components/sidebar.test.tsx
+++ b/app/frontend/src/components/sidebar.test.tsx
@@ -863,8 +863,8 @@ describe("Sidebar", () => {
       expect(entries.get("@0")?.index).toBe(1); // main inserted before logs
       expect(entries.get("@2")?.index).toBe(2); // logs unchanged
 
-      // onSelectWindow called with the drop target index
-      expect(onSelectWindow).toHaveBeenCalledWith("run-kit", 2);
+      // Reorder should not change selection
+      expect(onSelectWindow).not.toHaveBeenCalled();
 
       // Clean up: flush microtask to let action() run (assigns resolveApi), then resolve
       await act(async () => { await Promise.resolve(); });

--- a/app/frontend/src/components/sidebar/index.tsx
+++ b/app/frontend/src/components/sidebar/index.tsx
@@ -410,7 +410,6 @@ export function Sidebar({
     if (isMovePending) return;
 
     executeMoveWindow(data.session, data.index, windowIndex);
-    onSelectWindow(sessionName, windowIndex);
   }
 
   function handleDragEnd() {

--- a/app/frontend/src/components/sidebar/index.tsx
+++ b/app/frontend/src/components/sidebar/index.tsx
@@ -579,21 +579,24 @@ export function Sidebar({
                         />
                       );
                     })}
-                    {/* Drop zone after last window — enables moving items to the end */}
+                    {/* Drop zone after last window — enables moving items to the end.
+                        Relative wrapper keeps the absolute zone in flow position without adding height. */}
                     {dragSource?.session === session.name && (
-                      <div
-                        className="h-2"
-                        style={
-                          dropTarget?.session === session.name && dropTarget?.index === -1
-                            ? { borderTop: "2px solid var(--color-accent)" }
-                            : undefined
-                        }
-                        onDragOver={(e) => handleDragOver(e, session.name, -1)}
-                        onDrop={(e) => {
-                          const lastWin = session.windows[session.windows.length - 1];
-                          if (lastWin) handleDrop(e, session.name, lastWin.index + 1);
-                        }}
-                      />
+                      <div className="relative">
+                        <div
+                          className="absolute inset-x-0 top-0 h-4 -mt-1"
+                          style={
+                            dropTarget?.session === session.name && dropTarget?.index === -1
+                              ? { boxShadow: "0 -2px 0 0 var(--color-accent)" }
+                              : undefined
+                          }
+                          onDragOver={(e) => handleDragOver(e, session.name, -1)}
+                          onDrop={(e) => {
+                            const lastWin = session.windows[session.windows.length - 1];
+                            if (lastWin) handleDrop(e, session.name, lastWin.index + 1);
+                          }}
+                        />
+                      </div>
                     )}
                   </div>
                 )}

--- a/app/frontend/src/components/sidebar/index.tsx
+++ b/app/frontend/src/components/sidebar/index.tsx
@@ -579,6 +579,22 @@ export function Sidebar({
                         />
                       );
                     })}
+                    {/* Drop zone after last window — enables moving items to the end */}
+                    {dragSource?.session === session.name && (
+                      <div
+                        className="h-2"
+                        style={
+                          dropTarget?.session === session.name && dropTarget?.index === -1
+                            ? { borderTop: "2px solid var(--color-accent)" }
+                            : undefined
+                        }
+                        onDragOver={(e) => handleDragOver(e, session.name, -1)}
+                        onDrop={(e) => {
+                          const lastWin = session.windows[session.windows.length - 1];
+                          if (lastWin) handleDrop(e, session.name, lastWin.index + 1);
+                        }}
+                      />
+                    )}
                   </div>
                 )}
               </div>

--- a/app/frontend/src/components/sidebar/index.tsx
+++ b/app/frontend/src/components/sidebar/index.tsx
@@ -80,7 +80,7 @@ export function Sidebar({
   const killWindowStore = useWindowStore((state) => state.killWindow);
   const restoreWindow = useWindowStore((state) => state.restoreWindow);
   const clearSession = useWindowStore((state) => state.clearSession);
-  const swapWindowOrder = useWindowStore((state) => state.swapWindowOrder);
+  const moveWindowOrder = useWindowStore((state) => state.moveWindowOrder);
   const addGhostWindow = useWindowStore((state) => state.addGhostWindow);
   const removeGhost = useWindowStore((state) => state.removeGhost);
 
@@ -215,23 +215,36 @@ export function Sidebar({
     },
   });
 
-  // Optimistic swap for drag-drop window reorder
-  const lastSwapRef = useRef<{ session: string; srcIndex: number; dstIndex: number } | null>(null);
-  const { execute: executeSwapWindow, isPending: isSwapPending } = useOptimisticAction<[string, number, number]>({
+  // Optimistic move for drag-drop window reorder (insert-before semantics)
+  const preMoveEntriesRef = useRef<Map<string, { session: string; index: number }> | null>(null);
+  const { execute: executeMoveWindow, isPending: isMovePending } = useOptimisticAction<[string, number, number]>({
     action: (session, srcIndex, dstIndex) => moveWindow(session, srcIndex, dstIndex),
     onOptimistic: (session, srcIndex, dstIndex) => {
-      lastSwapRef.current = { session, srcIndex, dstIndex };
-      swapWindowOrder(session, srcIndex, dstIndex);
+      // Snapshot entries for rollback (move isn't self-inverse like swap)
+      const entries = useWindowStore.getState().entries;
+      const snapshot = new Map<string, { session: string; index: number }>();
+      for (const [id, e] of entries) {
+        if (e.session === session) snapshot.set(id, { session: e.session, index: e.index });
+      }
+      preMoveEntriesRef.current = snapshot;
+      moveWindowOrder(session, srcIndex, dstIndex);
     },
     onAlwaysRollback: () => {
-      if (lastSwapRef.current) {
-        const { session, srcIndex, dstIndex } = lastSwapRef.current;
-        swapWindowOrder(session, dstIndex, srcIndex);
-        lastSwapRef.current = null;
+      if (preMoveEntriesRef.current) {
+        const snapshot = preMoveEntriesRef.current;
+        useWindowStore.setState((state) => {
+          const newEntries = new Map(state.entries);
+          for (const [id, saved] of snapshot) {
+            const existing = newEntries.get(id);
+            if (existing) newEntries.set(id, { ...existing, index: saved.index });
+          }
+          return { entries: newEntries };
+        });
+        preMoveEntriesRef.current = null;
       }
     },
     onAlwaysSettled: () => {
-      lastSwapRef.current = null;
+      preMoveEntriesRef.current = null;
     },
     onError: (err) => {
       addToast(err.message || "Failed to move window");
@@ -240,7 +253,7 @@ export function Sidebar({
 
   // Optimistic cross-session window move
   const lastMoveToSessionRef = useRef<{ srcSession: string; windowId: string; optimisticId: string } | null>(null);
-  const { execute: executeMoveToSession, isPending: isMovePending } = useOptimisticAction<[string, number, string, string, string]>({
+  const { execute: executeMoveToSession, isPending: isCrossMovePending } = useOptimisticAction<[string, number, string, string, string]>({
     action: (srcSession, srcIndex, _windowId, _windowName, dstSession) =>
       moveWindowToSession(srcSession, srcIndex, dstSession),
     onOptimistic: (srcSession, _srcIndex, windowId, windowName, dstSession) => {
@@ -394,9 +407,9 @@ export function Sidebar({
     }
 
     if (data.session !== sessionName || data.index === windowIndex) return;
-    if (isSwapPending) return;
+    if (isMovePending) return;
 
-    executeSwapWindow(data.session, data.index, windowIndex);
+    executeMoveWindow(data.session, data.index, windowIndex);
     onSelectWindow(sessionName, windowIndex);
   }
 
@@ -433,7 +446,7 @@ export function Sidebar({
     }
 
     if (data.session === sessionName) return;
-    if (isMovePending) return;
+    if (isCrossMovePending) return;
 
     executeMoveToSession(data.session, data.index, data.windowId, data.name, sessionName);
   }

--- a/app/frontend/src/components/sidebar/session-row.tsx
+++ b/app/frontend/src/components/sidebar/session-row.tsx
@@ -46,7 +46,7 @@ export function SessionRow({
       onDragOver={onDragOver}
       onDragLeave={onDragLeave}
       onDrop={onDrop}
-      style={isSessionDropTarget ? { border: "2px solid var(--color-accent)", borderRadius: "4px" } : undefined}
+      style={isSessionDropTarget ? { boxShadow: "inset 0 0 0 2px var(--color-accent)", borderRadius: "4px" } : undefined}
     >
       <div className="flex items-center gap-1.5 min-w-0 flex-1">
         <button

--- a/app/frontend/src/components/sidebar/window-row.tsx
+++ b/app/frontend/src/components/sidebar/window-row.tsx
@@ -60,7 +60,7 @@ export function WindowRow({
       onDragOver={onDragOver}
       onDrop={onDrop}
       onDragEnd={onDragEnd}
-      style={isDragOver ? { borderTop: "2px solid var(--color-accent)" } : undefined}
+      style={isDragOver ? { boxShadow: "0 -2px 0 0 var(--color-accent)" } : undefined}
     >
       <button
         onClick={onSelectWindow}

--- a/app/frontend/src/contexts/optimistic-context.tsx
+++ b/app/frontend/src/contexts/optimistic-context.tsx
@@ -169,7 +169,7 @@ export function useMergedSessions(realSessions: ProjectSession[]): MergedSession
           const realWin = s.windows.find((w) => w.windowId === entry.windowId);
           if (!realWin) continue;
           const name = entry.pendingName ?? entry.name;
-          sessionEntries.push({ ...realWin, name });
+          sessionEntries.push({ ...realWin, name, index: entry.index });
         }
         // Sort by index ascending
         sessionEntries.sort((a, b) => a.index - b.index);

--- a/app/frontend/src/store/window-store.test.ts
+++ b/app/frontend/src/store/window-store.test.ts
@@ -351,68 +351,69 @@ describe("window-store", () => {
     });
   });
 
-  describe("swapWindowOrder", () => {
-    it("swaps index values of two windows in the same session", () => {
-      const { setWindowsForSession, swapWindowOrder } = getStore();
+  describe("moveWindowOrder", () => {
+    it("moves window forward (insert before): [a b c d] move 0→2 gives [b a c d]", () => {
+      const { setWindowsForSession, moveWindowOrder } = getStore();
       setWindowsForSession("alpha", [
-        makeWindow({ windowId: "@0", index: 0, name: "main" }),
-        makeWindow({ windowId: "@1", index: 1, name: "dev" }),
-        makeWindow({ windowId: "@2", index: 2, name: "logs" }),
+        makeWindow({ windowId: "@0", index: 0, name: "a" }),
+        makeWindow({ windowId: "@1", index: 1, name: "b" }),
+        makeWindow({ windowId: "@2", index: 2, name: "c" }),
+        makeWindow({ windowId: "@3", index: 3, name: "d" }),
       ]);
 
-      swapWindowOrder("alpha", 0, 2);
+      moveWindowOrder("alpha", 0, 2);
 
       const entries = useWindowStore.getState().entries;
-      expect(entries.get("@0")?.index).toBe(2);
-      expect(entries.get("@2")?.index).toBe(0);
-      // Middle window untouched
-      expect(entries.get("@1")?.index).toBe(1);
+      expect(entries.get("@1")?.index).toBe(0); // b shifted left
+      expect(entries.get("@0")?.index).toBe(1); // a inserted before c
+      expect(entries.get("@2")?.index).toBe(2); // c unchanged
+      expect(entries.get("@3")?.index).toBe(3); // d unchanged
+    });
+
+    it("moves window backward: [a b c d] move 3→1 gives [a d b c]", () => {
+      const { setWindowsForSession, moveWindowOrder } = getStore();
+      setWindowsForSession("alpha", [
+        makeWindow({ windowId: "@0", index: 0, name: "a" }),
+        makeWindow({ windowId: "@1", index: 1, name: "b" }),
+        makeWindow({ windowId: "@2", index: 2, name: "c" }),
+        makeWindow({ windowId: "@3", index: 3, name: "d" }),
+      ]);
+
+      moveWindowOrder("alpha", 3, 1);
+
+      const entries = useWindowStore.getState().entries;
+      expect(entries.get("@0")?.index).toBe(0); // a unchanged
+      expect(entries.get("@3")?.index).toBe(1); // d took b's slot
+      expect(entries.get("@1")?.index).toBe(2); // b shifted right
+      expect(entries.get("@2")?.index).toBe(3); // c shifted right
     });
 
     it("no-op when source entry is missing", () => {
-      const { setWindowsForSession, swapWindowOrder } = getStore();
+      const { setWindowsForSession, moveWindowOrder } = getStore();
       setWindowsForSession("alpha", [
         makeWindow({ windowId: "@0", index: 0, name: "main" }),
       ]);
 
-      swapWindowOrder("alpha", 5, 0);
+      moveWindowOrder("alpha", 5, 0);
 
       const entries = useWindowStore.getState().entries;
       expect(entries.get("@0")?.index).toBe(0);
     });
 
     it("no-op when destination entry is missing", () => {
-      const { setWindowsForSession, swapWindowOrder } = getStore();
+      const { setWindowsForSession, moveWindowOrder } = getStore();
       setWindowsForSession("alpha", [
         makeWindow({ windowId: "@0", index: 0, name: "main" }),
       ]);
 
-      swapWindowOrder("alpha", 0, 5);
+      moveWindowOrder("alpha", 0, 5);
 
       const entries = useWindowStore.getState().entries;
       expect(entries.get("@0")?.index).toBe(0);
     });
 
-    it("re-swap (rollback) restores original indices", () => {
-      const { setWindowsForSession, swapWindowOrder } = getStore();
-      setWindowsForSession("alpha", [
-        makeWindow({ windowId: "@0", index: 0, name: "main" }),
-        makeWindow({ windowId: "@1", index: 1, name: "dev" }),
-      ]);
-
-      // Forward swap
-      swapWindowOrder("alpha", 0, 1);
-      expect(useWindowStore.getState().entries.get("@0")?.index).toBe(1);
-      expect(useWindowStore.getState().entries.get("@1")?.index).toBe(0);
-
-      // Reverse swap (rollback)
-      swapWindowOrder("alpha", 1, 0);
-      expect(useWindowStore.getState().entries.get("@0")?.index).toBe(0);
-      expect(useWindowStore.getState().entries.get("@1")?.index).toBe(1);
-    });
-
     it("does not affect windows from other sessions", () => {
-      const { setWindowsForSession, swapWindowOrder } = getStore();
+      const { setWindowsForSession, moveWindowOrder } = getStore();
       setWindowsForSession("alpha", [
         makeWindow({ windowId: "@0", index: 0, name: "main" }),
         makeWindow({ windowId: "@1", index: 1, name: "dev" }),
@@ -421,7 +422,7 @@ describe("window-store", () => {
         makeWindow({ windowId: "@2", index: 0, name: "other" }),
       ]);
 
-      swapWindowOrder("alpha", 0, 1);
+      moveWindowOrder("alpha", 0, 1);
 
       expect(useWindowStore.getState().entries.get("@2")?.index).toBe(0);
     });

--- a/app/frontend/src/store/window-store.ts
+++ b/app/frontend/src/store/window-store.ts
@@ -81,7 +81,7 @@ type WindowStoreActions = {
    * Swap the index values of two windows within the same session.
    * No-op if either entry is missing.
    */
-  swapWindowOrder: (session: string, srcIndex: number, dstIndex: number) => void;
+  moveWindowOrder: (session: string, srcIndex: number, dstIndex: number) => void;
 
   /**
    * Clear all window entries and ghosts for a session (called after session kill).
@@ -253,22 +253,36 @@ export const useWindowStore = create<WindowStoreState & WindowStoreActions>((set
     }));
   },
 
-  swapWindowOrder: (session, srcIndex, dstIndex) => {
+  moveWindowOrder: (session, srcIndex, dstIndex) => {
     set((state) => {
-      let srcId: string | undefined;
-      let dstId: string | undefined;
+      // Collect session windows sorted by index
+      const sorted: Array<[string, WindowEntry]> = [];
       for (const [id, entry] of state.entries) {
-        if (entry.session !== session) continue;
-        if (entry.index === srcIndex) srcId = id;
-        if (entry.index === dstIndex) dstId = id;
-        if (srcId && dstId) break;
+        if (entry.session === session) sorted.push([id, entry]);
       }
-      if (!srcId || !dstId) return state;
-      const srcEntry = state.entries.get(srcId)!;
-      const dstEntry = state.entries.get(dstId)!;
+      sorted.sort((a, b) => a[1].index - b[1].index);
+
+      const srcPos = sorted.findIndex(([, e]) => e.index === srcIndex);
+      const dstPos = sorted.findIndex(([, e]) => e.index === dstIndex);
+      if (srcPos < 0 || dstPos < 0) return state;
+
+      // Preserve the original sorted indices for reassignment
+      const indices = sorted.map(([, e]) => e.index);
+
+      // "Insert before": source lands just before the target item.
+      // When moving forward, removing src shifts dst left by 1 in the
+      // reduced array; inserting at (dstPos - 1) puts src right before
+      // dst's new position. When moving backward, no shift — dstPos is
+      // correct as-is.
+      const [removed] = sorted.splice(srcPos, 1);
+      sorted.splice(srcPos < dstPos ? dstPos - 1 : dstPos, 0, removed);
+
+      // Reassign the original indices to the new ordering
       const newEntries = new Map(state.entries);
-      newEntries.set(srcId, { ...srcEntry, index: dstIndex });
-      newEntries.set(dstId, { ...dstEntry, index: srcIndex });
+      for (let i = 0; i < sorted.length; i++) {
+        const [id] = sorted[i];
+        newEntries.set(id, { ...newEntries.get(id)!, index: indices[i] });
+      }
       return { entries: newEntries };
     });
   },

--- a/app/frontend/src/store/window-store.ts
+++ b/app/frontend/src/store/window-store.ts
@@ -132,7 +132,7 @@ export const useWindowStore = create<WindowStoreState & WindowStoreActions>((set
           index: w.index,
           name: w.name,
           pendingName: existing?.pendingName,
-          killed: existing?.killed ?? false,
+          killed: existing?.session === session ? (existing.killed ?? false) : false,
           createdAt: existing?.createdAt ?? Date.now(),
           panes: w.panes ?? [],
         });

--- a/app/frontend/src/store/window-store.ts
+++ b/app/frontend/src/store/window-store.ts
@@ -263,19 +263,20 @@ export const useWindowStore = create<WindowStoreState & WindowStoreActions>((set
       sorted.sort((a, b) => a[1].index - b[1].index);
 
       const srcPos = sorted.findIndex(([, e]) => e.index === srcIndex);
-      const dstPos = sorted.findIndex(([, e]) => e.index === dstIndex);
-      if (srcPos < 0 || dstPos < 0) return state;
+      if (srcPos < 0) return state;
+      // Sentinel index (past last window) → move to end (full swap, not insert-before)
+      let dstPos = sorted.findIndex(([, e]) => e.index === dstIndex);
+      const sentinel = dstPos < 0;
+      if (sentinel) dstPos = sorted.length - 1;
 
       // Preserve the original sorted indices for reassignment
       const indices = sorted.map(([, e]) => e.index);
 
       // "Insert before": source lands just before the target item.
-      // When moving forward, removing src shifts dst left by 1 in the
-      // reduced array; inserting at (dstPos - 1) puts src right before
-      // dst's new position. When moving backward, no shift — dstPos is
-      // correct as-is.
+      // Sentinel override: source lands AT the end (full move, no -1 adjustment).
       const [removed] = sorted.splice(srcPos, 1);
-      sorted.splice(srcPos < dstPos ? dstPos - 1 : dstPos, 0, removed);
+      const insertPos = srcPos < dstPos && !sentinel ? dstPos - 1 : dstPos;
+      sorted.splice(insertPos, 0, removed);
 
       // Reassign the original indices to the new ordering
       const newEntries = new Map(state.entries);


### PR DESCRIPTION
## Summary

- Fix window drag-drop reorder: swap semantics → insert-before semantics across tmux, store, and API layers
- `[a b | c d]` (drag a to `|`) now correctly produces `[b a c d]` instead of `[c b a d]`
- Optimistic render: store entry index overrides SSE index in merge layer so reorder is instant
- Snapshot-based rollback for move (not self-inverse like swap)

## Test plan
- [x] Backend builds, `go test ./...` passes
- [x] Frontend type-checks, 387 vitest tests pass
- [ ] Manual: drag window forward (a→c position) → items shift correctly
- [ ] Manual: drag window backward → items shift correctly
- [ ] Manual: reorder is instant (no 2.5s SSE wait)
- [ ] Manual: API failure → rollback restores original order

🤖 Generated with [Claude Code](https://claude.com/claude-code)