### PR TITLE
docs: restructure README and add rk riff guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,14 @@
 
 [![Latest release](https://img.shields.io/github/v/release/sahil87/run-kit)](https://github.com/sahil87/run-kit/releases) [![Downloads](https://img.shields.io/github/downloads/sahil87/run-kit/total)](https://github.com/sahil87/run-kit/releases) [![Stars](https://img.shields.io/github/stars/sahil87/run-kit?style=social)](https://github.com/sahil87/run-kit/stargazers)
 
-Web-based agent orchestration dashboard. Monitor and interact with tmux sessions from the browser — session overview, live terminal windows, and fab-kit integration for change tracking.
+Web-based agent orchestration dashboard. Spawn Claude Code workspaces with `rk riff`, then monitor and drive them from the browser — sidebar of tmux servers, sessions, and panes; live terminal windows; mobile-friendly; keyboard-first.
+
+## Why run-kit?
+
+- **One command to start an agent workspace** — `rk riff` creates a git worktree, a tmux window, and one or more Claude Code panes in a single shot. Run several in parallel with `-N`.
+- **Browser dashboard for tmux** — every tmux session and pane shows up in a sidebar. Click a pane to get a live terminal in the browser, or open it on your phone over Tailscale.
+- **No database, no daemon magic** — state is derived from tmux and the filesystem. Agent sessions survive `rk` restarts because the daemon never touches them.
+- **Keyboard-first** — `Cmd+K` command palette is the primary discovery mechanism. Touch targets are tuned for mobile.
 
 ## Screenshots
 
@@ -25,16 +32,81 @@ brew install rk
 
 To upgrade later, run `rk update` — it pulls the latest version via Homebrew and restarts the daemon so the new binary takes effect immediately.
 
-## Usage
+## Quick start
 
 ```bash
-rk serve -d          # start daemon (default :3000)
-rk serve --restart   # restart daemon (idempotent)
-rk serve --stop      # graceful shutdown
-rk update            # upgrade via Homebrew and restart
+rk serve -d                  # start the dashboard daemon (default :3000)
+open http://localhost:3000   # open the dashboard
+
+# in any tmux session:
+rk riff --skill /fab-discuss # spawn an agent workspace
 ```
 
-## Prerequisites (development)
+## Commands
+
+| Command | What it does |
+|---------|--------------|
+| [`rk serve`](#serve) | Start the HTTP server (foreground or daemon). |
+| [`rk riff`](#riff) | Create a worktree + tmux window + Claude Code pane(s). |
+| `rk status` | Show a tmux session summary. |
+| `rk context` | Print agent-optimized environment info (server URL, ports, etc.). |
+| `rk doctor` | Check runtime dependencies. |
+| `rk init-conf` | Scaffold default tmux.conf and `tmux.d/` drop-in directory to `~/.rk/`. |
+| `rk update` | Upgrade via Homebrew and restart the daemon. |
+| `rk completion` | Generate shell completion scripts. |
+| `rk help` | Help about any command. |
+
+Run `rk <command> --help` for full flag details.
+
+### serve
+
+Start the HTTP server. Configurable via `RK_HOST` (default `127.0.0.1`) and `RK_PORT` (default `3000`).
+
+```bash
+rk serve                                # foreground on 127.0.0.1:3000
+RK_HOST=0.0.0.0 RK_PORT=8080 rk serve   # bind all interfaces, port 8080
+rk serve -d                             # background daemon in a tmux session
+rk serve --restart                      # idempotent restart
+rk serve --stop                         # graceful shutdown
+```
+
+### riff
+
+Spawn an agent workspace — a git worktree, a tmux window inside it, and one or more Claude Code panes. The headline feature; see the [riff guide](docs/wiki/riff.md) for the full reference.
+
+```bash
+rk riff                                              # 1 pane, default skill (/fab-discuss)
+rk riff --skill /fab-fff                             # 1 pane, specific slash-command
+rk riff --skill /fab-fff --cmd "just dev"            # 2 panes (agent + dev server)
+rk riff --skill /a --cmd x --cmd y --layout main-vertical
+rk riff ship                                         # invoke the 'ship' preset
+rk riff ship --count 3                               # 3 parallel ship workspaces
+rk riff -- --worktree-name pacing-canyon             # name the worktree
+```
+
+Highlights:
+
+- **Pane array model** — `--skill` and `--cmd` are repeatable; argv order becomes pane order. Bare `--skill` opens a blank Claude session; bare `--cmd` drops into `$SHELL`.
+- **Presets** — define common pane/layout combos in `fab/project/config.yaml` under `riff.presets.<name>`.
+- **Layouts** — `auto` (default), `tiled`, `even-horizontal`, `even-vertical`, `main-horizontal`, `main-vertical`.
+- **Parallel** — `-N <N>` spawns N workspaces in parallel; failures roll back successful ones.
+- **wt passthrough** — flags after `--` go to `wt create` (e.g. `--base`, `--reuse`, `--worktree-name`).
+
+Prerequisites: must be inside a tmux session, [`wt`](https://github.com/sahil87/wt) on `PATH`, and the launcher (default `claude --dangerously-skip-permissions`) available. Override the launcher per-project via `agent.spawn_command` in `fab/project/config.yaml`.
+
+## HTTPS
+
+Some browser features (e.g., copy to clipboard) require a secure context and only work over HTTPS. Accessing rk from other machines on your tailnet also requires HTTPS. To enable it:
+
+1. Enable HTTPS at [DNS > HTTPS Certificates](https://login.tailscale.com/admin/dns).
+2. Run `tailscale serve --bg http://localhost:3000`.
+3. Open `https://<machine>.<tailnet>.ts.net`.
+
+For custom hostnames, Funnel, and other options, see the [Tailscale guide](docs/wiki/tailscale.md).
+
+## Development
+
+### Prerequisites
 
 - [Node.js](https://nodejs.org/) (v20+)
 - [pnpm](https://pnpm.io/)
@@ -51,29 +123,21 @@ go install github.com/air-verse/air@latest
 
 Run `just doctor` to verify all dependencies are installed.
 
-## Getting Started
+### Getting started
 
 ```bash
 just doctor
 just setup
-just dev  # watch mode
+just dev   # watch mode (Go backend + Vite dev server)
 # OR
-just prod # Runs from built binary
+just prod  # run from built binary
 ```
 
-## HTTPS
+## Architecture notes
 
-Some browser features (e.g., copy to clipboard) require a secure context and only work over HTTPS. Accessing rk from other machines on your tailnet also requires HTTPS. To enable it:
+### Self-improvement loop
 
-1. Enable HTTPS at [DNS > HTTPS Certificates](https://login.tailscale.com/admin/dns).
-2. Run `tailscale serve --bg http://localhost:3000`.
-3. Open `https://<machine>.<tailnet>.ts.net`.
-
-For custom hostnames, Funnel, and other options, see the [Tailscale guide](docs/wiki/tailscale.md).
-
-## Self-Improvement Loop
-
-rk runs as a daemon in a dedicated tmux session. Lifecycle is managed via CLI flags on `rk serve`:
+rk runs as a daemon in a dedicated tmux session, managed via CLI flags on `rk serve`:
 
 - `rk serve -d` — start daemon in a tmux session (`rk-daemon` server)
 - `rk serve --restart` — idempotent restart (stop existing if running, start new)

--- a/docs/wiki/riff.md
+++ b/docs/wiki/riff.md
@@ -1,0 +1,128 @@
+# `rk riff` — spawn agent workspaces
+
+`rk riff` creates a git worktree, opens a new tmux window inside it, and launches one or more Claude Code panes — all in a single command. It's the primary way to start agent work in run-kit.
+
+A "riff" is one disposable workspace: one branch, one worktree, one tmux window, one or more agent panes. Tear it down by closing the window and deleting the worktree (`wt delete`).
+
+## Prerequisites
+
+- You must be running inside a tmux session (`$TMUX` set).
+- [`wt`](https://github.com/sahil87/wt) must be on your `PATH`.
+- The launcher (`claude --dangerously-skip-permissions` by default) must be available.
+
+The launcher can be overridden per-project via `agent.spawn_command` in `fab/project/config.yaml`.
+
+## Quick start
+
+```bash
+rk riff                                   # 1 pane, default skill (/fab-discuss)
+rk riff --skill /review                   # 1 pane, specific slash-command
+rk riff --skill /fab-fff --cmd "just dev" # 2 panes (agent + dev server)
+```
+
+Open the resulting window in the browser to drive it from the run-kit UI, or stay in tmux — both work, since the agent is just a tmux pane.
+
+## Pane array model
+
+`--skill` and `--cmd` are repeatable. Argv order (left to right) becomes pane order (pane 0, pane 1, …). The flags can be interleaved:
+
+```bash
+rk riff --skill /a --cmd htop --skill /b --cmd "tail -f log"
+# pane 0: claude /a   pane 1: htop   pane 2: claude /b   pane 3: tail
+```
+
+- **Bare `--skill`** (no value) launches a blank Claude session.
+- **Bare `--cmd`** drops into `$SHELL` (fallback `/bin/sh`).
+
+## Layouts
+
+`--layout` controls pane arrangement. Default is `auto` (1 pane = none, 2 = even-horizontal, 3+ = tiled).
+
+| Name | Shortform | Shape |
+|------|-----------|-------|
+| `auto` | `a` | pane-count-based default |
+| `tiled` | `t` | grid |
+| `even-horizontal` | `h` | side-by-side |
+| `even-vertical` | `v` | stacked |
+| `main-horizontal` | `deck-h` | main on top, deck below |
+| `main-vertical` | `deck-v` | main on left, deck on right |
+
+```bash
+rk riff --skill /a --cmd x --cmd y --layout main-vertical
+```
+
+## Presets
+
+Define common pane shapes in `fab/project/config.yaml` under `riff.presets.<name>`:
+
+```yaml
+riff:
+  presets:
+    ship:
+      layout: main-vertical
+      panes:
+        - skill: /fab-fff
+        - cmd: just dev
+        - cmd: just test-e2e --ui
+      wt_args: ["--base", "main"]
+```
+
+Invoke by name (positional or via `--preset`):
+
+```bash
+rk riff ship                # positional preset name
+rk riff --preset ship       # explicit form
+rk riff --list-presets      # list all defined presets
+```
+
+CLI `--skill` / `--cmd` flags **replace** the preset's panes entirely; CLI `--layout` overrides the preset's layout.
+
+## Parallel spawning with `--count`
+
+`-N <N>` (or `--count <N>`) creates N worktree/window pairs in parallel, each with the same pane shape:
+
+```bash
+rk riff ship --count 3      # 3 parallel ship workspaces
+rk riff -N 5 --skill /fab-fff
+```
+
+Worktree names come from `wt`'s adjective-noun generator (e.g. `swift-fox`, `zippy-yak`). On any failure, successful worktrees and windows are rolled back before exit.
+
+## Passing flags to `wt`
+
+Anything after `--` is forwarded verbatim to `wt create`. Useful for:
+
+```bash
+rk riff -- --worktree-name pacing-canyon   # name the worktree
+rk riff -- --base main                     # branch off main
+rk riff -- --reuse                         # reuse an existing branch
+```
+
+Run `wt create --help` for the full passthrough flag list.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | success |
+| 2 | precondition failure (`$TMUX` unset, `wt` not found) |
+| 3 | subprocess failure (`wt` or `tmux` non-zero, parse failure, timeout) |
+
+## Common patterns
+
+```bash
+# Solo planning session
+rk riff --skill /fab-discuss
+
+# Implement + watch dev server + watch tests
+rk riff --skill /fab-fff --cmd "just dev" --cmd "just test-watch" --layout main-vertical
+
+# Three parallel attempts at the same change
+rk riff ship --count 3
+
+# Investigate a bug with a shell pane handy
+rk riff --skill /fab-discuss --cmd
+
+# Branch off a specific base
+rk riff --skill /fab-fff -- --base release/v2
+```


### PR DESCRIPTION
## Summary

- Surface `rk riff` as the headline feature with a section, examples, and a link to the new guide — previously not mentioned in the README at all.
- Add a Commands table covering all 9 `rk` subcommands plus a dedicated `serve` subsection with env vars and lifecycle flags.
- Reframe the opening with a "Why run-kit?" block (one-shot agent workspaces, tmux-as-dashboard, no DB, keyboard-first) so first-time visitors see the value prop before installation.
- Move daemon internals into an "Architecture notes" section at the bottom — useful but not onboarding material.
- Add `docs/wiki/riff.md` with the full reference: pane array model, layouts (with shortform table), presets, `--count`, `wt` passthrough, exit codes, and common patterns.

## Test plan

- [ ] Render the README on GitHub and check that all anchor links resolve (`#serve`, `#riff`, `docs/wiki/riff.md`, `docs/wiki/tailscale.md`).
- [ ] Skim `docs/wiki/riff.md` for accuracy against `rk riff --help` output.
- [ ] Confirm the screenshots block still renders correctly under the new heading order.