### PR TITLE
docs: Require .spec.md companion for every Playwright spec

### DIFF
--- a/fab/project/constitution.md
+++ b/fab/project/constitution.md
@@ -31,6 +31,9 @@ Justfile recipes MUST be one-liners that delegate to `scripts/`. Logic, loops, a
 ### Test Integrity
 Tests MUST conform to the implementation spec — never the other way around. When tests fail, the fix SHALL either (a) update the tests to match the spec, or (b) update the implementation to match the spec. Modifying implementation code solely to accommodate test fixtures or test infrastructure is prohibited. Specs are the source of truth; tests verify conformance to specs.
 
+### Test Companion Docs (`.spec.md`)
+Every Playwright spec file (`*.spec.ts` under `app/frontend/tests/`) MUST ship with a sibling `*.spec.md` documenting, for each `test()` in the file: (a) **what it proves** — the user-visible behavior under test, in one or two sentences, and (b) **steps** — a numbered list mirroring the test body so a reviewer can reason about intent without reading Playwright APIs. Any shared setup (`beforeAll`, fixtures, viewport) goes in a Shared setup section. The companion file is part of the test definition: PRs that add or modify a `.spec.ts` SHALL update the matching `.spec.md` in the same commit. Unit tests (`*.test.ts`/`*.test.tsx`, `*_test.go`) are exempt — their scope is narrow enough that the test name plus code is self-documenting.
+
 ### Process Execution
 All `exec.CommandContext` calls MUST use a context with timeout (default 5-10 seconds for tmux operations, 30 seconds for build operations). Zombie processes from hung tmux commands MUST NOT block the server.
 
@@ -39,4 +42,4 @@ The restart mechanism uses tmux-based kill-and-restart: `run-kit serve --restart
 
 ## Governance
 
-**Version**: 1.1.0 | **Ratified**: 2026-03-02 | **Last Amended**: 2026-03-13
+**Version**: 1.2.0 | **Ratified**: 2026-03-02 | **Last Amended**: 2026-04-17


### PR DESCRIPTION
## Summary

PR #154 introduced `.spec.md` companion docs for every Playwright spec. This PR codifies that convention in the project constitution so it stays a requirement for future contributions, not just a one-off.

## Changes

- Added **Test Companion Docs (`.spec.md`)** clause under *Additional Constraints* in `fab/project/constitution.md`.
- Bumped constitution to `1.2.0`, amended `2026-04-17`.

## The policy (verbatim)

> Every Playwright spec file (`*.spec.ts` under `app/frontend/tests/`) MUST ship with a sibling `*.spec.md` documenting, for each `test()` in the file: (a) **what it proves** — the user-visible behavior under test, in one or two sentences, and (b) **steps** — a numbered list mirroring the test body so a reviewer can reason about intent without reading Playwright APIs. Any shared setup (`beforeAll`, fixtures, viewport) goes in a Shared setup section. The companion file is part of the test definition: PRs that add or modify a `.spec.ts` SHALL update the matching `.spec.md` in the same commit. Unit tests (`*.test.ts`/`*.test.tsx`, `*_test.go`) are exempt — their scope is narrow enough that the test name plus code is self-documenting.

Scope deliberately narrows to Playwright e2e specs — unit tests (`*.test.ts`, `*_test.go`) stay exempt because the test body is self-documenting at that scale.

## Test plan

- [x] Diff reviewed — single-file doc change, no code impact
- [ ] Reviewer: confirm the scope boundary (Playwright `*.spec.ts` only, unit tests exempt) matches your intent