### PR TITLE
feat: Pane panel — click rows to copy cwd/git/tmx/fab values

### DIFF
--- a/app/frontend/src/components/sidebar/status-panel.test.tsx
+++ b/app/frontend/src/components/sidebar/status-panel.test.tsx
@@ -1,7 +1,11 @@
-import { describe, it, expect, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
 import { StatusPanel } from "./status-panel";
 import type { WindowInfo } from "@/types";
+
+vi.mock("@/lib/clipboard", () => ({
+  copyToClipboard: vi.fn().mockResolvedValue(undefined),
+}));
 
 // Helper to exercise shortenPath via the component
 function renderCwd(cwd: string) {
@@ -17,8 +21,14 @@ function renderCwd(cwd: string) {
   render(<StatusPanel window={win} nowSeconds={0} />);
 }
 
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
 });
 
 function makeWindow(overrides: Partial<WindowInfo> = {}): WindowInfo {
@@ -164,9 +174,184 @@ describe("StatusPanel", () => {
 
     it("title attribute preserves full unmodified path", () => {
       renderCwd("/home/sahil/code/org/repo/src");
-      const cwdDiv = document.querySelector("[title='/home/sahil/code/org/repo/src']");
-      expect(cwdDiv).not.toBeNull();
-      expect(cwdDiv?.querySelector(".text-text-primary")?.textContent).toBe("\u2026/repo/src");
+      const cwdButton = document.querySelector("[title='/home/sahil/code/org/repo/src']");
+      expect(cwdButton).not.toBeNull();
+      expect(cwdButton?.querySelector(".text-text-primary")?.textContent).toBe("\u2026/repo/src");
     });
+  });
+});
+
+describe("StatusPanel copy behavior", () => {
+  function makeWindowWithPanes(overrides: Partial<WindowInfo> = {}): WindowInfo {
+    return {
+      windowId: "@0",
+      index: 0,
+      name: "zsh",
+      worktreePath: "/home/user/code/run-kit",
+      activity: "idle",
+      isActiveWindow: false,
+      activityTimestamp: 0,
+      panes: [
+        { paneId: "%5", paneIndex: 0, cwd: "/home/user/code/run-kit", command: "zsh", isActive: true, gitBranch: "main" },
+      ],
+      ...overrides,
+    };
+  }
+
+  it("clicking cwd row copies full path", async () => {
+    const { copyToClipboard } = await import("@/lib/clipboard");
+    const win = makeWindowWithPanes();
+    render(<StatusPanel window={win} nowSeconds={0} />);
+
+    const cwdButton = document.querySelector("[title='/home/user/code/run-kit']") as HTMLButtonElement;
+    expect(cwdButton).not.toBeNull();
+    expect(cwdButton.tagName).toBe("BUTTON");
+
+    fireEvent.click(cwdButton);
+
+    expect(copyToClipboard).toHaveBeenCalledWith("/home/user/code/run-kit");
+  });
+
+  it("clicking git row copies branch name", async () => {
+    const { copyToClipboard } = await import("@/lib/clipboard");
+    const win = makeWindowWithPanes();
+    render(<StatusPanel window={win} nowSeconds={0} />);
+
+    const gitButton = screen.getByRole("button", { name: /main/ });
+    fireEvent.click(gitButton);
+
+    expect(copyToClipboard).toHaveBeenCalledWith("main");
+  });
+
+  it("clicking tmx row copies pane ID", async () => {
+    const { copyToClipboard } = await import("@/lib/clipboard");
+    const win = makeWindowWithPanes();
+    render(<StatusPanel window={win} nowSeconds={0} />);
+
+    const tmxButton = screen.getByRole("button", { name: /pane 1\/1 %5/ });
+    fireEvent.click(tmxButton);
+
+    expect(copyToClipboard).toHaveBeenCalledWith("%5");
+  });
+
+  it("clicking fab row copies change ID", async () => {
+    const { copyToClipboard } = await import("@/lib/clipboard");
+    const win = makeWindowWithPanes({
+      fabChange: "260405-rx38-pane-cwd-tracking",
+      fabStage: "apply",
+    });
+    render(<StatusPanel window={win} nowSeconds={0} />);
+
+    const fabButton = screen.getByRole("button", { name: /rx38/ });
+    fireEvent.click(fabButton);
+
+    expect(copyToClipboard).toHaveBeenCalledWith("rx38");
+  });
+
+  it("shows 'copied' feedback after click and reverts after 1000ms", async () => {
+    const win = makeWindowWithPanes();
+    render(<StatusPanel window={win} nowSeconds={0} />);
+
+    const cwdButton = document.querySelector("[title='/home/user/code/run-kit']") as HTMLButtonElement;
+    fireEvent.click(cwdButton);
+
+    // Should show "copied" feedback
+    expect(screen.getByText(/copied \u2713/)).toBeInTheDocument();
+
+    // After 1000ms, should revert
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(screen.queryByText(/copied \u2713/)).not.toBeInTheDocument();
+    expect(screen.getByText("cwd")).toBeInTheDocument();
+  });
+
+  it("feedback moves between rows — clicking git while cwd shows 'copied' swaps immediately", async () => {
+    const win = makeWindowWithPanes();
+    render(<StatusPanel window={win} nowSeconds={0} />);
+
+    // Click cwd
+    const cwdButton = document.querySelector("[title='/home/user/code/run-kit']") as HTMLButtonElement;
+    fireEvent.click(cwdButton);
+    expect(screen.getByText(/copied \u2713/)).toBeInTheDocument();
+
+    // Click git within the feedback window
+    const gitButton = screen.getByRole("button", { name: /main/ });
+    fireEvent.click(gitButton);
+
+    // Only one "copied" indicator at a time — the one on git row
+    const copiedElements = screen.getAllByText(/copied \u2713/);
+    expect(copiedElements).toHaveLength(1);
+    // cwd label should have reverted
+    expect(screen.getByText("cwd")).toBeInTheDocument();
+  });
+
+  it("active text selection suppresses copy", async () => {
+    const { copyToClipboard } = await import("@/lib/clipboard");
+    vi.mocked(copyToClipboard).mockClear();
+
+    const win = makeWindowWithPanes();
+    render(<StatusPanel window={win} nowSeconds={0} />);
+
+    // Mock active text selection
+    const getSelectionSpy = vi.spyOn(window, "getSelection").mockReturnValue({
+      toString: () => "selected text",
+    } as Selection);
+
+    const cwdButton = document.querySelector("[title='/home/user/code/run-kit']") as HTMLButtonElement;
+    fireEvent.click(cwdButton);
+
+    expect(copyToClipboard).not.toHaveBeenCalled();
+    expect(screen.queryByText(/copied \u2713/)).not.toBeInTheDocument();
+
+    getSelectionSpy.mockRestore();
+  });
+
+  it("process-only row (no fab state) is not rendered as a button", () => {
+    const win = makeWindowWithPanes({
+      fabChange: undefined,
+      fabStage: undefined,
+      panes: [
+        { paneId: "%5", paneIndex: 0, cwd: "/home/user/code/run-kit", command: "zsh", isActive: true },
+      ],
+    });
+    render(<StatusPanel window={win} nowSeconds={0} />);
+
+    // The "run" row should be a div, not a button
+    const runText = screen.getByText("run");
+    expect(runText.closest("button")).toBeNull();
+    expect(runText.closest("div")).not.toBeNull();
+  });
+
+  it("empty paneId renders non-interactive tmx row", () => {
+    const win = makeWindowWithPanes({
+      panes: [
+        { paneId: "", paneIndex: 0, cwd: "/home/user/code/run-kit", command: "zsh", isActive: true, gitBranch: "main" },
+      ],
+    });
+    render(<StatusPanel window={win} nowSeconds={0} />);
+
+    // The tmx row should be a div, not a button
+    const tmxText = screen.getByText("tmx");
+    expect(tmxText.closest("button")).toBeNull();
+    expect(tmxText.closest("div")).not.toBeNull();
+  });
+
+  it("keyboard activation (Enter) triggers copy on cwd row", async () => {
+    const { copyToClipboard } = await import("@/lib/clipboard");
+    vi.mocked(copyToClipboard).mockClear();
+
+    const win = makeWindowWithPanes();
+    render(<StatusPanel window={win} nowSeconds={0} />);
+
+    const cwdButton = document.querySelector("[title='/home/user/code/run-kit']") as HTMLButtonElement;
+    cwdButton.focus();
+    fireEvent.keyDown(cwdButton, { key: "Enter" });
+    fireEvent.keyUp(cwdButton, { key: "Enter" });
+    // Button elements natively handle Enter via click event
+    fireEvent.click(cwdButton);
+
+    expect(copyToClipboard).toHaveBeenCalledWith("/home/user/code/run-kit");
   });
 });

--- a/app/frontend/src/components/sidebar/status-panel.tsx
+++ b/app/frontend/src/components/sidebar/status-panel.tsx
@@ -1,7 +1,13 @@
+import { useState, useRef, useEffect, type ReactNode } from "react";
 import { BrailleSpinner } from "@/components/braille-spinner";
 import { CollapsiblePanel } from "./collapsible-panel";
+import { copyToClipboard } from "@/lib/clipboard";
 import { formatDuration, parseFabChange } from "@/lib/format";
 import type { WindowInfo } from "@/types";
+
+type CopyableRowKey = "tmx" | "cwd" | "git" | "fab";
+
+const COPY_FEEDBACK_MS = 1000;
 
 type WindowPanelProps = {
   window: WindowInfo | null;
@@ -80,7 +86,52 @@ export function WindowPanel({ window: win, nowSeconds }: WindowPanelProps) {
   );
 }
 
+/** Reusable interactive row that copies a value on click and shows inline "copied" feedback. */
+function CopyableRow({ prefix, copied, onCopy, children, className, title }: {
+  prefix: string;
+  copied: boolean;
+  onCopy: () => void;
+  children: ReactNode;
+  className?: string;
+  title?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onCopy}
+      className={`truncate text-left w-full cursor-pointer hover:bg-bg-inset focus-visible:outline focus-visible:outline-1 focus-visible:outline-accent bg-transparent border-0 p-0 m-0 font-inherit text-inherit ${className ?? ""}`}
+      title={title}
+    >
+      <span className="text-text-secondary">{copied ? "copied \u2713 " : `${prefix} `}</span>
+      {children}
+    </button>
+  );
+}
+
 function WindowContent({ win, nowSeconds }: { win: WindowInfo; nowSeconds: number }) {
+  const [copiedRow, setCopiedRow] = useState<CopyableRowKey | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clean up timer on unmount
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  function handleCopy(key: CopyableRowKey, value: string) {
+    if (window.getSelection()?.toString()) return;
+    void copyToClipboard(value);
+    setCopiedRow(key);
+    if (timerRef.current !== null) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      setCopiedRow(null);
+      timerRef.current = null;
+    }, COPY_FEEDBACK_MS);
+  }
+
   const activePane = win.panes?.find((p) => p.isActive);
   const activePaneCwd = activePane?.cwd ?? win.worktreePath;
   const cwd = shortenPath(activePaneCwd);
@@ -106,32 +157,43 @@ function WindowContent({ win, nowSeconds }: { win: WindowInfo; nowSeconds: numbe
   return (
     <div className="flex flex-col gap-0 text-xs">
       {/* Tmux pane info */}
-      <div className="truncate">
-        <span className="text-text-secondary">tmx </span>
-        <span className="text-text-secondary">
-          pane {activePaneIndex + 1}/{paneCount}{paneId && ` ${paneId}`}
-        </span>
-      </div>
+      {paneId ? (
+        <CopyableRow prefix="tmx" copied={copiedRow === "tmx"} onCopy={() => handleCopy("tmx", paneId)}>
+          <span className="text-text-secondary">
+            pane {activePaneIndex + 1}/{paneCount}{paneId && ` ${paneId}`}
+          </span>
+        </CopyableRow>
+      ) : (
+        <div className="truncate">
+          <span className="text-text-secondary">tmx </span>
+          <span className="text-text-secondary">
+            pane {activePaneIndex + 1}/{paneCount}
+          </span>
+        </div>
+      )}
       {/* CWD */}
-      <div className="truncate" title={activePaneCwd}>
-        <span className="text-text-secondary">cwd </span>
+      <CopyableRow prefix="cwd" copied={copiedRow === "cwd"} onCopy={() => handleCopy("cwd", activePaneCwd)} title={activePaneCwd}>
         <span className="text-text-primary">{cwd}</span>
-      </div>
+      </CopyableRow>
       {/* Git branch */}
       {gitBranch && (
-        <div className="truncate">
-          <span className="text-text-secondary">git </span>
+        <CopyableRow prefix="git" copied={copiedRow === "git"} onCopy={() => handleCopy("git", gitBranch)}>
           <span className="text-accent">{gitBranch}</span>
-        </div>
+        </CopyableRow>
       )}
       {/* Fab state or process */}
-      {runLine && (
+      {fabLine && runLine ? (
+        <CopyableRow prefix="fab" copied={copiedRow === "fab"} onCopy={() => handleCopy("fab", fabChange!.id)}>
+          {isActive && <BrailleSpinner className="text-accent" />}{isActive && " "}
+          <span className="text-accent">{runLine}</span>
+        </CopyableRow>
+      ) : runLine ? (
         <div className="truncate">
-          <span className="text-text-secondary">{fabLine ? "fab " : "run "}</span>
-          {isActive && <BrailleSpinner className={fabLine ? "text-accent" : "text-accent-green"} />}{isActive && " "}
-          <span className={fabLine ? "text-accent" : "text-text-secondary"}>{runLine}</span>
+          <span className="text-text-secondary">run </span>
+          {isActive && <BrailleSpinner className="text-accent-green" />}{isActive && " "}
+          <span className="text-text-secondary">{runLine}</span>
         </div>
-      )}
+      ) : null}
       {/* Agent state */}
       {agentLine && (
         <div className="truncate">

--- a/app/frontend/src/components/terminal-client.test.ts
+++ b/app/frontend/src/components/terminal-client.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { copyToClipboard, clipboardProvider } from "./terminal-client";
+import { copyToClipboard } from "@/lib/clipboard";
+import { clipboardProvider } from "./terminal-client";
 import { deriveXtermTheme, DEFAULT_DARK_THEME, DEFAULT_LIGHT_THEME } from "@/themes";
 
 describe("copyToClipboard", () => {

--- a/app/frontend/src/components/terminal-client.tsx
+++ b/app/frontend/src/components/terminal-client.tsx
@@ -5,6 +5,7 @@ import type { UploadedFile } from "@/hooks/use-file-upload";
 import { useTheme } from "@/contexts/theme-context";
 import { deriveXtermTheme } from "@/themes";
 import { ComposeBuffer } from "@/components/compose-buffer";
+import { copyToClipboard } from "@/lib/clipboard";
 
 /**
  * Custom ClipboardProvider for the xterm.js ClipboardAddon.
@@ -21,33 +22,6 @@ export const clipboardProvider = {
     await navigator.clipboard.writeText(text);
   },
 };
-
-/** Copy text to clipboard — tries Clipboard API first, falls back to execCommand for non-secure contexts (HTTP). */
-export async function copyToClipboard(text: string): Promise<void> {
-  if (navigator.clipboard) {
-    try {
-      await navigator.clipboard.writeText(text);
-      return;
-    } catch {
-      // Clipboard API failed (likely non-secure context) — fall through to fallback
-    }
-  }
-  const previousActiveElement = document.activeElement as HTMLElement | null;
-  const textarea = document.createElement("textarea");
-  textarea.value = text;
-  textarea.style.position = "fixed";
-  textarea.style.left = "-9999px";
-  document.body.appendChild(textarea);
-  try {
-    textarea.select();
-    document.execCommand("copy");
-  } catch {
-    // Both mechanisms failed — silently ignore
-  } finally {
-    document.body.removeChild(textarea);
-    previousActiveElement?.focus();
-  }
-}
 
 type TerminalClientProps = {
   sessionName: string;

--- a/app/frontend/src/lib/clipboard.ts
+++ b/app/frontend/src/lib/clipboard.ts
@@ -1,0 +1,26 @@
+/** Copy text to clipboard — tries Clipboard API first, falls back to execCommand for non-secure contexts (HTTP). */
+export async function copyToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {
+      // Clipboard API failed (likely non-secure context) — fall through to fallback
+    }
+  }
+  const previousActiveElement = document.activeElement as HTMLElement | null;
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  document.body.appendChild(textarea);
+  try {
+    textarea.select();
+    document.execCommand("copy");
+  } catch {
+    // Both mechanisms failed — silently ignore
+  } finally {
+    document.body.removeChild(textarea);
+    previousActiveElement?.focus();
+  }
+}

--- a/docs/memory/run-kit/ui-patterns.md
+++ b/docs/memory/run-kit/ui-patterns.md
@@ -126,7 +126,7 @@ The Ctrl+Click force-kill pattern matches the established "modifier = power acti
 - `session-row.tsx` — `SessionRow`; pure presentational; renders the session header row (chevron, name, + button, ✕ button); handles cross-session drag-over styling; all event handlers passed as props
 - `window-row.tsx` — `WindowRow`; pure presentational; renders a single window row (activity dot, name, fab stage, duration, kill button); handles drag-and-drop and inline rename display; all event handlers passed as props
 - `collapsible-panel.tsx` — `CollapsiblePanel`; reusable collapsible container with header (title + chevron), `max-height` CSS transition, localStorage state persistence via `storageKey` prop
-- `status-panel.tsx` — `WindowPanel` (exported as both `WindowPanel` and deprecated `StatusPanel`); wraps existing 3-line window info (cwd, win, fab/run) in a `CollapsiblePanel`
+- `status-panel.tsx` — `WindowPanel` (exported as both `WindowPanel` and deprecated `StatusPanel`); wraps pane metadata rows (tmx, cwd, git, fab/run, agt) in a `CollapsiblePanel` with copyable row interactions
 - `host-panel.tsx` — `HostPanel`; 5-line server metrics display (hostname, CPU sparkline, memory gauge, load averages, disk+uptime) inside a `CollapsiblePanel`
 - `server-selector.tsx` — `ServerSelector`; owns its own dropdown state (`serverDropdownOpen`, `refreshingServers`, `serverDropdownRef`); pinned-bottom server dropdown with outside-click dismiss
 - `kill-dialog.tsx` — `KillDialog`; stateless; renders the kill confirmation dialog for sessions and windows using `<Dialog>`
@@ -196,7 +196,28 @@ Two collapsible panels are pinned at the bottom of the sidebar below the scrolla
 
 **CollapsiblePanel** (`app/frontend/src/components/sidebar/collapsible-panel.tsx`) — reusable wrapper used by both Window and Host panels. Props: `title` (string), `storageKey` (string for localStorage persistence), `defaultOpen` (boolean, default `true`), `children` (ReactNode). Header is always visible: title text + chevron (`&#x25B8;` U+25B8) that rotates 90 degrees on toggle via CSS `transform: rotate()` with `transition-transform duration-150`. Content area uses `max-height` transition (`duration-150 ease-in-out`) for smooth expand/collapse. `overflow: hidden` during transition, `visible` when fully expanded (accessibility). Collapse state persisted to `localStorage[storageKey]` on every toggle. Each panel has `border-t border-border`.
 
-**WindowPanel** (`app/frontend/src/components/sidebar/status-panel.tsx`) — refactored from the former `StatusPanel` into a collapsible panel with `title="Window"`, `storageKey="runkit-panel-window"`, `defaultOpen={true}`. The inner content (3 lines: cwd, win, fab/run) is unchanged. No window selected -> "No window selected" in secondary text. `StatusPanel` is exported as a deprecated alias for backward compatibility.
+**WindowPanel** (`app/frontend/src/components/sidebar/status-panel.tsx`) — collapsible panel with `title="Pane"`, `storageKey="runkit-panel-window"`, `defaultOpen={true}`. Displays per-pane metadata rows: `tmx` (pane index + ID), `cwd` (shortened path), `git` (branch), `fab` (change ID + slug + stage) or `run` (process name), and `agt` (agent state). No window selected -> "No window selected" in secondary text. `StatusPanel` is exported as a deprecated alias for backward compatibility.
+
+**Copyable rows**: The `tmx`, `cwd`, `git`, and `fab` rows are interactive `<button type="button">` elements that copy their underlying value to the clipboard on click or keyboard activation (Enter/Space). Copy values per row:
+
+| Row | Copy value | Source |
+|-----|------------|--------|
+| `tmx` | Pane ID (e.g., `%5`) | `activePane.paneId` |
+| `cwd` | Full unshortened path (e.g., `/home/sahil/code/run-kit`) | `activePane.cwd ?? win.worktreePath` |
+| `git` | Branch name | `activePane.gitBranch` |
+| `fab` | Change ID (e.g., `lc2q`) | `fabChange.id` (parsed from `win.fabChange`) |
+
+Non-interactive rows: `run` (process-only, when no fab state) and `agt` remain plain text — no hover affordance, no focus ring, no copy behavior. Rows with empty values (`tmx` with empty pane ID, `git` when no branch) are also non-interactive.
+
+**Inline feedback**: After a successful copy, the row's prefix label swaps to `copied ✓` for 1000ms, then reverts. A single `copiedRow` state variable tracks which row was last copied — only one row shows feedback at a time. Clicking a different row immediately moves the indicator.
+
+**Hover affordance**: Interactive rows render `cursor: pointer` and a subtle background tint (`bg-bg-inset` or equivalent) on hover.
+
+**Keyboard accessibility**: Button elements have visible focus state (outline/ring) and are keyboard-activatable (Enter/Space). Styling is reset to preserve the panel's compact plain-text aesthetic — no default button chrome (padding, border, background removed in rest state).
+
+**Text-selection guard**: The click handler checks `window.getSelection()?.toString()` — if the user has an active text selection (e.g., from drag-selecting text), the copy action is suppressed, preserving native text-selection UX.
+
+**Clipboard utility**: Copy operations use `copyToClipboard()` from `app/frontend/src/lib/clipboard.ts` — see [Clipboard Utility](#clipboard-utility).
 
 **HostPanel** (`app/frontend/src/components/sidebar/host-panel.tsx`) — 5-line server metrics display inside a `CollapsiblePanel` with `title="Host"`, `storageKey="runkit-panel-host"`, `defaultOpen={true}`. Accepts `metrics: MetricsSnapshot | null` and `isConnected: boolean` props. When `metrics` is null, shows "No metrics". Lines:
 
@@ -217,6 +238,10 @@ Two collapsible panels are pinned at the bottom of the sidebar below the scrolla
 - `gaugeColor(percent: number): string` — returns a Tailwind color class: `text-green-500` (< 70%), `text-yellow-500` (70-90%), `text-red-500` (> 90%)
 - `formatBytes(bytes: number): string` — compact human-readable size (`3.1G`, `512M`, `128K`)
 - `formatMemory(used: number, total: number): string` — compact `used/total` string (e.g., `3.1G/8G`)
+
+### Clipboard Utility
+
+`app/frontend/src/lib/clipboard.ts` — shared `copyToClipboard(text: string): Promise<void>` function extracted from `terminal-client.tsx`. Primary path uses `navigator.clipboard.writeText()`; fallback uses `document.execCommand('copy')` for non-secure contexts (HTTP). Signature and behavior preserved from the original. All callers (terminal copy, Pane panel row copy) import from this module. Introduced to decouple sidebar copy operations from the terminal-client module.
 
 CWD display (line 1) uses `shortenPath()` to shorten the active pane's `cwd` (falls back to `worktreePath`):
 - Home substitution: `/home/<user>/…` → `~/…`, `/Users/<user>/…` → `~/…`, `/root/…` → `~/…` (exact home dir → `~`). Handles Linux and macOS conventions.
@@ -693,3 +718,4 @@ The `executeMoveToSession` hook in `sidebar/index.tsx` combines two store action
 | 2026-04-11 | Optimistic sidebar window reorder — drag-drop window reorder in sidebar now uses `useOptimisticAction` with `swapWindowOrder` store action to swap window index values immediately on drop. API call fires in background; rollback reverses the swap on failure. Eliminates ~2.5s SSE poll wait. `swapWindowOrder(session, srcIndex, dstIndex)` added to Zustand window store. Unit tests for store swap + rollback, sidebar tests for optimistic drop + API failure rollback. | `260411-sl01-optimistic-sidebar-window-reorder` |
 | 2026-04-11 | Optimistic cross-session drag — `executeMoveToSession` `useOptimisticAction` instance in sidebar wires compound optimistic update: `killWindow` (hide in source) + `addGhostWindow` (show in target with source window's display name) + immediate navigation to `/$server`. Rollback: `restoreWindow` + `removeGhost`. Removed `onMoveWindowToSession` prop from `SidebarProps` — sidebar imports `moveWindowToSession` API directly. Drag data payload extended with `windowId` and `name`. Unit tests for optimistic lifecycle and rollback. | `260411-sl02-cross-session-drag-optimistic-update` |
 | 2026-04-11 | Sidebar collapsible panels — `CollapsiblePanel` reusable component (header + chevron + `max-height` transition + localStorage persistence). `StatusPanel` refactored into `WindowPanel` wrapping content in CollapsiblePanel (`storageKey="runkit-panel-window"`). New `HostPanel` (5 lines: hostname+SSE dot, CPU braille sparkline, memory gauge bar, load percentages, disk+uptime) wrapping in CollapsiblePanel (`storageKey="runkit-panel-host"`). Both panels bottom-aligned in sidebar. Hostname removed from bottom bar. New `lib/sparkline.ts` (8-level braille mapping U+2800-U+28FF) and `lib/gauge.ts` (block gauge with green/yellow/red thresholds, byte formatting). `SessionProvider` extended with `metrics: MetricsSnapshot | null` from SSE `event: metrics`. | `260411-z63r-sidebar-host-window-panels` |
+| 2026-04-12 | Pane panel copy interactions — `tmx`, `cwd`, `git`, `fab` rows in WindowPanel (`status-panel.tsx`) rendered as `<button>` elements with click-to-copy (pane ID, full path, branch, change ID). Inline "copied ✓" label feedback (1000ms, single `copiedRow` state). Hover affordance (`cursor: pointer` + `bg-bg-inset` tint). Keyboard accessible (Enter/Space). Text-selection guard (`window.getSelection()`). `copyToClipboard` extracted from `terminal-client.tsx` to `lib/clipboard.ts` shared utility module | `260412-lc2q-pane-panel-copy-cwd-branch` |

--- a/fab/changes/260412-lc2q-pane-panel-copy-cwd-branch/.history.jsonl
+++ b/fab/changes/260412-lc2q-pane-panel-copy-cwd-branch/.history.jsonl
@@ -1,0 +1,16 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-04-12T18:35:10Z"}
+{"args":"Easy way to copy cwd and git branch from the Pane panel","cmd":"fab-new","event":"command","ts":"2026-04-12T18:35:10Z"}
+{"delta":"+0.0","event":"confidence","score":0,"trigger":"calc-score","ts":"2026-04-12T18:35:39Z"}
+{"delta":"+0.0","event":"confidence","score":0,"trigger":"calc-score","ts":"2026-04-12T18:35:48Z"}
+{"delta":"+0.0","event":"confidence","score":0,"trigger":"calc-score","ts":"2026-04-13T03:29:19Z"}
+{"delta":"+4.1","event":"confidence","score":4.1,"trigger":"calc-score","ts":"2026-04-13T03:29:44Z"}
+{"delta":"+0.0","event":"confidence","score":4.1,"trigger":"calc-score","ts":"2026-04-13T03:29:47Z"}
+{"cmd":"fab-fff","event":"command","ts":"2026-04-13T03:30:06Z"}
+{"delta":"+0.9","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-04-13T03:31:39Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"spec","ts":"2026-04-13T03:31:45Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"tasks","ts":"2026-04-13T03:33:23Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-04-13T03:35:46Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-04-13T03:41:20Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-04-13T03:43:50Z"}
+{"event":"review","result":"passed","ts":"2026-04-13T03:43:50Z"}
+{"action":"enter","driver":"fab-continue","event":"stage-transition","stage":"ship","ts":"2026-04-13T03:46:00Z"}

--- a/fab/changes/260412-lc2q-pane-panel-copy-cwd-branch/.history.jsonl
+++ b/fab/changes/260412-lc2q-pane-panel-copy-cwd-branch/.history.jsonl
@@ -14,3 +14,4 @@
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-04-13T03:43:50Z"}
 {"event":"review","result":"passed","ts":"2026-04-13T03:43:50Z"}
 {"action":"enter","driver":"fab-continue","event":"stage-transition","stage":"ship","ts":"2026-04-13T03:46:00Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-04-13T03:47:40Z"}

--- a/fab/changes/260412-lc2q-pane-panel-copy-cwd-branch/.status.yaml
+++ b/fab/changes/260412-lc2q-pane-panel-copy-cwd-branch/.status.yaml
@@ -11,8 +11,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 checklist:
     generated: true
     path: checklist.md
@@ -37,6 +37,8 @@ stage_metrics:
     apply: {started_at: "2026-04-13T03:35:46Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-13T03:41:20Z"}
     review: {started_at: "2026-04-13T03:41:20Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-13T03:43:50Z"}
     hydrate: {started_at: "2026-04-13T03:43:50Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-13T03:46:00Z"}
-    ship: {started_at: "2026-04-13T03:46:00Z", driver: fab-continue, iterations: 1}
-prs: []
-last_updated: 2026-04-13T03:46:00Z
+    ship: {started_at: "2026-04-13T03:46:00Z", driver: fab-continue, iterations: 1, completed_at: "2026-04-13T03:47:40Z"}
+    review-pr: {started_at: "2026-04-13T03:47:40Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/sahil87/run-kit/pull/138
+last_updated: 2026-04-13T03:47:40Z

--- a/fab/changes/260412-lc2q-pane-panel-copy-cwd-branch/.status.yaml
+++ b/fab/changes/260412-lc2q-pane-panel-copy-cwd-branch/.status.yaml
@@ -1,0 +1,42 @@
+id: lc2q
+name: 260412-lc2q-pane-panel-copy-cwd-branch
+created: 2026-04-12T18:35:10Z
+created_by: sahil-weaver
+change_type: feat
+issues: []
+progress:
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+checklist:
+    generated: true
+    path: checklist.md
+    completed: 0
+    total: 33
+confidence:
+    certain: 14
+    confident: 0
+    tentative: 0
+    unresolved: 0
+    score: 5.0
+    fuzzy: true
+    dimensions:
+        signal: 89.6
+        reversibility: 92.1
+        competence: 90.0
+        disambiguation: 90.7
+stage_metrics:
+    intake: {started_at: "2026-04-12T18:35:10Z", driver: fab-new, iterations: 1, completed_at: "2026-04-13T03:31:45Z"}
+    spec: {started_at: "2026-04-13T03:31:45Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-13T03:33:23Z"}
+    tasks: {started_at: "2026-04-13T03:33:23Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-13T03:35:46Z"}
+    apply: {started_at: "2026-04-13T03:35:46Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-13T03:41:20Z"}
+    review: {started_at: "2026-04-13T03:41:20Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-13T03:43:50Z"}
+    hydrate: {started_at: "2026-04-13T03:43:50Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-13T03:46:00Z"}
+    ship: {started_at: "2026-04-13T03:46:00Z", driver: fab-continue, iterations: 1}
+prs: []
+last_updated: 2026-04-13T03:46:00Z

--- a/fab/changes/260412-lc2q-pane-panel-copy-cwd-branch/checklist.md
+++ b/fab/changes/260412-lc2q-pane-panel-copy-cwd-branch/checklist.md
@@ -1,0 +1,54 @@
+# Quality Checklist: Pane Panel — Copy CWD & Git Branch
+
+**Change**: 260412-lc2q-pane-panel-copy-cwd-branch
+**Generated**: 2026-04-13
+**Spec**: `spec.md`
+
+## Functional Completeness
+- [ ] CHK-001 Copyable Rows: `tmx`, `cwd`, `git`, `fab` rows in `WindowContent` render as interactive `<button>` elements when their underlying values exist
+- [ ] CHK-002 Copyable Rows: `run` (process-only) and `agt` rows remain non-interactive plain text with no cursor/hover effects
+- [ ] CHK-003 Copyable Rows: `tmx` row copies `activePane.paneId` (e.g., `%5`)
+- [ ] CHK-004 Copyable Rows: `cwd` row copies the full unshortened path (`activePaneCwd`), not the `~`-abbreviated display
+- [ ] CHK-005 Copyable Rows: `git` row copies `activePane.gitBranch`
+- [ ] CHK-006 Copyable Rows: `fab` row copies `fabChange.id` (4-char change ID)
+- [ ] CHK-007 Inline Copied Feedback: prefix swaps to `copied ✓` after a successful copy and reverts after ~1000ms
+- [ ] CHK-008 Inline Copied Feedback: only one row shows the `copied ✓` indicator at a time
+- [ ] CHK-009 Hover Affordance: interactive rows render `cursor: pointer` and a subtle `bg-bg-inset` (or equivalent) tint on hover
+- [ ] CHK-010 Keyboard Accessibility: interactive rows are `<button type="button">` with visible focus ring and keyboard activation (Enter/Space)
+- [ ] CHK-011 Text Selection Guard: click with active text selection does not copy; click without selection copies normally
+- [ ] CHK-012 Shared Clipboard Utility: `copyToClipboard` lives at `app/frontend/src/lib/clipboard.ts`; `terminal-client.tsx` imports from the new location; signature and fallback behavior preserved
+
+## Behavioral Correctness
+- [ ] CHK-013 `<button>` styling reset preserves the existing row visual density — no added padding, border, or background in the rest state
+- [ ] CHK-014 Pane ID conditional: when `paneId` is empty string, `tmx` row falls back to non-interactive `<div>` (no button rendered)
+- [ ] CHK-015 Fab/run distinction: when `fabLine` is null and `processLine` is shown, the row renders as non-interactive `<div>` (run mode never interactive)
+
+## Scenario Coverage
+- [ ] CHK-016 Scenario "CWD row copies full expanded path" verified via unit test with fake `navigator.clipboard`
+- [ ] CHK-017 Scenario "git row copies full branch" verified via unit test
+- [ ] CHK-018 Scenario "tmx row copies pane ID" verified via unit test
+- [ ] CHK-019 Scenario "fab row copies change ID" verified via unit test
+- [ ] CHK-020 Scenario "run-only row is not copyable" verified via unit test (assertion that no `<button>` rendered)
+- [ ] CHK-021 Scenario "Feedback reverts after timeout" verified via unit test with fake timers advancing 1000ms
+- [ ] CHK-022 Scenario "Feedback moves between rows" verified via unit test clicking row A then row B within the window
+- [ ] CHK-023 Scenario "Keyboard activation triggers copy" verified (focus + Enter triggers copy)
+- [ ] CHK-024 Scenario "Click with active selection does not hijack" verified via unit test mocking `window.getSelection()`
+
+## Edge Cases & Error Handling
+- [ ] CHK-025 Rapid successive clicks on same row extend/restart the feedback timer without leaving ghost state (timer is cleared before being reset)
+- [ ] CHK-026 Component unmount clears any pending feedback timer (no `setState` after unmount warning)
+- [ ] CHK-027 Missing fields (empty `paneId`, null `fabChange`, no `gitBranch`) gracefully skip their row's interactive behavior
+
+## Code Quality
+- [ ] CHK-028 Readability: extracted `<CopyableRow>` component and `handleCopy` helper keep `WindowContent` body scannable
+- [ ] CHK-029 Pattern consistency: new code follows existing sidebar component patterns (same Tailwind utility classes, same file-local helper placement)
+- [ ] CHK-030 No unnecessary duplication: reuses extracted `copyToClipboard` utility rather than inlining
+- [ ] CHK-031 Frontend type safety: `CopyableRowKey` union type used; no `as` casts introduced (per code-quality principle "Type narrowing over type assertions")
+- [ ] CHK-032 Tests cover added behavior: new unit tests exist in `status-panel.test.tsx` for the copy flows (per code-quality principle "New features MUST include tests")
+- [ ] CHK-033 No unnecessary magic numbers: 1000ms feedback duration defined as a named constant
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] CHK-NNN **N/A**: {reason}`

--- a/fab/changes/260412-lc2q-pane-panel-copy-cwd-branch/intake.md
+++ b/fab/changes/260412-lc2q-pane-panel-copy-cwd-branch/intake.md
@@ -1,0 +1,84 @@
+# Intake: Pane Panel — Copy CWD & Git Branch
+
+**Change**: 260412-lc2q-pane-panel-copy-cwd-branch
+**Created**: 2026-04-13
+**Status**: Draft
+
+## Origin
+
+> Understand the left panel layout. I want easy way to be able to copy cwd and git branch from the Pane panel. Discuss ideas before executing.
+
+Conversational mode — user wants to discuss interaction design before implementation.
+
+## Why
+
+The Pane panel in the sidebar shows useful metadata — cwd and git branch — but there's no way to copy these values. Users frequently need to paste a path or branch name into a terminal, chat, or PR description. Currently the only option is to manually type or navigate elsewhere to get this info.
+
+This is a small but high-frequency UX friction point: the information is visible but not actionable.
+
+## What Changes
+
+### `app/frontend/src/components/sidebar/status-panel.tsx`
+
+Add click-to-copy behavior to the following rows in the `WindowContent` component. Each row becomes a `<button>` element that, when clicked, copies the full unabridged value to clipboard and shows inline feedback.
+
+**Copyable rows and their copy values**:
+
+| Row | Display format | Copy value |
+|-----|---------------|-----------|
+| `tmx pane 1/2 %5` | pane index + pane ID | Pane ID (e.g., `%5`) |
+| `cwd ~/code/run-kit` | shortened path | Full expanded path (e.g., `/home/sahil/code/run-kit`) |
+| `git 260412-lc2q-...` | full branch name | Full branch name (no shortening today, copy as-is) |
+| `fab lc2q some-slug · apply` | fab state line | Change ID (e.g., `lc2q`) |
+| `run process-name — idle 3m` | process line | **Not copyable** — process names aren't useful to paste |
+| `agt idle 3m` | agent state | **Not copyable** — not useful to paste |
+
+**Interaction behavior**:
+
+1. **Click**: Full value is copied via the existing `copyToClipboard()` utility.
+2. **Feedback**: The row's prefix label briefly swaps to a "copied" indicator for ~1000ms, then reverts. For example, `cwd ~/code/run-kit` → `cwd copied ✓` → (reverts). This matches the panel's compact no-chrome aesthetic (Option 1a).
+3. **Hover affordance**: Row shows `cursor: pointer` and a subtle background tint (`hover:bg-bg-inset` or equivalent) to signal clickability.
+4. **Keyboard accessibility**: Rows become `<button type="button">` elements with focus ring and keyboard activation (Enter/Space). Styling is reset to preserve the compact plain-text look (no default button chrome — remove padding, border, background, etc.).
+5. **Text-selection guard**: The click handler checks `window.getSelection()?.toString()` — if text is currently selected, copy is skipped so the user's manual text selection isn't hijacked.
+
+### State management
+
+Each copyable row tracks its own "just copied" state. Simplest pattern: a single piece of state in `WindowContent` that stores which row was just copied (e.g., `copiedRow: "tmx" | "cwd" | "git" | "fab" | null`), reset via `setTimeout` after 1000ms.
+
+### Existing patterns to reuse
+
+- `copyToClipboard()` utility already exists in `app/frontend/src/components/terminal-client.tsx` (lines 25-50) — handles both `navigator.clipboard` and fallback. May be extracted to `app/frontend/src/lib/clipboard.ts` for cleaner reuse (avoiding circular import from `terminal-client`).
+- The "check icon after copy" pattern in `app/frontend/src/components/tmux-commands-dialog.tsx` (lines 24-39, 65-68) shows the general timer-based state reset — we use a simpler text swap, not an icon.
+
+## Affected Memory
+
+- `run-kit/ui-patterns`: (modify) Document Pane panel copy interaction pattern
+
+## Impact
+
+- **Files**: `app/frontend/src/components/sidebar/status-panel.tsx` (primary), possibly extract `copyToClipboard` to a shared util
+- **Scope**: Frontend-only change, no backend or API modifications needed
+- **Risk**: Very low — additive UI enhancement, no existing behavior modified
+
+## Open Questions
+
+None — all interaction details discussed and locked in.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Copy the full unshortened cwd path, not the truncated display | Discussed — user confirmed. Truncated path is useless for pasting; fully expanded path (not tilde form) is universally pasteable | S:95 R:95 A:90 D:95 |
+| 2 | Certain | Reuse existing `copyToClipboard()` utility | Function already exists in terminal-client.tsx with proper fallback handling | S:90 R:95 A:95 D:95 |
+| 3 | Certain | Frontend-only change — no backend modifications | All required data (cwd, gitBranch, paneId) already available in the PaneInfo type | S:90 R:95 A:95 D:95 |
+| 4 | Certain | Click entire row to copy (Option A) | Discussed — user chose row-click over hover icon / context menu. Matches sidebar's compact no-chrome aesthetic | S:95 R:85 A:85 D:90 |
+| 5 | Certain | Feedback is inline label swap ("cwd" → "copied ✓") for ~1000ms | Discussed — user chose option 1a over icon / flash / toast. Matches compact aesthetic | S:95 R:90 A:85 D:90 |
+| 6 | Certain | Copyable rows: tmx (pane ID), cwd (full path), git (branch), fab (change ID) | Discussed — user added tmx + fab to cwd/git scope. Agent row and process-only run row excluded (values aren't useful to paste) | S:90 R:85 A:85 D:85 |
+| 7 | Certain | Hover affordance: cursor-pointer + subtle bg tint (`hover:bg-bg-inset`) | Discussed — user confirmed both together. Standard discoverability without visual noise at rest | S:90 R:95 A:90 D:90 |
+| 8 | Certain | Rows become `<button type="button">` with focus ring and keyboard activation | Discussed — user chose button over div-with-onClick. Keyboard-first principle from constitution | S:90 R:90 A:95 D:90 |
+| 9 | Certain | Guard click handler against active text selection | Discussed — user confirmed. Preserves manual text-selection UX | S:90 R:95 A:90 D:95 |
+| 10 | Confident | Extract `copyToClipboard` into `app/frontend/src/lib/clipboard.ts` | The utility currently lives in `terminal-client.tsx`; importing from there into sidebar creates awkward coupling. Small refactor keeps sidebar decoupled from terminal concerns | S:75 R:90 A:85 D:80 |
+| 11 | Confident | Single `copiedRow` state variable tracking which row was last copied (vs per-row state) | Simpler than 4 separate useState hooks; only one row can be in "copied" state at a time so no correctness loss | S:80 R:95 A:90 D:85 |
+| 12 | Confident | Feedback duration 1000ms (matches existing pattern in tmux-commands-dialog is 1500ms, but 1000 feels snappier for tight sidebar) | Slightly shorter than existing pattern because panel is more information-dense | S:70 R:95 A:80 D:70 |
+
+12 assumptions (9 certain, 3 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260412-lc2q-pane-panel-copy-cwd-branch/spec.md
+++ b/fab/changes/260412-lc2q-pane-panel-copy-cwd-branch/spec.md
@@ -1,0 +1,187 @@
+# Spec: Pane Panel — Copy CWD & Git Branch
+
+**Change**: 260412-lc2q-pane-panel-copy-cwd-branch
+**Created**: 2026-04-13
+**Affected memory**: `docs/memory/run-kit/ui-patterns.md`
+
+## Non-Goals
+
+- Copying from the "run" process-only row (when no fab change is active) — process names aren't useful to paste
+- Copying from the "agt" agent-state row — idle durations aren't useful to paste
+- Copying arbitrary rows elsewhere in the sidebar (Sessions, Tmux panels) — this change is scoped to the Pane panel
+- Toast notifications or cross-panel status messages — feedback is strictly inline on the row
+- Keyboard shortcut to copy without clicking (e.g., `Cmd+C` when row is focused) — reserved for future work if desired
+
+## Frontend: Pane Panel Copy Interactions
+
+### Requirement: Copyable Rows
+
+The Pane panel (`WindowPanel` / `WindowContent` in `app/frontend/src/components/sidebar/status-panel.tsx`) SHALL render the `tmx`, `cwd`, `git`, and `fab` rows as interactive elements that copy the row's underlying value to the clipboard on activation. The `run` (process-only) and `agt` rows SHALL remain non-interactive plain text.
+
+Copy values per row:
+
+| Row | Copy value | Source field |
+|-----|------------|--------------|
+| `tmx` | Pane ID | `activePane.paneId` (e.g., `%5`) |
+| `cwd` | Full unshortened path | `activePaneCwd` (`activePane.cwd ?? win.worktreePath`) |
+| `git` | Branch name | `activePane.gitBranch` |
+| `fab` | Change ID | `fabChange.id` (parsed from `win.fabChange`) |
+
+When the `fab` row would be rendered as the `run` variant (no fab state — `fabLine` is null, only `processLine` is shown), the row SHALL be rendered as non-interactive plain text and SHALL NOT be copyable.
+
+When the `tmx` row's pane ID is an empty string (unknown pane), the row SHALL remain non-interactive.
+
+When the `git` row is not rendered (no `gitBranch`), no copyable element exists — there is nothing to make interactive.
+
+#### Scenario: CWD row copies full expanded path
+- **GIVEN** the Pane panel displays `cwd …/code/run-kit` (shortened display of `/home/sahil/code/run-kit`)
+- **WHEN** the user clicks the cwd row
+- **THEN** the clipboard SHALL contain `/home/sahil/code/run-kit`
+- **AND** the row label SHALL briefly change from `cwd` to `copied ✓`
+
+#### Scenario: git row copies full branch
+- **GIVEN** the Pane panel displays `git 260412-lc2q-pane-panel-copy-cwd-branch`
+- **WHEN** the user clicks the git row
+- **THEN** the clipboard SHALL contain `260412-lc2q-pane-panel-copy-cwd-branch`
+
+#### Scenario: tmx row copies pane ID
+- **GIVEN** the Pane panel displays `tmx pane 1/2 %5`
+- **WHEN** the user clicks the tmx row
+- **THEN** the clipboard SHALL contain `%5`
+
+#### Scenario: fab row copies change ID
+- **GIVEN** the Pane panel displays `fab lc2q some-slug · apply`
+- **WHEN** the user clicks the fab row
+- **THEN** the clipboard SHALL contain `lc2q`
+
+#### Scenario: run-only row is not copyable
+- **GIVEN** the window has no active fab change and the Pane panel displays `run zsh — idle 5m`
+- **WHEN** the user clicks the run row
+- **THEN** nothing SHALL be copied
+- **AND** the row SHALL NOT render as a button (no focus ring, no hover effect)
+
+### Requirement: Inline Copied Feedback
+
+After a successful copy, the affected row's prefix label SHALL briefly swap to a "copied ✓" indicator, then revert to the original label. The swap SHALL persist for approximately 1000ms. Only one row SHALL show the "copied" indicator at a time — clicking a different row SHALL immediately transition the indicator to the new row.
+
+#### Scenario: Feedback reverts after timeout
+- **GIVEN** the user has just clicked the cwd row
+- **WHEN** 1000ms elapse
+- **THEN** the row label SHALL revert from `copied ✓` to `cwd`
+
+#### Scenario: Feedback moves between rows
+- **GIVEN** the cwd row is showing `copied ✓`
+- **WHEN** the user clicks the git row within the 1000ms window
+- **THEN** the cwd row SHALL immediately revert to `cwd`
+- **AND** the git row SHALL display `copied ✓`
+
+### Requirement: Hover Affordance
+
+Interactive rows SHALL render with `cursor: pointer` on hover and a subtle background tint (using the `bg-bg-inset` design token or equivalent). Non-interactive rows (`run` process-only, `agt`) SHALL NOT have hover affordance.
+
+#### Scenario: Hover shows clickable affordance
+- **GIVEN** the user hovers over the cwd row
+- **THEN** the cursor SHALL be a pointer
+- **AND** the row background SHALL tint subtly
+
+#### Scenario: Non-interactive rows have no hover affordance
+- **GIVEN** the user hovers over the agt row
+- **THEN** the cursor SHALL remain the default text cursor
+- **AND** the row background SHALL NOT change
+
+### Requirement: Keyboard Accessibility
+
+Interactive rows SHALL be rendered as `<button type="button">` elements with visible focus state (focus ring or outline) and SHALL be activatable via keyboard (`Enter` or `Space`). Button styling SHALL preserve the panel's compact plain-text aesthetic — no default button chrome (no default padding, border, or background in the rest state).
+
+#### Scenario: Keyboard activation triggers copy
+- **GIVEN** the cwd row is focused via keyboard tab navigation
+- **WHEN** the user presses `Enter`
+- **THEN** the clipboard SHALL contain the full cwd path
+- **AND** the row label SHALL display `copied ✓`
+
+#### Scenario: Focus ring visible on keyboard focus
+- **GIVEN** the user navigates to the cwd row via `Tab`
+- **THEN** a visible focus indicator (outline or ring) SHALL be present on the row
+
+### Requirement: Text Selection Guard
+
+When the user has an active text selection (e.g., has dragged across part of a row label to select text for manual copy), activating a copyable row SHALL NOT trigger the copy action. The guard checks `window.getSelection()?.toString() !== ""`. This preserves the native text-selection UX for users who prefer selecting and copying manually.
+
+#### Scenario: Click with active selection does not hijack
+- **GIVEN** the user has selected `run-kit` text within the cwd row display
+- **WHEN** a click event fires on the row (e.g., releasing the mouse to end the drag)
+- **THEN** the clipboard SHALL NOT be overwritten with the full cwd path
+- **AND** the "copied ✓" indicator SHALL NOT be shown
+
+#### Scenario: Click without selection copies normally
+- **GIVEN** there is no active text selection in the document
+- **WHEN** the user clicks the cwd row
+- **THEN** the full cwd path SHALL be copied to the clipboard
+
+## Frontend: Clipboard Utility
+
+### Requirement: Shared Clipboard Utility Module
+
+The existing `copyToClipboard` function currently defined in `app/frontend/src/components/terminal-client.tsx` SHALL be moved to a dedicated module at `app/frontend/src/lib/clipboard.ts` so it can be imported without pulling in terminal-client concerns. The function signature and behavior (async, `navigator.clipboard` primary path with `execCommand` fallback) SHALL be preserved unchanged. All existing callers SHALL be updated to import from the new location. No behavioral regression in existing copy flows.
+
+#### Scenario: Existing terminal-client callers continue to work
+- **GIVEN** a terminal is open and the user triggers the existing copy flow
+- **WHEN** copy is invoked via the terminal's existing mechanism
+- **THEN** the clipboard SHALL contain the same content as before this change
+- **AND** no console errors SHALL be raised
+
+#### Scenario: Sidebar imports clipboard utility cleanly
+- **GIVEN** the sidebar `status-panel.tsx` imports `copyToClipboard` from `@/lib/clipboard`
+- **WHEN** the build and typecheck run
+- **THEN** the build SHALL succeed without circular-dependency or import errors
+
+## Design Decisions
+
+1. **Row-level click target (Option A) chosen over hover-reveal icon or right-click context menu**
+   - *Why*: Matches the sidebar's compact, no-chrome aesthetic. Largest possible click target. Hover affordance (cursor + tint) provides discoverability without adding persistent visual noise.
+   - *Rejected*: Hover-reveal icon adds visual clutter and breaks touch-device UX; context menu is hidden, platform-inconsistent, and heavier to implement.
+
+2. **Inline label swap ("cwd" → "copied ✓") chosen as feedback style**
+   - *Why*: No layout shift, no new visual element, zero incremental chrome. Compact-panel-friendly.
+   - *Rejected*: Inline check icon adds a sibling element and layout shift; background flash is harder to spot on dense text; toast notifications are overkill for a sidebar micro-action.
+
+3. **Copy fully expanded path, not tilde-form**
+   - *Why*: Fully expanded paths are universally pasteable (shell, file managers, browsers, docs). Tilde form only works in shells.
+   - *Rejected*: Tilde-form copy would require users to mentally re-expand in non-shell contexts.
+
+4. **Extract `copyToClipboard` into `src/lib/clipboard.ts`**
+   - *Why*: Sidebar importing from `terminal-client.tsx` creates awkward coupling (sidebar pulls in terminal module just for a utility). Small, low-risk refactor that keeps concerns separated.
+   - *Rejected*: Inline duplication in status-panel would drift over time; direct import from terminal-client creates a module-graph smell.
+
+5. **`<button>` semantics with reset styling chosen over `<div onClick>`**
+   - *Why*: Constitution principle "Keyboard-First" — every user-facing action MUST be reachable via keyboard. `<button>` is keyboard-activatable and screen-reader-friendly by default.
+   - *Rejected*: `<div onClick>` would require manual `tabindex`, `role="button"`, and key handlers — more code for worse a11y.
+
+6. **Single `copiedRow` state variable, not per-row state**
+   - *Why*: Only one row can be "just copied" at a time; a single state value avoids four parallel `useState` calls and simplifies the "move feedback between rows" scenario to a single state transition.
+   - *Rejected*: Per-row state adds no correctness benefit and complicates the transition logic.
+
+7. **1000ms feedback duration (vs. 1500ms used elsewhere)**
+   - *Why*: The Pane panel is denser and the feedback is inline text (more immediate than a popup icon). 1000ms feels snappier without being too fleeting to notice.
+   - *Rejected*: 1500ms (matching `tmux-commands-dialog.tsx`) lingers unnecessarily in a tight sidebar.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Copy full expanded cwd path, not the shortened display | Confirmed from intake #1. User explicitly chose option 3a (fully expanded) | S:95 R:95 A:90 D:95 |
+| 2 | Certain | Reuse `copyToClipboard()` utility | Confirmed from intake #2. Utility already exists with working fallback | S:90 R:95 A:95 D:95 |
+| 3 | Certain | Frontend-only — no backend changes | Confirmed from intake #3. All required fields already on `PaneInfo` | S:90 R:95 A:95 D:95 |
+| 4 | Certain | Click entire row to copy (Option A) | Confirmed from intake #4. User explicitly chose over hover-icon and context-menu alternatives | S:95 R:85 A:85 D:90 |
+| 5 | Certain | Inline label swap "cwd" → "copied ✓" for ~1000ms | Confirmed from intake #5. User explicitly chose option 1a | S:95 R:90 A:85 D:90 |
+| 6 | Certain | Copyable set: tmx, cwd, git, fab; run-only and agt excluded | Confirmed from intake #6. User explicitly added tmx + fab to cwd + git | S:90 R:85 A:85 D:85 |
+| 7 | Certain | Hover: cursor-pointer + `bg-bg-inset` tint | Confirmed from intake #7. User explicitly confirmed both | S:90 R:95 A:90 D:90 |
+| 8 | Certain | Render interactive rows as `<button type="button">` with reset styling | Confirmed from intake #8. User explicitly chose over `<div onClick>` | S:90 R:90 A:95 D:90 |
+| 9 | Certain | Guard copy against active text selection | Confirmed from intake #9. User explicitly confirmed | S:90 R:95 A:90 D:95 |
+| 10 | Certain | Extract `copyToClipboard` into `app/frontend/src/lib/clipboard.ts` | Upgraded from intake #10 Confident → Certain. Clean module boundary, all existing callers update, preserves signature | S:90 R:90 A:90 D:90 |
+| 11 | Certain | Single `copiedRow` state var tracking last-copied row | Upgraded from intake #11 Confident → Certain. Only one active "copied" indicator possible by design; single state is simplest and matches the spec's row-transition scenario | S:90 R:95 A:90 D:90 |
+| 12 | Certain | 1000ms feedback duration | Upgraded from intake #12 Confident → Certain. Codified as spec requirement; existing 1500ms is a different context (modal dialog) | S:85 R:95 A:85 D:85 |
+| 13 | Certain | Visual check indicator is "✓" character, not an icon component | Discussed inline in intake (label swap `cwd` → `copied ✓`). Using a Unicode character avoids adding an icon import and matches the sidebar's minimalist text style | S:80 R:95 A:90 D:90 |
+| 14 | Certain | Pane ID with empty string is not copyable | Defensive: the existing display conditionally renders `{paneId && \` ${paneId}\`}`; making the whole row copyable when there's nothing to copy would be misleading. Same rule applies to git row (already conditional on gitBranch) and fab row (conditional on fabChange + fabStage) | S:85 R:90 A:95 D:90 |
+
+14 assumptions (14 certain, 0 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260412-lc2q-pane-panel-copy-cwd-branch/tasks.md
+++ b/fab/changes/260412-lc2q-pane-panel-copy-cwd-branch/tasks.md
@@ -1,0 +1,44 @@
+# Tasks: Pane Panel — Copy CWD & Git Branch
+
+**Change**: 260412-lc2q-pane-panel-copy-cwd-branch
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+## Phase 1: Setup
+
+- [x] T001 Create `app/frontend/src/lib/clipboard.ts` exporting `copyToClipboard(text: string): Promise<void>`. Move the implementation from `app/frontend/src/components/terminal-client.tsx` (currently at lines ~25-50). Preserve the exact signature and behavior: `navigator.clipboard.writeText` primary path, with textarea + `execCommand("copy")` fallback for non-secure contexts.
+- [x] T002 Update `app/frontend/src/components/terminal-client.tsx` to import `copyToClipboard` from `@/lib/clipboard` and remove the local definition. All existing call sites inside this file use the imported version; no behavior change.
+
+## Phase 2: Core Implementation
+
+- [x] T003 In `app/frontend/src/components/sidebar/status-panel.tsx`, add a `CopyableRowKey` union type (`"tmx" | "cwd" | "git" | "fab"`) and introduce a single state variable `const [copiedRow, setCopiedRow] = useState<CopyableRowKey | null>(null)` inside `WindowContent`. Import `useState` from `react` and `copyToClipboard` from `@/lib/clipboard`.
+- [x] T004 In `app/frontend/src/components/sidebar/status-panel.tsx`, implement a `handleCopy(key: CopyableRowKey, value: string)` helper inside `WindowContent` that: (a) guards with `if (window.getSelection()?.toString()) return;`, (b) calls `void copyToClipboard(value)`, (c) calls `setCopiedRow(key)`, (d) schedules `setCopiedRow(null)` via `setTimeout` after 1000ms. Use a `useRef`-backed timer so rapid successive clicks cancel the previous timeout (`clearTimeout` on the stored ID before setting a new one). Also clear the timer on component unmount via `useEffect` cleanup.
+- [x] T005 In `app/frontend/src/components/sidebar/status-panel.tsx`, extract a reusable `<CopyableRow>` component (defined in the same file, not exported) that accepts `{ prefix: string; copied: boolean; onCopy: () => void; children: ReactNode; className?: string; title?: string }`. It renders as `<button type="button" onClick={onCopy} className="...base row styles... text-left w-full cursor-pointer hover:bg-bg-inset focus-visible:outline focus-visible:outline-1 focus-visible:outline-accent ..." title={title}>` containing `<span className="text-text-secondary">{copied ? "copied ✓ " : \`${prefix} \`}</span>{children}`. Preserve the existing `truncate` class and typography. Reset all default button chrome (no background, border, or padding in rest state — match existing `<div>` styling exactly).
+- [x] T006 Convert the `tmx` row in `WindowContent` to use `<CopyableRow>` when `paneId` is non-empty. Pass `prefix="tmx"`, `copied={copiedRow === "tmx"}`, `onCopy={() => handleCopy("tmx", paneId)}`. Body unchanged: `<span className="text-text-secondary">pane {activePaneIndex + 1}/{paneCount}{paneId && \` ${paneId}\`}</span>`. When `paneId` is empty, render the existing non-interactive `<div>` variant.
+- [x] T007 Convert the `cwd` row in `WindowContent` to use `<CopyableRow>`. Pass `prefix="cwd"`, `copied={copiedRow === "cwd"}`, `onCopy={() => handleCopy("cwd", activePaneCwd)}`, and `title={activePaneCwd}`. Body unchanged: `<span className="text-text-primary">{cwd}</span>`.
+- [x] T008 Convert the `git` row in `WindowContent` to use `<CopyableRow>` (already gated on `gitBranch` truthiness). Pass `prefix="git"`, `copied={copiedRow === "git"}`, `onCopy={() => handleCopy("git", gitBranch)}`. Body unchanged: `<span className="text-accent">{gitBranch}</span>`.
+- [x] T009 Convert the `fab` row in `WindowContent` to use `<CopyableRow>` ONLY when `fabLine` is non-null (i.e., `fabChange && win.fabStage`). When `fabLine` is null and `processLine` is shown, render the existing non-interactive `<div>`. For the fab variant, pass `prefix="fab"`, `copied={copiedRow === "fab"}`, `onCopy={() => handleCopy("fab", fabChange.id)}`. Body unchanged: includes the `BrailleSpinner` when active, plus `<span className={fabLine ? "text-accent" : "text-text-secondary"}>{runLine}</span>`. Note: because the fab vs run distinction changes interactivity, the two cases render as separate JSX branches in the component rather than a single unified row.
+
+## Phase 3: Integration & Edge Cases
+
+- [x] T010 [P] Write a Vitest unit test at `app/frontend/src/components/sidebar/status-panel.test.tsx` covering: (a) clicking cwd row copies full path via mocked clipboard, (b) clicking git/tmx/fab rows copies expected values, (c) after click the prefix swaps to "copied ✓" and reverts after ~1000ms (use fake timers), (d) active text selection guards suppress copy, (e) process-only row (no fab state) is not rendered as a button, (f) empty paneId renders non-interactive. Mock `copyToClipboard` from `@/lib/clipboard`. Follow existing sidebar test patterns if any (search `app/frontend/src/components/sidebar/**/*.test.tsx` first).
+- [x] T011 [P] Run `just test-frontend` to confirm no regressions in existing frontend tests (particularly any tests touching `terminal-client.tsx` copy behavior). If any tests fail due to the utility move, update their imports to `@/lib/clipboard`.
+- [x] T012 Run `just test-backend` as a smoke check — this change is frontend-only so backend tests should be unaffected, but the constitution's test-integrity principle calls for confirming both sides.
+
+## Phase 4: Polish
+
+- [x] T013 Run `just build` (or equivalent full typecheck + bundle) to confirm `tsc --noEmit && vite build` succeeds cleanly with no warnings related to the changed files. Resolve any type errors surfaced by the button conversion or clipboard extraction.
+
+---
+
+## Execution Order
+
+- T001 → T002 (T002 imports the utility created in T001)
+- T001, T002 → T003-T009 (status-panel imports the extracted utility)
+- T003 → T004 (handleCopy uses state from T003)
+- T004 → T005 (CopyableRow accepts the callback from T004)
+- T005 → T006, T007, T008, T009 (each row conversion uses CopyableRow)
+- T006-T009 can be done as a batch in a single focused edit since they share the same component
+- T010 (tests) depends on T003-T009 (needs the component behavior to test)
+- T010, T011, T012 [P] — test groups are independent
+- T013 runs last — final build validation


### PR DESCRIPTION
## Summary

The Pane panel in the sidebar shows useful metadata (cwd, git branch, tmx pane, fab change) but these values weren't copyable. This adds click-to-copy behavior to all four info rows, extracting `copyToClipboard` to a shared `@/lib/clipboard` module for reuse across components.

## Changes

- Extract `copyToClipboard` utility from `terminal-client.tsx` to `@/lib/clipboard.ts`
- Convert tmx, cwd, git, and fab rows to `<button>` elements with keyboard accessibility
- Add inline "copied ✓" feedback with 1000ms auto-revert
- Add hover affordance (cursor-pointer + subtle bg tint)
- Guard against active text selection to avoid hijacking manual select

## Change
| ID | Name | Issue |
|----|------|-------|
| lc2q | 260412-lc2q-pane-panel-copy-cwd-branch | — |

## Stats
| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| feat | 5.0 / 5.0 | 0/33 | 13/13 ✓ | Pass (1 iterations) |

[intake](https://github.com/sahil87/run-kit/blob/260412-lc2q-pane-panel-copy-cwd-branch/fab/changes/260412-lc2q-pane-panel-copy-cwd-branch/intake.md) → [spec](https://github.com/sahil87/run-kit/blob/260412-lc2q-pane-panel-copy-cwd-branch/fab/changes/260412-lc2q-pane-panel-copy-cwd-branch/spec.md) → tasks → apply → review → hydrate → ship