### PR TITLE
fix: key active-window tracker on base session name, not numeric session_group

### DIFF
--- a/app/backend/internal/tmux/active_window_test.go
+++ b/app/backend/internal/tmux/active_window_test.go
@@ -7,9 +7,37 @@ import (
 )
 
 // sessionGroupLine builds a list-sessions line for parseSessionGroups:
-// session_id<TAB>session_name<TAB>session_group.
-func sessionGroupLine(sid, name, group string) string {
-	return strings.Join([]string{sid, name, group}, listDelim)
+// session_id<TAB>session_name<TAB>session_group_list.
+//
+// NOTE: the third field is `#{session_group_list}` (comma-separated MEMBER
+// NAMES), NOT `#{session_group}`. tmux 3.6a reports `#{session_group}` as an
+// opaque numeric id (e.g. "0"), so the group key is derived from the member
+// names via baseGroupName instead.
+func sessionGroupLine(sid, name, groupList string) string {
+	return strings.Join([]string{sid, name, groupList}, listDelim)
+}
+
+func TestBaseGroupName(t *testing.T) {
+	tests := []struct {
+		name      string
+		sessName  string
+		groupList string
+		want      string
+	}{
+		{"ungrouped → own name", "solo", "", "solo"},
+		{"base member from list (queried as base)", "runKit", "runKit,rk-relay-abc", "runKit"},
+		{"base member from list (queried as ephemeral)", "rk-relay-abc", "runKit,rk-relay-abc", "runKit"},
+		{"anchor skipped, base chosen", "_rk-ctl", "_rk-ctl,runKit", "runKit"},
+		{"ephemeral-only list → own name fallback", "rk-relay-x", "rk-relay-x", "rk-relay-x"},
+		{"order independent — base is first non-special", "rk-relay-x", "rk-relay-x,runKit", "runKit"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := baseGroupName(tt.sessName, tt.groupList); got != tt.want {
+				t.Errorf("baseGroupName(%q, %q) = %q, want %q", tt.sessName, tt.groupList, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestParseSessionGroups(t *testing.T) {
@@ -19,12 +47,17 @@ func TestParseSessionGroups(t *testing.T) {
 		want  map[string]string
 	}{
 		{
-			name: "grouped base + ephemeral share group",
+			// Regression for the v2.1.4 bug: tmux reports group_list with member
+			// NAMES; both base and ephemeral $sid must resolve to the base name
+			// "runKit" so an event fired against the ephemeral updates the right
+			// group. (Previously keyed on numeric #{session_group}="0" → mismatch
+			// with the derivation lookup by session name → permanent Tier-2 fallback.)
+			name: "grouped base + ephemeral resolve to base name",
 			lines: []string{
-				sessionGroupLine("$0", "runKit", "runKit"),
-				sessionGroupLine("$34", "rk-relay-abc", "runKit"),
+				sessionGroupLine("$0", "runKit", "runKit,rk-relay-4c7ca880"),
+				sessionGroupLine("$124", "rk-relay-4c7ca880", "runKit,rk-relay-4c7ca880"),
 			},
-			want: map[string]string{"$0": "runKit", "$34": "runKit"},
+			want: map[string]string{"$0": "runKit", "$124": "runKit"},
 		},
 		{
 			name: "ungrouped session falls back to name as group",
@@ -36,11 +69,19 @@ func TestParseSessionGroups(t *testing.T) {
 		{
 			name: "mixed grouped and ungrouped",
 			lines: []string{
-				sessionGroupLine("$0", "runKit", "runKit"),
-				sessionGroupLine("$34", "rk-relay-x", "runKit"),
+				sessionGroupLine("$0", "runKit", "runKit,rk-relay-x"),
+				sessionGroupLine("$34", "rk-relay-x", "runKit,rk-relay-x"),
 				sessionGroupLine("$2", "solo", ""),
 			},
 			want: map[string]string{"$0": "runKit", "$34": "runKit", "$2": "solo"},
+		},
+		{
+			name: "anchor in group resolves members to base name",
+			lines: []string{
+				sessionGroupLine("$0", "runKit", "_rk-ctl,runKit"),
+				sessionGroupLine("$9", "_rk-ctl", "_rk-ctl,runKit"),
+			},
+			want: map[string]string{"$0": "runKit", "$9": "runKit"},
 		},
 		{
 			name:  "empty input",
@@ -52,7 +93,7 @@ func TestParseSessionGroups(t *testing.T) {
 			lines: []string{
 				"$0\trunKit", // only 2 fields
 				sessionGroupLine("", "x", "x"),
-				sessionGroupLine("$5", "ok", "ok"),
+				sessionGroupLine("$5", "ok", ""),
 			},
 			want: map[string]string{"$5": "ok"},
 		},
@@ -69,32 +110,47 @@ func TestParseSessionGroups(t *testing.T) {
 }
 
 // activeWindowLine builds a list-windows -a line for parseActiveWindowsByGroup:
-// session_group<TAB>session_name<TAB>window_id<TAB>window_active.
-func activeWindowLine(group, name, wid string, active int) string {
+// session_group_list<TAB>session_name<TAB>window_id<TAB>window_active.
+//
+// The first field is `#{session_group_list}` (member names), NOT
+// `#{session_group}` — see sessionGroupLine.
+func activeWindowLine(groupList, name, wid string, active int) string {
 	a := "0"
 	if active == 1 {
 		a = "1"
 	}
-	return strings.Join([]string{group, name, wid, a}, listDelim)
+	return strings.Join([]string{groupList, name, wid, a}, listDelim)
 }
 
 func TestParseActiveWindowsByGroup(t *testing.T) {
+	const gl = "runKit,rk-relay-x" // shared group-list for grouped cases
 	tests := []struct {
 		name  string
 		lines []string
 		want  map[string]string
 	}{
 		{
-			name: "leader pointer authoritative over ephemeral",
-			// Group runKit: leader (name==group) active @3; ephemeral active @0.
-			// The seed must reflect the LEADER (@3), mirroring Tier-2 base pointer.
+			// Regression: the seed must reflect the BASE session's pointer
+			// (the Tier-2 truth), keyed by the base NAME "runKit" — not by a
+			// numeric group, and not the ephemeral's independent pointer.
+			name: "base pointer authoritative over ephemeral, keyed by base name",
 			lines: []string{
-				activeWindowLine("runKit", "runKit", "@0", 0),
-				activeWindowLine("runKit", "runKit", "@3", 1),
-				activeWindowLine("runKit", "rk-relay-x", "@0", 1),
-				activeWindowLine("runKit", "rk-relay-x", "@3", 0),
+				activeWindowLine(gl, "runKit", "@0", 0),
+				activeWindowLine(gl, "runKit", "@3", 1),
+				activeWindowLine(gl, "rk-relay-x", "@0", 1),
+				activeWindowLine(gl, "rk-relay-x", "@3", 0),
 			},
 			want: map[string]string{"runKit": "@3"},
+		},
+		{
+			// Mirrors the exact live v2.1.4 state: base and ephemeral agree on
+			// @27. Keyed by base name "runKit" so the derivation lookup hits.
+			name: "live grouped shape keyed by base name",
+			lines: []string{
+				activeWindowLine("runKit,rk-relay-4c7ca880", "rk-relay-4c7ca880", "@27", 1),
+				activeWindowLine("runKit,rk-relay-4c7ca880", "runKit", "@27", 1),
+			},
+			want: map[string]string{"runKit": "@27"},
 		},
 		{
 			name: "ungrouped session keyed by name",
@@ -105,27 +161,28 @@ func TestParseActiveWindowsByGroup(t *testing.T) {
 			want: map[string]string{"solo": "@2"},
 		},
 		{
-			name: "leaderless group uses first active member as representative",
-			// No row where name==group (leader renamed); fall back to first
-			// active member row.
+			name: "no base-member row uses first active member as representative",
+			// Only an ephemeral row present (base session momentarily absent
+			// from the listing); fall back to first active member row, still
+			// keyed by the base name derived from the group-list.
 			lines: []string{
-				activeWindowLine("runKit", "rk-relay-x", "@7", 1),
+				activeWindowLine(gl, "rk-relay-x", "@7", 1),
 			},
 			want: map[string]string{"runKit": "@7"},
 		},
 		{
-			name: "leader row overrides earlier ephemeral fallback",
+			name: "base row overrides earlier ephemeral fallback",
 			lines: []string{
-				activeWindowLine("runKit", "rk-relay-x", "@7", 1), // ephemeral first
-				activeWindowLine("runKit", "runKit", "@3", 1),     // leader later
+				activeWindowLine(gl, "rk-relay-x", "@7", 1), // ephemeral first
+				activeWindowLine(gl, "runKit", "@3", 1),     // base later
 			},
 			want: map[string]string{"runKit": "@3"},
 		},
 		{
 			name: "inactive rows ignored",
 			lines: []string{
-				activeWindowLine("runKit", "runKit", "@0", 0),
-				activeWindowLine("runKit", "runKit", "@1", 0),
+				activeWindowLine(gl, "runKit", "@0", 0),
+				activeWindowLine(gl, "runKit", "@1", 0),
 			},
 			want: nil,
 		},
@@ -138,7 +195,7 @@ func TestParseActiveWindowsByGroup(t *testing.T) {
 			name: "short line skipped",
 			lines: []string{
 				"runKit\trunKit\t@3", // only 3 fields
-				activeWindowLine("g", "g", "@9", 1),
+				activeWindowLine("", "g", "@9", 1),
 			},
 			want: map[string]string{"g": "@9"},
 		},

--- a/app/backend/internal/tmux/tmux.go
+++ b/app/backend/internal/tmux/tmux.go
@@ -539,16 +539,44 @@ func ListWindows(ctx context.Context, session string, server string) ([]WindowIn
 	return windows, nil
 }
 
+// baseGroupName returns the user-facing base session name for a session group,
+// given the session's own name and its `#{session_group_list}` value (a
+// comma-separated list of MEMBER NAMES). The base is the member that is neither
+// an rk-relay-* ephemeral nor the _rk-ctl anchor — i.e. the real, user-facing
+// session that the dashboard keys on. When the list is empty (ungrouped
+// session) or yields no qualifying member, the session's own name is returned.
+//
+// This MUST NOT key on `#{session_group}`: tmux 3.6a reports that field as an
+// opaque NUMERIC group id (e.g. "0"), not the leader's name — so `name ==
+// session_group` is never true for real grouped sessions. The group-list is the
+// reliable cross-reference to the base session name. The returned name is the
+// same value `parseSessions` keeps as `SessionInfo.Name`, so the active-window
+// tracker keys (event + re-seed) align with the derivation lookup in
+// internal/sessions.
+func baseGroupName(name, groupList string) string {
+	for _, member := range strings.Split(groupList, ",") {
+		m := strings.TrimSpace(member)
+		if m == "" {
+			continue
+		}
+		if strings.HasPrefix(m, RelaySessionPrefix) || m == ControlAnchorSessionName {
+			continue
+		}
+		return m
+	}
+	return name
+}
+
 // parseSessionGroups parses `list-sessions` output of the form
-// `#{session_id}<delim>#{session_name}<delim>#{session_group}` into a
-// `$sid`→group map. tmux reports an EMPTY `#{session_group}` for ungrouped
-// sessions; in that case the session's own name is used as the group key so a
-// single-session (ungrouped) server still tracks under a stable key. The
-// rk-relay-* ephemerals and the _rk-ctl anchor are NOT filtered here — they
-// share their base session's group, so their `$sid` must resolve to that same
-// group for an active-window event fired against an ephemeral member to update
-// the correct (user-facing) group. Lines with fewer than 3 fields are skipped.
-// Exported (same-package) for testing.
+// `#{session_id}<delim>#{session_name}<delim>#{session_group_list}` into a
+// `$sid`→base-session-name map. The rk-relay-* ephemerals and the _rk-ctl
+// anchor are NOT filtered here — they share their base session's group, so their
+// `$sid` must resolve to the SAME base name for an active-window event fired
+// against an ephemeral member to update the correct (user-facing) group. The
+// group key is the base session name (via baseGroupName), NOT tmux's numeric
+// `#{session_group}` id, so it matches the `SessionInfo.Name` the derivation
+// path looks up. Lines with fewer than 3 fields are skipped. Exported
+// (same-package) for testing.
 func parseSessionGroups(lines []string) map[string]string {
 	out := make(map[string]string, len(lines))
 	for _, line := range lines {
@@ -558,13 +586,11 @@ func parseSessionGroups(lines []string) map[string]string {
 		}
 		sid := strings.TrimSpace(parts[0])
 		name := strings.TrimSpace(parts[1])
-		group := strings.TrimSpace(parts[2])
+		groupList := strings.TrimSpace(parts[2])
 		if sid == "" {
 			continue
 		}
-		if group == "" {
-			group = name
-		}
+		group := baseGroupName(name, groupList)
 		if group == "" {
 			continue
 		}
@@ -589,7 +615,7 @@ func ListSessionGroups(ctx context.Context, server string) (map[string]string, e
 	format := strings.Join([]string{
 		"#{session_id}",
 		"#{session_name}",
-		"#{session_group}",
+		"#{session_group_list}",
 	}, listDelim)
 
 	lines, err := tmuxExecServer(ctx, server, "list-sessions", "-F", format)
@@ -604,51 +630,52 @@ func ListSessionGroups(ctx context.Context, server string) (map[string]string, e
 }
 
 // parseActiveWindowsByGroup parses `list-windows -a` output of the form
-// `#{session_group}<delim>#{session_name}<delim>#{window_id}<delim>#{window_active}`
-// into a group→active-`@wid` map for use as the Tier-1 re-seed.
+// `#{session_group_list}<delim>#{session_name}<delim>#{window_id}<delim>#{window_active}`
+// into a base-session-name→active-`@wid` map for use as the Tier-1 re-seed.
 //
 // In a session group, EACH member carries its own active-window pointer, so
 // `list-windows -a` emits one `window_active=1` row per member. The seed MUST
-// reflect the BASE (leader) session's pointer — the same signal Tier 2 reads —
-// so only the leader row (where `session_name == session_group`) is honored for
-// grouped sessions. Ungrouped sessions report an empty group; their own name is
-// the group key and their sole `window_active=1` row is taken. A leaderless
-// group (renamed leader, no name==group row) records the first active row seen
-// as a best-effort representative. Lines with fewer than 4 fields are skipped.
+// reflect the BASE (user-facing) session's pointer — the same signal Tier 2
+// reads — so only the row whose `#{session_name}` IS the base name (derived from
+// `#{session_group_list}` via baseGroupName, never tmux's numeric
+// `#{session_group}`) is honored. The map is keyed by that base name so it
+// aligns with both parseSessionGroups and the derivation lookup
+// (SessionInfo.Name). Ungrouped sessions have an empty group-list, so the base
+// is their own name and their sole `window_active=1` row is taken. As a
+// best-effort fallback, if a group never produces a base-member row in this
+// listing (e.g. the base session is momentarily absent), the first active row
+// for that base name is recorded. Lines with fewer than 4 fields are skipped.
 // Exported (same-package) for testing.
 func parseActiveWindowsByGroup(lines []string) map[string]string {
 	out := make(map[string]string)
-	leaderSeen := make(map[string]bool)
+	baseSeen := make(map[string]bool)
 	for _, line := range lines {
 		parts := strings.Split(line, listDelim)
 		if len(parts) < 4 {
 			continue
 		}
-		group := strings.TrimSpace(parts[0])
+		groupList := strings.TrimSpace(parts[0])
 		name := strings.TrimSpace(parts[1])
 		wid := strings.TrimSpace(parts[2])
 		active := strings.TrimSpace(parts[3]) == "1"
 		if !active || wid == "" {
 			continue
 		}
-		if group == "" {
-			group = name
-		}
-		if group == "" {
+		base := baseGroupName(name, groupList)
+		if base == "" {
 			continue
 		}
-		isLeader := name == group
-		if isLeader {
-			// Leader pointer is authoritative for the group's seed.
-			out[group] = wid
-			leaderSeen[group] = true
+		if name == base {
+			// The base session's own pointer is authoritative for the seed.
+			out[base] = wid
+			baseSeen[base] = true
 			continue
 		}
-		// Non-leader (ephemeral) row — only used as a fallback if the group
-		// never produces a leader row in this listing.
-		if !leaderSeen[group] {
-			if _, ok := out[group]; !ok {
-				out[group] = wid
+		// Non-base (ephemeral/anchor) row — only used as a fallback if the
+		// group never produces a base-member row in this listing.
+		if !baseSeen[base] {
+			if _, ok := out[base]; !ok {
+				out[base] = wid
 			}
 		}
 	}
@@ -670,7 +697,7 @@ func ListActiveWindowsByGroup(ctx context.Context, server string) (map[string]st
 	defer cancel()
 
 	format := strings.Join([]string{
-		"#{session_group}",
+		"#{session_group_list}",
 		"#{session_name}",
 		"#{window_id}",
 		"#{window_active}",


### PR DESCRIPTION
## Problem

The active-window event derivation shipped in #212 (v2.1.x) **did not fix the symptom** — after `rk riff` (or any external `tmux new-window`), the sidebar still highlighted the old window.

Root cause: the per-group active-window tracker keyed on tmux's `#{session_group}` format variable, assuming it returns the group's base/leader session **name**. On tmux 3.6a, `#{session_group}` is an opaque **numeric id** (e.g. `0`), while the derivation in `sessions.FetchSessions` looks the tracker up by the user-facing session **name** (e.g. `runKit`). The keys never matched → Tier 1 (event-tracked active window) never hit → derivation fell back permanently to the stale base-session `#{window_active}` pointer. That stale pointer is exactly what #212 set out to stop reading.

Live tmux 3.6a, real `runKit` group:
```
name=runKit             group=[0]  group_list=[runKit,rk-relay-4c7ca880]
name=rk-relay-4c7ca880  group=[0]  group_list=[runKit,rk-relay-4c7ca880]
```
`name == session_group` is never true → the "leader" branch never fired; everything keyed under `"0"`, which the derivation (keyed by `"runKit"`) never looks up.

## Fix

Derive the group key from `#{session_group_list}` (comma-separated member **names**) via a new `baseGroupName` helper that selects the member which is neither an `rk-relay-*` ephemeral nor the `_rk-ctl` anchor — the same value `parseSessions` keeps as `SessionInfo.Name`. Both `parseSessionGroups` (sid→group) and `parseActiveWindowsByGroup` (reconnect re-seed) now key on that base name, so the tracker keys and the derivation lookup align. Ungrouped sessions (empty group-list) fall back to their own name, as before.

No behavior change to the tracker, derivation, or frontend — only the **key** the two tmux parsers emit.

## Why it shipped green before

The existing parser unit tests fed a third field of `"runKit"` (a name) — a format real tmux never produces for grouped sessions. They asserted a fictional input shape, so they passed while production was broken.

- Rewrote both parser tests to the **real** tmux format (`#{session_group_list}` with member names), with regression cases mirroring the live `runKit,rk-relay-*` data.
- Added `TestBaseGroupName` for the new helper (ungrouped, base-vs-ephemeral, anchor-skip, ordering).

## Verification

Verified **end-to-end against a live tmux server** (the step that was missing before): ran the real `ListSessionGroups`/`ListActiveWindowsByGroup` against the running group, and drove activations through a standalone server on the same tmux socket:

- `select-window @36` on base → API `isActiveWindow` follows to `@36`
- `new-window` (the `rk riff` mechanism) → new window becomes active → API follows
- **Ephemeral-driven activation** (the real `rk riff`-from-web-UI case): base pointer stayed stale on `@148`, ephemeral activated `@27`, and the API correctly reported `@27` — following the event, not the stale base pointer

`go build ./...`, `go vet`, and the `internal/tmux` / `internal/tmuxctl` / `internal/sessions` test packages all pass.