### PR TITLE
test(e2e): stop scraping xterm canvas text on board routes

### DIFF
--- a/app/frontend/tests/e2e/boards-same-session-multi-pane.spec.md
+++ b/app/frontend/tests/e2e/boards-same-session-multi-pane.spec.md
@@ -16,28 +16,46 @@ only its targeted window's PTY output.
 
 - `beforeAll` creates an `e2e-board-same-<timestamp>` tmux session on the
   `rk-test-e2e` server with two named windows (`win-a`, `win-b`). Each window's
-  initial command prints a unique marker (`PANE_ALPHA_OK`, `PANE_BRAVO_OK`)
-  then sleeps so the marker stays available for the relay to capture.
+  initial command prints a marker then sleeps so the pane has a live PTY for
+  the relay to attach to. (The markers are NOT scraped — see the note on
+  rendering below.)
 - A unique board name (`mp<digits>`) is used per run so reruns don't collide.
 - `afterAll` kills the test session.
 
+## Note on terminal-content verification
+
+xterm.js renders glyphs to a **WebGL canvas** with no DOM text layer
+(`.xterm-rows` is absent; `body.innerText()` never contains terminal output).
+So the original "scrape the marker text" assertion was unverifiable against the
+real renderer. Per-pane isolation is instead proven at the **relay layer**:
+each pinned window opens its own `/relay/<windowId>` WebSocket and each pane
+mounts its own live `.xterm` instance. Two distinct relay sockets for the two
+distinct window ids is the direct connection-level proof that the
+grouped-ephemeral relay isolates each pane. This matches the assertion style of
+`boards-desktop-suspend.spec.ts`.
+
 ## Tests
 
-### `two windows from one session show distinct pane content`
+### `two windows from one session each open their own relay pane`
 
-**What it proves:** Pinning two distinct windows of the same tmux session
-into a single board produces two pane terminals that render only their
-respective window's PTY output, with no cross-contamination. This is the
-multi-pane same-session correctness invariant restored by the grouped-session
-relay refactor.
+**What it proves:** Pinning two distinct windows of the same tmux session into
+a single board produces two independent pane terminals — each mounts its own
+live xterm instance and opens its own per-window relay WebSocket, with no
+shared/aliased socket. This is the multi-pane same-session relay-isolation
+invariant restored by the grouped-session refactor, verified at the connection
+layer (xterm's WebGL canvas exposes no DOM text to scrape).
 
 **Steps:**
 
 1. Resolve the `#{window_id}` of `win-a` and `win-b` via `tmux list-windows -F`.
-2. POST `/api/boards/<name>/pin` for `win-a`, then for `win-b`.
-3. Navigate to `/board/<name>` (waitUntil `domcontentloaded`).
-4. Assert both `win-a` and `win-b` pane headers render.
-5. Poll the page text content until BOTH `PANE_ALPHA_OK` and `PANE_BRAVO_OK`
-   markers are present — each pane's terminal must show its own marker.
-6. Unpin both windows via the API to clean up (empty boards are removed
+2. Register a `page.on("websocket")` listener that records the percent-decoded
+   window id of every `/relay/<id>` socket (ignoring Vite HMR / SSE sockets).
+3. POST `/api/boards/<name>/pin` for `win-a`, then for `win-b`.
+4. Navigate to `/board/<name>` (waitUntil `domcontentloaded`).
+5. Assert both `win-a` and `win-b` pane headers render.
+6. Assert exactly two `.xterm` instances mount (both panes' terminals are live).
+7. Poll until a relay WebSocket has opened for BOTH `win-a`'s and `win-b`'s
+   window ids, and assert at least two distinct relay sockets were seen — each
+   pane gets its own relay (isolation proof).
+8. Unpin both windows via the API to clean up (empty boards are removed
    per the boards spec).

--- a/app/frontend/tests/e2e/boards-same-session-multi-pane.spec.ts
+++ b/app/frontend/tests/e2e/boards-same-session-multi-pane.spec.ts
@@ -5,12 +5,24 @@ const TMUX_SERVER = process.env.E2E_TMUX_SERVER ?? "rk-test-e2e";
 const TEST_SESSION = `e2e-board-same-${Date.now()}`;
 const BOARD_NAME = `mp${Date.now().toString().slice(-6)}`;
 
-// Two distinct shell payloads so each window's terminal renders content unique
-// to that window. The test asserts that when both windows are pinned to one
-// board, each pane shows only its targeted window's payload — proving the
-// per-WebSocket grouped-ephemeral relay isolates active-window state correctly.
+// Two distinct shell payloads kept only so each window has real PTY output to
+// stream (the relay attaches to a live session). We do NOT scrape this text:
+// xterm renders glyphs to a WebGL canvas with NO DOM text layer (verified —
+// `.xterm-rows` is absent and `body.innerText()` never contains terminal
+// content), so the previous `innerText` assertion could never pass. Per-pane
+// isolation is instead proven at the relay layer: each pinned window opens its
+// OWN `/relay/<windowId>` WebSocket, and each pane mounts its own live `.xterm`
+// instance. Distinct relay sockets for the two distinct window ids is the
+// direct connection-level proof that the grouped-ephemeral relay isolates each
+// pane (matching the assertion style of boards-desktop-suspend.spec.ts).
 const WIN_A_MARKER = "PANE_ALPHA_OK";
 const WIN_B_MARKER = "PANE_BRAVO_OK";
+
+/** Extract the percent-decoded window id from a `/relay/<id>?...` WS url. */
+function relayWindowId(url: string): string | null {
+  const m = url.match(/\/relay\/([^?]+)/);
+  return m ? decodeURIComponent(m[1]) : null;
+}
 
 test.describe("Boards: same-session multi-pane", () => {
   test.beforeAll(() => {
@@ -40,7 +52,7 @@ test.describe("Boards: same-session multi-pane", () => {
     }
   });
 
-  test("two windows from one session show distinct pane content", async ({
+  test("two windows from one session each open their own relay pane", async ({
     page,
   }) => {
     test.setTimeout(45_000);
@@ -56,6 +68,15 @@ test.describe("Boards: same-session multi-pane", () => {
     const winB = wins.find((line) => line.endsWith(":win-b"))?.split(":")[0];
     expect(winA).toBeTruthy();
     expect(winB).toBeTruthy();
+
+    // Track which window ids opened a relay WebSocket. A distinct relay per
+    // window id is the isolation proof: two windows from ONE session each get
+    // their own grouped-ephemeral relay.
+    const relayWindowIds = new Set<string>();
+    page.on("websocket", (ws) => {
+      const wid = relayWindowId(ws.url());
+      if (wid) relayWindowIds.add(wid); // ignore Vite HMR / SSE sockets
+    });
 
     // Pin both windows from the same session to a fresh board.
     for (const winId of [winA, winB]) {
@@ -73,20 +94,20 @@ test.describe("Boards: same-session multi-pane", () => {
     await expect(page.getByText("win-a").first()).toBeVisible({ timeout: 10_000 });
     await expect(page.getByText("win-b").first()).toBeVisible({ timeout: 10_000 });
 
-    // Each pane's terminal text content should contain ONLY its own marker.
-    // We poll the rendered terminal text because xterm.js writes asynchronously
-    // after the WebSocket relay starts streaming PTY output.
+    // Both panes mount a live xterm instance (terminal attached). `.xterm` is
+    // the DOM signal that TerminalClient finished init; with the WebGL renderer
+    // the glyphs live on a canvas, so this is the robust "terminal is live"
+    // signal (vs. scraping canvas text, which has no DOM representation).
+    await expect(page.locator(".xterm")).toHaveCount(2, { timeout: 15_000 });
+
+    // Isolation proof: each distinct window id opened its OWN relay WebSocket.
     await expect
-      .poll(
-        async () => {
-          const text = await page.locator("body").innerText();
-          return (
-            text.includes(WIN_A_MARKER) && text.includes(WIN_B_MARKER)
-          );
-        },
-        { timeout: 15_000 },
-      )
+      .poll(() => relayWindowIds.has(winA!) && relayWindowIds.has(winB!), {
+        timeout: 15_000,
+      })
       .toBe(true);
+    // Two windows → two distinct relay sockets (not one shared/aliased socket).
+    expect(relayWindowIds.size).toBeGreaterThanOrEqual(2);
 
     // Cleanup: unpin both so the board disappears (empty boards are removed).
     for (const winId of [winA, winB]) {

--- a/app/frontend/tests/e2e/shell-rotation.spec.md
+++ b/app/frontend/tests/e2e/shell-rotation.spec.md
@@ -15,9 +15,9 @@ context).
 
 - `beforeAll` creates an `e2e-shell-rotation-<timestamp>` tmux session
   on the `rk-test-e2e` server with two named windows (`win-a`, `win-b`). Each
-  window prints a unique ready-marker (`PANE_ALPHA_RDY`, `PANE_BRAVO_RDY`)
-  and then runs `cat` so STDIN piped via the BottomBar relay accumulates
-  in the pane's view.
+  window prints a ready-marker and then runs `cat` so STDIN piped via the
+  BottomBar relay accumulates in the pane's view. (The markers are not
+  scraped — readiness is gated on the `.xterm` DOM signal; see step 4.)
 - A unique board name (`sr<digits>`) is used per run so reruns don't
   collide on the persistent tmux server.
 - `afterAll` kills the test session.
@@ -37,9 +37,11 @@ by the pane's `border-accent` class which marks the focused pane.
    `tmux list-windows -F`.
 2. POST `/api/boards/<name>/pin` with both window IDs.
 3. Navigate to `/board/<name>` (waitUntil `domcontentloaded`).
-4. Poll the rendered text until both ready-markers (`PANE_ALPHA_RDY`,
-   `PANE_BRAVO_RDY`) are present — confirms both panes' terminals
-   connected.
+4. Readiness gate: assert exactly two `.xterm` instances mount — confirms
+   both panes' terminals attached. (We assert the `.xterm` DOM signal rather
+   than scraping ready-marker text: xterm renders to a WebGL canvas with no
+   DOM text layer. The focus-cycling behavior under test is verified via
+   `border-accent` below, independent of terminal content.)
 5. Assert the shell-level `BottomBar` is present by locating the
    `Open command palette` button (a stable BottomBar affordance).
 6. Press `Meta+]` to cycle focus from pane 0 to pane 1.

--- a/app/frontend/tests/e2e/shell-rotation.spec.ts
+++ b/app/frontend/tests/e2e/shell-rotation.spec.ts
@@ -69,16 +69,13 @@ test.describe("Shell rotation: BottomBar focus tracking", () => {
     // Navigate to the board route — BottomBar is now present on this route.
     await page.goto(`/board/${BOARD_NAME}`, { waitUntil: "domcontentloaded" });
 
-    // Wait for both pane terminals to render their ready-markers.
-    await expect
-      .poll(
-        async () => {
-          const text = await page.locator("body").innerText();
-          return text.includes(WIN_A_MARKER) && text.includes(WIN_B_MARKER);
-        },
-        { timeout: 15_000 },
-      )
-      .toBe(true);
+    // Readiness gate: wait for both panes to mount a live xterm instance. We
+    // assert the `.xterm` DOM signal (terminal attached) rather than scraping
+    // the ready-marker text — xterm renders to a WebGL canvas with no DOM text
+    // layer, so `body.innerText()` never contains terminal content. The actual
+    // behavior under test (focus cycling) is asserted below via `border-accent`,
+    // independent of terminal content; this gate only needs both panes live.
+    await expect(page.locator(".xterm")).toHaveCount(2, { timeout: 15_000 });
 
     // BottomBar is rendered at shell level on the board route — confirm the
     // command-palette and modifier toggle (proxy for "BottomBar present") are


### PR DESCRIPTION
## Problem

`boards-same-session-multi-pane.spec.ts` and `shell-rotation.spec.ts` asserted on `page.locator(\"body\").innerText()` containing a terminal-content marker. **xterm.js renders glyphs to a WebGL canvas with no DOM text layer**, so terminal output never appears in `innerText` — these assertions could not pass against the real renderer. They timed out at 15s, **deterministically**, and have been red on CI since the specs were introduced (pre-dating the connection-pool PRs #215/#216/#219).

### Verified, not guessed

An isolated DOM probe confirmed: with the WebGL renderer, `.xterm-rows` count is **0**, and `body.innerText()` contains neither marker — while both relays connect and both `.xterm`/`.xterm-screen`/canvas elements mount. The bytes stream fine; there is simply no DOM text node to read.

## Fix (test-only)

Replace the brittle text scrape with robust DOM/relay signals, matching the already-passing `boards-desktop-suspend.spec.ts` pattern:

- **boards-same-session-multi-pane** — prove per-pane relay isolation at the **connection layer**: each pinned window opens its own `/relay/<windowId>` WebSocket (tracked via `page.on(\"websocket\")`) and each pane mounts its own `.xterm` instance. Two distinct windows → two distinct relay sockets. Renamed to *\"...each open their own relay pane\"* to match what's asserted. (This is arguably a more direct isolation proof than scraping text.)
- **shell-rotation** — the `innerText` poll was only a *readiness gate* before the real focus-cycling assertions (`border-accent`); replaced with a `.xterm` count gate. Behavior under test unchanged.

Companion `.spec.md` files updated in the same commit per the Test Companion Docs constitution rule.

## Verification

- `tsc --noEmit` clean.
- Both specs pass **deterministically**: 6/6 across `--repeat-each=3`, ~2s each (vs. the prior 15s timeout).
- No product code changed.

## Scope

Only the 2 e2e specs + their 2 companion docs. Independent of PR #220 (the `setsid` harness fix).