### PR TITLE
observability(sse): log when a real session disappears between polls

### DIFF
--- a/app/backend/api/sse.go
+++ b/app/backend/api/sse.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -135,6 +136,7 @@ type sseHub struct {
 	orderBootstrapAttempts   map[string]int           // per-server count of failed bootstrap attempts; capped at orderBootstrapMaxAttempts
 	previousBoardJSON        map[string]string        // per-server board bootstrap snapshot payload cache
 	previousWindowIDs        map[string]map[string]bool // per-server prior-tick live window ids for kill-detection
+	previousRealSessions     map[string]map[string]bool // per-server prior-tick real (non-relay/anchor) session names for disappearance logging
 	cache                    map[string]*cachedResult // per-server session fetch cache (500ms TTL)
 	polling                  bool
 	fetcher                  SessionFetcher
@@ -192,6 +194,7 @@ func newSSEHub(fetcher SessionFetcher, mc *metrics.Collector) *sseHub {
 		orderBootstrapAttempts: make(map[string]int),
 		previousBoardJSON:      make(map[string]string),
 		previousWindowIDs:      make(map[string]map[string]bool),
+		previousRealSessions:   make(map[string]map[string]bool),
 		cache:                  make(map[string]*cachedResult),
 		fetcher:                fetcher,
 		orderFetcher:           prodSessionOrderFetcher{},
@@ -378,6 +381,38 @@ func windowIDSetFromSessions(sess []sessions.ProjectSession) map[string]bool {
 	return out
 }
 
+// realSessionNameSet returns the set of *user-facing* session names in the
+// snapshot — excluding the per-connection relay ephemerals (rk-relay-*) and the
+// control-mode anchor (_rk-ctl), which churn constantly by design and are not
+// sessions a user would notice losing. Used to detect when a real session
+// disappears between poll ticks (observability for Constitution VI — tmux
+// sessions must survive).
+func realSessionNameSet(sess []sessions.ProjectSession) map[string]bool {
+	out := make(map[string]bool)
+	for _, s := range sess {
+		if s.Name == "" {
+			continue
+		}
+		if strings.HasPrefix(s.Name, tmux.RelaySessionPrefix) || s.Name == tmux.ControlAnchorSessionName {
+			continue
+		}
+		out[s.Name] = true
+	}
+	return out
+}
+
+// detectDisappearedSessions returns names present in prev but absent in
+// current. Pure; mirrors detectKilledWindowIDs.
+func detectDisappearedSessions(prev, current map[string]bool) []string {
+	var gone []string
+	for name := range prev {
+		if !current[name] {
+			gone = append(gone, name)
+		}
+	}
+	return gone
+}
+
 func (h *sseHub) poll() {
 	// Track per-server generation observed on the prior pass. The
 	// event-driven wait fires when generation advances past this.
@@ -545,6 +580,33 @@ func (h *sseHub) poll() {
 			}
 			h.mu.Lock()
 			h.previousWindowIDs[server] = currentIDs
+			h.mu.Unlock()
+
+			// Real-session disappearance logging (observability only — no
+			// behavior change). run-kit audit-logs every session IT kills
+			// (relay ephemerals, explicit kill-session), but a real user
+			// session can vanish OUTSIDE that path — a shell exiting, an
+			// external `tmux kill-session`, an OOM kill, or a server collapsing
+			// to zero under `exit-empty`. When that happens today the logs go
+			// silent, making post-hoc diagnosis impossible (see the `utils`
+			// incident). Emit one WARN per disappeared real session so the next
+			// occurrence is diagnosable. We exclude relay/anchor churn via
+			// realSessionNameSet. This does NOT prevent the loss — it records
+			// it; Constitution VI prevention (exit-empty off / anchor) is a
+			// separate change.
+			currentReal := realSessionNameSet(result)
+			h.mu.RLock()
+			prevReal, hadPrevReal := h.previousRealSessions[server]
+			h.mu.RUnlock()
+			if hadPrevReal {
+				for _, name := range detectDisappearedSessions(prevReal, currentReal) {
+					slog.Warn("real session disappeared between SSE polls (not killed by run-kit's audited path)",
+						"server", server, "session", name,
+						"remaining", len(currentReal))
+				}
+			}
+			h.mu.Lock()
+			h.previousRealSessions[server] = currentReal
 			h.mu.Unlock()
 		}
 

--- a/app/backend/api/sse_test.go
+++ b/app/backend/api/sse_test.go
@@ -762,3 +762,84 @@ func TestSSE_HubBootstrapReadsOrderOnFirstPoll(t *testing.T) {
 		t.Errorf("orderFetcher calls = %d, want >= 1", calls)
 	}
 }
+
+// TestRealSessionNameSet verifies the snapshot→real-session-name extraction
+// excludes relay ephemerals and the control anchor (which churn by design and
+// must not trip the disappearance log) while keeping user-facing sessions.
+func TestRealSessionNameSet(t *testing.T) {
+	in := []sessions.ProjectSession{
+		{Name: "shll", Windows: []tmux.WindowInfo{}},
+		{Name: "wt", Windows: []tmux.WindowInfo{}},
+		{Name: tmux.RelaySessionPrefix + "abc123", Windows: []tmux.WindowInfo{}},
+		{Name: tmux.ControlAnchorSessionName, Windows: []tmux.WindowInfo{}},
+		{Name: "", Windows: []tmux.WindowInfo{}}, // defensive: empty name ignored
+	}
+	got := realSessionNameSet(in)
+	want := map[string]bool{"shll": true, "wt": true}
+	if len(got) != len(want) {
+		t.Fatalf("realSessionNameSet size = %d, want %d (got %v)", len(got), len(want), got)
+	}
+	for name := range want {
+		if !got[name] {
+			t.Errorf("realSessionNameSet missing real session %q", name)
+		}
+	}
+	if got[tmux.RelaySessionPrefix+"abc123"] {
+		t.Error("realSessionNameSet must exclude relay ephemerals")
+	}
+	if got[tmux.ControlAnchorSessionName] {
+		t.Error("realSessionNameSet must exclude the control anchor")
+	}
+}
+
+// TestDetectDisappearedSessions verifies the pure prev→current diff: only names
+// present before and absent now are reported, and a grown/equal set yields none.
+func TestDetectDisappearedSessions(t *testing.T) {
+	cases := []struct {
+		name          string
+		prev, current map[string]bool
+		want          []string
+	}{
+		{
+			name:    "one disappeared",
+			prev:    map[string]bool{"shll": true, "wt": true},
+			current: map[string]bool{"wt": true},
+			want:    []string{"shll"},
+		},
+		{
+			name:    "none disappeared (stable)",
+			prev:    map[string]bool{"shll": true},
+			current: map[string]bool{"shll": true},
+			want:    nil,
+		},
+		{
+			name:    "session added, none gone",
+			prev:    map[string]bool{"shll": true},
+			current: map[string]bool{"shll": true, "new": true},
+			want:    nil,
+		},
+		{
+			name:    "all gone (server emptied)",
+			prev:    map[string]bool{"shll": true, "wt": true},
+			current: map[string]bool{},
+			want:    []string{"shll", "wt"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := detectDisappearedSessions(tc.prev, tc.current)
+			gotSet := map[string]bool{}
+			for _, g := range got {
+				gotSet[g] = true
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("detectDisappearedSessions = %v, want %v", got, tc.want)
+			}
+			for _, w := range tc.want {
+				if !gotSet[w] {
+					t.Errorf("detectDisappearedSessions missing %q (got %v)", w, got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

run-kit audit-logs every session **it** kills (relay ephemerals via `KillSessionCtx`, explicit `kill-session`). But a real user session can vanish **outside** that audited path — a shell exiting, an external `tmux kill-session`, an OOM kill, or a server collapsing to zero under tmux's default `exit-empty on`. When that happens today, **the logs go silent**, making post-hoc diagnosis impossible.

This was hit in practice: a live `utils` server with two real sessions (`shll`, `wt`) was lost, and `~/.cache/rk/daemon.log` showed only relay-ephemeral reaps (`kill-session target=rk-relay-*`) followed by `socket removed (tmux server exited)` — **never what killed the real sessions**. We could not determine the cause.

## What

The SSE hub already diffs per-tick window-id sets for board cleanup (`detectKilledWindowIDs`). This adds the **session-level analog**:

- Each poll tick, compute the set of *real* session names via `realSessionNameSet` — excluding `rk-relay-*` ephemerals and the `_rk-ctl` anchor, which churn by design and must not trip the log.
- Diff against the prior tick with `detectDisappearedSessions`.
- Emit one `WARN` per disappeared real session: `real session disappeared between SSE polls (not killed by run-kit's audited path)` with `server`, `session`, and `remaining` count.

**Observability only** — no broadcast, no kill, no control-flow change. It reads/writes one new per-server map under the existing lock discipline, mirroring `previousWindowIDs`.

## Scope note

This **records** the loss; it does not prevent it. The Constitution VI *prevention* (set `exit-empty off` + keep a persistent `_rk-ctl` anchor so a transient drop-to-zero can't permanently destroy a server) is intentionally a **separate change** — and we deliberately did not bundle a "fix" for a root cause we cannot yet prove. The next occurrence will now be diagnosable.

## Tests

- `TestRealSessionNameSet` — excludes relay/anchor, keeps user sessions, ignores empty names.
- `TestDetectDisappearedSessions` — table-driven: one gone, none gone, added-not-gone, all gone.
- Full `just test-backend` green (`rk/api` 28s).