### PR TITLE
fix: session disappears after rename due to tmux group filter and stale URL

### DIFF
--- a/app/backend/internal/tmux/tmux.go
+++ b/app/backend/internal/tmux/tmux.go
@@ -226,25 +226,68 @@ type SessionInfo struct {
 
 // parseSessions parses tmux list-sessions output lines into SessionInfo structs,
 // filtering out session-group copies.
-// Format: name, grouped, group, @color (4 fields).
+// Format: name, grouped, group, group_size, @color (5 fields).
 // Exported for testing.
 func parseSessions(lines []string) []SessionInfo {
-	var sessions []SessionInfo
+	type rawEntry struct {
+		name      string
+		grouped   bool
+		group     string
+		groupSize int
+		colorStr  string
+	}
+
+	// Pass 1: parse all valid lines.
+	var entries []rawEntry
 	for _, line := range lines {
 		parts := strings.Split(line, listDelim)
 		if len(parts) < 2 {
 			continue
 		}
-		name, grouped := parts[0], parts[1]
-		group := ""
+		e := rawEntry{name: parts[0], grouped: parts[1] == "1"}
 		if len(parts) >= 3 {
-			group = parts[2]
+			e.group = parts[2]
 		}
-		// Filter out session-group copies: keep if ungrouped or if name matches group
-		if grouped == "0" || name == group {
-			si := SessionInfo{Name: name}
-			if len(parts) >= 4 && parts[3] != "" {
-				if n, err := strconv.Atoi(parts[3]); err == nil {
+		if len(parts) >= 4 {
+			e.groupSize, _ = strconv.Atoi(parts[3])
+		}
+		if len(parts) >= 5 {
+			e.colorStr = parts[4]
+		}
+		entries = append(entries, e)
+	}
+
+	// Build set of groups that still have a name-matching leader.
+	groupHasLeader := make(map[string]bool)
+	for _, e := range entries {
+		if e.grouped && e.name == e.group {
+			groupHasLeader[e.group] = true
+		}
+	}
+
+	// Pass 2: filter — keep ungrouped sessions, group leaders, sole members,
+	// and one representative from leaderless groups (renamed leader).
+	leaderlessIncluded := make(map[string]bool)
+	var sessions []SessionInfo
+	for _, e := range entries {
+		keep := false
+		switch {
+		case !e.grouped:
+			keep = true
+		case e.name == e.group:
+			keep = true
+		case e.groupSize == 1:
+			keep = true
+		case !groupHasLeader[e.group] && !leaderlessIncluded[e.group]:
+			// Leader was renamed — no session matches the group name.
+			// Include the first member as representative.
+			leaderlessIncluded[e.group] = true
+			keep = true
+		}
+		if keep {
+			si := SessionInfo{Name: e.name}
+			if e.colorStr != "" {
+				if n, err := strconv.Atoi(e.colorStr); err == nil {
 					si.Color = &n
 				}
 			}
@@ -260,7 +303,7 @@ func ListSessions(ctx context.Context, server string) ([]SessionInfo, error) {
 	ctx, cancel := context.WithTimeout(ctx, TmuxTimeout)
 	defer cancel()
 
-	format := fmt.Sprintf("#{session_name}%s#{session_grouped}%s#{session_group}%s#{@session_color}", listDelim, listDelim, listDelim)
+	format := fmt.Sprintf("#{session_name}%s#{session_grouped}%s#{session_group}%s#{session_group_size}%s#{@session_color}", listDelim, listDelim, listDelim, listDelim)
 
 	lines, err := tmuxExecServer(ctx, server, "list-sessions", "-F", format)
 	if err != nil {

--- a/app/backend/internal/tmux/tmux_test.go
+++ b/app/backend/internal/tmux/tmux_test.go
@@ -4,17 +4,22 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
 
 // Helper to build a tab-delimited tmux line.
 func sessionLine(name, grouped, group string) string {
-	return strings.Join([]string{name, grouped, group}, listDelim)
+	return strings.Join([]string{name, grouped, group, "0"}, listDelim)
+}
+
+func sessionLineGrouped(name, grouped, group string, groupSize int) string {
+	return strings.Join([]string{name, grouped, group, strconv.Itoa(groupSize)}, listDelim)
 }
 
 func sessionLineColor(name, grouped, group, color string) string {
-	return strings.Join([]string{name, grouped, group, color}, listDelim)
+	return strings.Join([]string{name, grouped, group, "0", color}, listDelim)
 }
 
 func intPtr(n int) *int { return &n }
@@ -50,19 +55,70 @@ func TestParseSessions(t *testing.T) {
 			want: []SessionInfo{{Name: "alpha"}, {Name: "beta"}},
 		},
 		{
-			name: "filters out session-group copies (grouped=1, name != group)",
+			name: "filters out session-group copies (grouped=1, name != group, size > 1)",
 			lines: []string{
-				sessionLine("devshell", "0", "devshell"),
-				sessionLine("devshell-82", "1", "devshell"),
+				sessionLineGrouped("devshell", "1", "devshell", 2),
+				sessionLineGrouped("devshell-82", "1", "devshell", 2),
 			},
 			want: []SessionInfo{{Name: "devshell"}},
 		},
 		{
 			name: "keeps group-named session (grouped=1, name == group)",
 			lines: []string{
-				sessionLine("mygroup", "1", "mygroup"),
+				sessionLineGrouped("mygroup", "1", "mygroup", 1),
 			},
 			want: []SessionInfo{{Name: "mygroup"}},
+		},
+		{
+			name: "keeps sole group member after rename (grouped=1, name != group, size == 1)",
+			lines: []string{
+				sessionLine("other", "0", "other"),
+				sessionLineGrouped("run-kit-lane", "1", "run-kit-lanes", 1),
+			},
+			want: []SessionInfo{{Name: "other"}, {Name: "run-kit-lane"}},
+		},
+		{
+			name: "renamed leader in multi-member group — first member kept as representative",
+			lines: []string{
+				sessionLineGrouped("shell", "1", "devshell", 2),
+				sessionLineGrouped("devshell-82", "1", "devshell", 2),
+			},
+			want: []SessionInfo{{Name: "shell"}},
+		},
+		{
+			name: "renamed leader in 3-member group — only first member kept",
+			lines: []string{
+				sessionLineGrouped("renamed", "1", "original", 3),
+				sessionLineGrouped("original-1", "1", "original", 3),
+				sessionLineGrouped("original-2", "1", "original", 3),
+			},
+			want: []SessionInfo{{Name: "renamed"}},
+		},
+		{
+			name: "two independent groups — one with renamed leader, one normal",
+			lines: []string{
+				sessionLineGrouped("alpha", "1", "alpha", 2),
+				sessionLineGrouped("alpha-copy", "1", "alpha", 2),
+				sessionLineGrouped("new-beta", "1", "beta", 2),
+				sessionLineGrouped("beta-copy", "1", "beta", 2),
+			},
+			want: []SessionInfo{{Name: "alpha"}, {Name: "new-beta"}},
+		},
+		{
+			name: "group with leader plus ungrouped sessions — only leader kept from group",
+			lines: []string{
+				sessionLine("standalone", "0", ""),
+				sessionLineGrouped("grp", "1", "grp", 2),
+				sessionLineGrouped("grp-copy", "1", "grp", 2),
+			},
+			want: []SessionInfo{{Name: "standalone"}, {Name: "grp"}},
+		},
+		{
+			name: "sole group member with color preserved after rename",
+			lines: []string{
+				strings.Join([]string{"renamed-sess", "1", "old-sess", "1", "7"}, listDelim),
+			},
+			want: []SessionInfo{{Name: "renamed-sess", Color: intPtr(7)}},
 		},
 		{
 			name:  "empty input returns nil",
@@ -92,9 +148,9 @@ func TestParseSessions(t *testing.T) {
 		{
 			name: "multiple session-group copies filtered, original kept",
 			lines: []string{
-				sessionLine("proj", "0", "proj"),
-				sessionLine("proj-1", "1", "proj"),
-				sessionLine("proj-2", "1", "proj"),
+				sessionLineGrouped("proj", "1", "proj", 3),
+				sessionLineGrouped("proj-1", "1", "proj", 3),
+				sessionLineGrouped("proj-2", "1", "proj", 3),
 			},
 			want: []SessionInfo{{Name: "proj"}},
 		},
@@ -102,8 +158,8 @@ func TestParseSessions(t *testing.T) {
 			name: "mixed grouped and ungrouped sessions",
 			lines: []string{
 				sessionLine("alpha", "0", "alpha"),
-				sessionLine("beta", "1", "beta"),
-				sessionLine("beta-N", "1", "beta"),
+				sessionLineGrouped("beta", "1", "beta", 2),
+				sessionLineGrouped("beta-N", "1", "beta", 2),
 				sessionLine("gamma", "0", "gamma"),
 			},
 			want: []SessionInfo{{Name: "alpha"}, {Name: "beta"}, {Name: "gamma"}},

--- a/app/frontend/src/components/sidebar/index.tsx
+++ b/app/frontend/src/components/sidebar/index.tsx
@@ -196,16 +196,35 @@ export function Sidebar({
   });
 
   // Inline rename session (optimistic)
-  const lastRenameSessionRef = useRef<{ server: string; name: string } | null>(null);
+  const lastRenameSessionRef = useRef<{ server: string; oldName: string; newName: string } | null>(null);
   const { execute: executeRenameSession } = useOptimisticAction<[string, string, string]>({
     action: (srv, oldName, newName) => renameSession(srv, oldName, newName),
     onOptimistic: (srv, oldName, newName) => {
-      lastRenameSessionRef.current = { server: srv, name: oldName };
+      lastRenameSessionRef.current = { server: srv, oldName, newName };
       markRenamed("session", srv, oldName, newName);
+      // Navigate immediately so the URL stays in sync with the optimistic display name.
+      // Without this, computeKillRedirect sees the old URL + renamed session = "gone" and
+      // bounces the user to dashboard.
+      if (currentSession === oldName && currentWindowIndex) {
+        navigate({
+          to: "/$server/$session/$window",
+          params: { server: srv, session: newName, window: currentWindowIndex },
+          replace: true,
+        });
+      }
     },
     onRollback: () => {
       const last = lastRenameSessionRef.current;
-      if (last) unmarkRenamed(last.server, last.name);
+      if (last) {
+        unmarkRenamed(last.server, last.oldName);
+        if (currentSession === last.newName && currentWindowIndex) {
+          navigate({
+            to: "/$server/$session/$window",
+            params: { server, session: last.oldName, window: currentWindowIndex },
+            replace: true,
+          });
+        }
+      }
     },
     onError: (err) => {
       addToast(err.message || "Failed to rename session");

--- a/app/frontend/src/contexts/optimistic-context.tsx
+++ b/app/frontend/src/contexts/optimistic-context.tsx
@@ -163,7 +163,7 @@ export function useMergedSessions(realSessions: ProjectSession[], currentServer:
 
   if (!ctx) return realSessions;
 
-  const { ghosts, killed, renamed, removeGhost } = ctx;
+  const { ghosts, killed, renamed, removeGhost, unmarkRenamed } = ctx;
 
   return useMemo(() => {
     const realSessionNames = new Set(realSessions.map((s) => s.name));
@@ -180,6 +180,15 @@ export function useMergedSessions(realSessions: ProjectSession[], currentServer:
         queueMicrotask(() => removeGhost(ghost.optimisticId));
       } else {
         reconciledSessionGhosts.push(ghost);
+      }
+    }
+
+    // SSE reconciliation: clear renamed entries whose newName already appears
+    // in real SSE data — the rename is confirmed, optimistic overlay is stale.
+    for (const entry of renamed) {
+      if (entry.server !== currentServer) continue;
+      if (realSessionNames.has(entry.newName)) {
+        queueMicrotask(() => unmarkRenamed(entry.server, entry.identifier));
       }
     }
 
@@ -256,5 +265,5 @@ export function useMergedSessions(realSessions: ProjectSession[], currentServer:
     }
 
     return mergedSessions;
-  }, [realSessions, currentServer, ghosts, killed, renamed, removeGhost, windowEntries, windowGhosts]);
+  }, [realSessions, currentServer, ghosts, killed, renamed, removeGhost, unmarkRenamed, windowEntries, windowGhosts]);
 }


### PR DESCRIPTION
## Summary

Session rename from the sidebar causes the session to vanish — both immediately (URL mismatch bounces to dashboard) and after refresh (tmux group filter hides the renamed session from the API). Root cause: `tmux rename-session` doesn't update the `session_group` name, so `parseSessions` filters out the renamed session.

## Changes

- **Backend**: Rewrite `parseSessions` as a two-pass filter that detects leaderless groups (renamed leader) and sole-member groups, adding `session_group_size` to the tmux format string
- **Frontend**: Navigate optimistically on sidebar inline rename (keeps URL in sync with display name), rollback navigation on API failure
- **Frontend**: Auto-reconcile stale optimistic `renamed` entries against SSE data in `useMergedSessions`
- **Tests**: Exhaustive grouping test cases — renamed leader (solo + multi-member), independent groups, color preservation, boundary cases

## Test plan

- [ ] Rename a session from the sidebar — session stays visible, URL updates
- [ ] Rename fails (e.g. invalid name) — session reverts to old name, URL reverts
- [ ] Page refresh after rename — session appears with new name
- [ ] Session in a tmux group — rename doesn't cause it to vanish from the list
- [ ] `go test ./internal/tmux/ -run TestParseSessions` — all 17 cases pass
- [ ] `go test ./...` — full backend suite passes