### PR TITLE
docs: simplify Tailscale custom-hostname setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Some browser features (clipboard, secure context) require HTTPS. Accessing rk fr
 2. Run `tailscale serve --bg http://localhost:3000`.
 3. Open `https://<machine>.<tailnet>.ts.net` on your phone or another laptop.
 
-For custom hostnames, Funnel, and other options, see the [Tailscale guide](docs/wiki/tailscale.md).
+For a stable custom hostname or public access via Funnel, see the [Tailscale guide](docs/wiki/tailscale.md).
 
 ## Shell completion
 

--- a/docs/wiki/tailscale.md
+++ b/docs/wiki/tailscale.md
@@ -27,42 +27,41 @@ tailscale serve off
 
 ## Advanced: Custom hostname
 
-Use a Tailscale service to serve run-kit under a dedicated hostname like `runner1.<tailnet>.ts.net` instead of the machine name. The URL stays stable even if you move run-kit to a different host.
+Serve run-kit under a stable hostname like `runner1.<tailnet>.ts.net` instead of the machine name — the URL survives moving rk to another host.
 
-```sh
-tailscale serve --bg --service=svc:runner1 http://localhost:3000
-```
+Services need a tagged node. Do these in order:
 
-**Setup:** Services require a tagged node and ACL configuration. In your [Tailscale ACL policy](https://login.tailscale.com/admin/acls):
+1. **Define the `tag:server` tag.** In [Access controls](https://login.tailscale.com/admin/acls), Visual editor → **Tags** → add a tag named `server`. Owners can be left empty.
 
-1. Define a tag, grant yourself ownership, and auto-approve service advertisements:
-
-   ```jsonc
-   "tagOwners": {
-     "tag:server": ["your-email@example.com"]
-   },
-   "autoApprovers": {
-     "services": {
-       "svc:runner1": ["tag:server"]
-     }
-   }
-   ```
-
-2. Re-register the node with the tag and allow your user to manage Tailscale without sudo:
+2. **Re-register the node with the tag** (`--operator` lets you manage Tailscale without sudo afterward):
 
    ```sh
    sudo tailscale up --advertise-tags=tag:server --operator=$USER
    ```
 
-3. In the [admin console](https://login.tailscale.com/admin/machines), find the `svc:runner1` service and add `tcp:443` as an endpoint. Without this, you'll see "required ports are missing" even though the service is advertising.
+3. **Add the HTTPS endpoint.** In the [machines console](https://login.tailscale.com/admin/machines), open the `svc:runner1` service and add `tcp:443`. Skip this and you'll get "required ports are missing" even while the service advertises.
 
-4. Now the service command works:
+4. **Serve:**
 
    ```sh
    tailscale serve --bg --service=svc:runner1 http://localhost:3000
    ```
 
-> **Note:** Tagging a node removes the association with your user identity — ACL rules that grant access by user won't apply. Make sure your ACLs grant the tag access to what it needs.
+5. **Approve the service.** Open the [Services](https://login.tailscale.com/admin/services) page, find the pending `svc:runner1` advertisement under **Service hosts**, and click **Approve**. The service is inactive until you do.
+
+run-kit is now at `https://runner1.<tailnet>.ts.net`.
+
+> **Note:** Tagging a node drops its user-identity association — user-based ACL grants stop applying. Make sure your ACLs grant the tag what it needs.
+
+> **Tip:** If you advertise services often, you can skip the manual approval in step 5. In the [Access controls](https://login.tailscale.com/admin/acls) **JSON editor**, add an `autoApprovers` block as a top-level key (there's no Visual editor control for service approval), then save — leave the existing `grants` block untouched:
+>
+> ```jsonc
+> "autoApprovers": {
+>   "services": {
+>     "svc:runner1": ["tag:server"]
+>   }
+> },
+> ```
 
 ## Advanced: Public access (Funnel)
 


### PR DESCRIPTION
## Summary

- Restructure the **Advanced: Custom hostname** flow in [docs/wiki/tailscale.md](docs/wiki/tailscale.md) around **manual service approval** at [admin/services](https://login.tailscale.com/admin/services) instead of the JSON `autoApprovers` block. The auto-approver is demoted to an optional tip for users who advertise services often.
- Removes the ACL-editing step that had no Visual editor mapping (verified against Tailscale's [Visual policy editor reference](https://tailscale.com/kb/1587/visual-editor-reference) — `autoApprovers.services` is JSON-only, while `tagOwners` does have a Tags UI section).
- Tighten step ordering: no premature `serve` command in the intro, gotchas (auto-approval ordering, `tcp:443` endpoint) inline at the step where they bite.
- Fix the README pointer text to match the wiki's actual two advanced sections (custom hostname + Funnel), not "and other options."

## Why

The previous flow led with a JSON snippet (`tagOwners` + `autoApprovers`) that had to be merged into the Tailscale ACL policy with no clear UI mapping — easy to get stuck on. Manual service approval is a single button click and works whether or not the JSON block exists, so it's the better default; the JSON path is a convenience for frequent service advertisers.

## Test plan

- [ ] Render the wiki page and visually inspect the **Advanced: Custom hostname** section reads as a clean 5-step flow ending in the Approve step
- [ ] Follow the steps on a clean tailnet from a fresh state and confirm the pending advertisement appears at `admin/services` after `tailscale serve --service=...`
- [ ] Confirm the optional `> Tip:` JSON snippet at the bottom of the section is valid JSONC when pasted into the JSON editor as a top-level key
- [ ] Verify the README link text ("a stable custom hostname or public access via Funnel") still resolves to the correct wiki page