### PR TITLE
refactor: Brighten sidebar row tints and thicken selected-row accent

### DIFF
--- a/app/frontend/src/components/sidebar/window-row.tsx
+++ b/app/frontend/src/components/sidebar/window-row.tsx
@@ -81,14 +81,14 @@ export function WindowRow({
     }
     // Always reserve left border space to prevent text shift between states
     style.borderLeft = isSelected
-      ? `3px solid ${borderColor ?? "var(--color-accent)"}`
-      : "3px solid transparent";
+      ? `8px solid ${borderColor ?? "var(--color-accent)"}`
+      : "8px solid transparent";
     return Object.keys(style).length > 0 ? style : undefined;
   }, [tint, isSelected, borderColor]);
 
   // Build className for the button
   const buttonClass = useMemo(() => {
-    const base = "w-full text-left flex items-center justify-between gap-2 py-1 pl-2 pr-11 text-sm transition-colors min-h-[36px] rounded-l-lg rounded-r-none";
+    const base = "w-full text-left flex items-center justify-between gap-2 py-1 pl-2 pr-11 text-sm transition-colors min-h-[36px]";
     if (isSelected) {
       // Colored selected: inline bg via buttonStyle. Uncolored selected: bg-accent/15.
       return `${base} ${tint ? "" : "bg-accent/15 "}text-text-primary font-medium`;

--- a/app/frontend/src/themes.ts
+++ b/app/frontend/src/themes.ts
@@ -158,14 +158,14 @@ export const PICKER_ANSI_INDICES = [1, 2, 3, 4, 5, 6, 8] as const;
 
 /** Pre-blended row tint colors for a single ANSI index at three states. */
 export type RowTint = {
-  base: string;     // 7% ANSI into background
-  hover: string;    // 11% ANSI into background
-  selected: string; // 16% ANSI into background
+  base: string;     // 14% ANSI into background
+  hover: string;    // 22% ANSI into background
+  selected: string; // 32% ANSI into background
 };
 
 /**
  * Pre-compute blended hex values for all picker ANSI indices.
- * Single axis: blend ratio increases with interaction depth (7% → 11% → 16%).
+ * Single axis: blend ratio increases with interaction depth (14% → 22% → 32%).
  */
 export function computeRowTints(palette: ThemePalette): Map<number, RowTint> {
   const bg = palette.background;
@@ -174,9 +174,9 @@ export function computeRowTints(palette: ThemePalette): Map<number, RowTint> {
   for (const idx of PICKER_ANSI_INDICES) {
     const fg = palette.ansi[idx];
     tints.set(idx, {
-      base: blendHex(fg, bg, 0.07),
-      hover: blendHex(fg, bg, 0.11),
-      selected: blendHex(fg, bg, 0.16),
+      base: blendHex(fg, bg, 0.14),
+      hover: blendHex(fg, bg, 0.22),
+      selected: blendHex(fg, bg, 0.32),
     });
   }
 


### PR DESCRIPTION
## Summary

Bumps the ANSI row-tint blend ratios in the sidebar for better visual separation, and thickens / squares-off the selected window row's left accent to read as a crisper terminal-style marker.

Row tint blend ratios (base / hover / selected):
- **Before:** 7% / 11% / 16%
- **After:** 14% / 22% / 32%

Selected window row accent:
- **Before:** 3px `border-left` on a `rounded-l-lg` button — the rounded corners pinched the border into a crescent/pill shape.
- **After:** 8px `border-left` on a flat, rectangular row — flush vertical rule, no corner curving.

The swatch color picker auto-picks up the tint changes (it calls `computeRowTints`), so each swatch's rest/selected preview is consistent with the new brightness levels.

## Stats

| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| refactor | — | — | — | — |