### PR TITLE
fix(sse): surface external tmux changes promptly on uncovered servers

### DIFF
--- a/app/backend/api/sse.go
+++ b/app/backend/api/sse.go
@@ -106,6 +106,14 @@ const (
 type WindowChangeSubscriber interface {
 	Generation(server string) int64
 	Wait(server string, after int64) <-chan struct{}
+	// Covers reports whether this subscriber has a live control-mode driver
+	// for the named server. A covered server is woken event-driven (its Wait
+	// channel fires on tmux notifications), so the SSE loop can afford the long
+	// safety-net interval. An UNcovered server (no Client — e.g. rk-test-*
+	// servers the supervisor skips, or PTY-unavailable hosts) has no event
+	// driver, so the safety-net timer is its ONLY freshness source and must run
+	// at the fast cadence. See safetyIntervalEffective.
+	Covers(server string) bool
 }
 
 // cachedResult holds a cached FetchSessions result with a timestamp.
@@ -158,19 +166,29 @@ type sseHub struct {
 	safetyInterval time.Duration
 }
 
-// safetyIntervalEffective returns the per-hub safety interval. When a control-
-// mode subscriber is wired, the long 12s safety-net interval applies (control
-// mode is the primary driver). When no subscriber is wired (tests,
-// PTY-unavailable startup), the loop falls back to the legacy 2.5s cadence so
-// existing time-based assertions and PTY-disabled hosts behave identically.
-func (h *sseHub) safetyIntervalEffective() time.Duration {
+// safetyIntervalEffective returns the safety-net interval for a poll cycle
+// covering the given servers. The long 12s interval is correct ONLY when every
+// watched server is control-covered (its Wait channel fires event-driven, so
+// the timer is just a backstop). If ANY watched server is uncovered — no
+// control-mode Client, e.g. an rk-test-* server the supervisor skips, or a
+// PTY-unavailable host — that server has NO event driver, so the safety timer
+// is its only freshness source and must run at the fast legacy cadence;
+// otherwise an external change on it takes up to 12s to surface (the SSE-sync
+// e2e failures: tests assert at 5s but the test server was uncovered yet still
+// got the 12s interval). A per-hub override (h.safetyInterval) wins when set.
+func (h *sseHub) safetyIntervalEffective(servers []string) time.Duration {
 	if h.safetyInterval > 0 {
 		return h.safetyInterval
 	}
-	if h.subscriber != nil {
-		return safetyPollInterval
+	if h.subscriber == nil {
+		return legacyPollInterval
 	}
-	return legacyPollInterval
+	for _, server := range servers {
+		if !h.subscriber.Covers(server) {
+			return legacyPollInterval
+		}
+	}
+	return safetyPollInterval
 }
 
 // detectKilledWindowIDs is a pure function: it returns the set of window ids
@@ -671,7 +689,7 @@ func (h *sseHub) poll() {
 // perServerGen with each server's current generation so the next pass can
 // detect change.
 func (h *sseHub) waitForNext(servers []string, perServerGen map[string]int64, eventDrivenServers map[string]bool) {
-	timer := time.NewTimer(h.safetyIntervalEffective())
+	timer := time.NewTimer(h.safetyIntervalEffective(servers))
 	defer timer.Stop()
 
 	if h.subscriber == nil {

--- a/app/backend/api/sse_subscriber_test.go
+++ b/app/backend/api/sse_subscriber_test.go
@@ -49,6 +49,11 @@ func (s *stubSubscriber) Wait(server string, after int64) <-chan struct{} {
 	return w
 }
 
+// Covers always reports true: the stub models a control-covered server (Bump
+// wakes its Wait channel event-driven), so the hub may use the long safety
+// interval. Tests that need the uncovered fast-poll path use neverSubscriber.
+func (s *stubSubscriber) Covers(string) bool { return true }
+
 func (s *stubSubscriber) Bump(server string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -266,6 +271,10 @@ func (neverSubscriber) Wait(string, int64) <-chan struct{} {
 	return make(chan struct{})
 }
 
+// Covers reports false: neverSubscriber models the no-Client case, so every
+// server is uncovered and the hub must use the fast safety cadence.
+func (neverSubscriber) Covers(string) bool { return false }
+
 // TestSSE_PTYUnavailableDoesNotBusyLoop is the regression test for the
 // PTY-unavailable busy-loop fix: when the WindowChangeSubscriber returns a
 // never-closing Wait channel for a server (because Get(server) returned nil),
@@ -372,6 +381,51 @@ func TestSSE_WaitForNextDoesNotLeakGoroutines(t *testing.T) {
 		t.Errorf("goroutine count grew by %d after %d bumps (baseline %d, after %d) — possible leak in waitForNext",
 			after-baseline, iterations, baseline, after)
 	}
+}
+
+// coverageSubscriber is a WindowChangeSubscriber whose Covers result is driven
+// by a per-server map. Generation/Wait are inert (never fire) — this stub
+// exists only to exercise safetyIntervalEffective's coverage branching.
+type coverageSubscriber struct{ covered map[string]bool }
+
+func (coverageSubscriber) Generation(string) int64            { return 0 }
+func (coverageSubscriber) Wait(string, int64) <-chan struct{} { return make(chan struct{}) }
+func (c coverageSubscriber) Covers(server string) bool        { return c.covered[server] }
+
+// TestSafetyIntervalEffective verifies the per-server interval selection that
+// fixes the SSE-sync latency: the long control-mode interval applies only when
+// EVERY watched server is covered; one uncovered server (e.g. an rk-test-*
+// server the supervisor skips) forces the fast cadence so its external changes
+// surface within the test timeout instead of waiting for the 12s backstop.
+func TestSafetyIntervalEffective(t *testing.T) {
+	t.Run("no subscriber -> legacy fast", func(t *testing.T) {
+		h := newSSEHub(&fetchTracker{}, nil)
+		if got := h.safetyIntervalEffective([]string{"any"}); got != legacyPollInterval {
+			t.Fatalf("got %v, want %v", got, legacyPollInterval)
+		}
+	})
+	t.Run("all covered -> long safety interval", func(t *testing.T) {
+		h := newSSEHub(&fetchTracker{}, nil)
+		h.subscriber = coverageSubscriber{covered: map[string]bool{"a": true, "b": true}}
+		if got := h.safetyIntervalEffective([]string{"a", "b"}); got != safetyPollInterval {
+			t.Fatalf("got %v, want %v", got, safetyPollInterval)
+		}
+	})
+	t.Run("any uncovered -> legacy fast", func(t *testing.T) {
+		h := newSSEHub(&fetchTracker{}, nil)
+		h.subscriber = coverageSubscriber{covered: map[string]bool{"a": true, "rk-test-e2e": false}}
+		if got := h.safetyIntervalEffective([]string{"a", "rk-test-e2e"}); got != legacyPollInterval {
+			t.Fatalf("got %v, want %v (an uncovered server must force the fast cadence)", got, legacyPollInterval)
+		}
+	})
+	t.Run("explicit override wins", func(t *testing.T) {
+		h := newSSEHub(&fetchTracker{}, nil)
+		h.subscriber = coverageSubscriber{covered: map[string]bool{}}
+		h.safetyInterval = 99 * time.Millisecond
+		if got := h.safetyIntervalEffective([]string{"uncovered"}); got != 99*time.Millisecond {
+			t.Fatalf("got %v, want explicit override 99ms", got)
+		}
+	})
 }
 
 // Silence unused-import warning if the kit changes shape.

--- a/app/backend/api/tmuxctl_bridge.go
+++ b/app/backend/api/tmuxctl_bridge.go
@@ -58,6 +58,18 @@ func (s *supervisorSubscriber) Generation(server string) int64 {
 	return c.Generation()
 }
 
+// Covers reports whether the Supervisor has a live Client for the server. A
+// missing Client (rk-test-* servers the supervisor skips via
+// isTmuxSocketCandidate, or PTY-unavailable hosts) means no event-driven
+// wake-ups for that server, so the SSE loop must fall back to the fast safety
+// cadence rather than the 12s control-mode interval.
+func (s *supervisorSubscriber) Covers(server string) bool {
+	if s.sup == nil {
+		return false
+	}
+	return s.sup.Get(server) != nil
+}
+
 func (s *supervisorSubscriber) Wait(server string, after int64) <-chan struct{} {
 	if s.sup == nil {
 		return neverChan()

--- a/app/backend/internal/tmuxctl/client.go
+++ b/app/backend/internal/tmuxctl/client.go
@@ -308,6 +308,14 @@ func (c *Client) dispatch(ev Event) {
 		c.sink.OnWindowRenamed(v.WindowID, v.Name)
 	case SessionsChangedEvent:
 		c.sink.OnSessionsChanged()
+	case UnlinkedWindowEvent:
+		// A window changed in a session this client is not attached to. No
+		// sink callback — active-window state is session-scoped and tracked
+		// from the linked %session-window-changed for the attached session.
+		// We only need to bump the generation so the SSE hub rebuilds its
+		// snapshot, surfacing the external change without waiting for the 12s
+		// safety poll. The bumpGeneration below (shared with all handled
+		// events) does exactly that.
 	case LayoutChangeEvent:
 		c.sink.OnLayoutChange(v.WindowID)
 	case UnknownEvent, MalformedEvent:

--- a/app/backend/internal/tmuxctl/client_test.go
+++ b/app/backend/internal/tmuxctl/client_test.go
@@ -203,6 +203,49 @@ func TestClient_DispatchAndGenerationBump(t *testing.T) {
 	_ = c.Close()
 }
 
+// TestClient_UnlinkedWindowBumpsGeneration verifies the SSE-sync fix: a
+// %unlinked-window-* notification (a window change in a session this client is
+// not attached to) advances the generation counter so the SSE hub rebuilds its
+// snapshot — without invoking any session-scoped sink callback. Before this,
+// unlinked events were dropped, so an external window change in a non-attached
+// session only surfaced on the 12s safety poll.
+func TestClient_UnlinkedWindowBumpsGeneration(t *testing.T) {
+	resetLoggedUnknowns()
+	sink := &recordingSink{}
+
+	// %begin handshake, then an unlinked-window-add for a non-attached session.
+	stream := []byte("%begin 1 1 0\n%unlinked-window-add @77\n")
+	rwc := newPipeReaderFromBytes(stream)
+	dial := func(ctx context.Context, socket string) (*exec.Cmd, io.ReadWriteCloser, error) {
+		return &exec.Cmd{}, rwc, nil
+	}
+	c, err := openWith(context.Background(), "test", sink, dial, realSleep)
+	if err != nil {
+		t.Fatalf("openWith: %v", err)
+	}
+	defer c.Close()
+
+	// Generation must reach 1 (the unlinked event bumped it).
+	deadline := time.Now().Add(2 * time.Second)
+	for c.Generation() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("generation never advanced on %unlinked-window-add")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if c.Generation() != 1 {
+		t.Fatalf("expected generation=1 after one unlinked event, got %d", c.Generation())
+	}
+
+	// No session-scoped sink callback should fire for an unlinked (cross-session)
+	// event — active-window state is tracked only from the linked variants.
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	if len(sink.swcEvents) != 0 {
+		t.Errorf("expected no session-window-changed sink events, got %+v", sink.swcEvents)
+	}
+}
+
 // TestClient_WaitBlocksUntilEvent ensures Wait(after) returns a not-yet-closed
 // channel when generation == after, and closes when an event arrives.
 func TestClient_WaitBlocksUntilEvent(t *testing.T) {

--- a/app/backend/internal/tmuxctl/parser.go
+++ b/app/backend/internal/tmuxctl/parser.go
@@ -59,6 +59,22 @@ type WindowRenamedEvent struct {
 // SessionsChangedEvent is emitted when the session list changes (`%sessions-changed`).
 type SessionsChangedEvent struct{}
 
+// UnlinkedWindowEvent is emitted for window add/close/rename in a session the
+// control client is NOT attached to (`%unlinked-window-add @wid`,
+// `%unlinked-window-close @wid`, `%unlinked-window-renamed @wid name`). tmux
+// sends the `%window-*` (linked) variants only for the attached session, and
+// the `%unlinked-window-*` variants for every OTHER session on the server.
+//
+// run-kit's control client attaches to one bootstrap/anchor session per server
+// but renders ALL sessions, so an external change (e.g. a window created by
+// `rk riff`, a CLI, or another tool) in any non-attached session arrives ONLY
+// as an unlinked event. We don't need the per-session active-window detail from
+// these (that's tracked from the linked %session-window-changed for the
+// attached session) — we only need to know the window set changed so the SSE
+// hub rebuilds its snapshot. So this carries no payload; dispatch bumps the
+// generation counter, same as the linked window events.
+type UnlinkedWindowEvent struct{}
+
 // LayoutChangeEvent is emitted on pane layout change. Only WindowID is retained
 // in v1 — the other fields (window-layout / visible-layout / window-flags) are
 // parsed off but not surfaced (`%layout-change @wid layout vis flags`).
@@ -92,6 +108,7 @@ func (WindowAddEvent) isEvent()             {}
 func (WindowCloseEvent) isEvent()           {}
 func (WindowRenamedEvent) isEvent()         {}
 func (SessionsChangedEvent) isEvent()       {}
+func (UnlinkedWindowEvent) isEvent()        {}
 func (LayoutChangeEvent) isEvent()          {}
 func (UnknownEvent) isEvent()               {}
 func (MalformedEvent) isEvent()             {}
@@ -184,6 +201,13 @@ func ParseLine(line string) Event {
 			return MalformedEvent{Raw: line}
 		}
 		return WindowRenamedEvent{WindowID: wid, Name: n}
+	case "unlinked-window-add", "unlinked-window-close", "unlinked-window-renamed":
+		// Window add/close/rename in a NON-attached session on this server. We
+		// don't parse the payload (we only need "something changed" to trigger a
+		// snapshot rebuild — see UnlinkedWindowEvent). Tolerate any/empty rest:
+		// unlike the linked variants we never index the window id, so a missing
+		// argument is not malformed for our purposes.
+		return UnlinkedWindowEvent{}
 	case "sessions-changed":
 		return SessionsChangedEvent{}
 	case "layout-change":

--- a/app/backend/internal/tmuxctl/parser_test.go
+++ b/app/backend/internal/tmuxctl/parser_test.go
@@ -84,13 +84,31 @@ func TestParseLine_LayoutChange(t *testing.T) {
 	}
 }
 
-func TestParseLine_OutputAndUnlinkedDropped(t *testing.T) {
+func TestParseLine_OutputDropped(t *testing.T) {
 	resetLoggedUnknowns()
 	if _, ok := ParseLine("%output %1 hello world").(IgnoredEvent); !ok {
 		t.Fatal("expected IgnoredEvent for output line")
 	}
-	if _, ok := ParseLine("%unlinked-window-add @55").(IgnoredEvent); !ok {
-		t.Fatal("expected IgnoredEvent for unlinked-window-* line")
+}
+
+// %unlinked-window-* fires for window add/close/rename in a session the control
+// client is NOT attached to (every non-attached session on the server). These
+// must parse to UnlinkedWindowEvent so dispatch bumps generation and the SSE
+// hub rebuilds — previously they were dropped as IgnoredEvent, which is why an
+// external window change in a non-attached session took up to 12s (the safety
+// poll) to surface instead of being event-driven.
+func TestParseLine_UnlinkedWindowEvents(t *testing.T) {
+	resetLoggedUnknowns()
+	cases := []string{
+		"%unlinked-window-add @55",
+		"%unlinked-window-close @55",
+		"%unlinked-window-renamed @55 some new name",
+		"%unlinked-window-add", // tolerate missing payload — we never index it
+	}
+	for _, line := range cases {
+		if _, ok := ParseLine(line).(UnlinkedWindowEvent); !ok {
+			t.Errorf("ParseLine(%q) = %T, want UnlinkedWindowEvent", line, ParseLine(line))
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

The SSE-sync e2e cluster — `sidebar-window-sync` (:73, :98, :196, :254) and `sync-latency` (:197, :212, :302, …) — failed because an **external tmux change** (window add / rename / move) took **up to 12s** to appear in the sidebar, but the tests assert at 5s. Confirmed by isolated SSE-stream repro (window absent at 8s, present at 16s — the 12s safety poll). Pre-existing; red on CI since ≥ #214.

Two distinct root causes, both fixed:

### 1. Per-hub safety interval (the actual test fix)

`safetyIntervalEffective()` returned the long **12s** interval whenever a `WindowChangeSubscriber` was wired — a **hub-global** check. But the tmuxctl supervisor **deliberately skips `rk-test-*` servers** (`isTmuxSocketCandidate` → `IsTestServerName`, a resurrection-prevention guard). So the test server had **no control Client** → neither event-driven wake-ups **nor** the fast poll — it was stuck on the 12s backstop with no event fallback.

Fix: add `Covers(server) bool` to `WindowChangeSubscriber` (`supervisorSubscriber` returns `sup.Get(server) != nil`) and make the interval **per-server**: if **any** watched server is uncovered (no Client — `rk-test-*` or PTY-unavailable), use the fast **2.5s** legacy cadence, since the safety timer is that server's only freshness source. The 12s interval applies only when **every** watched server is control-covered.

### 2. Unlinked window events (product fix for real servers)

tmux emits `%unlinked-window-{add,close,renamed}` for windows in a session the control client is **not** attached to (every non-attached session on the server). These were parsed to `IgnoredEvent` and dropped, so a **cross-session** external change (e.g. a window from `rk riff`, a CLI, another tool) on a *covered* server still took 12s to surface. Parse them into a new `UnlinkedWindowEvent` and bump the generation counter in `dispatch` (no sink callback — active-window state is session-scoped, and these are cross-session), making such changes event-driven (~instant).

## Result

The cadence-dependent SSE-sync specs pass — **12/12**, stable across `--repeat-each=2` (10/10 on `sidebar-window-sync`). 

**One pre-existing failure remains, unrelated to SSE cadence:** `sync-latency:258` ("cross-session drag") — a stateful drag-drop interaction test (its *precondition* assert times out), also red on the pre-merge baseline. Within-session drag (test 6) passes; the cross-session drag is the fragile one. Left for a separate drag-drop investigation rather than scope-creep here.

## Tests

- `parser_test`: `%unlinked-window-*` → `UnlinkedWindowEvent` (add/close/rename + missing-payload tolerance); `%output` still `IgnoredEvent`.
- `client_test`: an unlinked event bumps generation and fires **no** session-scoped sink callback.
- `sse_subscriber_test`: `safetyIntervalEffective` branches — no subscriber → fast; all covered → 12s; any uncovered → fast; explicit override wins.
- Full `just test-backend` green (`rk/api` 28s).