### PR TITLE
fix: isolate metrics context to stop whole-tree re-renders on SSE tick

### DIFF
--- a/app/frontend/src/app.tsx
+++ b/app/frontend/src/app.tsx
@@ -121,7 +121,7 @@ function ServerNotFound({ serverName }: { serverName: string }) {
 function AppShell() {
   useVisualViewport();
 
-  const { sessions: rawSessions, isConnected, server, servers, refreshServers, metrics } = useSessionContext();
+  const { sessions: rawSessions, isConnected, server, servers, refreshServers } = useSessionContext();
   const sessions = useMergedSessions(rawSessions, server);
   const { sidebarOpen, drawerOpen, fixedWidth } = useChromeState();
   const { setCurrentSession, setCurrentWindow, setDrawerOpen, setSidebarOpen, toggleFixedWidth } = useChromeDispatch();
@@ -890,7 +890,6 @@ function AppShell() {
                 onCreateServer={() => setShowCreateServerDialog(true)}
                 onKillServer={(name) => setKillServerTarget(name)}
                 onRefreshServers={refreshServers}
-                metrics={metrics}
                 isConnected={isConnected}
               />
             </div>
@@ -991,7 +990,6 @@ function AppShell() {
                 onCreateServer={() => setShowCreateServerDialog(true)}
                 onKillServer={(name) => setKillServerTarget(name)}
                 onRefreshServers={refreshServers}
-                metrics={metrics}
                 isConnected={isConnected}
               />
             </div>

--- a/app/frontend/src/components/sidebar.test.tsx
+++ b/app/frontend/src/components/sidebar.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { render, screen, fireEvent, cleanup, act, within } from "@testing-library/react";
 import { Sidebar } from "./sidebar";
 import { OptimisticProvider, useOptimisticContext } from "@/contexts/optimistic-context";
+import { MetricsProvider } from "@/contexts/session-context";
 import { ThemeProvider } from "@/contexts/theme-context";
 import { ToastProvider } from "@/components/toast";
 import { useWindowStore } from "@/store/window-store";
@@ -104,21 +105,23 @@ function renderSidebar(overrides: Partial<React.ComponentProps<typeof Sidebar>> 
     <ThemeProvider>
     <ToastProvider>
       <OptimisticProvider>
-        <Sidebar
-          sessions={sessions}
-          currentSession="run-kit"
-          currentWindowIndex="0"
-          onSelectWindow={vi.fn()}
-          onCreateWindow={vi.fn()}
-          onCreateSession={vi.fn()}
-          server="runkit"
-          servers={[{ name: "runkit", sessionCount: 0 }]}
-          onSwitchServer={vi.fn()}
-          onCreateServer={vi.fn()}
-          onKillServer={vi.fn()}
-          onRefreshServers={vi.fn()}
-          {...overrides}
-        />
+        <MetricsProvider value={null}>
+          <Sidebar
+            sessions={sessions}
+            currentSession="run-kit"
+            currentWindowIndex="0"
+            onSelectWindow={vi.fn()}
+            onCreateWindow={vi.fn()}
+            onCreateSession={vi.fn()}
+            server="runkit"
+            servers={[{ name: "runkit", sessionCount: 0 }]}
+            onSwitchServer={vi.fn()}
+            onCreateServer={vi.fn()}
+            onKillServer={vi.fn()}
+            onRefreshServers={vi.fn()}
+            {...overrides}
+          />
+        </MetricsProvider>
       </OptimisticProvider>
     </ToastProvider>
     </ThemeProvider>,
@@ -814,21 +817,23 @@ describe("Sidebar", () => {
         <ThemeProvider>
         <ToastProvider>
           <OptimisticProvider>
-            <KilledCountDisplay />
-            <Sidebar
-              sessions={sessions}
-              currentSession="run-kit"
-              currentWindowIndex="0"
-              onSelectWindow={vi.fn()}
-              onCreateWindow={vi.fn()}
-              onCreateSession={vi.fn()}
-              server="runkit"
-              servers={[{ name: "runkit", sessionCount: 0 }]}
-              onSwitchServer={vi.fn()}
-              onCreateServer={vi.fn()}
-              onKillServer={vi.fn()}
-              onRefreshServers={vi.fn()}
-            />
+            <MetricsProvider value={null}>
+              <KilledCountDisplay />
+              <Sidebar
+                sessions={sessions}
+                currentSession="run-kit"
+                currentWindowIndex="0"
+                onSelectWindow={vi.fn()}
+                onCreateWindow={vi.fn()}
+                onCreateSession={vi.fn()}
+                server="runkit"
+                servers={[{ name: "runkit", sessionCount: 0 }]}
+                onSwitchServer={vi.fn()}
+                onCreateServer={vi.fn()}
+                onKillServer={vi.fn()}
+                onRefreshServers={vi.fn()}
+              />
+            </MetricsProvider>
           </OptimisticProvider>
         </ToastProvider>
         </ThemeProvider>,

--- a/app/frontend/src/components/sidebar/host-panel.tsx
+++ b/app/frontend/src/components/sidebar/host-panel.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { CollapsiblePanel } from "./collapsible-panel";
 import { sparkline } from "@/lib/sparkline";
 import { gaugeBar, gaugeColor, formatMemory } from "@/lib/gauge";
-import type { MetricsSnapshot } from "@/types";
+import { useMetrics } from "@/contexts/session-context";
 
 /** Format uptime seconds as "Nd Nh" or "Nh Nm" if < 1 day. */
 function formatUptime(secs: number): string {
@@ -24,11 +24,11 @@ function formatDisk(used: number, total: number): string {
 }
 
 type HostPanelProps = {
-  metrics: MetricsSnapshot | null;
   isConnected: boolean;
 };
 
-export function HostPanel({ metrics, isConnected }: HostPanelProps) {
+export function HostPanel({ isConnected }: HostPanelProps) {
+  const metrics = useMetrics();
   const hostnameHeader = metrics ? (
     <>
       <span className="truncate text-text-primary font-mono">{metrics.hostname}</span>

--- a/app/frontend/src/components/sidebar/index.tsx
+++ b/app/frontend/src/components/sidebar/index.tsx
@@ -6,7 +6,7 @@ import { useOptimisticContext } from "@/contexts/optimistic-context";
 import { useToast } from "@/components/toast";
 import { useTheme } from "@/contexts/theme-context";
 import { computeRowTints } from "@/themes";
-import type { MetricsSnapshot, ProjectSession } from "@/types";
+import type { ProjectSession } from "@/types";
 import { isGhostWindow } from "@/contexts/optimistic-context";
 import type { MergedSession } from "@/contexts/optimistic-context";
 import { useWindowStore } from "@/store/window-store";
@@ -30,7 +30,6 @@ export type SidebarProps = {
   onCreateServer: () => void;
   onKillServer: (name: string) => void;
   onRefreshServers: () => void;
-  metrics?: MetricsSnapshot | null;
   isConnected?: boolean;
 };
 
@@ -47,7 +46,6 @@ export function Sidebar({
   onCreateServer,
   onKillServer,
   onRefreshServers,
-  metrics = null,
   isConnected = false,
 }: SidebarProps) {
   // Pre-compute row tints from the active theme palette.
@@ -679,7 +677,7 @@ export function Sidebar({
 
       {/* Collapsible panels — pinned at bottom */}
       <WindowPanel window={selectedWindow} nowSeconds={nowSeconds} />
-      <HostPanel metrics={metrics} isConnected={isConnected} />
+      <HostPanel isConnected={isConnected} />
 
       {/* Kill confirmation */}
       {killTarget && (

--- a/app/frontend/src/contexts/session-context.tsx
+++ b/app/frontend/src/contexts/session-context.tsx
@@ -11,10 +11,13 @@ type SessionContextType = {
   server: string;
   servers: ServerInfo[];
   refreshServers: () => void;
-  metrics: MetricsSnapshot | null;
 };
 
 const SessionContext = createContext<SessionContextType | null>(null);
+
+// Metrics live in a separate context so that the ~2.5s metrics stream does not
+// cascade re-renders through the whole app tree — only HostPanel subscribes.
+const MetricsContext = createContext<MetricsSnapshot | null>(null);
 
 type SessionProviderProps = {
   children: React.ReactNode;
@@ -127,13 +130,15 @@ export function SessionProvider({ children, server }: SessionProviderProps) {
   }, [setChromeConnected, server]);
 
   const value = useMemo(
-    () => ({ sessions, isConnected, server, servers, refreshServers: fetchServers, metrics }),
-    [sessions, isConnected, server, servers, fetchServers, metrics],
+    () => ({ sessions, isConnected, server, servers, refreshServers: fetchServers }),
+    [sessions, isConnected, server, servers, fetchServers],
   );
 
   return (
     <SessionContext.Provider value={value}>
-      {children}
+      <MetricsContext.Provider value={metrics}>
+        {children}
+      </MetricsContext.Provider>
     </SessionContext.Provider>
   );
 }
@@ -142,4 +147,8 @@ export function useSessionContext(): SessionContextType {
   const ctx = useContext(SessionContext);
   if (!ctx) throw new Error("useSessionContext must be used within SessionProvider");
   return ctx;
+}
+
+export function useMetrics(): MetricsSnapshot | null {
+  return useContext(MetricsContext);
 }

--- a/app/frontend/src/contexts/session-context.tsx
+++ b/app/frontend/src/contexts/session-context.tsx
@@ -17,7 +17,9 @@ const SessionContext = createContext<SessionContextType | null>(null);
 
 // Metrics live in a separate context so that the ~2.5s metrics stream does not
 // cascade re-renders through the whole app tree — only HostPanel subscribes.
-const MetricsContext = createContext<MetricsSnapshot | null>(null);
+// The default sentinel is `undefined` so `useMetrics()` can distinguish
+// "outside provider" (throw) from the valid "no metrics yet" state (`null`).
+const MetricsContext = createContext<MetricsSnapshot | null | undefined>(undefined);
 
 type SessionProviderProps = {
   children: React.ReactNode;
@@ -150,5 +152,20 @@ export function useSessionContext(): SessionContextType {
 }
 
 export function useMetrics(): MetricsSnapshot | null {
-  return useContext(MetricsContext);
+  const ctx = useContext(MetricsContext);
+  if (ctx === undefined) throw new Error("useMetrics must be used within SessionProvider");
+  return ctx;
+}
+
+// Standalone provider for tests and storybook — supplies a `null` or fake
+// metrics value without requiring the full SessionProvider (which opens an
+// EventSource).
+export function MetricsProvider({
+  value,
+  children,
+}: {
+  value: MetricsSnapshot | null;
+  children: React.ReactNode;
+}) {
+  return <MetricsContext.Provider value={value}>{children}</MetricsContext.Provider>;
 }


### PR DESCRIPTION
## Summary
The backend SSE stream broadcasts host metrics every ~2.5s. `metrics` lived in `SessionContext` alongside `sessions`/`server`/etc., so every tick changed the context value and re-rendered every `useSessionContext` consumer — including `AppShell`, which cascades through the Sidebar, ServerPanel tile grid, Host/Window panels, and the xterm wrapper. With no `React.memo` anywhere in the frontend, the whole tree rebuilt every 2.5s, pausing the main thread enough to make keystrokes and scroll feel sluggish. Regression introduced in #135 (Sidebar Host & Window Panels with metrics).

## Changes
- Added a `MetricsContext` + `useMetrics()` hook in `session-context.tsx`. `SessionProvider` still owns the single EventSource; it nests the two providers so only `HostPanel` re-renders on metrics ticks.
- Removed `metrics` from `SessionContextType` and dropped the destructure in `AppShell`.
- Dropped the `metrics` prop from `SidebarProps` (both `<Sidebar>` call sites in `app.tsx`).
- `HostPanel` now consumes `useMetrics()` directly instead of receiving metrics as a prop.

## Stats
| Type | Confidence | Checklist | Tasks | Review |
|------|-----------|-----------|-------|--------|
| fix | — | — | — | — |

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` — all 457 unit tests pass (29 files)
- [x] Manual verification in `just dev`: typing and scroll feel noticeably snappier (confirmed locally)
- [ ] Spot-check that the Host panel still updates every ~2.5s and the SSE connection indicator still toggles correctly