### PR TITLE
feat: music widget — now-playing controls in top bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ go install github.com/air-verse/air@latest
 
 Run `just doctor` to verify all dependencies are installed.
 
+### Optional: Music widget
+
+The top-bar music widget shows the currently playing track and lets you play/pause/skip from any session. It requires [nowplaying-cli](https://github.com/kirtan403/nowplaying-cli) (macOS only):
+
+```sh
+brew install nowplaying-cli
+```
+
+Without it the widget simply stays hidden — no errors, no required action.
+
 ## Getting Started
 
 ```bash

--- a/app/backend/api/music.go
+++ b/app/backend/api/music.go
@@ -1,0 +1,133 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os/exec"
+	"strings"
+)
+
+// MusicBackend abstracts the system media layer so handlers can be tested without
+// a real nowplaying-cli binary or running music player.
+type MusicBackend interface {
+	NowPlaying() (NowPlayingResponse, error)
+	Control(action string) error
+}
+
+// NowPlayingResponse is the JSON shape returned by GET /api/music/now-playing.
+type NowPlayingResponse struct {
+	Title       string  `json:"title"`
+	Artist      string  `json:"artist"`
+	State       string  `json:"state"`       // "playing", "paused", or "stopped"
+	App         string  `json:"app"`         // source app/identifier
+	Duration    float64 `json:"duration"`    // total track length in seconds
+	ElapsedTime float64 `json:"elapsedTime"` // current position in seconds
+}
+
+// nowplayingCLI is the production MusicBackend using the nowplaying-cli binary.
+type nowplayingCLI struct{}
+
+func (nowplayingCLI) NowPlaying() (NowPlayingResponse, error) {
+	out, err := exec.Command("nowplaying-cli", "get", "title", "artist", "playbackRate", "duration", "elapsedTime").Output()
+	if err != nil {
+		return NowPlayingResponse{State: "stopped"}, err
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) < 3 {
+		return NowPlayingResponse{State: "stopped"}, nil
+	}
+
+	title := strings.TrimSpace(lines[0])
+	artist := strings.TrimSpace(lines[1])
+	rate := strings.TrimSpace(lines[2])
+
+	if title == "" || title == "null" {
+		return NowPlayingResponse{State: "stopped"}, nil
+	}
+
+	state := "paused"
+	if rate == "1" {
+		state = "playing"
+	}
+
+	var duration, elapsedTime float64
+	if len(lines) >= 4 {
+		fmt.Sscanf(strings.TrimSpace(lines[3]), "%f", &duration)
+	}
+	if len(lines) >= 5 {
+		fmt.Sscanf(strings.TrimSpace(lines[4]), "%f", &elapsedTime)
+	}
+
+	return NowPlayingResponse{
+		Title:       title,
+		Artist:      artist,
+		State:       state,
+		App:         "nowplaying",
+		Duration:    duration,
+		ElapsedTime: elapsedTime,
+	}, nil
+}
+
+func (nowplayingCLI) Control(action string) error {
+	cmd := nowplayingCommand(action)
+	if cmd == "" {
+		return nil
+	}
+	return exec.Command("nowplaying-cli", cmd).Run()
+}
+
+// musicBackend returns the server's MusicBackend, defaulting to nowplayingCLI.
+func (s *Server) musicBackend() MusicBackend {
+	if s.music != nil {
+		return s.music
+	}
+	return nowplayingCLI{}
+}
+
+func (s *Server) handleMusicNowPlaying(w http.ResponseWriter, r *http.Request) {
+	resp, _ := s.musicBackend().NowPlaying()
+	writeJSON(w, http.StatusOK, resp)
+}
+
+type MusicControlRequest struct {
+	Action string `json:"action"` // "play", "pause", "next", "previous"
+}
+
+func (s *Server) handleMusicControl(w http.ResponseWriter, r *http.Request) {
+	var req MusicControlRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if nowplayingCommand(req.Action) == "" {
+		writeError(w, http.StatusBadRequest, "unknown action")
+		return
+	}
+
+	if err := s.musicBackend().Control(req.Action); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to control media")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+func nowplayingCommand(action string) string {
+	switch action {
+	case "play":
+		return "play"
+	case "pause":
+		return "pause"
+	case "toggle":
+		return "togglePlayPause"
+	case "next":
+		return "next"
+	case "previous":
+		return "previous"
+	default:
+		return ""
+	}
+}

--- a/app/backend/api/music_test.go
+++ b/app/backend/api/music_test.go
@@ -1,0 +1,401 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+// --- mock backend ---
+
+type mockMusicBackend struct {
+	nowPlayingResp NowPlayingResponse
+	nowPlayingErr  error
+	controlErr     error
+	lastAction     string
+}
+
+func (m *mockMusicBackend) NowPlaying() (NowPlayingResponse, error) {
+	return m.nowPlayingResp, m.nowPlayingErr
+}
+
+func (m *mockMusicBackend) Control(action string) error {
+	m.lastAction = action
+	return m.controlErr
+}
+
+// --- helpers ---
+
+func newMusicRouter(t *testing.T, backend MusicBackend) http.Handler {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	s := &Server{
+		logger:   logger,
+		sessions: &mockSessionFetcher{},
+		tmux:     &mockTmuxOps{},
+		hostname: "test-host",
+		music:    backend,
+	}
+	return s.buildRouter()
+}
+
+func nowPlayingRequest(t *testing.T, router http.Handler) (int, NowPlayingResponse) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/music/now-playing", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	var resp NowPlayingResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return rec.Code, resp
+}
+
+func controlRequest(t *testing.T, router http.Handler, action string) (int, map[string]interface{}) {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"action": action})
+	req := httptest.NewRequest(http.MethodPost, "/api/music/control", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	var resp map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return rec.Code, resp
+}
+
+// --- now-playing tests ---
+
+func TestNowPlaying_AppleMusic_Playing(t *testing.T) {
+	backend := &mockMusicBackend{
+		nowPlayingResp: NowPlayingResponse{
+			Title:  "Confident",
+			Artist: "Demi Lovato",
+			State:  "playing",
+			App:    "nowplaying",
+		},
+	}
+	router := newMusicRouter(t, backend)
+	code, resp := nowPlayingRequest(t, router)
+
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if resp.Title != "Confident" {
+		t.Errorf("title = %q, want %q", resp.Title, "Confident")
+	}
+	if resp.Artist != "Demi Lovato" {
+		t.Errorf("artist = %q, want %q", resp.Artist, "Demi Lovato")
+	}
+	if resp.State != "playing" {
+		t.Errorf("state = %q, want playing", resp.State)
+	}
+}
+
+func TestNowPlaying_AppleMusic_Paused(t *testing.T) {
+	backend := &mockMusicBackend{
+		nowPlayingResp: NowPlayingResponse{
+			Title:  "Cool for the Summer",
+			Artist: "Demi Lovato",
+			State:  "paused",
+			App:    "nowplaying",
+		},
+	}
+	router := newMusicRouter(t, backend)
+	_, resp := nowPlayingRequest(t, router)
+
+	if resp.State != "paused" {
+		t.Errorf("state = %q, want paused", resp.State)
+	}
+	if resp.Title != "Cool for the Summer" {
+		t.Errorf("title = %q, want %q", resp.Title, "Cool for the Summer")
+	}
+}
+
+func TestNowPlaying_Spotify_Playing(t *testing.T) {
+	// Spotify registers with the macOS Media Remote framework, so nowplaying-cli
+	// surfaces it identically — state is "playing" when playbackRate == 1.
+	backend := &mockMusicBackend{
+		nowPlayingResp: NowPlayingResponse{
+			Title:  "Blinding Lights",
+			Artist: "The Weeknd",
+			State:  "playing",
+			App:    "nowplaying",
+		},
+	}
+	router := newMusicRouter(t, backend)
+	code, resp := nowPlayingRequest(t, router)
+
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if resp.Title != "Blinding Lights" {
+		t.Errorf("title = %q, want %q", resp.Title, "Blinding Lights")
+	}
+	if resp.Artist != "The Weeknd" {
+		t.Errorf("artist = %q, want %q", resp.Artist, "The Weeknd")
+	}
+	if resp.State != "playing" {
+		t.Errorf("state = %q, want playing", resp.State)
+	}
+}
+
+func TestNowPlaying_Spotify_Paused(t *testing.T) {
+	backend := &mockMusicBackend{
+		nowPlayingResp: NowPlayingResponse{
+			Title:  "Blinding Lights",
+			Artist: "The Weeknd",
+			State:  "paused",
+			App:    "nowplaying",
+		},
+	}
+	router := newMusicRouter(t, backend)
+	_, resp := nowPlayingRequest(t, router)
+
+	if resp.State != "paused" {
+		t.Errorf("state = %q, want paused", resp.State)
+	}
+}
+
+func TestNowPlaying_YouTubeMusic_Chrome_Playing(t *testing.T) {
+	// YouTube Music in Chrome/Safari registers with macOS Media Remote — same
+	// nowplaying-cli output, just different title/artist metadata.
+	backend := &mockMusicBackend{
+		nowPlayingResp: NowPlayingResponse{
+			Title:  "As It Was",
+			Artist: "Harry Styles",
+			State:  "playing",
+			App:    "nowplaying",
+		},
+	}
+	router := newMusicRouter(t, backend)
+	code, resp := nowPlayingRequest(t, router)
+
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if resp.Title != "As It Was" {
+		t.Errorf("title = %q, want %q", resp.Title, "As It Was")
+	}
+	if resp.State != "playing" {
+		t.Errorf("state = %q, want playing", resp.State)
+	}
+}
+
+func TestNowPlaying_YouTubeMusic_Safari_Playing(t *testing.T) {
+	backend := &mockMusicBackend{
+		nowPlayingResp: NowPlayingResponse{
+			Title:  "Flowers",
+			Artist: "Miley Cyrus",
+			State:  "playing",
+			App:    "nowplaying",
+		},
+	}
+	router := newMusicRouter(t, backend)
+	_, resp := nowPlayingRequest(t, router)
+
+	if resp.State != "playing" {
+		t.Errorf("state = %q, want playing", resp.State)
+	}
+	if resp.Title != "Flowers" {
+		t.Errorf("title = %q, want %q", resp.Title, "Flowers")
+	}
+}
+
+func TestNowPlaying_Stopped_NoActivePlayer(t *testing.T) {
+	backend := &mockMusicBackend{
+		nowPlayingResp: NowPlayingResponse{State: "stopped"},
+	}
+	router := newMusicRouter(t, backend)
+	code, resp := nowPlayingRequest(t, router)
+
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if resp.State != "stopped" {
+		t.Errorf("state = %q, want stopped", resp.State)
+	}
+	if resp.Title != "" {
+		t.Errorf("title should be empty when stopped, got %q", resp.Title)
+	}
+}
+
+func TestNowPlaying_BackendError_ReturnsStopped(t *testing.T) {
+	// If nowplaying-cli fails (e.g. not installed), we return stopped gracefully.
+	backend := &mockMusicBackend{
+		nowPlayingErr: errors.New("nowplaying-cli: command not found"),
+		nowPlayingResp: NowPlayingResponse{State: "stopped"},
+	}
+	router := newMusicRouter(t, backend)
+	code, resp := nowPlayingRequest(t, router)
+
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if resp.State != "stopped" {
+		t.Errorf("state = %q, want stopped", resp.State)
+	}
+}
+
+func TestNowPlaying_ResponseShape(t *testing.T) {
+	// Verify all expected fields are present in JSON output.
+	backend := &mockMusicBackend{
+		nowPlayingResp: NowPlayingResponse{
+			Title:  "T",
+			Artist: "A",
+			State:  "playing",
+			App:    "nowplaying",
+		},
+	}
+	router := newMusicRouter(t, backend)
+	req := httptest.NewRequest(http.MethodGet, "/api/music/now-playing", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	var raw map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&raw); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	for _, field := range []string{"title", "artist", "state", "app"} {
+		if _, ok := raw[field]; !ok {
+			t.Errorf("missing field %q in JSON response", field)
+		}
+	}
+}
+
+// --- control tests ---
+
+func TestControl_Play(t *testing.T) {
+	backend := &mockMusicBackend{}
+	router := newMusicRouter(t, backend)
+	code, resp := controlRequest(t, router, "play")
+
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if resp["ok"] != true {
+		t.Errorf("ok = %v, want true", resp["ok"])
+	}
+	if backend.lastAction != "play" {
+		t.Errorf("action = %q, want play", backend.lastAction)
+	}
+}
+
+func TestControl_Pause(t *testing.T) {
+	backend := &mockMusicBackend{}
+	router := newMusicRouter(t, backend)
+	code, _ := controlRequest(t, router, "pause")
+
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if backend.lastAction != "pause" {
+		t.Errorf("action = %q, want pause", backend.lastAction)
+	}
+}
+
+func TestControl_Next(t *testing.T) {
+	backend := &mockMusicBackend{}
+	router := newMusicRouter(t, backend)
+	code, _ := controlRequest(t, router, "next")
+
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if backend.lastAction != "next" {
+		t.Errorf("action = %q, want next", backend.lastAction)
+	}
+}
+
+func TestControl_Previous(t *testing.T) {
+	backend := &mockMusicBackend{}
+	router := newMusicRouter(t, backend)
+	code, _ := controlRequest(t, router, "previous")
+
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if backend.lastAction != "previous" {
+		t.Errorf("action = %q, want previous", backend.lastAction)
+	}
+}
+
+func TestControl_Toggle(t *testing.T) {
+	backend := &mockMusicBackend{}
+	router := newMusicRouter(t, backend)
+	code, _ := controlRequest(t, router, "toggle")
+
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if backend.lastAction != "toggle" {
+		t.Errorf("action = %q, want toggle", backend.lastAction)
+	}
+}
+
+func TestControl_InvalidAction(t *testing.T) {
+	backend := &mockMusicBackend{}
+	router := newMusicRouter(t, backend)
+	code, resp := controlRequest(t, router, "eject")
+
+	if code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", code)
+	}
+	if _, ok := resp["error"]; !ok {
+		t.Error("expected error field in response")
+	}
+}
+
+func TestControl_MalformedBody(t *testing.T) {
+	backend := &mockMusicBackend{}
+	router := newMusicRouter(t, backend)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/music/control", bytes.NewBufferString("not-json"))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestControl_BackendError(t *testing.T) {
+	// If nowplaying-cli fails mid-command, we return 500.
+	backend := &mockMusicBackend{controlErr: errors.New("media remote unavailable")}
+	router := newMusicRouter(t, backend)
+	code, resp := controlRequest(t, router, "play")
+
+	if code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", code)
+	}
+	if _, ok := resp["error"]; !ok {
+		t.Error("expected error field in response")
+	}
+}
+
+// --- nowplayingCommand mapping ---
+
+func TestNowplayingCommand(t *testing.T) {
+	cases := []struct{ action, want string }{
+		{"play", "play"},
+		{"pause", "pause"},
+		{"toggle", "togglePlayPause"},
+		{"next", "next"},
+		{"previous", "previous"},
+		{"eject", ""},
+		{"", ""},
+	}
+	for _, c := range cases {
+		got := nowplayingCommand(c.action)
+		if got != c.want {
+			t.Errorf("nowplayingCommand(%q) = %q, want %q", c.action, got, c.want)
+		}
+	}
+}

--- a/app/backend/api/router.go
+++ b/app/backend/api/router.go
@@ -61,6 +61,7 @@ type Server struct {
 	metrics  *metrics.Collector
 	sseHub   *sseHub
 	sseOnce  sync.Once
+	music    MusicBackend // nil → uses nowplayingCLI default
 }
 
 // initSSEHub lazily creates the SSE hub on first use.
@@ -242,6 +243,10 @@ func (s *Server) buildRouter() chi.Router {
 	r.Get("/api/servers", s.handleServersList)
 	r.Post("/api/servers", s.handleServerCreate)
 	r.Post("/api/servers/kill", s.handleServerKill)
+
+	// Music controls
+	r.Get("/api/music/now-playing", s.handleMusicNowPlaying)
+	r.Post("/api/music/control", s.handleMusicControl)
 
 	// Keybindings
 	r.Get("/api/keybindings", s.handleKeybindings)

--- a/app/frontend/src/api/client.ts
+++ b/app/frontend/src/api/client.ts
@@ -456,6 +456,31 @@ export async function getAllServerColors(): Promise<Record<string, number>> {
   return data.colors;
 }
 
+// --- Music controls ---
+
+export interface NowPlayingInfo {
+  title: string;
+  artist: string;
+  state: "playing" | "paused" | "stopped";
+  app: string;
+  duration: number;
+  elapsedTime: number;
+}
+
+export async function getNowPlaying(): Promise<NowPlayingInfo> {
+  const res = await deduplicatedFetch("/api/music/now-playing");
+  if (!res.ok) return { title: "", artist: "", state: "stopped", app: "", duration: 0, elapsedTime: 0 };
+  return res.json();
+}
+
+export async function controlMusic(action: "play" | "pause" | "next" | "previous"): Promise<void> {
+  await fetch("/api/music/control", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ action }),
+  });
+}
+
 export async function setServerColor(server: string, color: number | null): Promise<void> {
   const res = await fetch("/api/settings/server-color", {
     method: "PUT",

--- a/app/frontend/src/components/top-bar.tsx
+++ b/app/frontend/src/components/top-bar.tsx
@@ -1,11 +1,12 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { BreadcrumbDropdown } from "@/components/breadcrumb-dropdown";
 import { LogoSpinner } from "@/components/logo-spinner";
 import { useChromeState, useChromeDispatch } from "@/contexts/chrome-context";
 import { useTheme, useThemeActions } from "@/contexts/theme-context";
 import { useOptimisticAction } from "@/hooks/use-optimistic-action";
 import { useToast } from "@/components/toast";
-import { splitWindow, closePane } from "@/api/client";
+import { splitWindow, closePane, getNowPlaying, controlMusic } from "@/api/client";
+import type { NowPlayingInfo } from "@/api/client";
 import type { ProjectSession, WindowInfo } from "@/types";
 import type { BreadcrumbDropdownItem } from "@/contexts/chrome-context";
 
@@ -186,6 +187,9 @@ export function TopBar({
         </nav>
 
         <div className="flex items-center gap-3 text-xs text-text-secondary">
+          <span className="hidden sm:flex">
+            <MusicControls />
+          </span>
           <span className="hidden sm:flex">
             <ThemeToggle />
           </span>
@@ -433,6 +437,205 @@ function ClosePaneButton({
         </svg>
       )}
     </button>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────
+// Music mascot: the Run Kit hexagon that bobs its head to music
+// ──────────────────────────────────────────────────────────────
+function MusicMascot({ isPlaying, size = 18 }: { isPlaying: boolean; size?: number }) {
+  return (
+    <svg
+      viewBox="7 10 50 44"
+      width={size}
+      height={size}
+      aria-hidden="true"
+      style={{
+        animation: isPlaying ? "music-bob 0.95s ease-in-out infinite" : "none",
+        transformOrigin: "50% 50%",
+        transition: "filter 0.2s ease",
+        display: "block",
+        flexShrink: 0,
+      }}
+    >
+      {/* Border segments */}
+      <polygon points="44,11.2 56,32 47.5,32 39.5,17.2" fill={isPlaying ? "#7aa2f7" : "#b4b4b4"} style={{ transition: "fill 0.4s" }} />
+      <polygon points="56,32 44,52.8 39.5,46.8 47.5,32"  fill={isPlaying ? "#7aa2f7" : "#b4b4b4"} style={{ transition: "fill 0.4s" }} />
+      <polygon points="44,52.8 20,52.8 24.5,46.8 39.5,46.8" fill="#2a2a2a" />
+      <polygon points="20,52.8 8,32 16.5,32 24.5,46.8"    fill="#2a2a2a" />
+      <polygon points="8,32 20,11.2 24.5,17.2 16.5,32"    fill="#2a2a2a" />
+      <polygon points="20,11.2 44,11.2 39.5,17.2 24.5,17.2" fill={isPlaying ? "#9db8fb" : "#b4b4b4"} style={{ transition: "fill 0.4s" }} />
+      {/* Inner cube faces */}
+      <polygon points="24.5,17.2 39.5,17.2 47.5,32 32,32" fill={isPlaying ? "#5b8af0" : "#888888"} style={{ transition: "fill 0.4s" }} />
+      <polygon points="47.5,32 39.5,46.8 24.5,46.8 32,32" fill={isPlaying ? "#4a70cc" : "#737373"} style={{ transition: "fill 0.4s" }} />
+      <polygon points="24.5,46.8 16.5,32 24.5,17.2 32,32"  fill={isPlaying ? "#3558a8" : "#545454"} style={{ transition: "fill 0.4s" }} />
+    </svg>
+  );
+}
+
+// Animated equalizer bars — visible when playing
+function EqualizerBars() {
+  return (
+    <div className="flex items-end gap-px h-[12px]" aria-hidden="true">
+      {[
+        { animation: "music-eq1 0.7s ease-in-out infinite", height: "3px" },
+        { animation: "music-eq2 0.9s ease-in-out infinite 0.1s", height: "9px" },
+        { animation: "music-eq3 0.75s ease-in-out infinite 0.2s", height: "5px" },
+      ].map((bar, i) => (
+        <div
+          key={i}
+          className="w-[2px] rounded-sm bg-accent"
+          style={{ animation: bar.animation, height: bar.height }}
+        />
+      ))}
+    </div>
+  );
+}
+
+// Format seconds → m:ss
+function fmtTime(s: number) {
+  if (!s || !isFinite(s)) return "";
+  const m = Math.floor(s / 60);
+  const sec = Math.floor(s % 60);
+  return `${m}:${sec.toString().padStart(2, "0")}`;
+}
+
+function MusicControls() {
+  const [info, setInfo] = useState<NowPlayingInfo>({
+    title: "", artist: "", state: "stopped", app: "", duration: 0, elapsedTime: 0,
+  });
+  const [polledAt, setPolledAt] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const doPoll = useCallback(async () => {
+    try {
+      const data = await getNowPlaying();
+      setInfo(data);
+      setPolledAt(Date.now());
+    } catch {
+      // best-effort
+    }
+  }, []);
+
+  useEffect(() => {
+    doPoll();
+    intervalRef.current = setInterval(doPoll, 5000);
+    return () => { if (intervalRef.current) clearInterval(intervalRef.current); };
+  }, [doPoll]);
+
+  const handle = async (action: "play" | "pause" | "next" | "previous") => {
+    if (action === "play" || action === "pause") {
+      setInfo((prev) => ({ ...prev, state: action === "play" ? "playing" : "paused" }));
+    }
+    await controlMusic(action);
+    setTimeout(doPoll, 700);
+  };
+
+  if (info.state === "stopped" || !info.title) return null;
+
+  const isPlaying = info.state === "playing";
+  const progressPct = info.duration > 0 ? (info.elapsedTime / info.duration) * 100 : 0;
+  const remainingSecs = Math.max(0, info.duration - info.elapsedTime);
+  // How long since we last polled — approximate elapsed advance
+  const secondsSincePoll = isPlaying ? (Date.now() - polledAt) / 1000 : 0;
+  const liveElapsed = Math.min(info.duration, info.elapsedTime + secondsSincePoll);
+  const liveProgressPct = info.duration > 0 ? (liveElapsed / info.duration) * 100 : 0;
+
+  const btnBase =
+    "min-w-[24px] min-h-[24px] rounded border border-border text-text-secondary " +
+    "hover:border-accent hover:text-accent hover:scale-110 " +
+    "transition-all duration-150 flex items-center justify-center active:scale-95";
+
+  return (
+    <div
+      className="group relative flex items-center gap-1.5"
+      title={`${info.title} — ${info.artist}`}
+    >
+      {/* Mascot — always visible, bobs when playing, glows on hover */}
+      <div
+        className="hover:drop-shadow-[0_0_6px_rgba(91,138,240,0.8)] transition-[filter] duration-200 cursor-default"
+        title={isPlaying ? "Now playing" : "Paused"}
+      >
+        <MusicMascot isPlaying={isPlaying} size={18} />
+      </div>
+
+      {/* Equalizer — visible when playing, hidden on hover (controls take over) */}
+      {isPlaying && (
+        <div className="group-hover:opacity-0 group-hover:w-0 overflow-hidden transition-all duration-200">
+          <EqualizerBars />
+        </div>
+      )}
+
+      {/* Track name — compact always-visible label */}
+      <span className="text-xs text-text-secondary max-w-[88px] truncate block group-hover:opacity-0 group-hover:max-w-0 overflow-hidden transition-all duration-200 select-none">
+        {info.title}
+      </span>
+
+      {/* ── Hover panel ─────────────────────────────────────────── */}
+      <div
+        className="flex items-center gap-1.5 overflow-hidden max-w-0 opacity-0 group-hover:opacity-100 group-hover:max-w-[320px] transition-all duration-250 ease-in-out"
+      >
+        {/* Previous */}
+        <button type="button" onClick={() => handle("previous")} aria-label="Previous track" className={btnBase} title="Previous">
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <polygon points="19,20 9,12 19,4" />
+            <rect x="5" y="4" width="3" height="16" />
+          </svg>
+        </button>
+
+        {/* Play / Pause */}
+        <button
+          type="button"
+          onClick={() => handle(isPlaying ? "pause" : "play")}
+          aria-label={isPlaying ? "Pause" : "Play"}
+          className={`${btnBase} ${isPlaying ? "border-accent text-accent bg-accent/10" : ""}`}
+          title={isPlaying ? "Pause" : "Play"}
+        >
+          {isPlaying ? (
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <rect x="6" y="4" width="4" height="16" />
+              <rect x="14" y="4" width="4" height="16" />
+            </svg>
+          ) : (
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <polygon points="5,3 19,12 5,21" />
+            </svg>
+          )}
+        </button>
+
+        {/* Next */}
+        <button type="button" onClick={() => handle("next")} aria-label="Next track" className={btnBase} title="Next">
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <polygon points="5,4 15,12 5,20" />
+            <rect x="16" y="4" width="3" height="16" />
+          </svg>
+        </button>
+
+        {/* Track info + progress */}
+        <div className="flex flex-col justify-center min-w-0 gap-[2px] pl-0.5">
+          <span className="text-[11px] text-text-primary font-medium truncate max-w-[110px] leading-tight">{info.title}</span>
+          <span className="text-[10px] text-text-secondary truncate max-w-[110px] leading-tight">{info.artist}</span>
+
+          {/* Progress bar */}
+          {info.duration > 0 && (
+            <div className="flex items-center gap-1 mt-[2px]">
+              <span className="text-[9px] text-text-secondary tabular-nums">{fmtTime(liveElapsed)}</span>
+              <div className="relative h-[2px] flex-1 min-w-[40px] bg-border rounded-full overflow-hidden">
+                <div
+                  key={`${info.title}-${info.artist}`}
+                  className="absolute inset-y-0 left-0 bg-accent rounded-full"
+                  style={isPlaying ? {
+                    animation: `music-progress ${remainingSecs}s linear forwards`,
+                    "--music-progress-start": `${liveProgressPct}%`,
+                  } as React.CSSProperties : { width: `${progressPct}%` }}
+                />
+              </div>
+              <span className="text-[9px] text-text-secondary tabular-nums">{fmtTime(info.duration)}</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/app/frontend/src/globals.css
+++ b/app/frontend/src/globals.css
@@ -97,6 +97,32 @@ summary {
   16.6%, 33.3% { opacity: 1; }
 }
 
+/* Music: hexagon mascot head-bob */
+@keyframes music-bob {
+  0%   { transform: translateY(0px)  rotate(0deg)  scale(1);    }
+  20%  { transform: translateY(-3px) rotate(-7deg) scale(1.08); }
+  50%  { transform: translateY(-1px) rotate(0deg)  scale(1.04); }
+  80%  { transform: translateY(-2px) rotate(6deg)  scale(1.06); }
+  100% { transform: translateY(0px)  rotate(0deg)  scale(1);    }
+}
+
+/* Music: progress bar fill from a CSS-variable start point */
+@keyframes music-progress {
+  from { width: var(--music-progress-start, 0%); }
+  to   { width: 100%; }
+}
+
+/* Music: equalizer bar bounce (3 variants with different phases) */
+@keyframes music-eq1 {
+  0%, 100% { height: 3px; } 40% { height: 11px; }
+}
+@keyframes music-eq2 {
+  0%, 100% { height: 9px; } 25% { height: 3px;  } 65% { height: 12px; }
+}
+@keyframes music-eq3 {
+  0%, 100% { height: 5px; } 55% { height: 10px; }
+}
+
 /* Prevent iOS Safari page scroll/bounce — fullbleed always on in single-view. */
 html.fullbleed,
 html.fullbleed body {

--- a/docs/specs/api.md
+++ b/docs/specs/api.md
@@ -345,6 +345,65 @@ WebSocket endpoint for interactive terminal access.
 
 ---
 
+### Music Controls
+
+Media playback info and control, powered by `nowplaying-cli` on macOS. Both endpoints degrade gracefully when the binary is absent or no media app is running — they never return errors for those cases.
+
+#### `GET /api/music/now-playing`
+
+Returns the currently playing track.
+
+**Response** `200`:
+```json
+{
+  "title": "Neon Gravestones",
+  "artist": "twenty one pilots",
+  "state": "playing",
+  "app": "nowplaying",
+  "duration": 284.5,
+  "elapsedTime": 42.1
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `title` | `string` | Track title. Empty string when nothing is playing. |
+| `artist` | `string` | Artist name. |
+| `state` | `"playing" \| "paused" \| "stopped"` | Playback state. |
+| `app` | `string` | Source identifier (e.g. `"nowplaying"`). |
+| `duration` | `float64` | Total track length in seconds. `0` if unavailable. |
+| `elapsedTime` | `float64` | Current playback position in seconds. `0` if unavailable. |
+
+**Behavior:**
+- Returns `{ state: "stopped", title: "", ... }` when `nowplaying-cli` is absent, exits with error, or no media app is running.
+- Never returns a non-2xx status for a missing binary or stopped player.
+
+#### `POST /api/music/control`
+
+Send a playback command to the active media app.
+
+**Request:**
+```json
+{ "action": "next" }
+```
+
+| Field | Type | Required | Values |
+|-------|------|----------|--------|
+| `action` | `string` | yes | `"play"`, `"pause"`, `"next"`, `"previous"` |
+
+**Response** `200`:
+```json
+{ "ok": true }
+```
+
+**Errors:**
+- `400` — unknown action or malformed body
+- `500` — `nowplaying-cli` subprocess failed
+
+**Requirement:** `nowplaying-cli` must be installed and a supported media app must be running for control commands to take effect.
+
+---
+
 ### SPA Fallback
 
 #### `GET /*` (catch-all, lowest priority)
@@ -421,5 +480,7 @@ WebSocket endpoint for interactive terminal access.
 | `POST` | `/api/sessions/:session/windows/:index/keys` | `windows.go` | Send keystrokes |
 | `POST` | `/api/sessions/:session/upload` | `upload.go` | File upload |
 | `GET` | `/api/directories` | `directories.go` | Directory autocomplete |
+| `GET` | `/api/music/now-playing` | `music.go` | Current track info |
+| `POST` | `/api/music/control` | `music.go` | Playback control |
 | `WS` | `/relay/:session/:window` | `relay.go` | Terminal relay |
 | `GET` | `/*` | `spa.go` | SPA static + fallback |


### PR DESCRIPTION
Adds a top-bar music widget that shows the current track (title, artist, progress) and provides play/pause/prev/next controls via nowplaying-cli. Backend exposes GET /api/music/now-playing and POST /api/music/control; frontend polls every 5 s and animates the Run Kit hex mascot while playing.

Docs: README notes nowplaying-cli as an optional dependency; API spec documents both new endpoints and adds them to the route summary table.