### PR TITLE
fix(daemon): anchor tmux targets to avoid prefix-match collisions

### DIFF
--- a/app/backend/internal/daemon/daemon.go
+++ b/app/backend/internal/daemon/daemon.go
@@ -13,8 +13,14 @@ import (
 const (
 	// ServerSocket is the tmux server socket for the daemon (separate from agent sessions).
 	ServerSocket = "rk-daemon"
-	// SessionName is the tmux session name for the daemon.
-	SessionName = "rk"
+	// SessionName is the tmux session name for the daemon. Matches the socket
+	// name so the combined exact-match target (=rk-daemon) is unambiguous and
+	// cannot collide with user-facing sessions via tmux prefix matching.
+	SessionName = "rk-daemon"
+	// LegacySessionName is the pre-rename session name. Stop/Restart consult
+	// this so a daemon started by an older binary can be shut down cleanly
+	// during the first upgrade.
+	LegacySessionName = "rk"
 	// WindowName is the tmux window name where `rk serve` runs.
 	WindowName = "serve"
 
@@ -24,14 +30,26 @@ const (
 	stopPollInterval = 200 * time.Millisecond
 )
 
-// target returns the tmux target string "session:window".
+// target returns the tmux target string for the daemon's window, with both
+// session and window segments anchored (`=`) so tmux performs exact-match
+// instead of prefix-match lookup.
 func target() string {
-	return SessionName + ":" + WindowName
+	return targetFor(SessionName)
 }
+
+// targetFor returns an exact-match window target for the given session name.
+func targetFor(session string) string {
+	return "=" + session + ":=" + WindowName
+}
+
+// serverSocket is the variable form of ServerSocket — overridable in tests so
+// integration tests can exercise IsRunning/Stop against an isolated socket
+// without touching a production daemon.
+var serverSocket = ServerSocket
 
 // runTmux executes a tmux command on the daemon server, capturing stderr for diagnostics.
 func runTmux(ctx context.Context, args ...string) error {
-	fullArgs := append([]string{"-L", ServerSocket}, args...)
+	fullArgs := append([]string{"-L", serverSocket}, args...)
 	cmd := exec.CommandContext(ctx, "tmux", fullArgs...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -44,12 +62,33 @@ func runTmux(ctx context.Context, args ...string) error {
 	return nil
 }
 
-// isRunningCtx checks if the daemon tmux session exists using the provided context.
-func isRunningCtx(ctx context.Context) bool {
-	return runTmux(ctx, "has-session", "-t", SessionName) == nil
+// sessionExistsCtx returns true if a session with the exact given name exists
+// on the daemon socket. The `=` prefix forces exact-match lookup so a prefix
+// like "rk" cannot accidentally match "rk-relay-*" or "rk-daemon".
+func sessionExistsCtx(ctx context.Context, name string) bool {
+	return runTmux(ctx, "has-session", "-t", "="+name) == nil
 }
 
-// IsRunning returns true if the daemon tmux session exists.
+// runningSessionCtx returns the name of the live daemon session — preferring
+// the current SessionName, falling back to LegacySessionName for daemons
+// started by older binaries. Returns "" if neither exists.
+func runningSessionCtx(ctx context.Context) string {
+	if sessionExistsCtx(ctx, SessionName) {
+		return SessionName
+	}
+	if sessionExistsCtx(ctx, LegacySessionName) {
+		return LegacySessionName
+	}
+	return ""
+}
+
+// isRunningCtx reports whether any (current-or-legacy) daemon session exists.
+func isRunningCtx(ctx context.Context) bool {
+	return runningSessionCtx(ctx) != ""
+}
+
+// IsRunning returns true if the daemon tmux session exists (under the current
+// or legacy name).
 func IsRunning() bool {
 	ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
 	defer cancel()
@@ -114,17 +153,20 @@ func startSession(exe string) error {
 
 // Stop sends C-c to the daemon pane and waits up to 5 seconds for it to exit.
 // A single context bounds the entire operation (send-keys + polling + kill).
-// Returns nil if the daemon is not running.
+// Returns nil if the daemon is not running. Targets a legacy-named daemon
+// (SessionName == LegacySessionName) transparently so users upgrading from
+// older binaries can stop/restart without manual cleanup.
 func Stop() error {
 	ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
 	defer cancel()
 
-	if !isRunningCtx(ctx) {
+	session := runningSessionCtx(ctx)
+	if session == "" {
 		return nil
 	}
 
 	// Send C-c to trigger graceful shutdown.
-	if err := runTmux(ctx, "send-keys", "-t", target(), "C-c"); err != nil {
+	if err := runTmux(ctx, "send-keys", "-t", targetFor(session), "C-c"); err != nil {
 		return fmt.Errorf("sending C-c to daemon: %w", err)
 	}
 
@@ -135,12 +177,12 @@ func Stop() error {
 			// Timeout — kill forcefully with a fresh short context.
 			killCtx, killCancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer killCancel()
-			if err := runTmux(killCtx, "kill-session", "-t", SessionName); err != nil {
+			if err := runTmux(killCtx, "kill-session", "-t", "="+session); err != nil {
 				return fmt.Errorf("killing daemon session after timeout: %w", err)
 			}
 			return nil
 		case <-time.After(stopPollInterval):
-			if !isRunningCtx(ctx) {
+			if !sessionExistsCtx(ctx, session) {
 				return nil
 			}
 		}

--- a/app/backend/internal/daemon/daemon_test.go
+++ b/app/backend/internal/daemon/daemon_test.go
@@ -23,12 +23,25 @@ func useTestSocket(t *testing.T) {
 	})
 }
 
+// withServerSocket redirects the daemon package's runTmux to the test socket
+// for the duration of the test, so IsRunning/Stop can be exercised without
+// touching a real production daemon.
+func withServerSocket(t *testing.T, socket string) {
+	t.Helper()
+	orig := serverSocket
+	serverSocket = socket
+	t.Cleanup(func() { serverSocket = orig })
+}
+
 func TestConstants(t *testing.T) {
 	if ServerSocket != "rk-daemon" {
 		t.Errorf("ServerSocket = %q, want %q", ServerSocket, "rk-daemon")
 	}
-	if SessionName != "rk" {
-		t.Errorf("SessionName = %q, want %q", SessionName, "rk")
+	if SessionName != "rk-daemon" {
+		t.Errorf("SessionName = %q, want %q", SessionName, "rk-daemon")
+	}
+	if LegacySessionName != "rk" {
+		t.Errorf("LegacySessionName = %q, want %q", LegacySessionName, "rk")
 	}
 	if WindowName != "serve" {
 		t.Errorf("WindowName = %q, want %q", WindowName, "serve")
@@ -37,29 +50,43 @@ func TestConstants(t *testing.T) {
 
 func TestTarget(t *testing.T) {
 	got := target()
-	want := "rk:serve"
+	want := "=rk-daemon:=serve"
 	if got != want {
 		t.Errorf("target() = %q, want %q", got, want)
 	}
 }
 
-// isRunningOn checks if a session exists on the given socket.
-func isRunningOn(socket string) bool {
-	cmd := exec.Command("tmux", "-L", socket, "has-session", "-t", SessionName)
+func TestTargetFor_Legacy(t *testing.T) {
+	got := targetFor(LegacySessionName)
+	want := "=rk:=serve"
+	if got != want {
+		t.Errorf("targetFor(legacy) = %q, want %q", got, want)
+	}
+}
+
+// hasSessionOn checks if the given session exists on the socket using exact match.
+func hasSessionOn(socket, session string) bool {
+	cmd := exec.Command("tmux", "-L", socket, "has-session", "-t", "="+session)
 	return cmd.Run() == nil
 }
 
-// startOn creates a session on the given socket with a harmless command.
-func startOn(socket string) error {
+// isRunningOn checks if the current-name session exists on the given socket.
+func isRunningOn(socket string) bool {
+	return hasSessionOn(socket, SessionName)
+}
+
+// startOn creates a session with the given name on the socket using a harmless command.
+func startOn(socket, session string) error {
 	return exec.Command("tmux", "-L", socket,
-		"new-session", "-d", "-s", SessionName, "-n", WindowName,
+		"new-session", "-d", "-s", session, "-n", WindowName,
 		"sleep", "300").Run()
 }
 
-// stopOn sends C-c and kills the session on the given socket.
-func stopOn(socket string) {
-	_ = exec.Command("tmux", "-L", socket, "send-keys", "-t", SessionName+":"+WindowName, "C-c").Run()
-	_ = exec.Command("tmux", "-L", socket, "kill-session", "-t", SessionName).Run()
+// stopOn sends C-c and kills the named session on the given socket.
+func stopOn(socket, session string) {
+	_ = exec.Command("tmux", "-L", socket, "send-keys",
+		"-t", "="+session+":="+WindowName, "C-c").Run()
+	_ = exec.Command("tmux", "-L", socket, "kill-session", "-t", "="+session).Run()
 }
 
 func TestIsRunning_NoSession(t *testing.T) {
@@ -83,7 +110,7 @@ func TestStartAndStop(t *testing.T) {
 	useTestSocket(t)
 
 	// Start a session on the test socket.
-	if err := startOn(testSocket); err != nil {
+	if err := startOn(testSocket, SessionName); err != nil {
 		t.Fatalf("startOn() error: %v", err)
 	}
 	if !isRunningOn(testSocket) {
@@ -91,12 +118,12 @@ func TestStartAndStop(t *testing.T) {
 	}
 
 	// Starting again should fail (session already exists).
-	if err := startOn(testSocket); err == nil {
+	if err := startOn(testSocket, SessionName); err == nil {
 		t.Error("startOn() should error when session already exists")
 	}
 
 	// Stop should succeed.
-	stopOn(testSocket)
+	stopOn(testSocket, SessionName)
 	if isRunningOn(testSocket) {
 		t.Error("isRunningOn() = true after stopOn()")
 	}
@@ -112,7 +139,7 @@ func TestRestart_WhenNotRunning(t *testing.T) {
 	useTestSocket(t)
 
 	// Start on test socket (simulates restart when not running).
-	if err := startOn(testSocket); err != nil {
+	if err := startOn(testSocket, SessionName); err != nil {
 		t.Fatalf("startOn() error: %v", err)
 	}
 	if !isRunningOn(testSocket) {
@@ -151,6 +178,60 @@ func TestRestartWithBinary_InvalidPath(t *testing.T) {
 	}
 }
 
+// TestIsRunning_IgnoresPrefixCollision is the regression test for the bug
+// that motivated the SessionName rename + `=` anchors. A leftover relay-style
+// session "rk-relay-deadbeef" (prefix-matches the legacy name "rk") must not
+// be misidentified as a running daemon.
+func TestIsRunning_IgnoresPrefixCollision(t *testing.T) {
+	if !hasTmux() {
+		t.Skip("tmux not in PATH")
+	}
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	useTestSocket(t)
+	withServerSocket(t, testSocket)
+
+	// Plant a session whose name only collides under prefix matching.
+	if err := startOn(testSocket, "rk-relay-deadbeef"); err != nil {
+		t.Fatalf("startOn(relay) error: %v", err)
+	}
+
+	if IsRunning() {
+		t.Error("IsRunning() = true; expected false — relay session must not " +
+			"prefix-match the daemon session lookup")
+	}
+}
+
+// TestStop_LegacySessionName verifies the upgrade path: a daemon started by
+// an older binary under the legacy name "rk" can still be stopped by the new
+// Stop() implementation.
+func TestStop_LegacySessionName(t *testing.T) {
+	if !hasTmux() {
+		t.Skip("tmux not in PATH")
+	}
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	useTestSocket(t)
+	withServerSocket(t, testSocket)
+
+	// Simulate a legacy daemon running under the old session name.
+	if err := startOn(testSocket, LegacySessionName); err != nil {
+		t.Fatalf("startOn(legacy) error: %v", err)
+	}
+	if !IsRunning() {
+		t.Fatal("IsRunning() = false; expected true for legacy-named daemon")
+	}
+
+	if err := Stop(); err != nil {
+		t.Fatalf("Stop() error: %v", err)
+	}
+	if IsRunning() {
+		t.Error("IsRunning() = true after Stop(); legacy session should be gone")
+	}
+}
+
 func TestRestart_WhenRunning(t *testing.T) {
 	if !hasTmux() {
 		t.Skip("tmux not in PATH")
@@ -161,13 +242,13 @@ func TestRestart_WhenRunning(t *testing.T) {
 	useTestSocket(t)
 
 	// Start first.
-	if err := startOn(testSocket); err != nil {
+	if err := startOn(testSocket, SessionName); err != nil {
 		t.Fatalf("startOn() error: %v", err)
 	}
 
 	// Stop and re-start (simulates restart).
-	stopOn(testSocket)
-	if err := startOn(testSocket); err != nil {
+	stopOn(testSocket, SessionName)
+	if err := startOn(testSocket, SessionName); err != nil {
 		t.Fatalf("startOn() after stop error: %v", err)
 	}
 	if !isRunningOn(testSocket) {


### PR DESCRIPTION
## Summary

`rk serve --stop` and `rk serve --restart` could fail with:

```
Error: stopping daemon: sending C-c to daemon: exit status 1: can't find window: serve
```

…when an orphaned `rk-relay-*` session was left on the daemon's tmux socket. tmux's `-t` flag does **prefix matching**, so `has-session -t rk` matched `rk-relay-<hex>`, `IsRunning()` returned true, and `send-keys -t rk:serve` then resolved to the relay session (which has no `serve` window).

## Changes

- **Anchor every daemon-targeted lookup with `=`** so tmux performs exact-match instead of prefix-match (`has-session`, `send-keys`, `kill-session`).
- **Rename `SessionName` from `\"rk\"` to `\"rk-daemon\"`** so the daemon's identity is unambiguous even without anchors and cannot collide with any user-facing `rk*` session. The session name now matches the socket name.
- **Upgrade path** — add `LegacySessionName = \"rk\"` and a `runningSessionCtx()` fallback used by `IsRunning()` and `Stop()`. Daemons started by an older binary are stopped transparently during the first `rk serve --restart` or `rk upgrade` after install. No manual cleanup required.
- **Tests**:
  - `TestIsRunning_IgnoresPrefixCollision` — plants `rk-relay-deadbeef` and asserts `IsRunning() == false` (the exact regression).
  - `TestStop_LegacySessionName` — starts a session under the legacy name `\"rk\"` and asserts the new `Stop()` shuts it down.
  - Updated existing helpers to use exact-match anchors and an explicit session-name argument.

## Test plan

- [x] `go test ./internal/daemon/ -v` — all 11 tests pass (2 new)
- [x] `go test ./...` — no new failures (one pre-existing unrelated failure in `internal/sessions` exists on `main`)
- [ ] After install: `rk serve --restart` succeeds even when an `rk-relay-*` session is orphaned on the daemon socket
- [ ] After install on a host with an older daemon running: `rk serve --restart` shuts down the legacy `rk` session and starts a new `rk-daemon` session

## Notes

If a host has an orphaned `rk-relay-*` session blocking restart today, the new binary will start cleanly alongside it (the legacy fallback only matches the exact name `\"rk\"`, not `rk-relay-*`). The orphan will be reaped on the next `rk serve` startup by the existing `sweepOrphanedRelaySessions` housekeeping.