### PR TITLE
release: add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,17 +4,43 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
 
 permissions:
   contents: write
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   release:
+    # workflow_dispatch must run from main; tag-push is allowed from any ref.
+    if: github.event_name == 'push' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'main' || github.ref }}
+
+      - name: Create tag (manual dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        id: create_tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          ./scripts/release.sh "${{ inputs.bump }}"
+          echo "tag=$(git tag --sort=-v:refname | head -1)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
@@ -46,7 +72,11 @@ jobs:
       - name: Extract version from tag
         id: version
         run: |
-          tag="${GITHUB_REF#refs/tags/}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            tag="${{ steps.create_tag.outputs.tag }}"
+          else
+            tag="${GITHUB_REF#refs/tags/}"
+          fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
 
@@ -70,7 +100,7 @@ jobs:
       - name: Determine release notes base tag
         id: release-base
         run: |
-          tag="${GITHUB_REF#refs/tags/}"
+          tag="${{ steps.version.outputs.tag }}"
           # Extract major.minor from current tag (e.g. v0.2.0 → 0.2)
           current_minor=$(echo "$tag" | sed 's/^v//' | cut -d. -f1-2)
           patch=$(echo "$tag" | sed 's/^v//' | cut -d. -f3)
@@ -94,6 +124,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
+          tag_name: ${{ steps.version.outputs.tag }}
           files: dist/*.tar.gz
           generate_release_notes: true
           previous_tag: ${{ steps.release-base.outputs.base_tag }}


### PR DESCRIPTION
## Summary

Phase 2 of the toolkit-wide release-pipeline cleanup. The Release workflow can now be triggered manually from the Actions tab with a `bump` input (patch/minor/major, default patch). The existing tag-push trigger is preserved.

Builds on the Phase 1 tag-driven port — `scripts/release.sh` now just tags and pushes, which is exactly what the manual-dispatch path needs to run.

Downstream steps that read `$GITHUB_REF` now read `steps.version.outputs.tag` so both trigger paths share the same code.

## Test plan

- [ ] Tag-push path: cut a release with `just release patch` — should behave exactly as before.
- [ ] workflow_dispatch path: Actions → Release → "Run workflow", pick `patch`, confirm full pipeline runs (frontend build, cross-compile, GitHub Release, tap update).
- [ ] workflow_dispatch from a non-main branch: rejected by the job-level `if:` guard.