### PR TITLE
fix: Prevent sidebar text shift on window selection

### DIFF
--- a/app/frontend/src/components/sidebar/window-row.tsx
+++ b/app/frontend/src/components/sidebar/window-row.tsx
@@ -79,10 +79,10 @@ export function WindowRow({
     if (tint) {
       style.backgroundColor = isSelected ? tint.selected : tint.base;
     }
-    // Selected: left accent border (colored = ANSI hue, uncolored = accent via CSS var)
-    if (isSelected) {
-      style.borderLeft = `3px solid ${borderColor ?? "var(--color-accent)"}`;
-    }
+    // Always reserve left border space to prevent text shift between states
+    style.borderLeft = isSelected
+      ? `3px solid ${borderColor ?? "var(--color-accent)"}`
+      : "3px solid transparent";
     return Object.keys(style).length > 0 ? style : undefined;
   }, [tint, isSelected, borderColor]);
 


### PR DESCRIPTION
## Summary
- The active tab's left accent border (3px) was only rendered when selected, causing text to shift right on selection
- Now always reserves the 3px border space using `transparent` when unselected, keeping text position stable across selected/unselected/hover states

## Test plan
- [ ] Select a sidebar window — text should not shift horizontally
- [ ] Hover over windows — no layout shift
- [ ] Verify colored and uncolored rows both behave consistently