### PR TITLE
fix: Tighten ServerPanel default/min height to 56px

### DIFF
--- a/app/frontend/src/components/sidebar/server-panel.tsx
+++ b/app/frontend/src/components/sidebar/server-panel.tsx
@@ -112,8 +112,8 @@ export function ServerPanel({
       tint={activeTint}
       tintOnlyWhenCollapsed
       resizable
-      defaultHeight={60}
-      minHeight={60}
+      defaultHeight={56}
+      minHeight={56}
       mobileHeight={56}
     >
       {servers.length === 0 ? (


### PR DESCRIPTION
## Summary

- `defaultHeight` and `minHeight` on `ServerPanel` drop from 60 → 56px.
- 60px left a visible 4px gap below a single-row tile grid at rest; 56px fits one row exactly.
- Mobile layout already uses 56px (`mobileHeight={56}`), so desktop and mobile single-row heights are now consistent.

## Test plan
- [ ] Load the sidebar; Tmux panel at rest shows one row with no trailing empty space below the tiles.
- [ ] Drag the resize handle down — can't shrink below one row.
- [ ] Drag up — grows normally to show additional rows.