### PR TITLE
fix: ServerPanel resize — drag lag + tighten min height to 56px

### DIFF
--- a/app/frontend/src/components/sidebar/collapsible-panel.tsx
+++ b/app/frontend/src/components/sidebar/collapsible-panel.tsx
@@ -188,6 +188,9 @@ export function CollapsiblePanel({
       dragStateRef.current = null;
       document.removeEventListener("pointermove", onPointerMove);
       document.removeEventListener("pointerup", onPointerUp);
+      // Restore the CSS transition (suppressed during drag to prevent the 150ms
+      // height animation from chasing each pointermove — see onHandlePointerDown).
+      contentRef.current.style.transition = "";
       setHeight(final);
       writePersistedHeight(heightStorageKey, final);
     },
@@ -202,6 +205,9 @@ export function CollapsiblePanel({
         startY: e.clientY,
         startHeight: contentRef.current.getBoundingClientRect().height,
       };
+      // Disable the height transition during drag so direct style mutations
+      // in onPointerMove snap immediately instead of animating toward each value.
+      contentRef.current.style.transition = "none";
       document.addEventListener("pointermove", onPointerMove);
       document.addEventListener("pointerup", onPointerUp);
     },

--- a/app/frontend/src/components/sidebar/server-panel.tsx
+++ b/app/frontend/src/components/sidebar/server-panel.tsx
@@ -112,8 +112,8 @@ export function ServerPanel({
       tint={activeTint}
       tintOnlyWhenCollapsed
       resizable
-      defaultHeight={60}
-      minHeight={60}
+      defaultHeight={56}
+      minHeight={56}
       mobileHeight={56}
     >
       {servers.length === 0 ? (


### PR DESCRIPTION
## Summary

Two small fixes to the ServerPanel resize behavior:

- **Drag lag (~200ms)**: `CollapsiblePanel`'s content div has a 150ms height transition for the open/close animation. That same transition was active during drag-resize, so every \`pointermove\` mutation kicked off a fresh animation toward the latest height — the panel perpetually chased the cursor through an ease-in-out curve. Fixed by imperatively suppressing \`style.transition\` on pointer down and restoring it on pointer up. The collapse animation still works; drag now snaps 1:1.
- **Min height**: tightened \`defaultHeight\` and \`minHeight\` to 56px so the panel can collapse to exactly one tile row.

## Test plan

- [ ] \`just test-frontend\` (441 unit tests pass locally)
- [ ] Drag the resize handle between the server panel and sessions panel — verify no perceptible lag, panel tracks cursor directly
- [ ] Open/close the panel via the chevron — verify the 150ms collapse animation still works
- [ ] Resize down to the minimum — verify it stops at 56px (one tile row)