### PR TITLE
refactor: Sidebar row selection and color treatment

### DIFF
--- a/app/frontend/src/components/sidebar.test.tsx
+++ b/app/frontend/src/components/sidebar.test.tsx
@@ -172,7 +172,8 @@ describe("Sidebar", () => {
     renderSidebar();
     // First "main" is in the tree row
     const mainBtn = screen.getAllByText("main")[0].closest("button");
-    expect(mainBtn?.className).toContain("bg-accent/15");
+    expect(mainBtn?.getAttribute("aria-current")).toBe("page");
+    expect(mainBtn?.className).toContain("font-medium");
   });
 
   it("calls onSelectWindow when clicking a window", () => {

--- a/app/frontend/src/components/sidebar/window-row.tsx
+++ b/app/frontend/src/components/sidebar/window-row.tsx
@@ -3,7 +3,7 @@ import { isGhostWindow } from "@/contexts/optimistic-context";
 import { getWindowDuration } from "@/lib/format";
 import type { ProjectSession } from "@/types";
 import type { MergedSession } from "@/contexts/optimistic-context";
-import type { RowTint } from "@/themes";
+import { UNCOLORED_SELECTED_ANSI, type RowTint } from "@/themes";
 import { SwatchPopover } from "@/components/swatch-popover";
 
 type ProjectWindow = ProjectSession["windows"][number];
@@ -69,29 +69,41 @@ export function WindowRow({
     return rowTints.get(color) ?? null;
   }, [color, rowTints]);
 
+  // Uncolored rows borrow the gray tint only in the selected state.
+  const uncoloredSelectedTint = useMemo(() => {
+    if (color != null || !rowTints || !isSelected) return null;
+    return rowTints.get(UNCOLORED_SELECTED_ANSI) ?? null;
+  }, [color, rowTints, isSelected]);
+
   // Full-saturation ANSI color for the left border on selected rows.
-  // Colored rows use their ANSI color; uncolored rows use the theme accent.
-  const borderColor = color != null && ansiPalette ? ansiPalette[color] : undefined;
+  const borderColor = useMemo(() => {
+    if (!ansiPalette) return undefined;
+    if (color != null) return ansiPalette[color];
+    if (isSelected) return ansiPalette[UNCOLORED_SELECTED_ANSI];
+    return undefined;
+  }, [color, ansiPalette, isSelected]);
 
   // Compute inline style for the button (background + left accent border)
   const buttonStyle = useMemo(() => {
     const style: React.CSSProperties = {};
     if (tint) {
       style.backgroundColor = isSelected ? tint.selected : tint.base;
+    } else if (uncoloredSelectedTint) {
+      style.backgroundColor = uncoloredSelectedTint.selected;
     }
-    // Always reserve left border space to prevent text shift between states
+    // Always reserve left border space to prevent text shift between states.
     style.borderLeft = isSelected
       ? `8px solid ${borderColor ?? "var(--color-accent)"}`
       : "8px solid transparent";
     return Object.keys(style).length > 0 ? style : undefined;
-  }, [tint, isSelected, borderColor]);
+  }, [tint, uncoloredSelectedTint, isSelected, borderColor]);
 
   // Build className for the button
   const buttonClass = useMemo(() => {
     const base = "w-full text-left flex items-center justify-between gap-2 py-1 pl-2 pr-11 text-sm transition-colors min-h-[36px]";
     if (isSelected) {
-      // Colored selected: inline bg via buttonStyle. Uncolored selected: bg-accent/15.
-      return `${base} ${tint ? "" : "bg-accent/15 "}text-text-primary font-medium`;
+      // Colored selected uses tint.selected; uncolored selected borrows gray tint — both via buttonStyle.
+      return `${base} text-text-primary font-medium`;
     }
     if (tint) {
       // Colored non-selected: inline bg via buttonStyle, hover via JS

--- a/app/frontend/src/components/swatch-popover.test.tsx
+++ b/app/frontend/src/components/swatch-popover.test.tsx
@@ -33,14 +33,14 @@ describe("SwatchPopover", () => {
     vi.unstubAllGlobals();
   });
 
-  it("renders 7 color swatches", () => {
+  it("renders 6 color swatches", () => {
     const onSelect = vi.fn();
     const onClose = vi.fn();
     renderWithTheme(<SwatchPopover onSelect={onSelect} onClose={onClose} />);
 
     const options = screen.getAllByRole("option");
-    // 7 color swatches + 1 Clear button
-    expect(options).toHaveLength(8);
+    // 6 color swatches + 1 Clear button
+    expect(options).toHaveLength(7);
   });
 
   it("shows checkmark on selected color", () => {
@@ -90,16 +90,13 @@ describe("SwatchPopover", () => {
     expect(onClose).toHaveBeenCalledOnce();
   });
 
-  it("excludes ANSI indices 0, 7, 9-15 (except 8)", () => {
+  it("excludes ANSI indices 0, 7, 8, 9-15", () => {
     expect(PICKER_ANSI_INDICES).not.toContain(0);
     expect(PICKER_ANSI_INDICES).not.toContain(7);
+    expect(PICKER_ANSI_INDICES).not.toContain(8);
     for (let i = 9; i <= 15; i++) {
       expect(PICKER_ANSI_INDICES).not.toContain(i);
     }
-    expect(PICKER_ANSI_INDICES).toHaveLength(7);
-  });
-
-  it("includes ANSI index 8 (bright black)", () => {
-    expect(PICKER_ANSI_INDICES).toContain(8);
+    expect(PICKER_ANSI_INDICES).toHaveLength(6);
   });
 });

--- a/app/frontend/src/components/swatch-popover.tsx
+++ b/app/frontend/src/components/swatch-popover.tsx
@@ -88,7 +88,7 @@ export function SwatchPopover({ selectedColor, onSelect, onClose }: SwatchPopove
       onKeyDown={handleKeyDown}
       className="bg-bg-primary border border-border rounded-md shadow-lg p-1.5 z-50 w-max"
     >
-      <div className="grid grid-cols-7 gap-1">
+      <div className="grid grid-cols-3 gap-1">
         {PICKER_ANSI_INDICES.map((idx, i) => {
           const tint = rowTints.get(idx);
           const baseColor = tint?.base ?? theme.palette.ansi[idx];

--- a/app/frontend/src/themes.test.ts
+++ b/app/frontend/src/themes.test.ts
@@ -119,7 +119,7 @@ describe("deriveUIColors", () => {
     const ui = deriveUIColors(dracula.palette, "dark");
     expect(ui.bgPrimary).toBe("#282a36");
     expect(ui.textPrimary).toBe("#f8f8f2");
-    expect(ui.textSecondary).toBe("#6272a4"); // ansi[8]
+    expect(ui.textSecondary).toBe("#8f9abb"); // foreground blended 30% into ansi[8]
     expect(ui.accent).toBe("#bd93f9"); // ansi[4]
     expect(ui.accentGreen).toBe("#50fa7b"); // ansi[2]
   });

--- a/app/frontend/src/themes.ts
+++ b/app/frontend/src/themes.ts
@@ -151,10 +151,14 @@ export function deriveXtermTheme(palette: ThemePalette) {
 // ── Row tint computation ────────────────────────────────────────────────────
 
 /** ANSI palette indices available in the color picker.
- *  7 colors: the 6 standard hues (red, green, yellow, blue, magenta, cyan) + gray.
- *  Excludes 0 (black), 7 (white), 15 (bright white), and all bright variants
- *  (9-14) which are near-identical to normal at low blend ratios. */
-export const PICKER_ANSI_INDICES = [1, 2, 3, 4, 5, 6, 8] as const;
+ *  6 colors: the standard hues (red, green, yellow, blue, magenta, cyan).
+ *  Excludes 0 (black), 7 (white), 8 (gray — reused internally for uncolored
+ *  selected rows), 15 (bright white), and all bright variants (9-14) which
+ *  are near-identical to normal at low blend ratios. */
+export const PICKER_ANSI_INDICES = [1, 2, 3, 4, 5, 6] as const;
+
+/** ANSI index used to render uncolored rows in the selected state. */
+export const UNCOLORED_SELECTED_ANSI = 8;
 
 /** Pre-blended row tint colors for a single ANSI index at three states. */
 export type RowTint = {
@@ -171,7 +175,9 @@ export function computeRowTints(palette: ThemePalette): Map<number, RowTint> {
   const bg = palette.background;
   const tints = new Map<number, RowTint>();
 
-  for (const idx of PICKER_ANSI_INDICES) {
+  // Picker colors plus gray (ANSI 8), which backs the uncolored-selected state.
+  const indices = [...PICKER_ANSI_INDICES, UNCOLORED_SELECTED_ANSI];
+  for (const idx of indices) {
     const fg = palette.ansi[idx];
     tints.set(idx, {
       base: blendHex(fg, bg, 0.14),

--- a/app/frontend/src/themes.ts
+++ b/app/frontend/src/themes.ts
@@ -103,6 +103,48 @@ export function blendHex(fg: string, bg: string, ratio: number): string {
   });
 }
 
+function rgbToHsl(rgb: RGB): { h: number; s: number; l: number } {
+  const r = rgb.r / 255, g = rgb.g / 255, b = rgb.b / 255;
+  const max = Math.max(r, g, b), min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  if (max === min) return { h: 0, s: 0, l };
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  let h = 0;
+  if (max === r) h = (g - b) / d + (g < b ? 6 : 0);
+  else if (max === g) h = (b - r) / d + 2;
+  else h = (r - g) / d + 4;
+  return { h: h * 60, s, l };
+}
+
+function hslToRgb(hsl: { h: number; s: number; l: number }): RGB {
+  const { h, s, l } = hsl;
+  if (s === 0) return { r: l * 255, g: l * 255, b: l * 255 };
+  const hue2rgb = (p: number, q: number, t: number) => {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+  };
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+  const hh = h / 360;
+  return {
+    r: hue2rgb(p, q, hh + 1 / 3) * 255,
+    g: hue2rgb(p, q, hh) * 255,
+    b: hue2rgb(p, q, hh - 1 / 3) * 255,
+  };
+}
+
+/** Multiply the HSL saturation of a hex color by a factor, clamped to [0, 1]. */
+export function saturateHex(hex: string, factor: number): string {
+  const hsl = rgbToHsl(hexToRgb(hex));
+  hsl.s = Math.max(0, Math.min(1, hsl.s * factor));
+  return rgbToHex(hslToRgb(hsl));
+}
+
 // ── Derivation functions ─────────────────────────────────────────────────────
 
 /** Derive the 8 UI CSS colors from a full theme palette. */
@@ -113,7 +155,7 @@ export function deriveUIColors(palette: ThemePalette, category: "dark" | "light"
     bgCard: isDark ? lightenHex(palette.background, 8) : darkenHex(palette.background, 3),
     bgInset: isDark ? darkenHex(palette.background, 5) : darkenHex(palette.background, 6),
     textPrimary: palette.foreground,
-    textSecondary: palette.ansi[8],
+    textSecondary: blendHex(palette.foreground, palette.ansi[8], 0.3),
     border: blendHex(palette.foreground, palette.background, 0.25),
     accent: palette.ansi[4],
     accentGreen: palette.ansi[2],
@@ -162,27 +204,32 @@ export const UNCOLORED_SELECTED_ANSI = 8;
 
 /** Pre-blended row tint colors for a single ANSI index at three states. */
 export type RowTint = {
-  base: string;     // 14% ANSI into background
-  hover: string;    // 22% ANSI into background
-  selected: string; // 32% ANSI into background
+  base: string;     // 14% saturated-ANSI into background
+  hover: string;    // 22% saturated-ANSI into background
+  selected: string; // 32% saturated-ANSI into background
 };
 
 /**
  * Pre-compute blended hex values for all picker ANSI indices.
- * Single axis: blend ratio increases with interaction depth (14% → 22% → 32%).
+ * The ANSI hue is saturated (×1.5) before blending so row tints read as their
+ * intended color rather than grayish, while blend ratios stay muted.
+ * Gray (ANSI 8) is not saturated (near-zero saturation by definition) and uses
+ * a 0.5 selected ratio so uncolored selected rows beat the bg-card/50 hover.
  */
 export function computeRowTints(palette: ThemePalette): Map<number, RowTint> {
   const bg = palette.background;
   const tints = new Map<number, RowTint>();
 
-  // Picker colors plus gray (ANSI 8), which backs the uncolored-selected state.
   const indices = [...PICKER_ANSI_INDICES, UNCOLORED_SELECTED_ANSI];
   for (const idx of indices) {
-    const fg = palette.ansi[idx];
+    const fg = idx === UNCOLORED_SELECTED_ANSI
+      ? palette.ansi[idx]
+      : saturateHex(palette.ansi[idx], 1.5);
+    const selectedRatio = idx === UNCOLORED_SELECTED_ANSI ? 0.5 : 0.32;
     tints.set(idx, {
       base: blendHex(fg, bg, 0.14),
       hover: blendHex(fg, bg, 0.22),
-      selected: blendHex(fg, bg, 0.32),
+      selected: blendHex(fg, bg, selectedRatio),
     });
   }
 


### PR DESCRIPTION
## Summary
- **Uncolored selected rows** now borrow the gray (ANSI 8) tint for both background and left edge, replacing the dim `bg-accent/15` treatment. The gray tint's selected blend is bumped to 0.5 so uncolored selected rows always read brighter than the `bg-card/50` hover state, regardless of theme palette.
- **Gray is removed from the color picker** since it visually collapsed with the new uncolored-selected treatment. Swatch grid reflows from 7x1 to 3x2. Existing windows stored with `color=8` keep rendering as-is; they just can't be re-picked.
- **Secondary text is brighter**: `textSecondary` is now `blendHex(foreground, ansi[8], 0.3)` so dim text stays readable in palettes where `ansi[8]` sits too close to the background.
- **Row tints are more saturated**: ANSI hues are saturation-boosted (x1.5) via HSL before blending, so colored rows read as their intended color rather than grayish. Blend ratios (14/22/32) are unchanged — only hue punch goes up.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec vitest run` - 418 tests pass
- [ ] Visually confirm uncolored selected row is clearly brighter than hovered unselected across themes
- [ ] Visually confirm colored rows read as their color (blue looks blue, not gray-blue)
- [ ] Visually confirm dim text (timestamps, panel labels) is readable in previously-problematic themes
- [ ] Swatch popover shows 6 colors in a 3x2 grid plus Clear; keyboard nav still traverses all 6