### PR TITLE
feat: terminal multiplexing engine + session drag-and-drop reorder

### DIFF
--- a/.env
+++ b/.env
@@ -6,3 +6,9 @@
 # Prod mode: Go backend serves on this port directly.
 RK_PORT=3000
 RK_HOST=0.0.0.0
+
+# Seconds before an inactive terminal's WebSocket is closed to save bandwidth.
+# The terminal buffer stays cached — switching back shows content instantly
+# while the connection re-establishes in the background.
+# Set to 0 to keep all connections alive indefinitely.
+VITE_RK_POOL_IDLE_TIMEOUT=30

--- a/app/backend/api/relay.go
+++ b/app/backend/api/relay.go
@@ -75,18 +75,11 @@ func (s *Server) handleRelay(w http.ResponseWriter, r *http.Request) {
 	// Determine which tmux server this session lives on
 	server := serverFromRequest(r)
 
-	// Verify the session exists and select the target window
-	windows, err := s.tmux.ListWindows(r.Context(), session, server)
-	if err != nil || windows == nil {
-		slog.Warn("session not found", "session", session)
-		conn.WriteMessage(websocket.CloseMessage,
-			websocket.FormatCloseMessage(4004, "Session not found"))
-		return
-	}
+	// Select the target window — also validates that the session exists
 	if err := s.tmux.SelectWindow(session, winIdx, server); err != nil {
-		slog.Error("select-window failed", "err", err, "session", session, "window", windowIndex)
+		slog.Warn("select-window failed", "err", err, "session", session, "window", windowIndex)
 		conn.WriteMessage(websocket.CloseMessage,
-			websocket.FormatCloseMessage(4004, "Window not found"))
+			websocket.FormatCloseMessage(4004, "Session or window not found"))
 		return
 	}
 
@@ -107,6 +100,15 @@ func (s *Server) handleRelay(w http.ResponseWriter, r *http.Request) {
 	}
 	conn.SetReadDeadline(time.Time{}) // clear deadline
 
+	// Source-file the config into the running server so terminal-overrides
+	// (true color) and style settings are active even if the server was
+	// created outside of rk. Best-effort, non-blocking.
+	go func() {
+		if err := tmux.ReloadConfig(server); err != nil {
+			slog.Debug("config reload (best-effort)", "server", server, "err", err)
+		}
+	}()
+
 	// Attach to the session via PTY — renders the selected window as-is (no split)
 	ctx, cancel := context.WithCancel(context.Background())
 	var attachArgs []string
@@ -115,12 +117,6 @@ func (s *Server) handleRelay(w http.ResponseWriter, r *http.Request) {
 	}
 	if confPath := tmux.ConfigPath(); confPath != "" {
 		attachArgs = append(attachArgs, "-f", confPath)
-	}
-	// Source-file the config into the running server so terminal-overrides
-	// (true color) and style settings are active even if the server was
-	// created outside of rk. Best-effort — don't block the attach.
-	if err := tmux.ReloadConfig(server); err != nil {
-		slog.Debug("config reload before attach (best-effort)", "server", server, "err", err)
 	}
 
 	attachArgs = append(attachArgs, "attach-session", "-t", session)

--- a/app/frontend/src/app.tsx
+++ b/app/frontend/src/app.tsx
@@ -10,7 +10,7 @@ import { useVisualViewport } from "@/hooks/use-visual-viewport";
 import { useDialogState } from "@/hooks/use-dialog-state";
 import { TopBar } from "@/components/top-bar";
 import { Sidebar } from "@/components/sidebar";
-import { TerminalClient } from "@/components/terminal-client";
+import { TerminalPool } from "@/components/terminal-pool";
 import { IframeWindow } from "@/components/iframe-window";
 import { BottomBar } from "@/components/bottom-bar";
 import type { PaletteAction } from "@/components/command-palette";
@@ -936,7 +936,7 @@ function AppShell() {
                     </div>
                   )}
                   <div className="flex-1 min-h-0 py-0.5 px-1 flex flex-col">
-                    <TerminalClient
+                    <TerminalPool
                       sessionName={sessionName}
                       windowIndex={windowIndex}
                       server={server}

--- a/app/frontend/src/components/sidebar/index.tsx
+++ b/app/frontend/src/components/sidebar/index.tsx
@@ -91,6 +91,34 @@ export function Sidebar({
   const [dropTarget, setDropTarget] = useState<{ session: string; index: number } | null>(null);
   const [sessionDropTarget, setSessionDropTarget] = useState<string | null>(null);
 
+  // Session reorder — frontend-only, persisted to localStorage
+  const SESSION_ORDER_KEY = `runkit-session-order-${server}`;
+  const [sessionOrder, setSessionOrder] = useState<string[]>(() => {
+    try {
+      const stored = localStorage.getItem(`runkit-session-order-${server}`);
+      return stored ? JSON.parse(stored) : [];
+    } catch { return []; }
+  });
+  const [sessionDragSource, setSessionDragSource] = useState<string | null>(null);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(`runkit-session-order-${server}`);
+      setSessionOrder(stored ? JSON.parse(stored) : []);
+    } catch { setSessionOrder([]); }
+  }, [server]);
+
+  const orderedSessions = useMemo(() => {
+    if (sessionOrder.length === 0) return sessions;
+    const orderMap = new Map(sessionOrder.map((name, i) => [name, i]));
+    return [...sessions].sort((a, b) => {
+      const ai = orderMap.get(a.name) ?? Infinity;
+      const bi = orderMap.get(b.name) ?? Infinity;
+      if (ai === bi) return 0;
+      return ai - bi;
+    });
+  }, [sessions, sessionOrder]);
+
   const { markKilled, unmarkKilled, markRenamed, unmarkRenamed } = useOptimisticContext();
   const { addToast } = useToast();
   const navigate = useNavigate();
@@ -476,6 +504,35 @@ export function Sidebar({
     executeMoveToSession(server, data.session, data.index, data.windowId, data.name, sessionName);
   }
 
+  function handleSessionReorderStart(e: React.DragEvent, sessionName: string) {
+    setSessionDragSource(sessionName);
+    e.dataTransfer.setData("application/x-session-reorder", sessionName);
+    e.dataTransfer.effectAllowed = "move";
+  }
+
+  function handleSessionReorderOver(e: React.DragEvent, targetSession: string) {
+    if (!sessionDragSource || sessionDragSource === targetSession) return;
+    if (!e.dataTransfer.types.includes("application/x-session-reorder")) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+
+    setSessionOrder(() => {
+      const names = orderedSessions.map((s) => s.name);
+      const fromIdx = names.indexOf(sessionDragSource);
+      const toIdx = names.indexOf(targetSession);
+      if (fromIdx === -1 || toIdx === -1) return names;
+      const next = [...names];
+      next.splice(fromIdx, 1);
+      next.splice(toIdx, 0, sessionDragSource);
+      try { localStorage.setItem(SESSION_ORDER_KEY, JSON.stringify(next)); } catch {}
+      return next;
+    });
+  }
+
+  function handleSessionReorderEnd() {
+    setSessionDragSource(null);
+  }
+
   const toggleSession = useCallback((name: string) => {
     setCollapsed((prev) => ({ ...prev, [name]: !prev[name] }));
   }, []);
@@ -551,7 +608,7 @@ export function Sidebar({
             </button>
           </div>
         ) : (
-          sessions.map((session) => {
+          orderedSessions.map((session) => {
             const isCollapsed = collapsed[session.name] ?? false;
             const isGhostSession = "optimistic" in session && session.optimistic;
             return (
@@ -566,6 +623,10 @@ export function Sidebar({
                   editingSession={editingSession}
                   editingSessionName={editingSessionName}
                   sessionInputRef={sessionInputRef}
+                  draggable={!isGhostSession}
+                  isDragSource={sessionDragSource === session.name}
+                  onDragStart={isGhostSession ? undefined : (e) => handleSessionReorderStart(e, session.name)}
+                  onDragEnd={isGhostSession ? undefined : handleSessionReorderEnd}
                   onToggleCollapse={() => toggleSession(session.name)}
                   onSelectFirstWindow={() => onSelectWindow(session.name, session.windows[0]?.index ?? 0)}
                   onCreateWindow={() => onCreateWindow(session.name)}
@@ -584,7 +645,7 @@ export function Sidebar({
                   onSessionNameChange={setEditingSessionName}
                   onSessionRenameKeyDown={handleSessionRenameKeyDown}
                   onSessionRenameBlur={handleSessionRenameBlur}
-                  onDragOver={(e) => handleSessionDragOver(e, session.name)}
+                  onDragOver={(e) => { handleSessionDragOver(e, session.name); handleSessionReorderOver(e, session.name); }}
                   onDragLeave={(e) => handleSessionDragLeave(e, session.name)}
                   onDrop={(e) => handleSessionDrop(e, session.name)}
                   onColorChange={(c) => {

--- a/app/frontend/src/components/sidebar/session-row.tsx
+++ b/app/frontend/src/components/sidebar/session-row.tsx
@@ -21,6 +21,10 @@ type SessionRowProps = {
   onSessionNameChange: (value: string) => void;
   onSessionRenameKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   onSessionRenameBlur: () => void;
+  draggable?: boolean;
+  isDragSource?: boolean;
+  onDragStart?: (e: React.DragEvent) => void;
+  onDragEnd?: () => void;
   onDragOver: (e: React.DragEvent) => void;
   onDragLeave: (e: React.DragEvent) => void;
   onDrop: (e: React.DragEvent) => void;
@@ -44,6 +48,10 @@ export function SessionRow({
   onSessionNameChange,
   onSessionRenameKeyDown,
   onSessionRenameBlur,
+  draggable,
+  isDragSource,
+  onDragStart,
+  onDragEnd,
   onDragOver,
   onDragLeave,
   onDrop,
@@ -69,7 +77,10 @@ export function SessionRow({
 
   return (
     <div
-      className={`flex items-center justify-between group pl-1.5 sm:pl-2 relative${tint ? "" : " hover:bg-bg-card/50"} transition-colors`}
+      className={`flex items-center justify-between group pl-1.5 sm:pl-2 relative${tint ? "" : " hover:bg-bg-card/50"} transition-colors${isDragSource ? " opacity-50" : ""}`}
+      draggable={draggable}
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
       onDragOver={onDragOver}
       onDragLeave={onDragLeave}
       onDrop={onDrop}

--- a/app/frontend/src/components/terminal-client.tsx
+++ b/app/frontend/src/components/terminal-client.tsx
@@ -33,6 +33,7 @@ type TerminalClientProps = {
   onSessionNotFound?: () => void;
   focusRef?: React.MutableRefObject<(() => void) | null>;
   scrollLocked?: boolean;
+  active?: boolean;
 };
 
 export function TerminalClient({
@@ -45,16 +46,23 @@ export function TerminalClient({
   onSessionNotFound,
   focusRef,
   scrollLocked,
+  active = true,
 }: TerminalClientProps) {
   const terminalRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<import("@xterm/xterm").Terminal | null>(null);
   const fitAddonRef = useRef<import("@xterm/addon-fit").FitAddon | null>(null);
+  const localWsRef = useRef<WebSocket | null>(null);
   const [terminalReady, setTerminalReady] = useState(false);
+  const [wsGeneration, setWsGeneration] = useState(0);
+  const hasConnectedRef = useRef(false);
   const [dragOver, setDragOver] = useState(false);
   const [composeInitialText, setComposeInitialText] = useState<string | undefined>();
   const [composeFiles, setComposeFiles] = useState<UploadedFile[]>([]);
   const { uploadFiles, uploading } = useFileUpload(sessionName, windowIndex);
   const { theme: activeTheme } = useTheme();
+
+  const activeRef = useRef(active);
+  activeRef.current = active;
 
   const openComposeWithUploads = useCallback(
     (uploads: UploadedFile[]) => {
@@ -68,6 +76,7 @@ export function TerminalClient({
 
   // Clipboard paste interception for file upload
   useEffect(() => {
+    if (!active) return;
     function handlePaste(e: ClipboardEvent) {
       const files = e.clipboardData?.files;
       if (!files || files.length === 0) return;
@@ -76,7 +85,7 @@ export function TerminalClient({
     }
     document.addEventListener("paste", handlePaste);
     return () => document.removeEventListener("paste", handlePaste);
-  }, [uploadFiles, openComposeWithUploads]);
+  }, [active, uploadFiles, openComposeWithUploads]);
 
   // Drag and drop
   const handleDragOver = useCallback((e: React.DragEvent) => {
@@ -194,10 +203,10 @@ export function TerminalClient({
       }
       if (cancelled) { try { terminal.dispose(); } catch { /* WebGL addon may throw during teardown */ } return; }
 
-      // Keyboard input → current WebSocket (wsRef always points to latest)
+      // Keyboard input → this terminal's own WebSocket
       terminal.onData((data) => {
-        if (wsRef.current?.readyState === WebSocket.OPEN)
-          wsRef.current.send(data);
+        if (localWsRef.current?.readyState === WebSocket.OPEN)
+          localWsRef.current.send(data);
       });
 
       // Cmd+C / Ctrl+C: copy selection instead of sending SIGINT
@@ -228,8 +237,8 @@ export function TerminalClient({
           resizeRafId = null;
           fitAddonRef.current?.fit();
           xtermRef.current?.scrollToBottom();
-          if (wsRef.current?.readyState === WebSocket.OPEN && xtermRef.current) {
-            wsRef.current.send(
+          if (localWsRef.current?.readyState === WebSocket.OPEN && xtermRef.current) {
+            localWsRef.current.send(
               JSON.stringify({
                 type: "resize",
                 cols: xtermRef.current.cols,
@@ -247,7 +256,7 @@ export function TerminalClient({
       }
 
       resizeObserver.observe(terminalRef.current);
-      if (focusRef) focusRef.current = () => xtermRef.current?.focus();
+      if (focusRef && activeRef.current) focusRef.current = () => xtermRef.current?.focus();
       setTerminalReady(true);
     }
 
@@ -257,10 +266,9 @@ export function TerminalClient({
       cancelled = true;
       resizeObserver?.disconnect();
       if (resizeRafId) cancelAnimationFrame(resizeRafId);
-      // Close any active WS on true unmount
-      if (wsRef.current) {
-        wsRef.current.close();
-        wsRef.current = null;
+      if (localWsRef.current) {
+        localWsRef.current.close();
+        localWsRef.current = null;
       }
       if (focusRef) focusRef.current = null;
       xtermRef.current = null;
@@ -268,7 +276,53 @@ export function TerminalClient({
       try { terminal?.dispose(); } catch { /* WebGL addon may throw during teardown */ }
       setTerminalReady(false);
     };
-  }, [wsRef, focusRef]);
+  }, [focusRef]);
+
+  // Sync parent refs when this terminal becomes the active one.
+  // Refit after display:none → visible transition so xterm measures correctly.
+  useEffect(() => {
+    if (!active || !terminalReady) return;
+    wsRef.current = localWsRef.current;
+    if (focusRef) focusRef.current = () => xtermRef.current?.focus();
+    // Reconnect if the WS was closed during background idle
+    const ws = localWsRef.current;
+    if (!ws || ws.readyState === WebSocket.CLOSED || ws.readyState === WebSocket.CLOSING) {
+      setWsGeneration((g) => g + 1);
+    }
+    requestAnimationFrame(() => {
+      fitAddonRef.current?.fit();
+      xtermRef.current?.refresh?.(0, (xtermRef.current?.rows ?? 1) - 1);
+      xtermRef.current?.focus();
+      if (localWsRef.current?.readyState === WebSocket.OPEN && xtermRef.current) {
+        localWsRef.current.send(
+          JSON.stringify({
+            type: "resize",
+            cols: xtermRef.current.cols,
+            rows: xtermRef.current.rows,
+          }),
+        );
+      }
+    });
+  }, [active, terminalReady, wsRef, focusRef]);
+
+  // Background idle: close WS after a configurable timeout to save bandwidth.
+  // xterm.js buffer retains the last screen content, so reactivation shows
+  // cached output instantly while the WS reconnects in the background.
+  // Set VITE_RK_POOL_IDLE_TIMEOUT=0 to keep all connections alive indefinitely.
+  const IDLE_CLOSE_CODE = 4000;
+  useEffect(() => {
+    if (active || !terminalReady) return;
+    const envSeconds = Number(import.meta.env.VITE_RK_POOL_IDLE_TIMEOUT);
+    const timeoutMs = (Number.isFinite(envSeconds) ? envSeconds : 30) * 1000;
+    if (timeoutMs <= 0) return;
+    const timer = setTimeout(() => {
+      const ws = localWsRef.current;
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.close(IDLE_CLOSE_CODE, "idle");
+      }
+    }, timeoutMs);
+    return () => clearTimeout(timer);
+  }, [active, terminalReady]);
 
   // Scroll-lock: prevent xterm textarea from gaining focus when locked.
   // Instead of reactively blurring on focusin (which disrupts active touch
@@ -315,7 +369,7 @@ export function TerminalClient({
 
     function onTouchMove(e: TouchEvent) {
       if (e.touches.length !== 1) return;
-      const ws = wsRef.current;
+      const ws = localWsRef.current;
       if (!ws || ws.readyState !== WebSocket.OPEN) return;
 
       const currentY = e.touches[0].clientY;
@@ -349,7 +403,7 @@ export function TerminalClient({
       container.removeEventListener("touchstart", onTouchStart, { capture: true });
       container.removeEventListener("touchmove", onTouchMove, { capture: true });
     };
-  }, [terminalReady, wsRef]);
+  }, [terminalReady]);
 
   // Update xterm theme when the app theme changes
   useEffect(() => {
@@ -363,13 +417,19 @@ export function TerminalClient({
   const windowIndexRef = useRef(windowIndex);
   windowIndexRef.current = windowIndex;
 
-  // WebSocket connection — reconnects only when the session changes.
-  // Window switches within the same session are handled by the relay's
-  // tmux attach-session, which follows the active window automatically.
+  // WebSocket connection — connects once on mount and reconnects on drop.
+  // With terminal pooling, each TerminalClient has a fixed session and stays
+  // alive across navigation. Session switching is handled by the pool's
+  // CSS visibility, not by WS teardown/rebuild.
   useEffect(() => {
     if (!terminalReady || !xtermRef.current) return;
 
     const terminal = xtermRef.current;
+    if (!hasConnectedRef.current) {
+      terminal.reset();
+      terminal.write("\x1b[90mConnecting...\x1b[0m");
+      hasConnectedRef.current = true;
+    }
 
     let cancelled = false;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -399,9 +459,9 @@ export function TerminalClient({
       if (cancelled) return;
       const wsUrl = `${wsProto}//${window.location.host}/relay/${encodeURIComponent(sessionName)}/${windowIndexRef.current}?server=${server}`;
       const ws = new WebSocket(wsUrl);
-      wsRef.current = ws;
+      localWsRef.current = ws;
+      if (activeRef.current) wsRef.current = ws;
       ws.binaryType = "arraybuffer";
-      let needsReset = true;
 
       ws.onopen = () => {
         if (cancelled) return;
@@ -413,10 +473,6 @@ export function TerminalClient({
 
       ws.onmessage = (event) => {
         if (cancelled) return;
-        if (needsReset) {
-          needsReset = false;
-          terminal.reset();
-        }
         if (typeof event.data === "string") {
           textBuffer += event.data;
         } else {
@@ -436,6 +492,8 @@ export function TerminalClient({
         try { flushToTerminal(); } catch { /* terminal may be disposed */ }
 
         if (cancelled) return;
+        // 4000 = intentional idle close — pool will reconnect when active
+        if (event.code === 4000) return;
         // 4004 = session or window not found — redirect instead of reconnecting
         if (event.code === 4004) {
           terminal.write("\r\n\x1b[91m[session not found]\x1b[0m\r\n");
@@ -459,13 +517,13 @@ export function TerminalClient({
       cancelled = true;
       if (flushRafId) cancelAnimationFrame(flushRafId);
       if (reconnectTimer) clearTimeout(reconnectTimer);
-      if (wsRef.current) {
-        wsRef.current.close();
-        wsRef.current = null;
+      if (localWsRef.current) {
+        localWsRef.current.close();
+        localWsRef.current = null;
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [terminalReady, sessionName, server, wsRef]);
+  }, [terminalReady, sessionName, server, wsGeneration]);
 
   return (
     <div className="relative flex-1 min-h-0 flex flex-col">
@@ -474,21 +532,21 @@ export function TerminalClient({
         role="application"
         aria-label={`Terminal: ${sessionName}/${windowIndex}`}
         className={`flex-1 min-h-0 overflow-hidden touch-none transition-opacity ${
-          composeOpen ? "opacity-50" : ""
+          active && composeOpen ? "opacity-50" : ""
         } ${dragOver ? "ring-2 ring-accent ring-inset" : ""}`}
         onContextMenu={(e) => e.preventDefault()}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
       />
-      {uploading && (
+      {active && uploading && (
         <div className="absolute bottom-1 left-2 text-xs text-text-secondary bg-bg-card/80 px-2 py-0.5 rounded z-10">
           Uploading...
         </div>
       )}
-      {composeOpen && (
+      {active && composeOpen && (
         <ComposeBuffer
-          wsRef={wsRef}
+          wsRef={localWsRef}
           onClose={() => {
             setComposeOpen(false);
             setComposeInitialText(undefined);

--- a/app/frontend/src/components/terminal-pool.tsx
+++ b/app/frontend/src/components/terminal-pool.tsx
@@ -1,0 +1,95 @@
+import { useRef, useState } from "react";
+import { TerminalClient } from "./terminal-client";
+
+const MAX_WARM = 8;
+
+type PoolEntry = {
+  sessionName: string;
+  server: string;
+};
+
+type TerminalPoolProps = {
+  sessionName: string;
+  windowIndex: string;
+  server: string;
+  wsRef: React.MutableRefObject<WebSocket | null>;
+  composeOpen: boolean;
+  setComposeOpen: (open: boolean | ((prev: boolean) => boolean)) => void;
+  onSessionNotFound?: () => void;
+  focusRef?: React.MutableRefObject<(() => void) | null>;
+  scrollLocked?: boolean;
+};
+
+export function TerminalPool({
+  sessionName,
+  windowIndex,
+  server,
+  wsRef,
+  composeOpen,
+  setComposeOpen,
+  onSessionNotFound,
+  focusRef,
+  scrollLocked,
+}: TerminalPoolProps) {
+  const activeKey = `${server}\0${sessionName}`;
+  const [pool, setPool] = useState(() => new Map<string, PoolEntry>());
+  const lastAccessRef = useRef(new Map<string, number>());
+  const windowIndexCache = useRef(new Map<string, string>());
+
+  lastAccessRef.current.set(activeKey, Date.now());
+  windowIndexCache.current.set(activeKey, windowIndex);
+
+  if (!pool.has(activeKey)) {
+    setPool((prev) => {
+      const next = new Map(prev);
+      next.set(activeKey, { sessionName, server });
+
+      if (next.size > MAX_WARM) {
+        let oldestKey = "";
+        let oldestTime = Infinity;
+        for (const key of next.keys()) {
+          if (key === activeKey) continue;
+          const t = lastAccessRef.current.get(key) ?? 0;
+          if (t < oldestTime) {
+            oldestTime = t;
+            oldestKey = key;
+          }
+        }
+        if (oldestKey) {
+          next.delete(oldestKey);
+          lastAccessRef.current.delete(oldestKey);
+          windowIndexCache.current.delete(oldestKey);
+        }
+      }
+
+      return next;
+    });
+  }
+
+  return (
+    <>
+      {Array.from(pool.entries()).map(([key, entry]) => {
+        const isActive = key === activeKey;
+        return (
+          <div
+            key={key}
+            className={isActive ? "flex-1 min-h-0 flex flex-col" : "hidden"}
+          >
+            <TerminalClient
+              sessionName={entry.sessionName}
+              windowIndex={isActive ? windowIndex : (windowIndexCache.current.get(key) ?? "0")}
+              server={entry.server}
+              active={isActive}
+              wsRef={wsRef}
+              composeOpen={composeOpen}
+              setComposeOpen={setComposeOpen}
+              onSessionNotFound={isActive ? onSessionNotFound : undefined}
+              focusRef={focusRef}
+              scrollLocked={isActive ? scrollLocked : false}
+            />
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/app/frontend/vite-env.d.ts
+++ b/app/frontend/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_RK_POOL_IDLE_TIMEOUT?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary

- **Terminal pool**: Keeps up to 8 warm xterm.js + WebSocket pairs alive across session switches — switching is now a CSS visibility swap (zero latency) instead of full WS teardown/rebuild
- **Relay optimization**: Removed redundant `ListWindows` tmux call, made `ReloadConfig` non-blocking — faster initial connection
- **Idle disconnect**: Background terminals close their WS after a configurable timeout (`VITE_RK_POOL_IDLE_TIMEOUT`, default 30s) to save bandwidth; cached xterm buffer provides instant visual on reactivation
- **Session drag-and-drop**: Sidebar sessions are reorderable via drag-and-drop, order persisted to localStorage per server

## Test plan

- [ ] Switch between sessions — verify instant switching (no blank flash, no reconnection delay)
- [ ] Switch away from a session, wait >30s, switch back — verify cached content shows instantly and WS reconnects in background
- [ ] Set `VITE_RK_POOL_IDLE_TIMEOUT=0` in `.env.local` — verify background terminals never disconnect
- [ ] Drag sessions up/down in sidebar — verify live reorder and persistence across page reload
- [ ] Drag a window to a different session — verify existing cross-session window move still works
- [ ] Kill a session while others are warm in the pool — verify no errors
- [ ] Open 9+ sessions — verify LRU eviction (oldest warm session gets cleaned up)
- [ ] Verify BottomBar keyboard buttons and ComposeBuffer send to the correct terminal after switching