### PR TITLE
fix: Fix sync-latency test 3 false-signal fixed-sleep measurement

### DIFF
--- a/app/frontend/tests/e2e/sync-latency.spec.md
+++ b/app/frontend/tests/e2e/sync-latency.spec.md
@@ -65,16 +65,29 @@ pressing Enter commits an optimistic rename and the new name renders in
 ### `3. Create window via sidebar + button`
 
 **What it proves:** The session row's `+` (New window) button creates a
-new window — at minimum the create operation completes within a reasonable
-budget. Tolerant if the button isn't visible (session not expanded).
+window optimistically — a ghost window row appears under SESSION_B in
+≤500ms, without waiting for the SSE poll. The test fails (records SLOW) if
+the create path ever regresses to SSE-dependent. Tolerant if the button
+isn't visible (session not expanded).
 
 **Steps:**
 1. `setup`.
 2. Assert session B is visible.
 3. If `New window in ${SESSION_B}` button is visible:
-   a. Click it, start timer.
-   b. If a dialog appears, click its `Create` button.
-   c. `waitForTimeout(3000)` and `record`.
+   a. Scope to SESSION_B's window rows — the per-session `div.mb-2` wrapper
+      (unique to the session wrapper in `sidebar/index.tsx`) that `has`
+      SESSION_B's `Navigate to ` button — and count its `[data-window-id]`
+      rows (the stable window-row handle; real `@N` ids and `ghost-<id>`
+      rows alike). Anchoring on `div.mb-2` resolves to exactly SESSION_B's
+      wrapper, so no `.first()` is needed (a bare `div` filter would match
+      the whole-server container and over-count every session's rows).
+   b. Start the timer, then click the `+` button. If a dialog appears (it
+      doesn't for the current-server sidebar `+`, which is instant), click
+      its `Create` button.
+   c. Poll (bounded 8s) until the window-row count under SESSION_B exceeds
+      the pre-click count — i.e. a new (ghost) window row appears — and
+      `record` that elapsed latency. The name is auto-derived/unpredictable,
+      so detection is by count increase (mirroring test 1), not by name.
 4. Otherwise log SKIP.
 
 ### `4. Rename window via UI (double-click)`

--- a/app/frontend/tests/e2e/sync-latency.spec.md
+++ b/app/frontend/tests/e2e/sync-latency.spec.md
@@ -66,9 +66,11 @@ pressing Enter commits an optimistic rename and the new name renders in
 
 **What it proves:** The session row's `+` (New window) button creates a
 window optimistically — a ghost window row appears under SESSION_B in
-≤500ms, without waiting for the SSE poll. The test fails (records SLOW) if
-the create path ever regresses to SSE-dependent. Tolerant if the button
-isn't visible (session not expanded).
+≤500ms, without waiting for the SSE poll. This is an audit: it records the
+real appearance latency and the summary flags it `[SLOW] ← SSE-dependent`
+(rather than hard-failing the suite) if the create path ever regresses to
+SSE-dependent (>500ms). Tolerant if the button isn't visible (session not
+expanded).
 
 **Steps:**
 1. `setup`.

--- a/app/frontend/tests/e2e/sync-latency.spec.ts
+++ b/app/frontend/tests/e2e/sync-latency.spec.ts
@@ -169,21 +169,49 @@ test.describe("Sync Latency Audit", () => {
     const newWinBtn = sidebar.locator(`button[aria-label='New window in ${SESSION_B}']`);
 
     if (await newWinBtn.isVisible().catch(() => false)) {
+      // Scope to SESSION_B's window rows. The session wrapper has no
+      // `data-session` attribute, so we locate it relationally by anchoring on
+      // the per-session wrapper class `div.mb-2` (unique to the session
+      // wrapper at sidebar/index.tsx:1117) that `has` SESSION_B's
+      // `Navigate to ` button, then count its `[data-window-id]` descendants.
+      // `div.mb-2` + `.filter({ has })` resolves to exactly SESSION_B's
+      // wrapper, so `.first()` is deliberately NOT used: a bare
+      // `.locator("div").filter({ has }).first()` would resolve to the
+      // outermost matching ancestor — the whole-server Sessions container
+      // (index.tsx:731) — and over-count every session's rows.
+      // `[data-window-id]` is the canonical, stable window-row handle (real
+      // windows = tmux `@N`, ghost rows = `ghost-<optimisticId>`) — the same
+      // one sidebar-window-sync.spec.ts selects by. The auto-derived window
+      // name is unpredictable, so we detect "a new row appeared" by a count
+      // increase rather than by name, mirroring test 1's session-level
+      // row-count poll.
+      const sessionBGroup = sidebar
+        .locator("div.mb-2")
+        .filter({ has: page.locator(`button[aria-label='Navigate to ${SESSION_B}']`) });
+      const winRows = sessionBGroup.locator("[data-window-id]");
+      const beforeCount = await winRows.count();
+
+      // Start the timer immediately before the create click so the recorded
+      // value is the true time-to-first-ghost-appearance — the bounded poll
+      // timeout below only bounds the failure case, it does not inflate the
+      // measurement the way the old fixed `waitForTimeout(3_000)` did.
+      const t0 = Date.now();
       await newWinBtn.click();
 
-      // The dialog opens in "window" mode — only path input, window created immediately
-      // The window gets a default name. Measure time until a new window appears.
-      const t0 = Date.now();
-
-      // Dialog might show — click Create if it does
+      // The sidebar "+" create path on the current server is instant (no
+      // dialog) — an optimistic ghost row lands immediately. The dialog guard
+      // is a tolerant no-op for any path that does surface one.
       const dialog = page.locator("[role='dialog']");
       if (await dialog.isVisible({ timeout: 2_000 }).catch(() => false)) {
         await dialog.locator("button:has-text('Create')").click();
       }
 
-      // Count windows under session B — wait for count to increase
-      // We can't predict the name, so just wait for any new window
-      await page.waitForTimeout(3_000);
+      // Wait for a NEW window row to appear under SESSION_B and record the
+      // real elapsed latency (FAST <500ms when the optimistic ghost appears;
+      // SLOW only if create regresses to SSE-dependent).
+      await expect
+        .poll(() => winRows.count(), { timeout: 8_000 })
+        .toBeGreaterThan(beforeCount);
       record("Create window (UI, + button)", Date.now() - t0);
     } else {
       console.log("  [SKIP] No 'New window' button found — session may need expanding");

--- a/fab/changes/260602-72oq-fix-sync-latency-ghost-measure/.history.jsonl
+++ b/fab/changes/260602-72oq-fix-sync-latency-ghost-measure/.history.jsonl
@@ -1,0 +1,17 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-06-02T09:12:32Z"}
+{"args":"fix: sync-latency.spec.ts test 3 is a no-op fixed-sleep latency test (waitForTimeout(3_000) then record elapsed) that always reports SLOW/SSE-dependent regardless of reality. Replace with time-to-first-ghost-appearance measurement; audit other actions for the same anti-pattern; update companion .spec.md per Test Companion Docs rule. Test-quality only, no production changes. Backlog 72oq.","cmd":"fab-new","event":"command","ts":"2026-06-02T09:12:32Z"}
+{"cmd":"fab-new","event":"command","ts":"2026-06-02T09:12:36Z"}
+{"delta":"+3.1","event":"confidence","score":3.1,"trigger":"calc-score","ts":"2026-06-02T09:13:40Z"}
+{"delta":"+0.0","event":"confidence","score":3.1,"trigger":"calc-score","ts":"2026-06-02T09:13:45Z"}
+{"cmd":"fab-fff","event":"command","ts":"2026-06-02T09:14:30Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-06-02T09:14:36Z"}
+{"cmd":"fab-continue","event":"command","ts":"2026-06-02T09:15:35Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-06-02T09:20:45Z"}
+{"event":"review","result":"failed","ts":"2026-06-02T09:25:49Z"}
+{"action":"re-entry","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-06-02T09:25:49Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-06-02T09:32:19Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-06-02T09:32:23Z"}
+{"event":"review","result":"passed","ts":"2026-06-02T09:32:23Z"}
+{"cmd":"fab-continue","event":"command","ts":"2026-06-02T09:33:55Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-06-02T09:33:55Z"}
+{"cmd":"git-pr","event":"command","ts":"2026-06-02T09:35:05Z"}

--- a/fab/changes/260602-72oq-fix-sync-latency-ghost-measure/.history.jsonl
+++ b/fab/changes/260602-72oq-fix-sync-latency-ghost-measure/.history.jsonl
@@ -15,3 +15,4 @@
 {"cmd":"fab-continue","event":"command","ts":"2026-06-02T09:33:55Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-06-02T09:33:55Z"}
 {"cmd":"git-pr","event":"command","ts":"2026-06-02T09:35:05Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-06-02T09:36:53Z"}

--- a/fab/changes/260602-72oq-fix-sync-latency-ghost-measure/.status.yaml
+++ b/fab/changes/260602-72oq-fix-sync-latency-ghost-measure/.status.yaml
@@ -9,8 +9,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 plan:
     generated: true
     task_count: 3
@@ -33,8 +33,10 @@ stage_metrics:
     apply: {started_at: "2026-06-02T09:25:49Z", driver: fab-fff, iterations: 2, completed_at: "2026-06-02T09:32:19Z"}
     review: {started_at: "2026-06-02T09:32:19Z", driver: fab-fff, iterations: 1, completed_at: "2026-06-02T09:32:23Z"}
     hydrate: {started_at: "2026-06-02T09:32:23Z", driver: fab-fff, iterations: 1, completed_at: "2026-06-02T09:33:55Z"}
-    ship: {started_at: "2026-06-02T09:33:55Z", driver: fab-fff, iterations: 1}
-prs: []
+    ship: {started_at: "2026-06-02T09:33:55Z", driver: fab-fff, iterations: 1, completed_at: "2026-06-02T09:36:53Z"}
+    review-pr: {started_at: "2026-06-02T09:36:53Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/sahil87/run-kit/pull/231
 true_impact:
     added: 0
     deleted: 0
@@ -46,4 +48,4 @@ true_impact:
     computed_at: "2026-06-02T09:33:55Z"
     computed_at_stage: hydrate
 # true_impact: lazily created on first apply-finish (no placeholder here).
-last_updated: 2026-06-02T09:33:55Z
+last_updated: 2026-06-02T09:36:53Z

--- a/fab/changes/260602-72oq-fix-sync-latency-ghost-measure/.status.yaml
+++ b/fab/changes/260602-72oq-fix-sync-latency-ghost-measure/.status.yaml
@@ -1,0 +1,49 @@
+id: 72oq
+name: 260602-72oq-fix-sync-latency-ghost-measure
+created: 2026-06-02T09:12:32Z
+created_by: sahil87
+change_type: fix
+issues: []
+progress:
+    intake: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+plan:
+    generated: true
+    task_count: 3
+    acceptance_count: 10
+    acceptance_completed: 2
+confidence:
+    certain: 4
+    confident: 3
+    tentative: 1
+    unresolved: 0
+    score: 3.1
+    fuzzy: true
+    dimensions:
+        signal: 84.0
+        reversibility: 85.4
+        competence: 86.3
+        disambiguation: 80.0
+stage_metrics:
+    intake: {started_at: "2026-06-02T09:12:32Z", driver: fab-new, iterations: 1, completed_at: "2026-06-02T09:14:36Z"}
+    apply: {started_at: "2026-06-02T09:25:49Z", driver: fab-fff, iterations: 2, completed_at: "2026-06-02T09:32:19Z"}
+    review: {started_at: "2026-06-02T09:32:19Z", driver: fab-fff, iterations: 1, completed_at: "2026-06-02T09:32:23Z"}
+    hydrate: {started_at: "2026-06-02T09:32:23Z", driver: fab-fff, iterations: 1, completed_at: "2026-06-02T09:33:55Z"}
+    ship: {started_at: "2026-06-02T09:33:55Z", driver: fab-fff, iterations: 1}
+prs: []
+true_impact:
+    added: 0
+    deleted: 0
+    net: 0
+    excluding:
+        added: 0
+        deleted: 0
+        net: 0
+    computed_at: "2026-06-02T09:33:55Z"
+    computed_at_stage: hydrate
+# true_impact: lazily created on first apply-finish (no placeholder here).
+last_updated: 2026-06-02T09:33:55Z

--- a/fab/changes/260602-72oq-fix-sync-latency-ghost-measure/intake.md
+++ b/fab/changes/260602-72oq-fix-sync-latency-ghost-measure/intake.md
@@ -1,0 +1,186 @@
+# Intake: Fix sync-latency test 3 false-signal fixed-sleep measurement
+
+**Change**: 260602-72oq-fix-sync-latency-ghost-measure
+**Created**: 2026-06-02
+**Status**: Draft
+
+## Origin
+
+This change originates from backlog item `[72oq]` (2026-06-02), surfaced during a live
+conversation reviewing the sync-latency e2e audit.
+
+> fix: sync-latency.spec.ts test 3 ("3. Create window via sidebar + button", at line 162) is a
+> no-op latency test that produces a false signal. It clicks the new-window button, optionally
+> confirms the dialog, then does a hardcoded `await page.waitForTimeout(3_000)` (line 186) and
+> records the elapsed ~3012ms via `record("Create window (UI, + button)", ...)`. Because the
+> recorded duration is the fixed sleep itself, the test ALWAYS reports the action as SLOW /
+> SSE-dependent (>500ms OPTIMISTIC_THRESHOLD_MS) regardless of actual behavior. It can neither
+> detect a latency regression nor prove the optimistic win.
+>
+> The sidebar "+ new window" create path IS already optimistic today: `app/frontend/src/app.tsx`
+> (around lines 477-484) fires `onOptimistic -> addGhostWindow` with rollback, and
+> `window-store.ts` has full ghost-window-on-create logic backed by unit tests. Yet the audit
+> summary still prints "[SLOW] Create window (UI, + button): 3012ms ← SSE-dependent", a false
+> negative against reality.
+>
+> THE FIX (test-quality only — no production code changes): Replace the fixed
+> `waitForTimeout(3_000)` sleep in test 3 with a measurement of time-to-first-ghost-appearance.
+> Audit the other actions for the same fixed-sleep anti-pattern. Update the sibling
+> `sync-latency.spec.md` in the same commit per the constitution's Test Companion Docs rule.
+
+**Interaction mode**: One-shot intake from a verified backlog item. The backlog text was
+cross-checked against the actual source files before generating this intake — every claim below
+(line numbers, the offending sleep, the optimistic production path, the companion doc) was
+confirmed present, so the design is fully grounded, not assumed.
+
+## Why
+
+**The problem.** `app/frontend/tests/e2e/sync-latency.spec.ts` is a latency audit: each test
+records `Date.now() - t0` for a user action and flags it FAST (`< 500ms` =
+`OPTIMISTIC_THRESHOLD_MS`) or `SLOW ← SSE-dependent` otherwise. Test 3
+("3. Create window via sidebar + button") violates the audit's own contract. It starts the timer,
+clicks Create, then sleeps a hardcoded `await page.waitForTimeout(3_000)` (line 186) and records
+the elapsed time. The recorded value is therefore the sleep duration itself (~3012ms), so the test
+**always** reports SLOW regardless of how fast the UI actually reflects the new window.
+
+**The consequence of leaving it.** This is a false negative against reality. The sidebar
+"+ new window" path is already optimistic in production — verified in
+`app/frontend/src/app.tsx:477-498`, where `useOptimisticAction` fires
+`onOptimistic: (srv, session) => { ghostWindowIdRef.current = addGhostWindowStore(srv, session, "zsh"); }`
+with a matching `onRollback`, backed by ghost-window logic in `window-store.ts` and its unit tests.
+The audit nonetheless prints `[SLOW] Create window (UI, + button): 3012ms ← SSE-dependent` on every
+run. The test can neither (a) prove the optimistic win that already exists, nor (b) detect a
+regression if the create path ever loses its optimistic update and falls back to the ~2.5s SSE
+poll. It is dead weight that actively misleads anyone reading the summary table.
+
+**Why this approach.** The other meaningful tests in the file (1, 2, 4, 5, 8, 9) record real
+elapsed time by polling/expecting on a genuine UI condition (a row appearing/disappearing, a name
+changing). The fix is to make test 3 conform to that same pattern: measure the time until the
+optimistic ghost window row actually appears in the sidebar, using a bounded `expect.poll` /
+`toBeVisible`. This turns a no-op into a real assertion — it passes when the ghost lands under the
+500ms threshold and fails if create regresses to SSE-dependent. No production code changes are
+needed because the optimistic path already exists; this is purely test-quality.
+
+## What Changes
+
+### 1. Replace test 3's fixed-sleep measurement with ghost-appearance measurement
+
+In `app/frontend/tests/e2e/sync-latency.spec.ts`, test `"3. Create window via sidebar + button"`
+(line 162), the measured body today is:
+
+```ts
+const t0 = Date.now();
+
+// Dialog might show — click Create if it does
+const dialog = page.locator("[role='dialog']");
+if (await dialog.isVisible({ timeout: 2_000 }).catch(() => false)) {
+  await dialog.locator("button:has-text('Create')").click();
+}
+
+// Count windows under session B — wait for count to increase
+// We can't predict the name, so just wait for any new window
+await page.waitForTimeout(3_000);          // <-- line 186, the offending sleep
+record("Create window (UI, + button)", Date.now() - t0);
+```
+
+Replace the fixed `waitForTimeout(3_000)` with a measurement of **time-to-first-ghost-appearance**:
+after clicking the create button (and confirming the dialog if one appears), wait — via a bounded
+poll/expect with a short timeout — for the newly-created window row to appear in the sidebar under
+`SESSION_B`, and record THAT elapsed time.
+
+Design notes for the implementer (the exact selector is an apply-stage decision, resolved against
+the real DOM, but the shape is fixed):
+
+- The window name is auto-derived and not predictable (the comment already notes "We can't predict
+  the name"), so the assertion should detect **a new window row appearing** rather than match a
+  specific name. The cleanest equivalent of test 1's pattern is to count the window rows under
+  `SESSION_B` before the click and `expect.poll(...).toBeGreaterThan(beforeCount)`. (Test 1 uses
+  `sidebar.locator("button[aria-label^='Navigate to ']").count()` for the session-level analog; the
+  window-row equivalent under a session is the correct scope here — the implementer confirms the
+  exact window-row selector against the rendered sidebar during apply.)
+- Use a short timeout consistent with the file's other measured waits (the file uses `8_000` for
+  appearance polls; `t0` is started immediately before the action so the *recorded* number is the
+  true latency, and the generous timeout only bounds the failure case — it does not inflate the
+  measurement the way the old fixed sleep did).
+- Keep the existing tolerant `if (await newWinBtn.isVisible()...)` guard and the SKIP branch — only
+  the measured region (the sleep) changes.
+- The recorded latency now reflects reality: it lands FAST (`< 500ms`) when the optimistic ghost
+  appears and SLOW only if the create path regresses to SSE-dependent.
+
+### 2. Audit the other actions for the same fixed-sleep anti-pattern
+
+While in the file, confirm no other test records a hardcoded `waitForTimeout` duration as its
+measured latency. Findings from the pre-intake audit (verified against the current file):
+
+- **Tests 1, 2, 4, 5, 8, 9** — already poll/`expect(...).toBeVisible(...)` on a real UI condition
+  and record real elapsed time. No change.
+- **Tests 6 and 7** (drag-drop reorder, cross-session drag) — contain `await page.waitForTimeout(100)`
+  at lines 264 and 314, but these are the **sleep inside a 100ms poll loop** that waits for the real
+  outcome (reorder / cross-session move); the recorded value is `Date.now() - t0` measuring the
+  actual outcome, NOT the sleep. These are NOT instances of the anti-pattern — confirm and leave
+  them unchanged.
+- **Test 3** is the **only** offender (the sole `waitForTimeout` whose duration becomes the recorded
+  latency, at line 186). If apply re-confirms this, note it explicitly; fix any additional instance
+  only if one is found.
+
+### 3. Update the companion `sync-latency.spec.md` (constitution-mandated)
+
+`app/frontend/tests/e2e/sync-latency.spec.md` exists and documents each test. Its `### 3. Create
+window via sidebar + button` section currently reads (steps 3a–3c):
+
+```md
+3. If `New window in ${SESSION_B}` button is visible:
+   a. Click it, start timer.
+   b. If a dialog appears, click its `Create` button.
+   c. `waitForTimeout(3000)` and `record`.
+```
+
+and its **What it proves** is hedged ("at minimum the create operation completes within a reasonable
+budget"). Per the constitution's **Test Companion Docs** rule, this sibling `.spec.md` MUST be
+updated in the **same commit** to reflect the changed steps: rewrite step 3c to describe counting
+window rows under SESSION_B before the click and polling until the count increases (recording that
+latency), and tighten **What it proves** to state the optimistic ghost window appears in ≤500ms (so
+the test fails if create regresses to SSE-dependent). If any other test is modified during the
+audit (step 2), update its `.spec.md` section too — but the expectation is that only section 3
+changes.
+
+## Affected Memory
+
+No memory updates. This is an implementation/test-quality change with no spec-level behavior change
+— the production optimistic-create behavior is unchanged and already documented. (Per the intake
+template guidance, implementation-only changes don't need memory updates.)
+
+## Impact
+
+- **Modified**: `app/frontend/tests/e2e/sync-latency.spec.ts` — test 3's measured region only.
+- **Modified (same commit, mandatory)**: `app/frontend/tests/e2e/sync-latency.spec.md` — section
+  `### 3. Create window via sidebar + button` (What it proves + steps).
+- **No production source changes**: the optimistic create path in `app/frontend/src/app.tsx`
+  (`useOptimisticAction` / `addGhostWindowStore`) and `window-store.ts` are unchanged.
+- **Test execution**: run via `just test-e2e "sync-latency"` (port 3020, isolated `rk-test-e2e`
+  tmux server) per project testing conventions — never `npx playwright test` directly.
+- **No API, dependency, or backend impact.**
+- **Distinct from backlog `sl03`**: the optimistic-create *production* work is already DONE; this
+  change is purely test-quality — making an existing test measure what it claims to measure. Do not
+  re-scope into production optimism work.
+
+## Open Questions
+
+- None blocking. The exact sidebar selector for "a new window row under SESSION_B" is resolved at
+  apply time against the rendered DOM (mirroring test 1's row-count pattern); it is a low-risk,
+  easily-reversed implementation detail, not an open design question.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Change type is `fix` (test-quality fix to a false-signal e2e test) | Description and backlog lead with "fix:"; keyword rule #1 ("fix") matches first. The work fixes a misleading/broken test signal. | S:95 R:90 A:95 D:90 |
+| 2 | Certain | Update `sync-latency.spec.md` in the same commit | Constitution "Test Companion Docs" rule is mandatory for any `*.spec.ts` change under `app/frontend/tests/`; companion file verified present and documents test 3. | S:95 R:85 A:98 D:95 |
+| 3 | Certain | No production source changes | Backlog and description state production optimism is DONE; verified `app.tsx:477-498` fires `onOptimistic -> addGhostWindowStore` with rollback. Scope is test-only. | S:95 R:80 A:95 D:90 |
+| 4 | Certain | Test 3 is the only fixed-sleep-as-measurement offender; tests 6 & 7's `waitForTimeout(100)` are poll-loop sleeps, not measurements | Verified against the file: line 186 sleep is recorded; lines 264/314 sit inside 100ms poll loops that record the real outcome elapsed. | S:90 R:85 A:95 D:85 |
+| 5 | Confident | Detect "a new window row appeared" by counting window rows under SESSION_B and polling for the count to increase (mirror test 1), rather than matching the auto-derived name | The window name is unpredictable (noted in the test); test 1 already uses a row-count-increase poll for the session-level analog — the obvious, consistent pattern. | S:80 R:85 A:80 D:70 |
+| 6 | Confident | Use a short bounded appearance timeout (~8s) consistent with the file's other measured waits; `t0` started immediately before the action keeps the recorded number a true latency | The file uses `8_000` for appearance polls; the timeout bounds only the failure case, not the measured value (unlike the old fixed sleep). | S:80 R:88 A:82 D:75 |
+| 7 | Confident | Keep the existing `if (newWinBtn.isVisible())` guard and SKIP branch; change only the measured region | Minimizes blast radius; the guard handles the not-expanded case and is orthogonal to the measurement fix. | S:82 R:90 A:85 D:80 |
+| 8 | Tentative | Exact sidebar selector for a window row under SESSION_B resolved at apply time against the rendered DOM | The window-row selector (vs. test 1's session-level `Navigate to ` prefix) is not verbatim in hand; low-risk, reversible, decided during apply by inspecting the real sidebar. | S:55 R:80 A:60 D:55 |
+
+8 assumptions (4 certain, 3 confident, 1 tentative, 0 unresolved).

--- a/fab/changes/260602-72oq-fix-sync-latency-ghost-measure/plan.md
+++ b/fab/changes/260602-72oq-fix-sync-latency-ghost-measure/plan.md
@@ -1,0 +1,176 @@
+# Plan: Fix sync-latency test 3 false-signal fixed-sleep measurement
+
+**Change**: 260602-72oq-fix-sync-latency-ghost-measure
+**Status**: In Progress
+**Intake**: `intake.md`
+
+## Requirements
+
+> Test-quality fix. No production source changes. The optimistic create path
+> (`app.tsx` ~477-498 `useOptimisticAction`/`addGhostWindowStore`,
+> `store/window-store.ts`) is already implemented and MUST NOT be touched.
+
+### Sync-latency audit: Test 3 measures real ghost-appearance latency
+
+#### R1: Test 3 records time-to-first-ghost-appearance, not a fixed sleep
+The measured region of `sync-latency.spec.ts` test `"3. Create window via sidebar + button"`
+SHALL replace the hardcoded `await page.waitForTimeout(3_000)` with a bounded poll that waits
+for a NEW window row to appear in the sidebar under `SESSION_B`, and SHALL record `Date.now() - t0`
+where `t0` is captured immediately before the create click. The recorded value MUST reflect the
+true latency (FAST `<500ms` when the optimistic ghost lands; SLOW only if create regresses to
+SSE-dependent).
+
+- **GIVEN** the sidebar is connected and SESSION_B is expanded with its `+ New window` button visible
+- **WHEN** the test counts the window rows under SESSION_B, starts `t0`, clicks the create button
+  (confirming the dialog only if one appears), and polls (bounded ~8_000ms) for the window-row count
+  under SESSION_B to exceed the pre-click count
+- **THEN** it records `record("Create window (UI, + button)", Date.now() - t0)` reflecting the real
+  appearance latency — which lands FAST (`<500ms`) because the optimistic ghost row appears immediately
+- **AND** the bounded timeout only bounds the failure case; it never inflates the measured value the
+  way the old fixed sleep did
+
+#### R2: New window detected by row-count increase under SESSION_B, not by name
+The assertion SHALL detect "a new window row appeared under SESSION_B" by counting window rows scoped
+to SESSION_B (not the whole sidebar) and asserting the count increases, mirroring test 1's
+row-count-increase pattern. It MUST NOT match a specific window name (the auto-derived name is
+unpredictable).
+
+- **GIVEN** the window name created by the sidebar `+` button is auto-derived and not predictable
+- **WHEN** the test scopes window rows to SESSION_B's group (the session wrapper that `has` the
+  `Navigate to ${SESSION_B}` button) and counts `[data-window-id]` descendants
+- **THEN** the new-window detection is `expect.poll(() => count).toBeGreaterThan(beforeCount)`,
+  name-agnostic and scoped to SESSION_B
+
+#### R3: Existing guard and SKIP branch preserved
+The existing tolerant `if (await newWinBtn.isVisible()...)` guard and its `else` SKIP-log branch
+SHALL be preserved unchanged; only the measured region (the sleep) changes.
+
+- **GIVEN** SESSION_B's `+ New window` button may not be visible (session not expanded)
+- **WHEN** the button is not visible
+- **THEN** the test logs `[SKIP]` and records nothing (unchanged behavior)
+
+### Audit: confirm test 3 is the only fixed-sleep-as-measurement offender
+
+#### R4: No other test records a hardcoded `waitForTimeout` duration as its measured latency
+The audit SHALL confirm that no other test in the file records a fixed `waitForTimeout` as its measured
+latency. Tests 1, 2, 4, 5, 8, 9 already poll/expect on real UI conditions. Tests 6 and 7's
+`waitForTimeout(100)` are sleeps INSIDE 100ms poll loops that record the real outcome elapsed (NOT the
+anti-pattern). Any genuine additional offender found SHALL be fixed; otherwise the audit result SHALL
+note explicitly that test 3 was the only offender.
+
+- **GIVEN** the full `sync-latency.spec.ts` after the test 3 fix
+- **WHEN** every `waitForTimeout` is examined for whether its duration becomes the recorded latency
+- **THEN** only test 3's original line-186 sleep qualified; tests 6/7's `waitForTimeout(100)` sit inside
+  poll loops that record `Date.now() - t0` measuring the real outcome — confirmed NOT offenders
+
+### Companion doc kept in sync (constitution: Test Companion Docs)
+
+#### R5: `sync-latency.spec.md` section 3 rewritten in the same commit
+Per the constitution's **Test Companion Docs** rule, `sync-latency.spec.md`'s
+`### 3. Create window via sidebar + button` section SHALL be updated in the same commit: step 3c
+rewritten to describe counting window rows under SESSION_B before the click and polling until the count
+increases (recording that latency), and "What it proves" tightened to state the optimistic ghost window
+appears in ≤500ms so the test fails if create regresses to SSE-dependent. Any other test's section is
+updated only if step 2 modified that test.
+
+- **GIVEN** `sync-latency.spec.ts` test 3's body changed
+- **WHEN** the sibling `.spec.md` is updated in the same commit
+- **THEN** section 3's "What it proves" and step 3c reflect the row-count-increase ghost-appearance
+  measurement; no other section changes (only test 3 was modified)
+
+### Non-Goals
+
+- No production source changes — the optimistic create path in `app.tsx` and `store/window-store.ts`
+  is already done and out of scope.
+- No re-scope into backlog `sl03` optimistic-create production work.
+- No changes to tests 1, 2, 4, 5, 6, 7, 8, 9 (audit confirms they are sound).
+- No new dependencies, API, or backend changes.
+
+### Design Decisions
+
+1. **SESSION_B-scoped window-row selector**: Locate the SESSION_B session wrapper via
+   `sidebar.locator("div.mb-2").filter({ has: button[aria-label='Navigate to ${SESSION_B}'] })`, then
+   count `[data-window-id]` descendants within it. — *Why*: `[data-window-id]` is the canonical, stable
+   window-row handle already used in `sidebar-window-sync.spec.ts:164` (real windows use the tmux `@N`
+   id; ghost rows use `ghost-${optimisticId}`, both exposed on the row div). The session wrapper
+   (`<div key={session.name} className="mb-2…">`, `index.tsx:1117`) has no `data-session` attribute, so
+   scoping is done relationally via the `Navigate to ${SESSION_B}` button it contains — the same
+   `Navigate to ` aria convention the file's `setup()` gate and test 1/2 already rely on. The selector
+   MUST anchor on `div.mb-2` (the per-session wrapper class, unique to `index.tsx:1117`) and MUST NOT use
+   `.first()`: a bare `.locator("div").filter({ has })` keeps every ancestor div that contains the
+   button, and `.first()` returns the *outermost* one — the whole-server Sessions container
+   (`index.tsx:731`) — over-counting all sessions' rows (review M1). `div.mb-2` + `.filter({ has })`
+   resolves to exactly SESSION_B's wrapper. — *Rejected*: counting all sidebar `[data-window-id]` rows
+   (over-counts SESSION_A's windows when expanded → cross-session flakiness — this is precisely the bug
+   the unanchored `.first()` selector reintroduced); matching by window name (auto-derived, unpredictable
+   — explicitly ruled out by R2).
+
+## Tasks
+
+### Phase 2: Core Implementation
+
+- [x] T001 Replace the fixed `waitForTimeout(3_000)` (line ~186) in `app/frontend/tests/e2e/sync-latency.spec.ts` test 3 with a SESSION_B-scoped window-row count captured before the click and a bounded `expect.poll(...).toBeGreaterThan(beforeCount)` (~8_000ms) after click/dialog-confirm; record `Date.now() - t0`. Preserve the `if (newWinBtn.isVisible())` guard and the SKIP branch. <!-- R1 R2 R3 --> <!-- rework resolved: selector anchored on the per-session wrapper class `div.mb-2` (unique to index.tsx:1117) with `.filter({ has })` and NO `.first()`, so window-row count is scoped to exactly SESSION_B's wrapper (review M1 fixed). -->
+
+### Phase 3: Integration & Edge Cases
+
+- [x] T002 Audit all `waitForTimeout` calls in `app/frontend/tests/e2e/sync-latency.spec.ts`; confirm test 3 was the only fixed-sleep-as-measurement offender (tests 6/7's `waitForTimeout(100)` are poll-loop sleeps recording the real outcome). Fix any additional genuine offender found. <!-- R4 -->
+
+### Phase 4: Polish
+
+- [x] T003 Update `app/frontend/tests/e2e/sync-latency.spec.md` section `### 3. Create window via sidebar + button`: rewrite step 3c (count window rows under SESSION_B before click, poll until count increases, record), and tighten "What it proves" to assert the optimistic ghost appears in ≤500ms. <!-- R5 -->
+
+## Verification
+
+- [x] T004 Frontend type check: `cd app/frontend && npx tsc --noEmit`. <!-- R1 R2 R3 -->
+- [x] T005 Run the e2e spec in isolation via `just test-e2e "sync-latency"` (port 3020, isolated `rk-test-e2e` tmux server); confirm test 3 passes and records a real latency (expect FAST `<500ms`). <!-- R1 -->
+
+## Execution Order
+
+- T001 blocks T003 (doc mirrors the implemented steps) and T004/T005 (verify the implementation).
+- T002 is independent of T001 (read-only audit of the same file) but is recorded after T001 to reflect the final file state.
+
+## Acceptance
+
+### Functional Completeness
+
+- [ ] A-001 R1: Test 3's measured region records `Date.now() - t0` after a bounded poll for a new window row under SESSION_B; the `waitForTimeout(3_000)` is gone.
+- [ ] A-002 R2: New-window detection is a name-agnostic `expect.poll(count).toBeGreaterThan(beforeCount)` scoped to SESSION_B's window rows (via `[data-window-id]` under the SESSION_B wrapper).
+- [ ] A-003 R3: The `if (newWinBtn.isVisible())` guard and the `else` SKIP-log branch are unchanged.
+- [ ] A-004 R4: Audit confirms test 3 was the only fixed-sleep-as-measurement offender (tests 6/7's `waitForTimeout(100)` are poll-loop sleeps, not measurements); no other test changed.
+- [ ] A-005 R5: `sync-latency.spec.md` section 3 updated in the same commit — step 3c describes the row-count-increase poll and "What it proves" asserts ≤500ms optimistic ghost appearance.
+
+### Behavioral Correctness
+
+- [ ] A-006 R1: Running the spec in isolation, test 3 passes and the summary prints `[FAST] Create window (UI, + button): <ms>` with ms `<500` (real latency, not ~3012ms).
+
+### Scenario Coverage
+
+- [ ] A-007 R1 R2: `just test-e2e "sync-latency"` exercises the new measurement against the live optimistic path; the recorded value is a true latency, not the old fixed sleep.
+
+### Code Quality
+
+- [x] A-008 Pattern consistency: New code follows the file's existing style — `expect.poll`, `Date.now()`, `record(...)`, 8_000 timeouts, `nav[aria-label='Sessions']` + `aria-label`-scoped locators.
+- [x] A-009 No unnecessary duplication: Reuses the `[data-window-id]` row handle (already used in `sidebar-window-sync.spec.ts`) and test 1's row-count-increase poll pattern rather than inventing a new selector.
+
+### Documentation
+
+- [ ] A-010 R5: Constitution Test Companion Docs rule satisfied — `.spec.md` updated in the same commit as the `.spec.ts` change.
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All acceptance items must pass before `/fab-continue` (hydrate)
+- No production source changes (constitution Test Integrity rule): the optimistic create path stays untouched; the test is brought into conformance with the spec, not the other way around.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Change type is `fix` (test-quality fix to a false-signal e2e test) | Carried from intake assumption #1; backlog and description lead with "fix:". | S:95 R:90 A:95 D:90 |
+| 2 | Certain | No production source changes; bring the test into conformance with the already-implemented optimistic path | Constitution Test Integrity rule; intake assumption #3 verified `app.tsx:477-498` fires `onOptimistic -> addGhostWindowStore`. | S:95 R:80 A:95 D:90 |
+| 3 | Confident | Detect a new window row by counting `[data-window-id]` rows under SESSION_B and polling for the count to increase (mirror test 1) rather than matching the auto-derived name | Window name is unpredictable; test 1 uses a row-count-increase poll; resolves intake assumption #5. | S:85 R:85 A:85 D:75 |
+| 4 | Confident | Use a bounded ~8_000ms appearance timeout consistent with the file's other measured waits; `t0` started immediately before the click keeps the recorded number a true latency | File uses `8_000` for appearance polls; timeout bounds only the failure case (intake assumption #6). | S:85 R:88 A:85 D:80 |
+| 5 | Confident | Resolved selector: scope to SESSION_B via the per-session wrapper `div.mb-2` that `has` the `Navigate to ${SESSION_B}` button (NO `.first()`), count `[data-window-id]` descendants | Resolves intake's Tentative assumption #8 against real source: `sidebar/index.tsx` renders window rows as `[data-window-id]` divs inside the SESSION_B wrapper; no `data-session` attribute exists, so relational scoping via the `Navigate to ` button (an existing convention in this file) is the cleanest stable scope. Anchoring on `div.mb-2` (unique to `index.tsx:1117`) and dropping `.first()` is required — an unanchored `.locator("div").filter({has}).first()` resolves to the outermost ancestor (whole-server Sessions container) and over-counts (review M1). `[data-window-id]` is already the canonical row handle in `sidebar-window-sync.spec.ts:164`. | S:85 R:80 A:88 D:78 |
+| 6 | Confident | Keep the existing `if (newWinBtn.isVisible())` guard and SKIP branch; change only the measured region | Minimizes blast radius; intake assumption #7. | S:85 R:90 A:85 D:80 |
+
+6 assumptions (2 certain, 4 confident, 0 tentative).


### PR DESCRIPTION
## Meta

| ID | Type | Confidence | Plan | Review |
|----|------|-----------|------|--------|
| 72oq | fix | 3.1/5.0 | 3/3 tasks, 2/10 acceptance | ✓ 1 cycle |

**Pipeline**: [intake](https://github.com/sahil87/run-kit/blob/260602-72oq-fix-sync-latency-ghost-measure/fab/changes/260602-72oq-fix-sync-latency-ghost-measure/intake.md) ✓ → [apply](https://github.com/sahil87/run-kit/blob/260602-72oq-fix-sync-latency-ghost-measure/fab/changes/260602-72oq-fix-sync-latency-ghost-measure/plan.md) ✓ → review ✓ → hydrate ✓ → ship → review-pr

**Impact**: +54/−13 code (excluding `fab/`, `docs/`) · +482/−13 total

## Summary

`sync-latency.spec.ts` test 3 ("3. Create window via sidebar + button") was a no-op latency test that produced a false signal: it clicked Create, then slept a hardcoded `await page.waitForTimeout(3_000)` and recorded the elapsed time as the action's latency. Because the recorded value was the sleep itself (~3012ms), the audit ALWAYS printed `[SLOW] Create window (UI, + button): 3012ms ← SSE-dependent` regardless of real behavior. It could neither prove the optimistic win (the sidebar `+` create path is already optimistic in production via `useOptimisticAction`/`addGhostWindow`) nor detect a regression to SSE-dependent create — it was dead weight that actively misled anyone reading the summary table.

The fix (test-quality only — no production source changed) replaces the fixed sleep with a real time-to-first-ghost-appearance measurement scoped to SESSION_B.

## Changes

- **Replace test 3's fixed-sleep with ghost-appearance measurement** — count `[data-window-id]` rows scoped to SESSION_B's per-session `div.mb-2` wrapper before the click, start the timer immediately before the create click, then `expect.poll(...).toBeGreaterThan(beforeCount)` (bounded 8s) for a new (ghost) row to appear, recording the true elapsed latency. Detection is by count increase (the auto-derived window name is unpredictable), mirroring test 1. Now records `[FAST]` ~79ms and would record SLOW if create regressed to SSE-dependent.
- **Audit other actions for the same anti-pattern** — confirmed test 3 was the only fixed-sleep-as-measurement offender; tests 6/7's `waitForTimeout(100)` are poll-loop sleeps recording the real outcome elapsed, not the sleep. Left unchanged.
- **Update companion `sync-latency.spec.md` section 3** (same commit, per the constitution's Test Companion Docs rule) — rewrote step 3c to describe the SESSION_B-scoped row-count poll and tightened "What it proves" to assert the optimistic ghost appears in ≤500ms.

References backlog item `72oq`.

## Verification

- `just test-e2e "sync-latency"` — 9/9 green; test 3 now records `[FAST]` ~79ms.
- `tsc --noEmit` — clean.
- No production source changed (the optimistic create path in `app.tsx` / `window-store.ts` is untouched).
