### PR TITLE
docs: Fix rk riff doc comments and typos from Copilot review

### DIFF
--- a/app/backend/cmd/rk/riff.go
+++ b/app/backend/cmd/rk/riff.go
@@ -197,7 +197,8 @@ func runWtCreate(parent context.Context, passthrough []string) (string, error) {
 
 // parseWorktreePath scans wt's combined output line by line looking for
 // `^Path: <path>$` (after trimming whitespace). Returns the path or "" if
-// not found. Exported for direct testing.
+// not found. Split into its own function so riff_test.go can assert the
+// parsing rules directly, without staging a full wt invocation.
 func parseWorktreePath(output string) string {
 	for _, raw := range strings.Split(output, "\n") {
 		line := strings.TrimSpace(raw)
@@ -260,9 +261,11 @@ func tmuxChildEnv() []string {
 	return env
 }
 
-// escapeSingleQuotes returns s with every literal ' replaced by '\” so it
-// can be embedded inside a single-quoted shell string. This matches the
-// canonical POSIX shell-safe encoding.
+// escapeSingleQuotes returns s with every literal ' replaced by the
+// 4-character sequence '\'' so the result can be embedded inside a
+// single-quoted shell string. This matches the canonical POSIX shell-safe
+// encoding: close the current single-quoted string, escape a literal quote,
+// then reopen.
 func escapeSingleQuotes(s string) string {
 	return strings.ReplaceAll(s, "'", `'\''`)
 }

--- a/app/backend/cmd/rk/riff_test.go
+++ b/app/backend/cmd/rk/riff_test.go
@@ -103,7 +103,6 @@ func TestResolveLauncher(t *testing.T) {
 		name       string
 		setup      func(t *testing.T, root string)
 		withChdir  bool
-		wantSuffix string // allow OS path normalization where relevant
 		want       string
 	}{
 		{

--- a/docs/memory/run-kit/rk-riff.md
+++ b/docs/memory/run-kit/rk-riff.md
@@ -27,7 +27,7 @@ rk riff [--cmd <command>] [--split <setup-cmd>] [-- <wt-flags...>]
 | `--split` | string | `""` | When non-empty, splits the window horizontally and runs this setup command in the right pane |
 | `--` | separator | — | Everything after `--` forwards verbatim to `wt create` (e.g., `--worktree-name`, `--base`, `--reuse`) |
 
-Cobra's `SetInterspersed(false)` is called in `init()` so the `--` terminator routes passthrough args into `cmd.Args` unmolested. No other user-facing flags exist.
+Cobra's `SetInterspersed(false)` is called in `init()` so the `--` terminator routes passthrough args straight through to `RunE`'s `args []string` parameter unmolested (rather than being mis-parsed as flags for `rk riff`). No other user-facing flags exist.
 
 ## Precondition Checks
 

--- a/fab/changes/260416-r1j6-add-riff-command/spec.md
+++ b/fab/changes/260416-r1j6-add-riff-command/spec.md
@@ -325,7 +325,7 @@ Installing this change SHALL NOT disturb any user's existing `riff` / `riffs` sh
    - *Rejected*: separate `rk riffs` subcommand — doubles the test surface, surprises users who discover only one.
 
 5. **Keep launcher concatenation inside tmux's shell string (not Go exec args)**
-   - *Why*: `agent.spawn_command` is a shell-syntax string that may contain shell subsitutions like `$(basename "$(pwd)")`. Passing it as an argv slice would break those. Concatenating inside tmux's own shell string preserves the user's configured expansion semantics.
+   - *Why*: `agent.spawn_command` is a shell-syntax string that may contain shell substitutions like `$(basename "$(pwd)")`. Passing it as an argv slice would break those. Concatenating inside tmux's own shell string preserves the user's configured expansion semantics.
    - *Rejected*: splitting `spawn_command` on whitespace and passing as argv — breaks quoted args and shell substitution.
 
 6. **New Go file at `app/backend/cmd/rk/riff.go`; new `internal/fabconfig/` (or similar) helper for reading `fab/project/config.yaml`**

--- a/fab/changes/260417-aaon-fix-riff-copilot-feedback/.history.jsonl
+++ b/fab/changes/260417-aaon-fix-riff-copilot-feedback/.history.jsonl
@@ -1,0 +1,12 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-04-17T08:05:17Z"}
+{"args":"Address 5 Copilot review comments on merged PR #146 (rk riff command)","cmd":"fab-new","event":"command","ts":"2026-04-17T08:05:17Z"}
+{"delta":"+3.8","event":"confidence","score":3.8,"trigger":"calc-score","ts":"2026-04-17T08:06:41Z"}
+{"delta":"+0.0","event":"confidence","score":3.8,"trigger":"calc-score","ts":"2026-04-17T08:06:48Z"}
+{"delta":"-0.6","event":"confidence","score":3.2,"trigger":"calc-score","ts":"2026-04-17T08:12:48Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"spec","ts":"2026-04-17T08:12:51Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"tasks","ts":"2026-04-17T08:14:49Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-04-17T08:17:08Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-04-17T08:21:04Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-04-17T08:23:38Z"}
+{"event":"review","result":"passed","ts":"2026-04-17T08:23:38Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-04-17T08:24:24Z"}

--- a/fab/changes/260417-aaon-fix-riff-copilot-feedback/.status.yaml
+++ b/fab/changes/260417-aaon-fix-riff-copilot-feedback/.status.yaml
@@ -1,0 +1,42 @@
+id: aaon
+name: 260417-aaon-fix-riff-copilot-feedback
+created: 2026-04-17T08:05:17Z
+created_by: sahil-weaver
+change_type: fix
+issues: []
+progress:
+    intake: done
+    spec: done
+    tasks: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+checklist:
+    generated: true
+    path: checklist.md
+    completed: 0
+    total: 0
+confidence:
+    certain: 6
+    confident: 6
+    tentative: 0
+    unresolved: 0
+    score: 3.2
+    fuzzy: true
+    dimensions:
+        signal: 83.8
+        reversibility: 84.2
+        competence: 87.5
+        disambiguation: 88.8
+stage_metrics:
+    intake: {started_at: "2026-04-17T08:05:17Z", driver: fab-new, iterations: 1, completed_at: "2026-04-17T08:12:51Z"}
+    spec: {started_at: "2026-04-17T08:12:51Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-17T08:14:49Z"}
+    tasks: {started_at: "2026-04-17T08:14:49Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-17T08:17:08Z"}
+    apply: {started_at: "2026-04-17T08:17:08Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-17T08:21:04Z"}
+    review: {started_at: "2026-04-17T08:21:04Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-17T08:23:38Z"}
+    hydrate: {started_at: "2026-04-17T08:23:38Z", driver: fab-fff, iterations: 1, completed_at: "2026-04-17T08:24:24Z"}
+    ship: {started_at: "2026-04-17T08:24:24Z", driver: fab-fff, iterations: 1}
+prs: []
+last_updated: 2026-04-17T08:24:24Z

--- a/fab/changes/260417-aaon-fix-riff-copilot-feedback/checklist.md
+++ b/fab/changes/260417-aaon-fix-riff-copilot-feedback/checklist.md
@@ -1,0 +1,91 @@
+# Quality Checklist: Fix rk riff Copilot Review Feedback
+
+**Change**: 260417-aaon-fix-riff-copilot-feedback
+**Generated**: 2026-04-17
+**Spec**: `spec.md`
+
+## Functional Completeness
+
+- [ ] CHK-001 `escapeSingleQuotes` doc comment fixed: the comment preceding `func escapeSingleQuotes` in `app/backend/cmd/rk/riff.go` names the 4-character `'\''` sequence using only ASCII characters, and contains no curly/smart quotes (U+2018–U+201F). Verify via `grep -n 'escapeSingleQuotes' riff.go` → view the comment block; check for absence of `”` / `’` / `‘` / `“`.
+
+- [ ] CHK-002 `parseWorktreePath` doc comment corrected: the comment preceding `func parseWorktreePath` in `app/backend/cmd/rk/riff.go` does NOT contain the phrases "Exported for" or "Public for" or "Exposed for testing" (no false-export claim). The comment describes the real rationale (direct unit testing of parsing rules without staging a full `wt` invocation). The function identifier remains lowercase (`parseWorktreePath`, not `ParseWorktreePath`).
+
+- [ ] CHK-003 `wantSuffix` field removed: in `app/backend/cmd/rk/riff_test.go`, the anonymous struct inside `TestResolveLauncher` has exactly 4 fields (`name`, `setup`, `withChdir`, `want`) — no `wantSuffix`. The trailing comment `// allow OS path normalization where relevant` is also removed (it existed only to document the removed field). Verify via `grep -n 'wantSuffix' riff_test.go` → 0 hits.
+
+- [ ] CHK-004 `subsitutions` typo fixed: `fab/changes/260416-r1j6-add-riff-command/spec.md` contains `substitutions` (correctly spelled) on the line that previously held the typo. Verify via `grep -c 'subsitutions' spec.md` → 0 AND `grep -c 'substitutions' spec.md` → ≥ 1.
+
+- [ ] CHK-005 `rk-riff.md` line 30 corrected: line 30 of `docs/memory/run-kit/rk-riff.md` describes forwarded-arg handling via `RunE`'s `args []string` parameter, not via `cmd.Args`. Verify via `grep -c 'cmd\.Args' rk-riff.md` → 0, AND the line mentions `args []string` (or `args` as a named RunE parameter).
+
+## Behavioral Correctness
+
+- [ ] CHK-006 Zero runtime behavior change: no new/removed/modified code paths in `riff.go` function bodies. Verify via `git diff HEAD -- app/backend/cmd/rk/riff.go` — the only diff hunks are on comment lines (no lines starting with `func`, no lines starting with non-comment statements inside existing functions).
+
+- [ ] CHK-007 Zero signature change on `parseWorktreePath`: `func parseWorktreePath(output string) string` is byte-identical (same name, same parameter types/names, same return type). Verify via `grep 'func parseWorktreePath' riff.go` → exactly one hit with the unchanged signature.
+
+- [ ] CHK-008 Zero signature change on `escapeSingleQuotes`: `func escapeSingleQuotes(s string) string` is byte-identical. Body unchanged (`return strings.ReplaceAll(s, "'", \`'\\''\`)`).
+
+- [ ] CHK-009 Zero test case additions or removals in `TestResolveLauncher`: the `cases` slice has the same 5 literals (same `name:` strings as before). Verify via `grep -c 'name:.*"' riff_test.go` — case-count inside TestResolveLauncher is unchanged. Only the struct type loses a field.
+
+## Removal Verification
+
+- [ ] CHK-010 No dead code introduced: the `wantSuffix` removal does not leave any test logic referencing a non-existent field (would be a compile error). `go build ./cmd/rk/...` passes cleanly.
+
+- [ ] CHK-011 No orphaned comments on removed field: the trailing `// allow OS path normalization where relevant` comment is gone. Verify via `grep -n 'OS path normalization' riff_test.go` → 0 hits.
+
+- [ ] CHK-012 r1j6 `.status.yaml` untouched: `fab/changes/260416-r1j6-add-riff-command/.status.yaml` is byte-identical to its state before this change. Verify via `git diff HEAD -- fab/changes/260416-r1j6-add-riff-command/.status.yaml` → empty diff.
+
+## Scenario Coverage
+
+- [ ] CHK-013 Scenario "Minimum grammar fix present" verified: `app/backend/cmd/rk/riff.go` contains `'\''` literally in the `escapeSingleQuotes` doc comment. No Unicode U+2018–U+201F characters anywhere in the file.
+
+- [ ] CHK-014 Scenario "Explanation is pedagogically useful" verified: the revised `escapeSingleQuotes` comment identifies `'\''` as a 4-character sequence and describes the close-escape-reopen trick.
+
+- [ ] CHK-015 Scenario "No false export claim" verified: `parseWorktreePath` comment contains no phrase implying exported status.
+
+- [ ] CHK-016 Scenario "Same-package test keeps compiling and passing" verified: `go test -run 'TestParseWorktreePath|TestResolveLauncher' ./cmd/rk/...` passes.
+
+- [ ] CHK-017 Scenario "Struct field count goes from 5 to 4" verified: manual field-count confirmation in the `cases` anonymous struct.
+
+- [ ] CHK-018 Scenario "r1j6 pipeline status is preserved" verified: diff check on `.status.yaml` shows empty.
+
+- [ ] CHK-019 Scenario "File audit confirms no other `cmd.Args` misuses" verified: `grep -n 'cmd\.Args' docs/memory/run-kit/rk-riff.md` → 0 hits post-edit.
+
+- [ ] CHK-020 Scenario "Surrounding content preserved" verified: lines 29 and 31 of `rk-riff.md` are byte-identical to their pre-edit state.
+
+## Edge Cases & Error Handling
+
+- [ ] CHK-021 If `rk-riff.md` audit (T005) surfaces additional `cmd.Args` occurrences beyond line 30, those are also fixed in the same commit. Spec confirmed 1 hit pre-edit, but the audit re-runs during apply as defense-in-depth.
+
+- [ ] CHK-022 If the line-30 rewrite exceeds the pre-edit line width and wraps, the overflow MUST NOT spill into neighboring headings or tables (lines 22–28 table, line 32 heading stay intact).
+
+## Code Quality
+
+- [ ] CHK-023 Principle "Readability and maintainability over cleverness" applied: the rewritten `escapeSingleQuotes` comment is clearer than the original (even the non-garbled intent), not just fixed.
+
+- [ ] CHK-024 Principle "Follow existing project patterns unless there's compelling reason to deviate" applied: comment style (lowercase start, sentence-cased, no emojis, no trailing periods on single-line comments when inline) matches neighboring doc comments in `riff.go`.
+
+- [ ] CHK-025 Principle "Go backend: Use `exec.CommandContext` with timeouts" — N/A for this change (no subprocess code changed).
+
+- [ ] CHK-026 Principle "New features and bug fixes MUST include tests covering the added/changed behavior" — N/A: this is documentation/typo/unused-field cleanup, no behavior change. Existing tests continue to cover the unchanged behavior.
+
+- [ ] CHK-027 Anti-pattern "God functions (>50 lines without clear reason)" — N/A: no function body changed.
+
+- [ ] CHK-028 Anti-pattern "Magic strings or numbers without named constants" — N/A: no constants added or removed.
+
+- [ ] CHK-029 Anti-pattern "Shell string construction for subprocess calls" — N/A: no subprocess calls changed.
+
+- [ ] CHK-030 Pattern consistency: comment style and formatting in the two rewritten doc comments matches the surrounding `riff.go` conventions (GoDoc style: comment immediately precedes the function, first word is the identifier, concluded with a period).
+
+- [ ] CHK-031 No unnecessary duplication: no helper function, constant, or type was added that duplicates existing `internal/tmux/`, `internal/sessions/`, or `internal/fab/` utilities (N/A — nothing was added; this is removal/rewrite only).
+
+## Verification Gates (from `fab/project/code-quality.md` §Verification)
+
+- [ ] CHK-032 `cd app/backend && go test ./cmd/rk/...` passes (exit 0). All pre-existing subtests in `TestParseWorktreePath`, `TestEscapeSingleQuotes`, `TestResolveLauncher`, `TestResolveLauncher_ReadsFromSubdir`, and `TestFabconfigIntegration` still PASS.
+
+- [ ] CHK-033 `cd app/backend && go vet ./cmd/rk/...` passes (exit 0, no diagnostics).
+
+- [ ] CHK-034 `cd app/backend && go build ./...` passes (exit 0).
+
+- [ ] CHK-035 Belt-and-suspenders: `cd app/backend && go test ./internal/fabconfig/...` passes. (Not strictly required — this package isn't touched — but confirms nothing downstream broke.)
+
+- [ ] CHK-036 `just test` — full backend + frontend + e2e sweep. Optional for doc-only change but recommended for merge-ready confidence. Expect 0 regressions attributable to this change. N/A if the change has zero Go or frontend diff (only .md fixes) — but here we do have two .go files modified, so full sweep is warranted.

--- a/fab/changes/260417-aaon-fix-riff-copilot-feedback/intake.md
+++ b/fab/changes/260417-aaon-fix-riff-copilot-feedback/intake.md
@@ -1,0 +1,177 @@
+# Intake: Fix rk riff Copilot Review Feedback
+
+**Change**: 260417-aaon-fix-riff-copilot-feedback
+**Created**: 2026-04-17
+**Status**: Draft
+
+## Origin
+
+> User: "Address 5 Copilot review comments on merged PR #146 (rk riff command): 1) riff.go:263 escapeSingleQuotes doc comment has garbled escape sequence, fix to describe the actual single-quote-escape replacement; 2) riff_test.go:107 TestResolveLauncher has unused wantSuffix field, remove it; 3) fab/changes/260416-r1j6-add-riff-command/spec.md:328 typo subsitutions should be substitutions; 4) docs/memory/run-kit/rk-riff.md:30 incorrectly references cmd.Args, cobra passes forwarded args via args []string parameter to RunE; 5) riff.go:200 comment says Exported for direct testing but parseWorktreePath is lowercase, either export it or update the comment. Reviewer: Copilot. Source PR https://github.com/sahil87/run-kit/pull/146 already merged to main."
+
+Interaction mode: one-shot, precise. User supplied exact file, line, and issue for every item — no ambiguity, no follow-up questions needed. Original riff work shipped via PR #146 (commit `9d33e8c`, merged to `main`) under change folder `260416-r1j6-add-riff-command/`. Copilot left 5 review comments that didn't block merge; this change is the cleanup pass.
+
+Key scoping decision made up front: this change is a follow-up *fix* on already-merged code, not a reopening of the `r1j6` change. A fresh change folder keeps the original `r1j6` intake/spec/tasks frozen as shipped and makes the review-feedback cycle traceable as its own pipeline.
+
+## Why
+
+PR #146 shipped the `rk riff` command to production. Copilot's review flagged 5 low-severity issues (4 documentation/typo, 1 unused test field) that were not merge blockers, so the PR landed with them outstanding. Left unaddressed these:
+
+1. **Mislead future readers** — `escapeSingleQuotes`'s doc comment is garbled (`'\”` instead of `'\''`), so a reader trying to understand the POSIX single-quote escape pattern has to stare at the code to work out what the comment *meant* to say. The whole point of that comment is to explain a non-obvious shell-escape trick — if it's wrong, it's worse than no comment.
+2. **Leave misleading dead code** — the `wantSuffix` field in `TestResolveLauncher`'s test-case struct is never read by the loop body (only `want` is). A future reader editing the test will add a `wantSuffix:` value expecting it to assert something, which it won't. Dead struct fields in test tables are especially corrosive because they suggest assertion coverage that isn't real.
+3. **Permanent documentation errors** — the spec.md typo (`subsitutions`) and the rk-riff.md memory inaccuracy (`cmd.Args` vs `args []string`) live forever in the project's historical record. Memory files in particular are load-bearing for `/fab-*` skills and subagent dispatch; inaccurate memory propagates into future agent-generated code and specs.
+4. **Incorrect export-claim comment** — `parseWorktreePath`'s doc comment says "Exported for direct testing" but the function name is lowercase (package-private). Same-package tests can already call package-private functions directly; there's no export requirement. The comment is both inaccurate and rationale-less.
+
+None of these are bugs in behavior, but all five degrade the reading/review experience for the next person (or agent) touching this code. The fix is cheap — under 10 line-level edits across 4 files — and the alternative (deferring indefinitely) accumulates cruft.
+
+**Why not batch with other cleanup work?** No other pending changes touch these files. A dedicated follow-up change is the cleanest traceability for "Copilot review on #146 → addressed."
+
+**Why a new change folder and not reopening r1j6?** The `260416-r1j6-add-riff-command` pipeline is at `hydrate: done` (ship stage). Reopening it would rewrite history on the shipped intake/spec/tasks. A new change folder preserves that record and gives this fix its own independent pipeline (intake → spec → tasks → apply → review → hydrate → ship → PR review).
+
+## What Changes
+
+Five localized edits across four files. No behavior change, no new code paths, no test coverage change.
+
+### 1. `app/backend/cmd/rk/riff.go:263-268` — fix `escapeSingleQuotes` doc comment
+
+**Current** (garbled):
+```go
+// escapeSingleQuotes returns s with every literal ' replaced by '\” so it
+// can be embedded inside a single-quoted shell string. This matches the
+// canonical POSIX shell-safe encoding.
+func escapeSingleQuotes(s string) string {
+	return strings.ReplaceAll(s, "'", `'\''`)
+}
+```
+
+The ending `'\”` in the first line is a curly closing quote (`”` U+201D) rather than the intended escape sequence. The function body clearly replaces `'` with `'\''` — the comment should say so literally.
+
+**Proposed**:
+```go
+// escapeSingleQuotes returns s with every literal ' replaced by the 4-character
+// sequence '\'' so the result can be embedded inside a single-quoted shell
+// string. This matches the canonical POSIX shell-safe encoding: close the
+// current single-quoted string, escape a literal quote, then reopen.
+func escapeSingleQuotes(s string) string {
+	return strings.ReplaceAll(s, "'", `'\''`)
+}
+```
+
+Rationale for the expanded form: the literal `'\''` is hard to parse visually in a comment. Calling out that it's a 4-character sequence and briefly naming the trick (close-escape-reopen) makes the intent obvious without the reader needing to decode the string.
+
+### 2. `app/backend/cmd/rk/riff_test.go:101-154` — remove unused `wantSuffix` field
+
+The test-case struct in `TestResolveLauncher` declares:
+
+```go
+cases := []struct {
+    name       string
+    setup      func(t *testing.T, root string)
+    withChdir  bool
+    wantSuffix string // allow OS path normalization where relevant
+    want       string
+}{
+    ...
+}
+```
+
+The loop body (lines 156-174) only reads `tc.name`, `tc.setup`, `tc.withChdir`, and `tc.want`. No case sets `wantSuffix`; no assertion reads it. Confirmed via `grep -n 'wantSuffix' riff_test.go` → single hit on the field declaration.
+
+**Change**: delete the `wantSuffix string` line and its comment. The struct becomes 4 fields. No case-literal changes are needed because no case populates `wantSuffix`.
+
+### 3. `fab/changes/260416-r1j6-add-riff-command/spec.md:328` — typo fix
+
+**Current**:
+> `agent.spawn_command` is a shell-syntax string that may contain shell subsitutions like `$(basename "$(pwd)")`.
+
+**Proposed**: `subsitutions` → `substitutions`. Single-character fix (insert `t`). Nothing else on the line changes.
+
+> **Cross-branch note**: This file lives in the already-shipped `r1j6` change folder but is not worktree-tied — editing it on a fresh branch from `main` is safe. The edit does not invalidate that change's status (still `hydrate: done`).
+
+### 4. `docs/memory/run-kit/rk-riff.md:30` — correct cobra arg plumbing description
+
+**Current**:
+> Cobra's `SetInterspersed(false)` is called in `init()` so the `--` terminator routes passthrough args into `cmd.Args` unmolested. No other user-facing flags exist.
+
+The claim that passthrough args land in `cmd.Args` is wrong. Cobra's `RunE` receives forwarded positional arguments via the `args []string` parameter (second parameter of the `func(cmd *cobra.Command, args []string) error` signature). `cmd.Args` is the `cobra.PositionalArgs` *validator* function, not the collected args.
+
+**Proposed rewrite**:
+> Cobra's `SetInterspersed(false)` is called in `init()` so the `--` terminator routes passthrough args straight through to `RunE`'s `args []string` parameter unmolested (rather than being mis-parsed as flags for `rk riff`). No other user-facing flags exist.
+
+Also audit the same memory file for any downstream mentions of `cmd.Args` in the same incorrect sense — if any are found, fix them as part of this change.
+
+### 5. `app/backend/cmd/rk/riff.go:198-200` — fix misleading export-claim comment
+
+**Current**:
+```go
+// parseWorktreePath scans wt's combined output line by line looking for
+// `^Path: <path>$` (after trimming whitespace). Returns the path or "" if
+// not found. Exported for direct testing.
+func parseWorktreePath(output string) string {
+```
+
+`parseWorktreePath` is lowercase → package-private. Same-package tests (`riff_test.go` at `riff_test.go:65`) call it directly without any export requirement.
+
+**Preferred fix**: update the comment rather than export. Exporting would widen the package API surface for no external consumer; the only caller outside `riff.go` is `riff_test.go` in the same package.
+
+**Proposed**:
+```go
+// parseWorktreePath scans wt's combined output line by line looking for
+// `^Path: <path>$` (after trimming whitespace). Returns the path or "" if
+// not found. Split into its own function so riff_test.go can assert the
+// parsing rules directly, without staging a full wt invocation.
+func parseWorktreePath(output string) string {
+```
+
+Rationale: captures the real "why" — testability through separation of concerns — without falsely claiming exported status.
+
+## Affected Memory
+
+- `run-kit/rk-riff`: (modify) correct the cobra passthrough-args description on line 30 from `cmd.Args` to `args []string` (RunE parameter). No new memory file, no structural change to the existing one. If any other lines in this memory file reference `cmd.Args` in the same incorrect sense, fix them too.
+
+No other memory file is affected. The four code/test/spec edits (items 1, 2, 3, 5) do not change any post-implementation behavior captured in memory — they're documentation-level fixes inside source artifacts, not in memory files.
+
+## Impact
+
+**Affected files (4 total)**:
+- `app/backend/cmd/rk/riff.go` — two comment edits (items 1 and 5), no code changes
+- `app/backend/cmd/rk/riff_test.go` — one struct-field removal (item 2), no test-logic changes
+- `fab/changes/260416-r1j6-add-riff-command/spec.md` — one-character typo fix (item 3)
+- `docs/memory/run-kit/rk-riff.md` — one sentence rewrite (item 4), plus possible audit for same error elsewhere in file
+
+**APIs, dependencies, systems**: None affected. No public API change (the `parseWorktreePath` function stays lowercase), no dependency change, no behavior change observable from tests or at runtime.
+
+**Test impact**: `TestResolveLauncher` struct shape changes (one field removed). Test still compiles and passes because no case populated the removed field. No new tests required — these are documentation-level fixes, not behavior fixes.
+
+**CI / review tooling impact**: The build artifacts (`go vet`, `go test ./...`) should pass unchanged. Copilot re-reviewing this PR should see 0 of its original 5 comments resurface.
+
+**Base-branch consideration**: This change must branch from `main` (which contains PR #146's merged code at commit `9d33e8c`) rather than from the current worktree HEAD. The current worktree (`snowy-bobcat` at `9e02980`) is one commit behind `origin/main` and does not contain any of the files being edited. The apply stage MUST rebase onto or branch from `main` before making any edits.
+
+**Scope boundary — what this change is NOT**:
+- Not a behavior fix for `rk riff` (no user-facing bug is being patched)
+- Not a refactor (no restructuring of the function layout, no API change)
+- Not a test-coverage expansion (no new cases; just removes an unused field)
+- Not a revisit of architectural decisions in the original spec (those are frozen)
+
+## Open Questions
+
+None. The user provided exact file paths, line numbers, issue descriptions, and preferred resolutions for all 5 items. All resolutions verified against the current state of `main` before intake write:
+- `riff.go:263-265` comment garbling confirmed
+- `riff_test.go:106` unused `wantSuffix` confirmed (single grep hit on declaration)
+- `spec.md:328` typo confirmed
+- `rk-riff.md:30` `cmd.Args` error confirmed
+- `riff.go:198-200` lowercase `parseWorktreePath` with "Exported for direct testing" comment confirmed
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | All 5 review items are in scope; no others will be pulled in | User enumerated exactly 5 items with file:line specificity; no ambient invitation to expand scope | S:95 R:90 A:95 D:95 |
+| 2 | Certain | Fix is made on a new branch from `main`, not by reopening the `r1j6` change folder | User explicitly framed as "address 5 Copilot review comments on merged PR #146", implying a follow-up cycle. Reopening would rewrite shipped pipeline artifacts | S:95 R:70 A:90 D:95 |
+| 3 | Certain | For item 5 (parseWorktreePath), update the comment rather than export the function | User wrote "either export it or update the comment" — exporting widens API surface needlessly since the only external caller is same-package test code. Comment update is the lower-impact fix | S:85 R:85 A:95 D:85 |
+| 4 | Confident | For item 1, expand the comment beyond the minimal grammar fix to explain the 4-char close-escape-reopen trick | The whole purpose of that comment is to demystify a non-obvious shell trick. Minimal fix (`'\”` → `'\''`) would leave a cryptic comment; a brief explanatory rewrite is more useful to future readers. Low-reversibility-cost: single comment edit | S:70 R:90 A:80 D:75 |
+| 5 | Confident | For item 4, also audit the rest of `rk-riff.md` for the same `cmd.Args` misconception and fix any other instances | Memory files propagate into agent-generated code; if the error appears elsewhere in the same doc, it'll re-infect future work. Grep is cheap | S:65 R:85 A:85 D:80 |
+| 6 | Confident | For item 2, delete the `wantSuffix` field and its trailing `// allow OS path normalization where relevant` comment together | The comment only exists to explain a field that's being removed. Keeping the orphaned comment would make the next reader wonder what it refers to | S:75 R:90 A:85 D:90 |
+| 7 | Certain | No new test cases needed; no spec change; no memory-file additions | Documentation/typo/unused-field fixes don't change behavior. Existing tests exercise the code; their results are unaffected | S:90 R:85 A:95 D:90 |
+| 8 | Confident | Editing `spec.md` of the already-shipped `r1j6` change is acceptable (one-char typo fix) | Spec files in change folders persist as historical records but aren't immutable — typo corrections preserve the record's accuracy without altering its decisions or semantics. Status stays `hydrate: done` | S:65 R:80 A:75 D:85 |
+
+8 assumptions (4 certain, 4 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260417-aaon-fix-riff-copilot-feedback/spec.md
+++ b/fab/changes/260417-aaon-fix-riff-copilot-feedback/spec.md
@@ -1,0 +1,231 @@
+# Spec: Fix rk riff Copilot Review Feedback
+
+**Change**: 260417-aaon-fix-riff-copilot-feedback
+**Created**: 2026-04-17
+**Affected memory**: `docs/memory/run-kit/rk-riff.md`
+
+## Non-Goals
+
+- No behavior change to `rk riff` runtime — all edits are documentation, test-struct, or typo level. No new arguments, flags, exit codes, or execution paths.
+- No new tests — the unused-field removal does not expand or contract coverage; existing tests still exercise the same code paths.
+- No change to the exported API surface — `parseWorktreePath` stays package-private (item 5 rejects the "export it" branch).
+- No rework of the already-shipped `260416-r1j6-add-riff-command` pipeline — only a one-character typo edit inside its spec.md.
+- No audit or refactor beyond the single-file rk-riff.md `cmd.Args` audit (confirmed zero additional occurrences; if later grep finds more during apply, fix in place but do not expand scope).
+
+## Code: `escapeSingleQuotes` Doc Comment
+
+### Requirement: Doc Comment Accurately Describes the Escape Encoding
+
+The doc comment on `escapeSingleQuotes` in `app/backend/cmd/rk/riff.go` MUST describe the replacement pattern using valid ASCII characters (`'` U+0027), and SHALL NOT contain curly/smart quotes (`”` U+201D, `’` U+2019, or similar). The comment SHALL name the 4-character sequence (`'\''`) that the replacement produces, and SHOULD briefly explain why that sequence is shell-safe inside a single-quoted string.
+
+#### Scenario: Minimum grammar fix present
+
+- **GIVEN** `app/backend/cmd/rk/riff.go` contains `func escapeSingleQuotes(s string) string`
+- **WHEN** a reader inspects the doc comment immediately preceding the function
+- **THEN** the comment mentions `'\''` literally (four ASCII chars: `'`, `\`, `'`, `'`)
+- **AND** the comment contains no characters in the Unicode General Punctuation block (U+2018–U+201F)
+
+#### Scenario: Explanation is pedagogically useful
+
+- **GIVEN** the revised comment
+- **WHEN** a reader unfamiliar with POSIX shell quoting reads it
+- **THEN** the comment identifies `'\''` as a 4-character sequence (avoiding visual ambiguity)
+- **AND** briefly notes that the trick closes the current single-quoted string, escapes a literal quote, and reopens — either inline or via concise wording that conveys the same idea
+
+#### Scenario: Implementation stays untouched
+
+- **GIVEN** the comment fix
+- **WHEN** `git diff` is inspected on `riff.go`
+- **THEN** only comment lines on this function are changed
+- **AND** the function body (`return strings.ReplaceAll(s, "'", \`'\\''\`)`) is byte-identical to before the change
+
+## Code: `parseWorktreePath` Doc Comment
+
+### Requirement: Comment Reflects Real Visibility and Rationale
+
+The doc comment on `parseWorktreePath` in `app/backend/cmd/rk/riff.go` MUST NOT claim the function is "Exported". The function SHALL remain package-private (lowercase identifier) — no rename. The comment SHOULD state the real reason the parsing logic is factored into its own function: same-package tests assert the parsing rules without staging a full `wt` invocation.
+
+#### Scenario: No false export claim
+
+- **GIVEN** the revised comment
+- **WHEN** a reader compares the comment against the function signature
+- **THEN** the comment contains no phrase implying the function is exported (e.g., "Exported for", "Public for", "Exposed for testing")
+- **AND** the function identifier remains `parseWorktreePath` (first character lowercase)
+
+#### Scenario: Comment explains the real factoring rationale
+
+- **GIVEN** the revised comment
+- **WHEN** a reader asks "why is this a separate function?"
+- **THEN** the comment answers: separated to enable direct unit testing of the parsing rules, without standing up a real `wt` subprocess
+
+#### Scenario: Same-package test keeps compiling and passing
+
+- **GIVEN** the revised comment
+- **WHEN** `go test ./app/backend/cmd/rk/...` runs
+- **THEN** `riff_test.go` compiles (it still calls `parseWorktreePath` from the same package at `riff_test.go:65`)
+- **AND** all existing `parseWorktreePath` test cases pass unchanged
+
+## Code: `TestResolveLauncher` Unused Field
+
+### Requirement: Struct Field `wantSuffix` Removed
+
+The anonymous struct in `TestResolveLauncher` (`app/backend/cmd/rk/riff_test.go`) MUST NOT declare a `wantSuffix` field. The adjoining trailing comment (`// allow OS path normalization where relevant`) SHALL be removed in the same edit — it exists only to document the removed field. No case-literal body is modified (no case populates `wantSuffix` currently).
+
+#### Scenario: Field is absent after the edit
+
+- **GIVEN** `app/backend/cmd/rk/riff_test.go`
+- **WHEN** the file is searched for the literal `wantSuffix`
+- **THEN** zero matches are returned (confirmed via `grep -n 'wantSuffix' riff_test.go`)
+
+#### Scenario: Orphaned comment removed with the field
+
+- **GIVEN** the field removal
+- **WHEN** the surrounding struct declaration is inspected
+- **THEN** no trailing comment references the removed field (no dangling `// allow OS path normalization where relevant`)
+
+#### Scenario: Test continues to pass
+
+- **GIVEN** the field is gone
+- **WHEN** `go test -run TestResolveLauncher ./app/backend/cmd/rk/...` runs
+- **THEN** the test binary compiles without errors
+- **AND** all 5 subtests pass (`config present with spawn_command returns value`, `config missing key returns fallback`, `empty spawn_command returns fallback`, `no git repo returns fallback`, `config file missing returns fallback`)
+
+#### Scenario: Struct field count goes from 5 to 4
+
+- **GIVEN** the test-case struct type definition
+- **WHEN** its declared field list is enumerated
+- **THEN** it contains exactly `name`, `setup`, `withChdir`, `want` — in that order — and nothing else
+
+## Docs: Historical Spec Typo
+
+### Requirement: `subsitutions` → `substitutions`
+
+The string `subsitutions` in `fab/changes/260416-r1j6-add-riff-command/spec.md` (currently at line 328 inside Design Decision #5) SHALL be replaced with `substitutions`. No other character on that line or in that file is modified. The `.status.yaml` of the r1j6 change MUST remain unchanged (stage `hydrate: done`, stage `ship`/`review-pr` state as-is).
+
+#### Scenario: Typo fixed in place
+
+- **GIVEN** `fab/changes/260416-r1j6-add-riff-command/spec.md`
+- **WHEN** the file is grepped for the incorrect spelling
+- **THEN** `grep -c 'subsitutions' spec.md` returns 0
+- **AND** `grep -c 'substitutions' spec.md` returns >= 1 on the line that previously held the typo
+
+#### Scenario: r1j6 pipeline status is preserved
+
+- **GIVEN** the typo fix
+- **WHEN** `fab/changes/260416-r1j6-add-riff-command/.status.yaml` is inspected
+- **THEN** the file content is byte-identical to its state before this change
+
+## Docs: rk-riff Memory — Cobra Arg Plumbing
+
+### Requirement: Correct Description of Forwarded-Arg Handling
+
+Line 30 of `docs/memory/run-kit/rk-riff.md` MUST NOT claim that `SetInterspersed(false)` routes passthrough args into `cmd.Args`. The corrected description SHALL state that forwarded args are delivered to `RunE`'s `args []string` parameter (the second parameter of the cobra `RunE` function signature). The rewritten sentence SHOULD preserve the adjacent context (mention of the `--` terminator, the purpose of `SetInterspersed(false)`, and the closing phrase "No other user-facing flags exist.").
+
+#### Scenario: Line 30 rewrite
+
+- **GIVEN** `docs/memory/run-kit/rk-riff.md` after the edit
+- **WHEN** line 30 is read
+- **THEN** the line references `args []string` (or `args` as a named parameter of `RunE`) — not `cmd.Args`
+
+#### Scenario: File audit confirms no other `cmd.Args` misuses
+
+- **GIVEN** the post-edit `rk-riff.md`
+- **WHEN** the file is grepped for the literal `cmd.Args`
+- **THEN** zero matches are returned (confirmed pre-edit: only line 30 matched; audit completes with zero other hits to fix)
+
+#### Scenario: Surrounding content preserved
+
+- **GIVEN** the edited line 30
+- **WHEN** diff is inspected
+- **THEN** line 29 and line 31 are byte-identical to their pre-edit state
+- **AND** the `## Flag Surface` heading (line 22), the flag table (lines 24-28), and the `## Precondition Checks` heading (line 32) are all unmodified
+
+### Requirement: Memory Accuracy Preserved Across Sections
+
+All other factual claims in `rk-riff.md` (launcher resolution algorithm, workflow step order, exit-code discipline, single-quote escaping examples, fabconfig subset, `tmux.OriginalTMUX` usage, tests summary, related files, changelog) MUST remain byte-identical. This change is a line-30 surgical edit, not a memory refresh.
+
+#### Scenario: Unrelated sections unchanged
+
+- **GIVEN** the post-edit `rk-riff.md`
+- **WHEN** a diff is produced against the pre-edit file
+- **THEN** only line 30 content is modified (plus possibly wrapping adjustments if the rewritten sentence exceeds original width — adjustment MUST NOT spill into neighboring headings)
+
+## Tests: Regression Coverage
+
+### Requirement: No New Tests Required, No Existing Tests Broken
+
+No new test files MAY be added. Existing test invocations (`go test ./app/backend/cmd/rk/...` and `go test ./app/backend/internal/fabconfig/...`) MUST continue to pass with zero case failures and zero compile errors after this change.
+
+#### Scenario: Full rk package tests pass
+
+- **GIVEN** the five edits applied
+- **WHEN** `cd app/backend && go test ./cmd/rk/...` runs
+- **THEN** exit code is 0
+- **AND** every pre-existing subtest in `TestParseWorktreePath`, `TestEscapeSingleQuotes`, `TestResolveLauncher`, `TestResolveLauncher_ReadsFromSubdir`, and `TestFabconfigIntegration` still reports PASS
+
+#### Scenario: Affected-module test scope is sufficient
+
+- **GIVEN** this change touches only `app/backend/cmd/rk/riff.go`, `app/backend/cmd/rk/riff_test.go`, and two `.md` files
+- **WHEN** a reviewer asks "what tests cover this change?"
+- **THEN** running the `cmd/rk` package tests is sufficient — no other Go package depends on symbols altered by this change
+
+### Requirement: Code-Quality Gates Still Clean
+
+`go vet` and `go build` MUST succeed on the backend module after the edits. Comment-only and struct-field-only changes SHALL NOT introduce unused-import warnings or other lint regressions.
+
+#### Scenario: go vet passes
+
+- **GIVEN** the edits applied
+- **WHEN** `cd app/backend && go vet ./cmd/rk/...` runs
+- **THEN** exit code is 0 with no diagnostics
+
+#### Scenario: go build passes
+
+- **GIVEN** the edits applied
+- **WHEN** `cd app/backend && go build ./...` runs
+- **THEN** exit code is 0
+
+## Design Decisions
+
+1. **Fresh change folder, not reopening `r1j6`**
+   - *Why*: The `260416-r1j6-add-riff-command` pipeline is at `hydrate: done` (ship stage). Treating this follow-up as a new change preserves the shipped pipeline's artifact history and gives Copilot's review-feedback cycle its own traceable pipeline (intake → spec → tasks → apply → review → hydrate → ship → review-pr).
+   - *Rejected*: Reopening `r1j6` — would rewrite the shipped intake/spec/tasks, hiding the fact that these issues were a post-merge cleanup pass. Reviewer attribution (Copilot on PR #146) would also get buried.
+
+2. **Update `parseWorktreePath` comment rather than export the function**
+   - *Why*: The only caller outside `riff.go` is `riff_test.go` — same package, which can access lowercase identifiers freely. Exporting would widen the package's public API surface for zero benefit.
+   - *Rejected*: Renaming to `ParseWorktreePath` — pointless API expansion; would require updating `riff.go` call site and `riff_test.go` call site, with no external consumer.
+
+3. **Expand `escapeSingleQuotes` comment beyond minimal character fix**
+   - *Why*: The comment's purpose is to demystify a non-obvious POSIX shell trick. Fixing only the curly quote (`'\”` → `'\''`) leaves the reader still staring at a cryptic 4-character sequence. A brief explanatory rewrite (name the sequence, name the trick) is more useful.
+   - *Rejected*: Minimal one-character edit — satisfies Copilot but fails the "comment should help future readers" bar.
+
+4. **Delete `wantSuffix` field and its trailing comment together**
+   - *Why*: The `// allow OS path normalization where relevant` comment exists solely to document the removed field. Keeping it orphaned would puzzle the next reader ("what field does this refer to?").
+   - *Rejected*: Keep the comment as a "reminder" — it'd re-invite someone to re-add the field without understanding why it was removed.
+
+5. **One-char spec.md typo fix is acceptable despite r1j6 being shipped**
+   - *Why*: Spec files in change folders are historical artifacts but not immutable — correcting a typo preserves historical accuracy without altering decisions, semantics, or pipeline state. The alternative (leaving the typo in perpetuity) accumulates cruft in the docs surface.
+   - *Rejected*: Leave the typo to preserve "the exact text as shipped" — this privileges historical literalism over documentation quality. Typo fixes are routine in any codebase.
+
+6. **All 5 edits go in one change and one PR**
+   - *Why*: All 5 are Copilot comments on the same PR, touch tightly related files, and are low risk. One PR keeps the review surface focused ("here's my response to Copilot"). Splitting into 5 PRs (or 2: code vs docs) would be review overhead without benefit.
+   - *Rejected*: Split by file type (code vs docs) — would force artificial dependency coordination for work that has no coupling.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | All 5 Copilot review items in scope; no other changes | User enumerated exactly 5 items with file:line specificity. Confirmed from intake #1 | S:95 R:90 A:95 D:95 |
+| 2 | Certain | Fresh change folder, not reopening `r1j6` | Preserves shipped pipeline history; confirmed from intake #2 | S:95 R:75 A:90 D:95 |
+| 3 | Certain | Update comment on `parseWorktreePath`, don't export | Only caller outside `riff.go` is same-package test; exporting is pointless API widening. Confirmed from intake #3 | S:90 R:85 A:95 D:90 |
+| 4 | Certain | Delete `wantSuffix` + its trailing comment together | Orphaned comment would puzzle readers; confirmed from intake #6 | S:85 R:90 A:90 D:90 |
+| 5 | Confident | Expand `escapeSingleQuotes` comment beyond minimal grammar fix | Minimal fix leaves the shell trick still cryptic; confirmed from intake #4 | S:75 R:90 A:80 D:80 |
+| 6 | Certain | `rk-riff.md` audit complete — only one `cmd.Args` occurrence | `grep -c 'cmd.Args' rk-riff.md` returned 1 (line 30). Upgrade from intake Confident #5 — audit actually ran during spec generation | S:95 R:90 A:95 D:95 |
+| 7 | Confident | Historical spec.md typo fix is acceptable | Spec artifacts not immutable; 1-char correction preserves accuracy without altering decisions. Confirmed from intake #8 | S:70 R:80 A:75 D:85 |
+| 8 | Certain | No new tests, no new files; existing tests continue to pass | Doc/typo/unused-field fixes don't change behavior. Confirmed from intake #7 | S:95 R:85 A:95 D:95 |
+| 9 | Confident | One PR, not split by file type | Tight cohesion (all 5 are Copilot-on-PR-#146 comments); splitting adds review overhead without benefit. New assumption at spec level | S:75 R:80 A:85 D:85 |
+| 10 | Confident | Test-package scope sufficient: `cmd/rk/...` (no wider gates needed) | Only `cmd/rk` package symbols/comments affected; `internal/fabconfig` tests unaffected though they MAY be run as a belt-and-suspenders check | S:75 R:80 A:85 D:85 |
+| 11 | Confident | `go vet` + `go build` also pass (not only `go test`) | Comment/field changes don't introduce new imports or syntax; lint is safe. New assumption at spec level | S:80 R:85 A:85 D:85 |
+| 12 | Confident | Minimal diff on rk-riff.md: only line 30 modified (line 29/31 byte-identical) | Line 30 is a standalone sentence; rewrite fits on one line without wrap-over. New assumption at spec level | S:75 R:80 A:80 D:85 |
+
+12 assumptions (7 certain, 5 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260417-aaon-fix-riff-copilot-feedback/tasks.md
+++ b/fab/changes/260417-aaon-fix-riff-copilot-feedback/tasks.md
@@ -1,0 +1,56 @@
+# Tasks: Fix rk riff Copilot Review Feedback
+
+**Change**: 260417-aaon-fix-riff-copilot-feedback
+**Spec**: `spec.md`
+**Intake**: `intake.md`
+
+<!--
+  All 5 edits are localized, independent, and low-risk. Phase 2 tasks are all [P] —
+  they touch different files (or different functions within riff.go) and have no
+  ordering dependency. Phase 3 runs the verification gates. No setup phase
+  (no dependencies or scaffolding), no polish phase (no docs/readme to write).
+-->
+
+## Phase 2: Core Edits
+
+- [x] T001 [P] Fix `escapeSingleQuotes` doc comment in `app/backend/cmd/rk/riff.go:263-265` — replace the garbled first line (which contains a curly closing quote `'\”` U+201D) with an ASCII-only description. Name the 4-character `'\''` sequence literally and briefly explain the close-escape-reopen trick. Preserve the function body byte-for-byte; only comment lines change. Final comment MUST contain no characters in U+2018–U+201F. (Spec: "Doc Comment Accurately Describes the Escape Encoding")
+
+- [x] T002 [P] Fix `parseWorktreePath` doc comment in `app/backend/cmd/rk/riff.go:198-200` — remove the phrase "Exported for direct testing" (and any similar export-claim phrasing). Replace with text that states the real rationale: the parsing logic is factored into its own function so `riff_test.go` can assert the parsing rules directly, without staging a full `wt` invocation. The function identifier `parseWorktreePath` MUST remain lowercase (not renamed/exported). (Spec: "Comment Reflects Real Visibility and Rationale")
+
+- [x] T003 [P] Remove the unused `wantSuffix` field from the anonymous struct in `TestResolveLauncher` in `app/backend/cmd/rk/riff_test.go:101-108`. Specifically: delete line 106 (`wantSuffix string // allow OS path normalization where relevant`). Do not modify any case literals — none populate `wantSuffix`. After the edit, the struct's field list is exactly: `name`, `setup`, `withChdir`, `want`. Verify with `grep -c 'wantSuffix' riff_test.go` → 0. (Spec: "Struct Field `wantSuffix` Removed")
+
+- [x] T004 [P] Fix the `subsitutions` typo in `fab/changes/260416-r1j6-add-riff-command/spec.md:328` → change to `substitutions` (insert `t` between `i` and `u`). Change exactly one character on that line; do not touch any other content in the file. Do NOT modify that change folder's `.status.yaml`. Verify with `grep -c 'subsitutions' spec.md` → 0. (Spec: "`subsitutions` → `substitutions`")
+
+- [x] T005 [P] Rewrite line 30 of `docs/memory/run-kit/rk-riff.md` — replace the incorrect `cmd.Args` claim with a description of how forwarded args reach `RunE` via the `args []string` parameter. Proposed wording (from intake): `Cobra's `SetInterspersed(false)` is called in `init()` so the `--` terminator routes passthrough args straight through to `RunE`'s `args []string` parameter unmolested (rather than being mis-parsed as flags for `rk riff`). No other user-facing flags exist.` Preserve lines 29 and 31 byte-identical. Also re-grep the whole file for any additional `cmd.Args` references — spec confirmed none at spec-gen time, but re-verify at apply time and fix any that surface. (Spec: "Correct Description of Forwarded-Arg Handling" + "Memory Accuracy Preserved Across Sections")
+
+## Phase 3: Verification Gates
+
+- [x] T006 Run `grep -n 'wantSuffix' app/backend/cmd/rk/riff_test.go` and confirm zero hits. Run `grep -n 'subsitutions' fab/changes/260416-r1j6-add-riff-command/spec.md` and confirm zero hits. Run `grep -n 'cmd\.Args' docs/memory/run-kit/rk-riff.md` and confirm zero hits. Run `grep -n 'Exported for' app/backend/cmd/rk/riff.go` and confirm zero hits (the old misleading comment must be gone). Any non-zero result fails the task. (Spec: scenarios "Field is absent after the edit", "Typo fixed in place", "File audit confirms no other `cmd.Args` misuses", "No false export claim")
+
+- [x] T007 Run `grep -n '[\x{2018}-\x{201F}]' app/backend/cmd/rk/riff.go` (or ripgrep with `[\u2018-\u201F]`) to confirm no Unicode General Punctuation quote characters remain in the file. Zero hits = pass. (Spec: scenario "Minimum grammar fix present" — curly-quote absence)
+
+- [x] T008 Run `cd app/backend && go vet ./cmd/rk/...` — exit 0, no diagnostics. Then `go build ./...` from `app/backend/` — exit 0. (Spec: "Code-Quality Gates Still Clean")
+
+- [x] T009 Run `cd app/backend && go test ./cmd/rk/...` — all pre-existing subtests pass (`TestParseWorktreePath`, `TestEscapeSingleQuotes`, `TestResolveLauncher`, `TestResolveLauncher_ReadsFromSubdir`, `TestFabconfigIntegration`). Belt-and-suspenders: also run `go test ./internal/fabconfig/...` — expect pass with zero changes (no file in that package touched). (Spec: "No New Tests Required, No Existing Tests Broken")
+
+- [x] T010 Confirm the r1j6 pipeline status is preserved: `diff <(git show HEAD:fab/changes/260416-r1j6-add-riff-command/.status.yaml) fab/changes/260416-r1j6-add-riff-command/.status.yaml` → empty diff. (Spec: scenario "r1j6 pipeline status is preserved")
+
+---
+
+## Execution Order
+
+All Phase 2 tasks (T001-T005) are independent and MAY execute in parallel — each touches a different file (or a different function within `riff.go` for T001 vs T002). Phase 3 verification tasks (T006-T010) MUST run after all Phase 2 edits are applied. Within Phase 3, T006-T007 (grep checks) MAY run in parallel; T008 and T009 are sequential on the Go toolchain but independent of each other; T010 is independent.
+
+**Minimum successful path**: apply T001-T005 → run T006-T010 → all green. If T001-T005 are done serially, total apply time is <5 min; verification <2 min.
+
+## Edit Scope Summary
+
+| Task | File | Change Type | LOC Impact |
+|------|------|-------------|------------|
+| T001 | `app/backend/cmd/rk/riff.go:263-265` | Comment rewrite | ~3-5 lines |
+| T002 | `app/backend/cmd/rk/riff.go:198-200` | Comment rewrite | ~3-4 lines |
+| T003 | `app/backend/cmd/rk/riff_test.go:106` | Field deletion | 1 line removed |
+| T004 | `fab/changes/260416-r1j6-add-riff-command/spec.md:328` | 1-char typo fix | 1 char changed |
+| T005 | `docs/memory/run-kit/rk-riff.md:30` | Sentence rewrite | 1 line |
+
+Total: ~10-15 lines of diff across 4 files. Zero behavior change. Zero new tests. Zero deleted tests.


### PR DESCRIPTION
## Summary
Addresses 5 Copilot review comments left on PR #146 (merged) for the `rk riff` command. All low-severity: 4 doc/typo fixes, 1 unused test-struct field. No behavior change.

## Changes
- `app/backend/cmd/rk/riff.go`: fix garbled `escapeSingleQuotes` doc comment (curly quote → correct `'\''` description); replace misleading "Exported for direct testing" claim on `parseWorktreePath` (function is package-private)
- `app/backend/cmd/rk/riff_test.go`: remove unused `wantSuffix` field from `TestResolveLauncher` test-case struct
- `docs/memory/run-kit/rk-riff.md`: correct `cmd.Args` → `RunE`'s `args []string` parameter for cobra arg plumbing description
- `fab/changes/260416-r1j6-add-riff-command/spec.md`: typo `subsitutions` → `substitutions`

## Test plan
- [x] `go test ./app/backend/cmd/rk/...` passes
- [x] `go test ./app/backend/internal/fabconfig/...` passes
- [x] `go vet ./app/backend/cmd/rk/...` clean
- [x] `go build ./...` clean
- [x] No curly-quote characters in `riff.go` (grep confirmed)
- [x] Zero runtime behavior change — diff is comments/struct-field-only