### PR TITLE
fix: Always invoke fab pane map for sidebar fab/agt enrichment

### DIFF
--- a/app/backend/internal/sessions/sessions.go
+++ b/app/backend/internal/sessions/sessions.go
@@ -35,10 +35,12 @@ type paneMapEntry struct {
 }
 
 // fetchPaneMap runs `fab pane map --json --all-sessions` via the fab router on
-// PATH and returns a lookup map keyed by "session:windowIndex". The subprocess
-// runs with cmd.Dir = repoRoot so the router can resolve the project's
-// fab_version from fab/project/config.yaml. Returns nil map and an error on
-// failure.
+// PATH and returns a lookup map keyed by "session:windowIndex". When repoRoot
+// is non-empty, cmd.Dir is set to it so the router can resolve the project's
+// fab_version from fab/project/config.yaml; otherwise the subprocess inherits
+// the server's CWD, which is fine because --all-sessions output is repo-
+// independent and the router tolerates running outside a fab project. Returns
+// nil map and an error on failure.
 func fetchPaneMap(repoRoot string) (map[string]paneMapEntry, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -337,8 +339,9 @@ func FetchSessions(ctx context.Context, server string) ([]ProjectSession, error)
 		}
 	}
 
-	// Fetch pane-map once for all sessions. On error, paneMap is nil
-	// and all windows get empty fab fields (graceful degradation).
+	// Fetch pane-map once for all sessions. If refreshing the cache fails,
+	// fetchPaneMapCached may return a stale cached paneMap; if no data is
+	// available, windows keep empty fab fields (graceful degradation).
 	paneMap, _ := fetchPaneMapCached(repoRoot)
 
 	// Collect all pane cwds for git branch resolution.

--- a/app/backend/internal/sessions/sessions.go
+++ b/app/backend/internal/sessions/sessions.go
@@ -44,7 +44,9 @@ func fetchPaneMap(repoRoot string) (map[string]paneMapEntry, error) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "fab", "pane", "map", "--json", "--all-sessions")
-	cmd.Dir = repoRoot
+	if repoRoot != "" {
+		cmd.Dir = repoRoot
+	}
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
@@ -337,10 +339,7 @@ func FetchSessions(ctx context.Context, server string) ([]ProjectSession, error)
 
 	// Fetch pane-map once for all sessions. On error, paneMap is nil
 	// and all windows get empty fab fields (graceful degradation).
-	var paneMap map[string]paneMapEntry
-	if repoRoot != "" {
-		paneMap, _ = fetchPaneMapCached(repoRoot)
-	}
+	paneMap, _ := fetchPaneMapCached(repoRoot)
 
 	// Collect all pane cwds for git branch resolution.
 	var allCwds []string


### PR DESCRIPTION
## Summary

The sidebar Pane Panel's **fab** and **agt** lines were silently hidden whenever none of the active tmux sessions happened to live under a directory containing `fab/project/config.yaml`. This was a regression-by-design: a stale gate from when the fab CLI refused to run outside a fab repo.

## Changes

- `app/backend/internal/sessions/sessions.go`
  - Drop the `if repoRoot != ""` guard in `FetchSessions`, so `fab pane map --json --all-sessions` is always invoked — the CLI now handles the no-fab-project case on its own.
  - In `fetchPaneMap`, only set `cmd.Dir = repoRoot` when non-empty (keeps fab's version-dispatch hint working when a project is present, otherwise inherits the server's cwd).

## Why this matters

`fab pane map --all-sessions` is session-scoped, not repo-scoped — there is no reason to skip it just because the first window's cwd isn't inside a fab project. The gate caused user-visible enrichment (change ID, stage, agent state, idle duration) to silently disappear for entire classes of sessions.

## Stats

| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| fix | — | — | — | — |

## Test plan

- [ ] Start `rk serve` with tmux sessions whose cwds are **outside** any fab project — confirm the sidebar now shows "fab" and "agt" lines for those sessions
- [ ] Start `rk serve` with at least one session cwd inside a fab project — confirm existing enrichment still works and version dispatch still picks up the project's pinned fab version
- [ ] `just test-backend` — confirm no new test regressions beyond the pre-existing `TestFetchPaneMapIntegration` environment failure (fails on `main` too — unrelated)