### PR TITLE
Draft three intakes for rk riff rework

### DIFF
--- a/fab/changes/260423-ba9f-rk-riff-correctness-fixes/.history.jsonl
+++ b/fab/changes/260423-ba9f-rk-riff-correctness-fixes/.history.jsonl
@@ -1,0 +1,4 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-04-23T02:18:42Z"}
+{"args":"rk riff: correctness and portability fixes (bugs 1,3,8,9,10,11)","cmd":"fab-new","event":"command","ts":"2026-04-23T02:18:42Z"}
+{"delta":"+1.2","event":"confidence","score":1.2,"trigger":"calc-score","ts":"2026-04-23T02:20:17Z"}
+{"delta":"+0.0","event":"confidence","score":1.2,"trigger":"calc-score","ts":"2026-04-23T02:20:31Z"}

--- a/fab/changes/260423-ba9f-rk-riff-correctness-fixes/.status.yaml
+++ b/fab/changes/260423-ba9f-rk-riff-correctness-fixes/.status.yaml
@@ -1,0 +1,37 @@
+id: ba9f
+name: 260423-ba9f-rk-riff-correctness-fixes
+created: 2026-04-23T02:18:42Z
+created_by: sahil-weaver
+change_type: fix
+issues: []
+progress:
+    intake: ready
+    spec: pending
+    tasks: pending
+    apply: pending
+    review: pending
+    hydrate: pending
+    ship: pending
+    review-pr: pending
+checklist:
+    generated: false
+    path: checklist.md
+    completed: 0
+    total: 0
+confidence:
+    certain: 2
+    confident: 6
+    tentative: 2
+    unresolved: 0
+    score: 1.2
+    indicative: true
+    fuzzy: true
+    dimensions:
+        signal: 75.0
+        reversibility: 79.0
+        competence: 78.0
+        disambiguation: 76.5
+stage_metrics:
+    intake: {started_at: "2026-04-23T02:18:42Z", driver: fab-new, iterations: 1}
+prs: []
+last_updated: 2026-04-23T02:20:34Z

--- a/fab/changes/260423-ba9f-rk-riff-correctness-fixes/intake.md
+++ b/fab/changes/260423-ba9f-rk-riff-correctness-fixes/intake.md
@@ -1,0 +1,233 @@
+# Intake: rk riff — Correctness and Portability Fixes
+
+**Change**: 260423-ba9f-rk-riff-correctness-fixes
+**Created**: 2026-04-23
+**Status**: Draft
+
+## Origin
+
+This change was identified during a multi-angle evaluation of `rk riff` where three subagents reviewed the command from bug, DX, and feature angles. The user picked a subset of findings and asked for a grouping plan across 2–3 changes. We agreed on a three-change split organized by risk/reversibility:
+
+1. **This change** — correctness and portability fixes that do not alter the CLI surface.
+2. A later change for CLI surface refinement (flag renames, default policy, help text, and the `/fab-discuss` delivery fix).
+3. A later change for workflow features (presets, fab-change bridge, `--fan-out`).
+
+The split keeps mechanical fixes in one reviewable PR, isolates the surface-breaking change to a second PR, and leaves features additive on a stable surface. This change is intentionally the "boring" one — no new flags, no renames, no user-visible behavior changes beyond "the pane no longer dies on launcher exit."
+
+Items covered here (per the prior triage):
+
+- **Bug 1** — `--cmd` pane has no shell wrapper, dies on launcher exit (`runTmuxNewWindow`).
+- **Bug 3** — Launcher runs under non-interactive `sh -c`, so `.zshrc` aliases/functions don't load.
+- **Bug 8** — `exec zsh` hardcoded in `--split`, breaks bash/fish users.
+- **Bug 9** — `agent.spawn_command` shell-injection surface needs explicit documentation (no code change).
+- **Bug 10** — No SIGINT handling; Ctrl-C during `wt create` hang leaves zombies.
+- **Bug 11** — Window-name collision on `riff-<basename>` is silent; produces duplicate names.
+
+Explicitly deferred to the CLI-surface change:
+
+- **Bug 2** — `/fab-discuss` is passed as a positional argv to `claude`, not typed into the REPL. The fix may require `tmux send-keys` which IS a surface change, so it ships with the flag-rename/help-text change.
+
+## Why
+
+Five of the six items are unrelated mechanical correctness fixes. Bundling them is purely for review efficiency — each one in isolation would be a trivial PR with high ceremony overhead. Bundling them is safe because none of them change the CLI contract.
+
+**The stakes per item:**
+
+- **Bug 1 (pane death)**: the current behavior — Claude exits, pane disappears — is hostile. After a Claude session the user expects to drop back into a shell in the worktree (same as `--split` already provides). Today they either lose the window or have to squint at `[exited]` depending on tmux's `remain-on-exit` setting.
+- **Bug 3 (non-interactive shell)**: users who have `claude` aliased, or have PATH tweaks that only run in interactive shells, silently don't get them. This is the class of bug that makes `rk riff` "works for me, breaks on my teammate's machine."
+- **Bug 8 (`exec zsh`)**: portability papercut. Trivial to fix.
+- **Bug 9 (trust boundary doc)**: security posture hygiene. The spec should name the trust boundary explicitly so a future reviewer doesn't flag it as an oversight.
+- **Bug 10 (SIGINT)**: Ctrl-C during a hung `wt create` currently leaves the `wt` process running after rk exits. Low-probability, but the fix is a one-liner.
+- **Bug 11 (name collision)**: silent dupes in `tmux list-windows` make it impossible to tell two riffs apart. Users resort to visual inspection of pane content.
+
+None of these are sharp-edge user-blocking bugs today, but they compound: a user whose first riff's pane died, whose second riff collided with the first's window name, and whose Ctrl-C didn't work, quickly loses confidence in the tool.
+
+**Why not fix one at a time:** each fix touches `riff.go` in a small, orthogonal way. Bundling avoids five separate PR cycles and one rebase per fix. The tests are additive — one new test per bug fix plus a refactor of `TestBuildNewWindowArgs` to account for the shell wrap.
+
+## What Changes
+
+### 1. Shell-wrap the `--cmd` pane so it survives launcher exit
+
+**Current** (`app/backend/cmd/rk/riff.go:225-229`):
+
+```go
+func buildNewWindowArgs(worktreePath, launcher, cmdArg string) []string {
+    windowName := "riff-" + filepath.Base(worktreePath)
+    shellCmd := fmt.Sprintf("%s '%s'", launcher, escapeSingleQuotes(cmdArg))
+    return []string{"new-window", "-n", windowName, "-c", worktreePath, shellCmd}
+}
+```
+
+The `shellCmd` runs directly; when `claude` exits, the pane dies (tmux default behavior) or shows `[exited]` (if `remain-on-exit` is on).
+
+**Target** — mirror the `--split` pattern with a shared helper:
+
+```go
+// shellWrap returns a shell command string that runs cmd and then re-execs
+// the user's shell so the pane stays interactive after cmd exits. $SHELL is
+// expanded by tmux's shell at window-creation time.
+func shellWrap(cmd string) string {
+    return fmt.Sprintf(`%s; exec "${SHELL:-/bin/sh}"`, cmd)
+}
+
+func buildNewWindowArgs(worktreePath, launcher, cmdArg string) []string {
+    windowName := "riff-" + filepath.Base(worktreePath)
+    shellCmd := shellWrap(fmt.Sprintf("%s '%s'", launcher, escapeSingleQuotes(cmdArg)))
+    return []string{"new-window", "-n", windowName, "-c", worktreePath, shellCmd}
+}
+```
+
+`runTmuxSplitWindow` uses the same helper: `shellCmd := shellWrap(setupCmd)`.
+
+### 2. Decide whether to wrap the launcher in an *interactive* shell (Bug 3)
+
+**[NEEDS CLARIFICATION]** — two options, user must pick one:
+
+**Option A (recommended)**: wrap the launcher invocation itself in `$SHELL -i -c` so that `.zshrc`/`.bashrc` aliases, functions, and PATH additions are available to the launcher:
+
+```go
+// shellCmd before wrapping:
+shellCmd := fmt.Sprintf(`%s -i -c %s`, shellBin(), singleQuote(launcherWithArg))
+// then wrap with shellWrap to keep the pane alive:
+return shellWrap(shellCmd)
+```
+
+Risks:
+- `.zshrc` side effects (powerlevel10k instant-prompt warnings, heavy init) run twice — once for the launcher, once for the post-exit shell.
+- Interactive rc files that assume a tty might print warnings or behave oddly when invoked via `-i -c`.
+
+**Option B (conservative)**: leave non-interactive, document the limitation in `rk-riff.md`. Users who need aliases can set `agent.spawn_command` to include explicit PATH / absolute binary path.
+
+Default recommendation in this intake: Option A with an escape hatch — if a future config key like `agent.shell_mode: non-interactive` is ever needed it can be added then. Don't add it preemptively.
+
+### 3. Replace hardcoded `exec zsh` with `exec "${SHELL:-/bin/sh}"`
+
+**Current** (`app/backend/cmd/rk/riff.go:258`):
+
+```go
+shellCmd := fmt.Sprintf("%s; exec zsh", setupCmd)
+```
+
+**Target** — use the `shellWrap` helper from (1):
+
+```go
+shellCmd := shellWrap(setupCmd)
+```
+
+`shellWrap` already handles the `${SHELL:-/bin/sh}` expansion, so this is a natural unification with (1).
+
+### 4. SIGINT handling on `runRiff`
+
+**Current** (`app/backend/cmd/rk/riff.go:102-137`): `runRiff` uses `cmd.Context()` from Cobra, which has no signal handler. Ctrl-C during any of the three child processes (`wt create`, `tmux new-window`, `tmux split-window`) terminates rk but leaves the child process running (rk reparents to init).
+
+**Target** — wrap the context once, at the top of `runRiff`:
+
+```go
+func runRiff(cmd *cobra.Command, args []string) error {
+    ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+    defer stop()
+
+    // ... propagate ctx to all three CommandContext calls instead of cmd.Context()
+}
+```
+
+All three `exec.CommandContext` call sites (`runWtCreate`, `runTmuxNewWindow`, `runTmuxSplitWindow`) need their `parent context.Context` argument swapped from `cmd.Context()` to the wrapped context. This is a mechanical change.
+
+### 5. Window-name collision auto-suffix
+
+**Current** (`app/backend/cmd/rk/riff.go:226`): `windowName := "riff-" + filepath.Base(worktreePath)`. If a window with this name exists, tmux silently creates a duplicate (or errors if the user has `set-option -g allow-rename off` — uncommon).
+
+**Target** — before constructing the new-window argv, query existing window names and auto-suffix:
+
+```go
+func resolveWindowName(ctx context.Context, base string) (string, error) {
+    existing, err := listWindowNames(ctx) // tmux list-windows -F '#W'
+    if err != nil {
+        return "", subprocessErr("rk riff: tmux list-windows failed: %v", err)
+    }
+    name := base
+    taken := map[string]bool{}
+    for _, n := range existing {
+        taken[n] = true
+    }
+    for i := 2; taken[name]; i++ {
+        name = fmt.Sprintf("%s-%d", base, i)
+    }
+    return name, nil
+}
+```
+
+`buildNewWindowArgs` now takes the resolved name instead of deriving it from the path. The name derivation split (basename → resolved) is still pure and testable.
+
+**Edge cases to handle in the spec:**
+
+- `tmux list-windows` fails (tmux server died between precondition check and window creation) → bubble as subprocess error.
+- `tmux list-windows` output empty → no collision, proceed with base name.
+- Race between list and new-window (another process creates `riff-foo` in the gap): low-probability, acceptable — worst case is a duplicate, which is the current behavior.
+
+### 6. Document the `agent.spawn_command` trust boundary
+
+Add a section to `docs/memory/run-kit/rk-riff.md` titled **Security / Trust Boundary**:
+
+```markdown
+## Security / Trust Boundary
+
+`fabconfig.ReadSpawnCommand` returns the `agent.spawn_command` value from
+`fab/project/config.yaml` **unescaped and verbatim**. It is then concatenated
+into a shell command string that tmux's shell executes. This means:
+
+- `fab/project/config.yaml` is a trust boundary equivalent to committed code.
+  A hostile or careless edit can execute arbitrary shell.
+- `escapeSingleQuotes` ONLY protects `--cmd`. It does not protect the launcher.
+- Shell expansion in the launcher (e.g., `claude -n "$(basename "$(pwd)")"`)
+  is **intentional**; this is the documented exception to the constitution's
+  argv-only rule (§I Security First).
+- Users who consume third-party repos SHOULD audit `fab/project/config.yaml`
+  before running `rk riff` against them, the same way they would audit a
+  `justfile` or `Makefile`.
+```
+
+No code change. This is purely making the implicit-safe-because-we-trust-the-repo posture explicit in the spec.
+
+## Affected Memory
+
+- `run-kit/rk-riff.md`: (modify) — update workflow-step-order to document shell-wrap helper for new-window pane; update `--split` section to note `$SHELL` expansion; add Security / Trust Boundary section; add SIGINT and window-name-suffix behaviors; update the Changelog with this change's entry.
+
+## Impact
+
+**Code:**
+- `app/backend/cmd/rk/riff.go` — majority of changes. New `shellWrap` helper, updated `buildNewWindowArgs` signature, new `resolveWindowName` + `listWindowNames` helpers, `signal.NotifyContext` wrap in `runRiff`, context propagation through subprocess calls.
+- `app/backend/cmd/rk/riff_test.go` — update `TestBuildNewWindowArgs` cases to assert the shell-wrap suffix; add `TestShellWrap`; add `TestResolveWindowName` (pure function over a stub window-list).
+
+**Docs:**
+- `docs/memory/run-kit/rk-riff.md` — sections called out above.
+
+**APIs/flags**: none. The CLI surface is unchanged.
+
+**Dependencies**: no new packages. `os/signal`, `syscall`, `context` are all stdlib and already in use adjacent to this code.
+
+**Ship order inside this change:** the fixes are mostly independent but the `shellWrap` helper factoring should land first so (1), (2), (3) all reuse it.
+
+## Open Questions
+
+- Interactive vs non-interactive shell wrap for the launcher (Bug 3 — see §2 above). **Must resolve before spec finalization.** Default recommendation: interactive.
+- `resolveWindowName` — query `tmux list-windows` up front (explicit, one extra tmux call) or catch tmux's duplicate-name error retroactively (fewer calls but surfaces a race)? Recommendation: query up front; the extra call is ~5ms and the logic is easier to reason about.
+- Do we test the SIGINT behavior? A unit test here requires forking a hanging child; probably out of scope. Manual verification via `rk doctor`-style smoke test is enough. Recommendation: skip automated SIGINT test; note the manual check in the spec.
+- Should `shellWrap` use `${SHELL:-/bin/sh}` (POSIX safe, works everywhere) or `$SHELL` (simpler, fails if `$SHELL` is unset which is rare)? Recommendation: the `${SHELL:-/bin/sh}` form.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Bundle five mechanical fixes + one doc-only fix in a single change, defer Bug 2 to the CLI-surface change | User-specified in the grouping plan — explicit directive | S:95 R:70 A:80 D:90 |
+| 2 | Certain | Factor a shared `shellWrap` helper used by both `runTmuxNewWindow` and `runTmuxSplitWindow` | Simple DRY; both paths now need identical "exec $SHELL" suffix | S:90 R:85 A:90 D:95 |
+| 3 | Confident | Use `${SHELL:-/bin/sh}` form over bare `$SHELL` | POSIX-safe fallback with zero downside; matches conservative stdlib patterns elsewhere in rk | S:70 R:90 A:85 D:80 |
+| 4 | Confident | Auto-suffix `-2`, `-3`, … on window-name collision rather than erroring or reusing | User explicitly preferred auto-suffix in the plan discussion (non-destructive, cheapest option) | S:80 R:75 A:75 D:70 |
+| 5 | Confident | Query `tmux list-windows` up front to detect collisions | More explicit than catching tmux's duplicate-name error; one extra fast call; reasoning-simpler | S:70 R:80 A:80 D:70 |
+| 6 | Confident | Wrap `runRiff`'s root context once via `signal.NotifyContext`, propagate to all three subprocess calls | Simpler than per-subprocess wrapping; matches stdlib idiom for CLI tools | S:75 R:85 A:85 D:85 |
+| 7 | Confident | Skip automated SIGINT test — verify manually | Unit-testing signal handling here requires forking a hung child; ROI is low, other bug fixes have clean unit tests | S:60 R:85 A:70 D:80 |
+| 8 | Confident | Add Security / Trust Boundary section to `rk-riff.md` as the Bug 9 "fix" — no code change | User-approved in the triage — explicit documentation of the existing design rather than new mitigation | S:85 R:90 A:85 D:85 |
+| 9 | Tentative | Use option A (`$SHELL -i -c`) over option B (non-interactive) for Bug 3 | Recommended default in the intake pending user confirmation; reversible via a config flag later if rc-file side effects bite | S:55 R:55 A:55 D:45 |
+| 10 | Tentative | Keep the existing `exitCodeError` discipline unchanged in this change | Promoting to a shared `internal/cliexit` helper was flagged as a DX concern but belongs in a follow-up change, not this one | S:70 R:75 A:75 D:65 |
+
+10 assumptions (2 certain, 6 confident, 2 tentative, 0 unresolved).

--- a/fab/changes/260423-jmwu-rk-riff-workflow-features/.history.jsonl
+++ b/fab/changes/260423-jmwu-rk-riff-workflow-features/.history.jsonl
@@ -1,0 +1,4 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-04-23T02:22:25Z"}
+{"args":"rk riff: workflow features (presets, fab-change bridge, fan-out)","cmd":"fab-new","event":"command","ts":"2026-04-23T02:22:25Z"}
+{"delta":"+0.0","event":"confidence","score":0,"trigger":"calc-score","ts":"2026-04-23T02:23:59Z"}
+{"delta":"+0.0","event":"confidence","score":0,"trigger":"calc-score","ts":"2026-04-23T02:24:03Z"}

--- a/fab/changes/260423-jmwu-rk-riff-workflow-features/.status.yaml
+++ b/fab/changes/260423-jmwu-rk-riff-workflow-features/.status.yaml
@@ -1,0 +1,37 @@
+id: jmwu
+name: 260423-jmwu-rk-riff-workflow-features
+created: 2026-04-23T02:22:25Z
+created_by: sahil-weaver
+change_type: feat
+issues: []
+progress:
+    intake: ready
+    spec: pending
+    tasks: pending
+    apply: pending
+    review: pending
+    hydrate: pending
+    ship: pending
+    review-pr: pending
+checklist:
+    generated: false
+    path: checklist.md
+    completed: 0
+    total: 0
+confidence:
+    certain: 2
+    confident: 9
+    tentative: 4
+    unresolved: 0
+    score: 0.0
+    indicative: true
+    fuzzy: true
+    dimensions:
+        signal: 73.0
+        reversibility: 71.3
+        competence: 76.3
+        disambiguation: 72.0
+stage_metrics:
+    intake: {started_at: "2026-04-23T02:22:25Z", driver: fab-new, iterations: 1}
+prs: []
+last_updated: 2026-04-23T02:24:03Z

--- a/fab/changes/260423-jmwu-rk-riff-workflow-features/intake.md
+++ b/fab/changes/260423-jmwu-rk-riff-workflow-features/intake.md
@@ -1,0 +1,182 @@
+# Intake: rk riff — Workflow Features
+
+**Change**: 260423-jmwu-rk-riff-workflow-features
+**Created**: 2026-04-23
+**Status**: Draft
+
+## Origin
+
+Third and final change in the `rk riff` rework. Changes 1 (correctness) and 2 (CLI surface) establish a stable foundation; this change adds the three workflow features the user starred during triage as compounding wins:
+
+1. **Feature 1 — fab-change bridge.** `rk riff --new-change "<desc>"` or `--change <id>` creates/attaches a fab change folder alongside the worktree and tmux window in one shot. Today the sequence is: user runs `rk riff`, then inside Claude runs `/fab-new` or `/fab-draft`. This inverts it so the change is created up front.
+2. **Feature 2 — Presets.** Named bundles of `--skill`/`--setup-pane`/`wt` flags in `fab/project/config.yaml` under `riff.presets.<name>`, invoked positionally: `rk riff investigate`, `rk riff ship`, `rk riff fff`. Turns riff from a flag-heavy one-off into a named-workflow launcher.
+3. **Feature 3 — `--fan-out N`.** Parallel riffs on the same task for the `fab-operator` multi-agent workflow. Spawns N worktrees + windows so the user can race or compare agents.
+
+These three were grouped because they compound: presets should reference the fab-change bridge (a preset can embed `--new-change "<desc>"`), and fan-out can consume a preset (`rk riff --fan-out 3 investigate`). Shipping them together avoids mid-feature churn.
+
+## Why
+
+Each feature on its own is valuable; together they move `rk riff` from "flag-heavy plumbing" to a composable workflow DSL. Concretely:
+
+- **Fab-change bridge** closes a manual-step gap. The user already creates a change for nearly every `rk riff` they spawn; automating it saves 30 seconds per invocation and avoids the "oh, I forgot to make a change" error case. It also makes worktree name → change folder name → branch name alignment automatic (all three derive from a single slug).
+- **Presets** encode team/user conventions declaratively. Instead of typing `rk riff --skill /fab-fff --setup-pane "just dev" -- --base main` every time, it's `rk riff ship`. Teams with more than one riff-shape benefit immediately. Presets are also the natural extension point for future features (e.g., a preset can one day include a `--layout` shape).
+- **`--fan-out N`** formalizes a workflow the user already does manually via `fab-operator`. Without it, fanning out is: run `rk riff` once per agent, type flags each time, remember to vary worktree names. With it, one command.
+
+Why now vs. later: the three features interlock. If presets ship without the fab-change bridge, they can't embed "create a change." If fan-out ships without presets, users lose the ergonomic win. And all three benefit from the stable flag names that change 2 settles — if we shipped features first, we'd rename `--cmd` after users have baked it into their preset YAML.
+
+## What Changes
+
+### 1. Fab-change bridge — `--new-change "<desc>"` and `--change <id>`
+
+Two new mutually-exclusive flags:
+
+| Flag | Arg | Behavior |
+|------|-----|----------|
+| `--new-change "<desc>"` | quoted description | Creates a new fab change via `fab change new --slug <slugified-desc> --log-args "<desc>"`, captures the resulting folder name, passes it to `wt create` as the branch name so `wt` uses the fab-change folder name as the branch. |
+| `--change <id>` | 4-char change ID or folder substring | Resolves to an existing change folder via `fab resolve --folder <id>`. Passes the resolved folder name to `wt create` as the branch name. If the change has an associated worktree already, errors unless `-- --reuse` is passed. |
+
+**Shell-out entry points:** use the `fab` CLI that's already installed (confirmed present — this project is fab-based). For `--new-change`, shell out to `fab change new --slug <slug> --log-args <desc>` and capture stdout (which is the folder name). For `--change`, shell out to `fab resolve --folder <arg>` and capture stdout.
+
+**[NEEDS CLARIFICATION]** whether the bridge also calls `/fab-draft` or `/fab-new` inside the spawned Claude session. Two options:
+
+- **(a)** Just create the folder on disk; the user runs `/fab-new` themselves inside the Claude session.
+- **(b)** Auto-prefill `--skill` with `/fab-new` and pass the description as an initial-prompt continuation (requires the send-keys delivery from change 2).
+
+Recommendation: (a) for simplicity. (b) can be layered via a preset once presets are available.
+
+**Slugification** for `--new-change`: mirror whatever `fab change new --slug` already normalizes (likely lowercase, kebab-case, drop articles). If the user's description contains more than ~6 words, truncate. Pure helper, test seam.
+
+**Example:**
+
+```
+rk riff --new-change "investigate flaky user-auth test" --skill /fab-discuss
+# → creates fab/changes/260423-xxxx-investigate-flaky-user-auth/
+# → creates worktree on branch 260423-xxxx-investigate-flaky-user-auth
+# → opens tmux window riff-260423-xxxx-investigate-flaky-user-auth (or truncated)
+# → launches claude /fab-discuss in that window
+```
+
+### 2. Presets in `fab/project/config.yaml`
+
+New config block under `riff.presets.<name>`:
+
+```yaml
+# fab/project/config.yaml
+riff:
+    presets:
+        investigate:
+            skill: /fab-discuss
+            setup_pane: ""
+            wt_args: ["--base", "main"]
+        ship:
+            skill: /fab-fff
+            setup_pane: "just dev"
+            wt_args: []
+        fff:
+            skill: /fab-fff
+            new_change_from_positional: true   # positional arg becomes --new-change value
+```
+
+**Invocation:** `rk riff <preset-name> [args...]`. The preset name is positional (before `--`). If the first positional argument matches a preset, it's consumed; remaining args are merged as follows:
+
+- Flags explicitly passed override preset values (`rk riff ship --skill /review` overrides preset skill).
+- `wt_args` from preset are prepended to `--` passthrough; user passthrough wins on conflict.
+- If preset sets `new_change_from_positional: true`, the next positional arg becomes the `--new-change` description: `rk riff fff "add oauth flow"`.
+
+**Resolution order** (effective flag values):
+
+1. Explicit `--skill` / `--setup-pane` / `--new-change` on the command line.
+2. Preset values (if a preset is invoked).
+3. `agent.default_skill` from config (introduced in change 2 if policy (c)).
+4. Built-in default (empty).
+
+**`internal/fabconfig` changes:** grow `ReadPresets(root string) map[string]Preset` alongside the existing `ReadSpawnCommand` / `ReadDefaultSkill`. Same best-effort-never-errors pattern.
+
+**Listing presets:** `rk riff --list-presets` prints the preset names and their resolved values. Nice-to-have; belongs in this change.
+
+**Conflict with fab-change bridge:** presets can themselves include `new_change_from_positional` or a literal `new_change: true` — the bridge triggers whether from preset or flag.
+
+### 3. `--fan-out N`
+
+Spawn N riffs in parallel.
+
+**[NEEDS CLARIFICATION]** semantics — must resolve before spec:
+
+- **Window vs pane layout:** N separate windows (each `riff-<name>-i`), or one window with N panes tiled? Recommendation: N separate windows. Consistent with the "one worktree = one window" mental model.
+- **Worktree naming:** auto-suffix `-1`, `-2`, …, `-N`? Or use `wt create` N times and let `wt` assign names, then rename? Recommendation: auto-suffix from a base (derived from the slug or preset name), so all N have an obvious relationship.
+- **Same `--skill` for all, or different?** Recommendation: same skill for all (that's the fan-out model — same task, different agents). If users want different skills, they run `rk riff` N times manually.
+- **Parallel vs sequential `wt create`?** 30s timeout × N serialized = slow. Recommendation: parallel via goroutines; aggregate errors. If any `wt create` fails, clean up the successful ones (match the partial-failure rollback behavior discussed for the correctness change — but this change doesn't depend on that since it's its own code path).
+
+**Interaction with `--new-change`:** when fanning out a new change, all N worktrees share the same fab change (one change folder, N worktrees/branches on top). The branches are named `<change-folder>-1`, `<change-folder>-2`, etc. [NEEDS CLARIFICATION] — alternatively, each gets its own change folder. Recommendation: one change, N branches (simpler; matches the "compare agents on the same task" use case).
+
+**Example:**
+
+```
+rk riff --fan-out 3 --new-change "try oauth approaches" --skill /fab-fff
+# creates one change folder
+# creates 3 worktrees on 3 branches
+# opens 3 tmux windows
+# launches /fab-fff in all 3
+```
+
+### 4. Wire presets → `--list-presets`
+
+Add a flag `--list-presets` (boolean) that prints the resolved preset names and their values, then exits 0. Useful for discoverability; avoids the "what presets does this project have?" question.
+
+## Affected Memory
+
+- `run-kit/rk-riff.md`: (modify) — new sections for fab-change bridge, presets config format, `--fan-out`, updated flag table, Workflow Step Order updates for each path, Changelog entry.
+- `run-kit/tmux-sessions.md`: (modify) — document the N-window fan-out layout if it affects how sessions enumerate riff-prefixed windows.
+
+No new memory files needed; everything lives under the existing `rk-riff.md`.
+
+## Impact
+
+**Code:**
+- `app/backend/cmd/rk/riff.go` — three new code paths (fab bridge, preset resolution, fan-out). Likely grows enough that a helper extraction is warranted — specifically: extract the "single riff" spawn sequence into `spawnRiff(ctx, opts) error` so `--fan-out` can call it N times in a goroutine pool.
+- `app/backend/cmd/rk/riff_test.go` — new tests for preset resolution, fan-out argv construction, slugification helper.
+- `app/backend/internal/fabconfig/fabconfig.go` — new `ReadPresets` + `Preset` struct.
+- `app/backend/internal/fabconfig/fabconfig_test.go` — preset parsing cases (empty, malformed, partial, shell-string wt_args).
+- `app/backend/cmd/rk/context.go` — if `rk context` output lists commands, keep it in sync.
+
+**Docs:** `docs/memory/run-kit/rk-riff.md` per §§ above.
+
+**APIs/flags**: additive — `--new-change`, `--change`, `--fan-out`, `--list-presets`, plus positional preset name. No removals. No rename of the base flags (those shipped in change 2).
+
+**Dependencies**: shell-out to `fab change new` and `fab resolve`. These are already assumed present in this project (it's a fab repo); `rk riff` SHOULD detect `fab` on PATH and fail gracefully if absent (same posture as the current `wt` check). [NEEDS CLARIFICATION] — do we add a `fab` precondition check, or only error when the user tries `--new-change` / `--change`? Recommendation: detect lazily (only when the fab bridge is invoked) so non-fab users are unaffected.
+
+**Ordering**: depends on change 2 landing first for stable flag names and (if policy (c)) the `agent.default_skill` config key.
+
+## Open Questions
+
+- **Fan-out layout:** N windows or one window with N panes? Rec: N windows.
+- **Fan-out worktree naming:** suffix `-1`..`-N` from a base, or delegate to `wt`? Rec: suffix from base.
+- **Fan-out change mapping:** one change / N branches, or N changes? Rec: one change / N branches.
+- **Parallel vs sequential `wt create` in fan-out:** parallel? Rec: parallel goroutines with aggregated errors.
+- **Fab-bridge delivery:** just create folder (rec a), or auto-run `/fab-new` inside Claude (b)?
+- **`fab` CLI precondition:** preflight check, or lazy detection? Rec: lazy.
+- **Preset schema:** is `riff.presets.<name>` the right location, or should it live under `agent.riff.presets`? Rec: top-level `riff.presets`, keeps the agent block focused on the spawn command.
+- **Positional preset arg vs `--preset <name>`:** positional is more ergonomic, but clashes with future positional uses. Rec: positional with a `--preset` alias for scripts.
+- **`--list-presets` format:** plain text, YAML echo, or `--json`? Rec: plain text by default, add `--json` if/when scripting need arrives.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Ship fab-change bridge, presets, and fan-out in one change; depends on changes 1 and 2 | User-specified three-change grouping; features interlock | S:95 R:65 A:85 D:90 |
+| 2 | Certain | Shell out to `fab change new` / `fab resolve` rather than reimplementing change management | Constitution §III: Wrap, Don't Reinvent | S:95 R:85 A:95 D:95 |
+| 3 | Confident | Preset config lives at `riff.presets.<name>` in `fab/project/config.yaml` | Namespaces cleanly away from `agent.*`; preserves the "riff is one feature of rk" framing | S:75 R:70 A:75 D:70 |
+| 4 | Confident | Presets are positional (`rk riff investigate`) with a `--preset` alias for scripts | Positional is ergonomic for CLI use; named flag for scripts and discoverability | S:70 R:65 A:75 D:65 |
+| 5 | Confident | Resolution order: explicit flags > preset > config default > built-in default | Standard precedence convention for CLI tools with presets | S:80 R:75 A:80 D:80 |
+| 6 | Confident | Extract a `spawnRiff(ctx, opts) error` helper so fan-out can call it N times | Avoids duplicating the full spawn sequence; clean test seam | S:80 R:85 A:85 D:85 |
+| 7 | Confident | Fan-out spawns N separate windows (not one window with N panes) | Matches "one worktree = one window" model; presets and tmux-sessions memory already assume this | S:75 R:70 A:70 D:70 |
+| 8 | Confident | Fan-out uses parallel goroutines for `wt create`, aggregates errors, cleans up successful ones on failure | 30s × N serial is too slow; parallel is the obvious stdlib pattern | S:70 R:75 A:80 D:75 |
+| 9 | Confident | `--new-change` slug is derived via the same rules `fab change new --slug` already applies | Avoids drift between fab and rk slugification | S:80 R:85 A:90 D:85 |
+| 10 | Confident | Detect `fab` on PATH lazily — only error when `--new-change` / `--change` is invoked | Non-fab users should be unaffected; follows the `wt` precondition pattern already in place | S:75 R:80 A:85 D:80 |
+| 11 | Tentative | Fab-bridge does NOT auto-run `/fab-new` inside Claude — it just creates the folder. User picks (a) over (b) | Simpler; (b) can be implemented as a preset later. Recommendation pending user confirmation | S:55 R:55 A:55 D:50 |
+| 12 | Tentative | Fan-out worktree naming: base + `-1`..`-N` suffix from the preset/change slug | Simple; keeps related worktrees adjacent in `wt list`. Alternative delegations to `wt` also work | S:55 R:55 A:60 D:50 |
+| 13 | Tentative | Fan-out change mapping: one fab change, N branches | Matches the "compare agents on the same task" use case. Alternative (N changes) is also defensible | S:55 R:50 A:60 D:50 |
+| 14 | Tentative | `--list-presets` emits plain text; add `--json` later only if scripting need emerges | YAGNI for structured output until a real consumer appears | S:60 R:85 A:75 D:65 |
+| 15 | Confident | No new positional arg besides the preset name and the optional `--new-change` description; everything else is flags | Keeps the command shape predictable and leaves room for future features | S:75 R:70 A:75 D:70 |
+
+15 assumptions (2 certain, 9 confident, 4 tentative, 0 unresolved).

--- a/fab/changes/260423-udhe-rk-riff-cli-surface/.history.jsonl
+++ b/fab/changes/260423-udhe-rk-riff-cli-surface/.history.jsonl
@@ -1,0 +1,4 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-04-23T02:20:39Z"}
+{"args":"rk riff: CLI surface refinement (bug 2 + DX 1,2,3,4)","cmd":"fab-new","event":"command","ts":"2026-04-23T02:20:39Z"}
+{"delta":"+0.0","event":"confidence","score":0,"trigger":"calc-score","ts":"2026-04-23T02:22:11Z"}
+{"delta":"+0.0","event":"confidence","score":0,"trigger":"calc-score","ts":"2026-04-23T02:22:16Z"}

--- a/fab/changes/260423-udhe-rk-riff-cli-surface/.status.yaml
+++ b/fab/changes/260423-udhe-rk-riff-cli-surface/.status.yaml
@@ -1,0 +1,37 @@
+id: udhe
+name: 260423-udhe-rk-riff-cli-surface
+created: 2026-04-23T02:20:39Z
+created_by: sahil-weaver
+change_type: refactor
+issues: []
+progress:
+    intake: ready
+    spec: pending
+    tasks: pending
+    apply: pending
+    review: pending
+    hydrate: pending
+    ship: pending
+    review-pr: pending
+checklist:
+    generated: false
+    path: checklist.md
+    completed: 0
+    total: 0
+confidence:
+    certain: 2
+    confident: 5
+    tentative: 3
+    unresolved: 1
+    score: 0.0
+    indicative: true
+    fuzzy: true
+    dimensions:
+        signal: 68.2
+        reversibility: 67.7
+        competence: 69.5
+        disambiguation: 68.2
+stage_metrics:
+    intake: {started_at: "2026-04-23T02:20:39Z", driver: fab-new, iterations: 1}
+prs: []
+last_updated: 2026-04-23T02:22:16Z

--- a/fab/changes/260423-udhe-rk-riff-cli-surface/intake.md
+++ b/fab/changes/260423-udhe-rk-riff-cli-surface/intake.md
@@ -1,0 +1,179 @@
+# Intake: rk riff — CLI Surface Refinement
+
+**Change**: 260423-udhe-rk-riff-cli-surface
+**Created**: 2026-04-23
+**Status**: Draft
+
+## Origin
+
+Second change in the three-change `rk riff` rework. The first change (`260423-ba9f-rk-riff-correctness-fixes`) handles mechanical bug fixes with no CLI surface impact. This change consolidates every CLI-visible refinement into one "break the surface once" PR before features land on top.
+
+Items covered (from the prior triage):
+
+- **Bug 2** — `/fab-discuss` passed as positional argv to `claude` rather than typed into the REPL; may require switching from the inline tmux-shell arg to `tmux send-keys`. Whether this is actually broken depends on current `claude` CLI behavior — must verify before designing the fix.
+- **DX 1** — Default `--cmd=/fab-discuss` is broken-by-default for users without fab-kit. Policy decision: fall back to empty when no fab config, or make the default itself configurable.
+- **DX 2** — `Long` help text mentions neither preconditions nor the default command nor launcher resolution; compare `serve.go:25-34` for house style.
+- **DX 3** — `Use: "riff [-- wt-flags...]"` hides `--cmd` and `--split` from the synopsis line.
+- **DX 4** — Flag names `--cmd` and `--split` are generic. Rename to more descriptive names (e.g., `--skill`, `--setup-pane`).
+
+Why these four belong together: any one of them alone is a CLI-surface change that breaks muscle memory and requires users to update scripts/aliases/docs. Bundling them into one break minimizes pain and lets users learn the new surface once.
+
+## Why
+
+The main user-impact argument: `rk riff` today leaks its author's private workflow through defaults, flag names, and silent rc-file assumptions. If rk is to be installed by anyone outside the author's immediate context, the surface needs to stop surprising strangers:
+
+- **Bug 2 is an unknown** — we do not currently know whether `claude ... /fab-discuss` as positional argv even invokes the slash command, or just drops into an empty REPL. If it's broken, the default has been silently useless since the feature landed. **Verification step is the first task.** If broken, the fix is likely `tmux new-window` (bare shell) + `tmux send-keys '<cmd>' Enter` after confirming the launcher has started.
+- **DX 1 (broken default)** — `/fab-discuss` assumes fab-kit is installed. A user who `brew install rk` and runs `rk riff` gets a Claude session that immediately hits an unknown slash-command. This is the single biggest onboarding landmine.
+- **DX 2 and 3 (help text)** — pure ergonomics; the help output should tell a new user what they need and how. Compare `serve.go:25-34` — it enumerates env vars and gives examples; riff's help is a two-line stub.
+- **DX 4 (flag names)** — a one-time rename is cheaper than living with confusing names forever. `--cmd` is especially bad (ambiguous: shell command? claude command? REPL input?). `--skill` is more honest (it's a Claude Code slash-command / skill).
+
+Why renaming once, here, and not later: once presets (change 3) reference flag names in config, renames get more expensive. Settle the surface now.
+
+## What Changes
+
+### 1. Verify and fix Bug 2 — `/fab-discuss` delivery mechanism
+
+**Verification-first:** before deciding the fix, run `claude --help` (or the equivalent for whatever binary `agent.spawn_command` resolves to) and confirm what happens when a slash-command is passed as a positional argv. Two possible outcomes:
+
+- **(a) Positional arg IS interpreted as initial prompt and fires the slash-command** — current behavior is correct, no fix needed for this bug. Mark it as investigated-and-ruled-out, update the spec's Changelog.
+- **(b) Positional arg is NOT interpreted, or is sent as literal prompt text with no slash-handling** — the current implementation is silently broken. Fix by changing delivery from "pass as argv" to "launch launcher, then send keys":
+
+  ```go
+  // NEW delivery path:
+  // 1. tmux new-window -n <name> -c <path> '<launcher>'   (no quoted cmd arg)
+  // 2. wait for the launcher to be ready (fixed short delay, e.g., 800ms — launcher
+  //    start time. Or poll tmux capture-pane output for a readiness marker.)
+  // 3. tmux send-keys -t <window> '<cmd>' Enter
+  ```
+
+  The send-keys approach handles any Claude Code command (skills, slash commands, arbitrary prompts) uniformly; the current approach only works if `claude` happens to interpret `argv[1]` as a prompt.
+
+**[NEEDS CLARIFICATION]** the verification result (a vs b) and, if (b), whether we use a fixed delay or poll `tmux capture-pane`. Default recommendation: fixed 800ms delay — it matches the typical launcher start time and is the simplest correct implementation.
+
+### 2. Rename `--cmd` → `--skill` and `--split` → `--setup-pane`
+
+Cobra supports deprecated flag aliases. Two sub-questions:
+
+- **Do we keep `--cmd` and `--split` as hidden deprecated aliases?** [NEEDS CLARIFICATION] — user input requested. Recommendation: hard-rename (rk is early; no external muscle memory to protect). If we do keep aliases, wire them via `pflag.Flag.Deprecated` so `--help` hides them and using them prints a deprecation warning.
+
+Updated flag definitions (sketch):
+
+```go
+riffCmd.Flags().StringVar(&riffSkillFlag, "skill", "", "Claude Code skill or slash-command to run in the new window (e.g., /fab-discuss)")
+riffCmd.Flags().StringVar(&riffSetupPaneFlag, "setup-pane", "", "If non-empty, split the window and run this setup command in the right pane")
+```
+
+Rename in internal code: `riffCmdFlag` → `riffSkillFlag`, `riffSplitFlag` → `riffSetupPaneFlag`. Tests updated accordingly.
+
+### 3. Default `--skill` resolution policy (DX 1)
+
+**[NEEDS CLARIFICATION]** — three candidate policies, user must pick:
+
+- **(a)** Keep `/fab-discuss` as the hardcoded default (status quo).
+- **(b)** Default to empty when no `fab/project/config.yaml` is detected; `/fab-discuss` only when fab is present.
+- **(c)** Move the default itself to `fab/project/config.yaml` under a new key like `agent.default_skill` (or `riff.default_skill`), with a built-in fallback of empty.
+
+Recommendation: (c) — composes naturally with the presets feature (change 3), and lets each project own its defaults. This means:
+
+```yaml
+# fab/project/config.yaml
+agent:
+    spawn_command: claude --dangerously-skip-permissions ...
+    default_skill: /fab-discuss      # new
+```
+
+`internal/fabconfig` grows a `ReadDefaultSkill(root string) string` function, same shape as `ReadSpawnCommand`. Empty return means no default. `runRiff` resolves the effective skill in this order: explicit `--skill` flag → config `agent.default_skill` → empty.
+
+If the user picks (b) instead, the flag default stays `/fab-discuss` but flipping to empty happens based on whether `fab/project/config.yaml` was readable. (b) is simpler but less extensible.
+
+### 4. Expand help text (DX 2 and 3)
+
+**`Use:` synopsis (DX 3):** show all flags in the one-liner.
+
+```go
+Use: "riff [--skill <name>] [--setup-pane <cmd>] [-- <wt-flags>...]"
+```
+
+**`Long:` text (DX 2):** rewrite to match the `serve.go:25-34` house style — prerequisites, examples, pointer to `wt create --help`, note about exit codes. Draft:
+
+```
+Create a git worktree via wt, open a new tmux window in it, and launch a
+Claude Code session with a skill or slash-command.
+
+Prerequisites:
+  - You must be inside a tmux session ($TMUX set).
+  - 'wt' must be on your PATH (https://github.com/sahil87/wt).
+  - The launcher binary (default: 'claude') must be installed.
+
+Flags before -- are parsed by rk; flags after -- are forwarded verbatim to
+wt create (e.g., --worktree-name, --base, --reuse). Run 'wt create --help' to
+see the available passthrough flags.
+
+Launcher resolution:
+  If 'fab/project/config.yaml' has 'agent.spawn_command', that value is used
+  as the launcher. Otherwise, falls back to 'claude --dangerously-skip-permissions'.
+
+Examples:
+  rk riff                                     # default skill in a new worktree
+  rk riff --skill /review                     # pick a specific skill
+  rk riff --setup-pane "just dev"             # add a setup pane running 'just dev'
+  rk riff -- --worktree-name pacing-canyon    # name the worktree
+  rk riff --skill /ship -- --reuse --base main
+
+Exit codes:
+  0  success
+  2  precondition failure ($TMUX unset, wt not found)
+  3  subprocess failure (wt or tmux non-zero, output parse failure, timeout)
+```
+
+### 5. Update memory and tests
+
+- `docs/memory/run-kit/rk-riff.md` — update every reference to `--cmd`/`--split`, the flag table, the flag-surface section, and the Changelog. Add a section on default-skill resolution and, if Bug 2 required a delivery change, update the "Workflow Step Order" to reflect the send-keys approach.
+- `app/backend/cmd/rk/riff_test.go` — rename test variables/cases to match new flag names; add a test for default-skill resolution (if policy c); update `TestBuildNewWindowArgs` if Bug 2 delivery changed.
+- `app/backend/internal/fabconfig/fabconfig.go` + test — add `ReadDefaultSkill` (if policy c).
+
+## Affected Memory
+
+- `run-kit/rk-riff.md`: (modify) — flag renames, default-skill policy, Long text rewrite, Use synopsis update, Changelog entry. If Bug 2 required a delivery-mechanism change, update "Workflow Step Order" accordingly.
+
+## Impact
+
+**Code:**
+- `app/backend/cmd/rk/riff.go` — flag renames, `runTmuxNewWindow` delivery change (conditional on Bug 2 verification), resolveLauncher / effective-skill resolution, help text, possibly a helper for `tmux send-keys`.
+- `app/backend/cmd/rk/riff_test.go` — renames + new test cases for default-skill resolution and (if applicable) the send-keys flow.
+- `app/backend/internal/fabconfig/fabconfig.go` — new `ReadDefaultSkill` function (if policy c).
+- `app/backend/internal/fabconfig/fabconfig_test.go` — tests for `ReadDefaultSkill`.
+
+**Docs:** `docs/memory/run-kit/rk-riff.md` per §5.
+
+**APIs/flags**: **BREAKING** — `--cmd` and `--split` are renamed. If we keep deprecated aliases they stay functional; if we hard-rename, existing scripts/aliases break. This is the reason the change is grouped at this boundary.
+
+**Dependencies**: none new. `tmux send-keys` (if Bug 2 path) is just another tmux subprocess call.
+
+**Ordering caveat**: this change depends on change 1 landing first because change 1 introduces `shellWrap` and the window-name-suffix helper, both of which survive into this change's code unchanged.
+
+## Open Questions
+
+- **Bug 2 verification** — what does `claude /fab-discuss` (as positional arg) actually do today? Need a one-command smoke test. This determines whether the delivery-mechanism change ships or not.
+- **DX 1 default-skill policy** — pick (a), (b), or (c). Recommendation: (c).
+- **DX 4 back-compat aliases** — hard-rename or keep deprecated `--cmd`/`--split` aliases for one release? Recommendation: hard-rename (rk is early).
+- **Bug 2 readiness signal** (only relevant if we go down the send-keys path) — fixed delay, or poll `tmux capture-pane`? Recommendation: fixed delay (800ms) for simplicity.
+- Should `tmux send-keys` escape the `--skill` value any differently than `escapeSingleQuotes` already does? send-keys uses tmux's own parsing, which has different rules than shell single-quoting. Needs a short investigation in the spec.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Bundle Bug 2 + DX 1/2/3/4 into one "surface break" change; change 1 ships first (no surface change), change 3 ships after (features on stable surface) | User-specified three-change grouping | S:95 R:70 A:85 D:90 |
+| 2 | Certain | Change depends on 260423-ba9f (change 1) landing first — specifically the `shellWrap` and `resolveWindowName` helpers | Temporal dependency stated in the grouping plan | S:95 R:80 A:90 D:95 |
+| 3 | Confident | Rename `--cmd` to `--skill` | `--cmd` is ambiguous (shell cmd? claude cmd?); `--skill` matches Claude Code terminology and the default value's nature | S:75 R:65 A:75 D:70 |
+| 4 | Confident | Rename `--split` to `--setup-pane` | `--split` reads as a boolean; current value is a setup command for a pane. `--setup-pane` encodes intent | S:75 R:65 A:75 D:70 |
+| 5 | Confident | Expand `Long` help text to match `serve.go:25-34` house style with Prerequisites, Examples, and exit-code table | Pure ergonomics; low-risk pattern already established elsewhere in the codebase | S:85 R:95 A:85 D:90 |
+| 6 | Confident | Expand `Use:` synopsis to list all primary flags, not just the passthrough separator | Standard CLI convention; every other rk subcommand already does this | S:85 R:95 A:85 D:90 |
+| 7 | Tentative | Default-skill resolution policy: option (c) — move default to `fab/project/config.yaml`'s `agent.default_skill` key with empty built-in fallback | Composes with presets feature; three policy options are all valid but user input required | S:55 R:55 A:55 D:45 |
+| 8 | Tentative | Bug 2 fix path: verify first, then if broken switch to `tmux new-window` + `tmux send-keys` with 800ms fixed delay | Verification outcome unknown; delay-based readiness is the simplest correct approach if switch is needed | S:40 R:50 A:60 D:50 |
+| 9 | Tentative | DX 4 back-compat: hard-rename without deprecated aliases | rk is early; low blast radius — but a case can be made for aliases during the 1.x window | S:55 R:60 A:55 D:55 |
+| 10 | Confident | Default value of `--skill` flag itself is empty string; actual default comes from config resolution chain | Separates "flag defaulting" from "effective value resolution" cleanly | S:75 R:70 A:80 D:70 |
+| 11 | Unresolved | What does `claude --dangerously-skip-permissions /fab-discuss` actually do today (positional argv → slash command or no-op)? | Asked — user has not verified; blocks design of the Bug 2 fix path | S:15 R:40 A:20 D:25 |
+
+11 assumptions (2 certain, 5 confident, 3 tentative, 1 unresolved).


### PR DESCRIPTION
## Summary

Splits the recent `rk riff` triage findings into three sequenced intakes, each landing on a `intake:ready` state with indicative scoring:

- **`260423-ba9f-rk-riff-correctness-fixes`** (fix) — Bugs 1, 3, 8, 9, 10, 11. Shell-wraps the `--cmd` pane so it survives launcher exit, swaps hardcoded `exec zsh` for `exec "${SHELL:-/bin/sh}"`, adds SIGINT handling in `runRiff`, auto-suffixes `riff-<name>-2/-3/...` on window-name collision, documents the `agent.spawn_command` trust boundary. No CLI surface change.
- **`260423-udhe-rk-riff-cli-surface`** (refactor) — Bug 2 + DX 1/2/3/4. Verifies and fixes `/fab-discuss` delivery (possibly via `tmux send-keys`), renames `--cmd` → `--skill` and `--split` → `--setup-pane`, adds `agent.default_skill` config key, rewrites `Long` help text and `Use:` synopsis to match the `serve.go` house style.
- **`260423-jmwu-rk-riff-workflow-features`** (feat) — Features 1/2/3. Fab-change bridge (`--new-change "<desc>"` / `--change <id>`), config-driven presets at `riff.presets.<name>`, `--fan-out N` for parallel riffs.

Ordering matters: change 1 is purely mechanical (low-risk review). Change 2 settles the flag surface before features key off it. Change 3 is additive on a stable surface.

## Test plan
- [ ] Review intake content in each `fab/changes/260423-*/intake.md`
- [ ] Confirm indicative scores and assumption grades make sense
- [ ] Decide the [NEEDS CLARIFICATION] items flagged in each intake before advancing to spec