### PR TITLE
fix(tmuxctl): skip tmux .lock files to stop recursive server spawn

### DIFF
--- a/app/backend/internal/tmuxctl/supervisor.go
+++ b/app/backend/internal/tmuxctl/supervisor.go
@@ -6,10 +6,27 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/fsnotify/fsnotify"
 )
+
+// isTmuxSocketCandidate returns false for entries that are known to live in
+// $TMUX_TMPDIR but are not server sockets. tmux writes a `<socket>.lock`
+// advisory-lock file next to each server socket during startup; opening a
+// control-mode client against the `.lock` name would cause tmux to create a
+// fresh server with that name (which in turn births `<socket>.lock.lock`),
+// triggering unbounded recursion under fsnotify.
+func isTmuxSocketCandidate(name string) bool {
+	if name == "" || name == "." || name == ".." {
+		return false
+	}
+	if strings.HasSuffix(name, ".lock") {
+		return false
+	}
+	return true
+}
 
 // openFn is the function used by Supervisor to instantiate a Client for a
 // newly-observed socket. Production: Open. Tests inject a stub.
@@ -96,6 +113,9 @@ func (s *Supervisor) Start(ctx context.Context) error {
 			if e.IsDir() {
 				continue
 			}
+			if !isTmuxSocketCandidate(e.Name()) {
+				continue
+			}
 			s.openSocket(ctx, e.Name())
 		}
 	}
@@ -162,7 +182,7 @@ func (s *Supervisor) run() {
 				return
 			}
 			name := filepath.Base(ev.Name)
-			if name == "" || name == "." {
+			if !isTmuxSocketCandidate(name) {
 				continue
 			}
 			if ev.Op&fsnotify.Create != 0 {

--- a/app/backend/internal/tmuxctl/supervisor_test.go
+++ b/app/backend/internal/tmuxctl/supervisor_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -96,6 +97,69 @@ func TestSupervisor_StartEnumerates(t *testing.T) {
 	got := reg.opened()
 	if len(got) != 3 {
 		t.Fatalf("expected 3 opens, got %d: %v", len(got), got)
+	}
+}
+
+// TestSupervisor_SkipsLockFiles verifies that tmux's `<socket>.lock` companion
+// files are not opened — neither during initial enumeration nor on subsequent
+// fsnotify Create events. Opening a `.lock` would cause tmux to create a fresh
+// server named `<socket>.lock`, recursively spawning `<socket>.lock.lock`, etc.
+func TestSupervisor_SkipsLockFiles(t *testing.T) {
+	resetLoggedUnknowns()
+	dir := t.TempDir()
+
+	// Pre-create a socket and its lock companion. Only the socket should
+	// be opened.
+	if err := os.WriteFile(filepath.Join(dir, "kits"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "kits.lock"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := newTestOpenRegistry()
+	s := NewSupervisor(NoOpSink{})
+	s.watchDirOverride = dir
+	s.open = reg.openFn()
+
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = s.Stop(stopCtx)
+	})
+
+	if got := reg.opened(); len(got) != 1 || got[0] != "kits" {
+		t.Fatalf("initial enum: expected [kits], got %v", got)
+	}
+
+	// Runtime Create of a `.lock` file must also be ignored.
+	if err := os.WriteFile(filepath.Join(dir, "kits2.lock"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Real socket alongside it should still trigger an open.
+	if err := os.WriteFile(filepath.Join(dir, "kits2"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		got := reg.opened()
+		if len(got) == 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected 2 opens (kits, kits2), got %v", got)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	for _, name := range reg.opened() {
+		if strings.HasSuffix(name, ".lock") {
+			t.Fatalf("supervisor opened a .lock entry: %q", name)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

The control-mode `Supervisor` introduced in #198 enumerates every entry in `$TMUX_TMPDIR` and opens a tmux `-CC` client against it. tmux writes a `<socket>.lock` advisory-lock file next to each server socket, so those got opened too — and `tmux -L <socket>.lock attach …` happily creates a brand-new server with that name, which produces `<socket>.lock.lock`, which fsnotify fires Create for, which the supervisor opens, …

Result: unbounded recursion, one new tmux server per iteration. The sidebar surfaces each generation as its own server (with `_rk-ctl` filtered out, so each shows "no sessions"), producing the visible `RK-DAEMON-TEST.LOCK.LOCK.LOCK…` chain.

## Fix

Skip names ending in `.lock` in both code paths:

- `Supervisor.Start` initial enumeration (`supervisor.go`)
- `Supervisor.run` fsnotify event loop (`supervisor.go`)

Centralised in a new `isTmuxSocketCandidate` helper with a comment explaining the recursion risk so the guard isn't accidentally removed later.

The `.lock` suffix is tmux's own invariant — companion lock files for server sockets — so the filter is precise and matches §III ("wrap, don't reinvent": follow tmux's convention rather than reinventing socket-mode detection). Defense-in-depth via `os.Lstat().Mode()&os.ModeSocket` was considered; rejected for now because (a) the suffix check is sufficient to break the recursion and (b) the existing supervisor tests deliberately use regular files as fake sockets, and the mode check would have required converting those to real `net.Listen("unix", …)` fixtures for no additional safety in production.

## Test plan

- [x] New `TestSupervisor_SkipsLockFiles` covers both paths — pre-existing `.lock` companion at startup, and a runtime `.lock` Create alongside a real socket.
- [x] `go test ./internal/tmuxctl/...` — all pass.
- [x] `go test ./...` — same single pre-existing `sessions.TestFetchPaneMapIntegration` flake noted in #198 as unrelated; no new failures.
- [ ] Manual: leave a stale `<name>.lock` in `$TMUX_TMPDIR` (e.g. `touch /tmp/tmux-$UID/foo.lock`), start `rk serve`, confirm no new `foo` or `foo.lock` tmux servers are spawned.

## Cleanup for affected hosts

Anyone hit by the wild state should clear leaked `<socket>.lock[.lock]*` tmux servers manually:

```bash
for s in $(ls /tmp/tmux-$UID | grep '\.lock'); do
  tmux -L "$s" kill-server 2>/dev/null
  rm -f "/tmp/tmux-$UID/$s"
done
```

Not added to `sweepOrphanedRelaySessions` because (a) it only runs once at startup, (b) the new guard makes the leak unreachable going forward, and (c) the sweep's current scope is `rk-relay-*` sessions, not arbitrary leaked servers.