### PR TITLE
docs: Conform repo to shll.ai README-extraction contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="assets/logo.svg" alt="run-kit logo" width="32" height="32"> run-kit
+# <img src="https://raw.githubusercontent.com/sahil87/run-kit/main/assets/logo.svg" alt="run-kit logo" width="32" height="32"> run-kit
 
 > Part of [@sahil87's open source toolkit](https://shll.ai) — see all projects there.
 
@@ -83,7 +83,7 @@ rk riff -- --worktree-name pacing-canyon             # name the worktree
 
 **Prerequisites:** must be inside a tmux session, [`wt`](https://github.com/sahil87/wt) on `PATH`, and the launcher (default `claude --dangerously-skip-permissions`) available. Override the launcher per-project via `agent.spawn_command` in `fab/project/config.yaml`.
 
-See the [riff guide](docs/wiki/riff.md) for the full reference.
+See the [riff guide](docs/site/workflows.md) for the full reference.
 
 ## `rk serve` — the dashboard daemon
 
@@ -126,7 +126,7 @@ Some browser features (clipboard, secure context) require HTTPS. Accessing rk fr
 2. Run `tailscale serve --bg http://localhost:3000`.
 3. Open `https://<machine>.<tailnet>.ts.net` on your phone or another laptop.
 
-For a stable custom hostname or public access via Funnel, see the [Tailscale guide](docs/wiki/tailscale.md).
+For a stable custom hostname or public access via Funnel, see the [Tailscale guide](docs/site/install.md).
 
 ## Shell completion
 
@@ -166,13 +166,3 @@ Run `rk <command> --help` for full flag details.
 ## Architecture
 
 rk's daemon runs in a dedicated tmux server (`rk-daemon`), separate from agent sessions (`runkit`). Restarts use kill-and-restart (no polling loop or signal files), are idempotent (`--restart` works whether or not a daemon is running), and never touch agent tmux sessions — agents survive daemon restarts unaffected.
-
-## Contributing
-
-Run `just doctor` to check development prerequisites (Node 20+, pnpm, tmux, just, Go 1.22+, air, direnv), then:
-
-```bash
-just setup
-just dev       # watch mode (Go backend + Vite dev server)
-just prod      # run from built binary
-```

--- a/docs/site/install.md
+++ b/docs/site/install.md
@@ -1,0 +1,130 @@
+# Install & access
+
+How to install `rk`, keep it up to date, check your runtime, set up a development environment, and reach the dashboard over HTTPS.
+
+## Install
+
+run-kit ships as a Homebrew formula:
+
+```bash
+brew install sahil87/tap/rk
+```
+
+This puts the `rk` binary on your `PATH`. From there, a clean install to a working dashboard with one agent running is:
+
+```bash
+rk serve -d                     # start the dashboard daemon on :3000
+open http://localhost:3000      # open the dashboard in your browser
+
+# in any tmux session:
+rk riff --skill /fab-discuss    # spawn an agent workspace
+```
+
+## Upgrade
+
+```bash
+rk update
+```
+
+`rk update` pulls the latest version via Homebrew and restarts the daemon so the new binary takes effect immediately.
+
+## Prerequisites
+
+`rk riff` requires:
+
+- A running tmux session (`$TMUX` set).
+- [`wt`](https://github.com/sahil87/wt) on your `PATH` — install via `brew install sahil87/tap/wt`, or via the toolkit meta-formula `brew install sahil87/tap/all`.
+- The launcher (default `claude --dangerously-skip-permissions`) available.
+
+When something breaks, run:
+
+```bash
+rk doctor
+```
+
+`rk doctor` checks tmux, `wt`, the launcher binary, port availability, and prints per-dependency status. Run this first when something isn't working.
+
+## Development
+
+Run `just doctor` to check development prerequisites (Node 20+, pnpm, tmux, just, Go 1.22+, air, direnv), then:
+
+```bash
+just setup
+just dev       # watch mode (Go backend + Vite dev server)
+just prod      # run from built binary
+```
+
+## Tailscale HTTPS
+
+run-kit binds to `127.0.0.1` by default. Some browser features (e.g., copy to clipboard) require HTTPS, and accessing run-kit from other machines on your tailnet does too. Tailscale Serve handles both with zero TLS config.
+
+### Prerequisites
+
+Enable HTTPS on your tailnet in the [Tailscale admin console](https://login.tailscale.com/admin/dns) under **DNS > HTTPS Certificates**.
+
+### Quickstart
+
+```sh
+tailscale serve --bg http://localhost:3000
+```
+
+run-kit is now available at:
+
+```
+https://<machine>.<tailnet>.ts.net
+```
+
+To check status or stop:
+
+```sh
+tailscale serve status
+tailscale serve off
+```
+
+### Advanced: Custom hostname
+
+Serve run-kit under a stable hostname like `runner1.<tailnet>.ts.net` instead of the machine name — the URL survives moving rk to another host.
+
+Services need a tagged node. Do these in order:
+
+1. **Define the `tag:server` tag.** In [Access controls](https://login.tailscale.com/admin/acls), Visual editor → **Tags** → add a tag named `server`. Owners can be left empty.
+
+2. **Re-register the node with the tag** (`--operator` lets you manage Tailscale without sudo afterward):
+
+   ```sh
+   sudo tailscale up --advertise-tags=tag:server --operator=$USER
+   ```
+
+3. **Add the HTTPS endpoint.** In the [machines console](https://login.tailscale.com/admin/machines), open the `svc:runner1` service and add `tcp:443`. Skip this and you'll get "required ports are missing" even while the service advertises.
+
+4. **Serve:**
+
+   ```sh
+   tailscale serve --bg --service=svc:runner1 http://localhost:3000
+   ```
+
+5. **Approve the service.** Open the [Services](https://login.tailscale.com/admin/services) page, find the pending `svc:runner1` advertisement under **Service hosts**, and click **Approve**. The service is inactive until you do.
+
+run-kit is now at `https://runner1.<tailnet>.ts.net`.
+
+> **Note:** Tagging a node drops its user-identity association — user-based ACL grants stop applying. Make sure your ACLs grant the tag what it needs.
+
+> **Tip:** If you advertise services often, you can skip the manual approval in step 5. In the [Access controls](https://login.tailscale.com/admin/acls) **JSON editor**, add an `autoApprovers` block as a top-level key (there's no Visual editor control for service approval), then save — leave the existing `grants` block untouched:
+>
+> ```jsonc
+> "autoApprovers": {
+>   "services": {
+>     "svc:runner1": ["tag:server"]
+>   }
+> },
+> ```
+
+### Advanced: Public access (Funnel)
+
+To expose run-kit to the public internet (not just your tailnet):
+
+```sh
+tailscale funnel --bg http://localhost:3000
+```
+
+> **Warning:** Funnel makes your terminal relay publicly accessible. Only use this if you understand the security implications.

--- a/docs/site/workflows.md
+++ b/docs/site/workflows.md
@@ -1,0 +1,128 @@
+# `rk riff` — spawn agent workspaces
+
+`rk riff` creates a git worktree, opens a new tmux window inside it, and launches one or more Claude Code panes — all in a single command. It's the primary way to start agent work in run-kit.
+
+A "riff" is one disposable workspace: one branch, one worktree, one tmux window, one or more agent panes. Tear it down by closing the window and deleting the worktree (`wt delete`).
+
+## Prerequisites
+
+- You must be running inside a tmux session (`$TMUX` set).
+- [`wt`](https://github.com/sahil87/wt) must be on your `PATH`.
+- The launcher (`claude --dangerously-skip-permissions` by default) must be available.
+
+The launcher can be overridden per-project via `agent.spawn_command` in `fab/project/config.yaml`.
+
+## Quick start
+
+```bash
+rk riff                                   # 1 pane, default skill (/fab-discuss)
+rk riff --skill /review                   # 1 pane, specific slash-command
+rk riff --skill /fab-fff --cmd "just dev" # 2 panes (agent + dev server)
+```
+
+Open the resulting window in the browser to drive it from the run-kit UI, or stay in tmux — both work, since the agent is just a tmux pane.
+
+## Pane array model
+
+`--skill` and `--cmd` are repeatable. Argv order (left to right) becomes pane order (pane 0, pane 1, …). The flags can be interleaved:
+
+```bash
+rk riff --skill /a --cmd htop --skill /b --cmd "tail -f log"
+# pane 0: claude /a   pane 1: htop   pane 2: claude /b   pane 3: tail
+```
+
+- **Bare `--skill`** (no value) launches a blank Claude session.
+- **Bare `--cmd`** drops into `$SHELL` (fallback `/bin/sh`).
+
+## Layouts
+
+`--layout` controls pane arrangement. Default is `auto` (1 pane = none, 2 = even-horizontal, 3+ = tiled).
+
+| Name | Shortform | Shape |
+|------|-----------|-------|
+| `auto` | `a` | pane-count-based default |
+| `tiled` | `t` | grid |
+| `even-horizontal` | `h` | side-by-side |
+| `even-vertical` | `v` | stacked |
+| `main-horizontal` | `deck-h` | main on top, deck below |
+| `main-vertical` | `deck-v` | main on left, deck on right |
+
+```bash
+rk riff --skill /a --cmd x --cmd y --layout main-vertical
+```
+
+## Presets
+
+Define common pane shapes in `fab/project/config.yaml` under `riff.presets.<name>`:
+
+```yaml
+riff:
+  presets:
+    ship:
+      layout: main-vertical
+      panes:
+        - skill: /fab-fff
+        - cmd: just dev
+        - cmd: just test-e2e --ui
+      wt_args: ["--base", "main"]
+```
+
+Invoke by name (positional or via `--preset`):
+
+```bash
+rk riff ship                # positional preset name
+rk riff --preset ship       # explicit form
+rk riff --list-presets      # list all defined presets
+```
+
+CLI `--skill` / `--cmd` flags **replace** the preset's panes entirely; CLI `--layout` overrides the preset's layout.
+
+## Parallel spawning with `--count`
+
+`-N <N>` (or `--count <N>`) creates N worktree/window pairs in parallel, each with the same pane shape:
+
+```bash
+rk riff ship --count 3      # 3 parallel ship workspaces
+rk riff -N 5 --skill /fab-fff
+```
+
+Worktree names come from `wt`'s adjective-noun generator (e.g. `swift-fox`, `zippy-yak`). On any failure, successful worktrees and windows are rolled back before exit.
+
+## Passing flags to `wt`
+
+Anything after `--` is forwarded verbatim to `wt create`. Useful for:
+
+```bash
+rk riff -- --worktree-name pacing-canyon   # name the worktree
+rk riff -- --base main                     # branch off main
+rk riff -- --reuse                         # reuse an existing branch
+```
+
+Run `wt create --help` for the full passthrough flag list.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | success |
+| 2 | precondition failure (`$TMUX` unset, `wt` not found) |
+| 3 | subprocess failure (`wt` or `tmux` non-zero, parse failure, timeout) |
+
+## Common patterns
+
+```bash
+# Solo planning session
+rk riff --skill /fab-discuss
+
+# Implement + watch dev server + watch tests
+rk riff --skill /fab-fff --cmd "just dev" --cmd "just test-watch" --layout main-vertical
+
+# Three parallel attempts at the same change
+rk riff ship --count 3
+
+# Investigate a bug with a shell pane handy
+rk riff --skill /fab-discuss --cmd
+
+# Branch off a specific base
+rk riff --skill /fab-fff -- --base release/v2
+```

--- a/fab/changes/260608-j6bs-shllai-readme-extraction-contract/.history.jsonl
+++ b/fab/changes/260608-j6bs-shllai-readme-extraction-contract/.history.jsonl
@@ -9,3 +9,4 @@
 {"event":"review","result":"passed","ts":"2026-06-08T10:07:35Z"}
 {"cmd":"fab-continue","event":"command","ts":"2026-06-08T10:08:18Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-06-08T10:09:00Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-06-08T10:10:52Z"}

--- a/fab/changes/260608-j6bs-shllai-readme-extraction-contract/.history.jsonl
+++ b/fab/changes/260608-j6bs-shllai-readme-extraction-contract/.history.jsonl
@@ -1,0 +1,11 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-06-08T09:58:30Z"}
+{"args":"Conform repo to shll.ai README-extraction contract: restructure README.md (Part 1 — head order, tail denylist, absolute images, no site-escaping relative links) and add docs/site/** tree (Part 2 — install.md + workflows.md) following the per-tool table row for run-kit (slug run-kit, reserved overview/readme/commands).","cmd":"fab-new","event":"command","ts":"2026-06-08T09:58:30Z"}
+{"cmd":"fab-new","event":"command","ts":"2026-06-08T09:58:40Z"}
+{"delta":"+3.8","event":"confidence","score":3.8,"trigger":"calc-score","ts":"2026-06-08T09:59:26Z"}
+{"delta":"+0.0","event":"confidence","score":3.8,"trigger":"calc-score","ts":"2026-06-08T09:59:30Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-06-08T10:00:25Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-06-08T10:04:45Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-06-08T10:07:35Z"}
+{"event":"review","result":"passed","ts":"2026-06-08T10:07:35Z"}
+{"cmd":"fab-continue","event":"command","ts":"2026-06-08T10:08:18Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-06-08T10:09:00Z"}

--- a/fab/changes/260608-j6bs-shllai-readme-extraction-contract/.status.yaml
+++ b/fab/changes/260608-j6bs-shllai-readme-extraction-contract/.status.yaml
@@ -9,8 +9,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 plan:
     generated: true
     task_count: 7
@@ -33,8 +33,10 @@ stage_metrics:
     apply: {started_at: "2026-06-08T10:00:25Z", driver: fab-fff, iterations: 1, completed_at: "2026-06-08T10:04:45Z"}
     review: {started_at: "2026-06-08T10:04:45Z", driver: fab-fff, iterations: 1, completed_at: "2026-06-08T10:07:35Z"}
     hydrate: {started_at: "2026-06-08T10:07:35Z", driver: fab-fff, iterations: 1, completed_at: "2026-06-08T10:09:00Z"}
-    ship: {started_at: "2026-06-08T10:09:00Z", driver: fab-fff, iterations: 1}
-prs: []
+    ship: {started_at: "2026-06-08T10:09:00Z", driver: fab-fff, iterations: 1, completed_at: "2026-06-08T10:10:52Z"}
+    review-pr: {started_at: "2026-06-08T10:10:52Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/sahil87/run-kit/pull/237
 true_impact:
     added: 0
     deleted: 0
@@ -46,4 +48,4 @@ true_impact:
     computed_at: "2026-06-08T10:09:00Z"
     computed_at_stage: hydrate
 # true_impact: lazily created on first apply-finish (no placeholder here).
-last_updated: 2026-06-08T10:09:00Z
+last_updated: 2026-06-08T10:10:52Z

--- a/fab/changes/260608-j6bs-shllai-readme-extraction-contract/.status.yaml
+++ b/fab/changes/260608-j6bs-shllai-readme-extraction-contract/.status.yaml
@@ -1,0 +1,49 @@
+id: j6bs
+name: 260608-j6bs-shllai-readme-extraction-contract
+created: 2026-06-08T09:58:30Z
+created_by: sahil-noon
+change_type: docs
+issues: []
+progress:
+    intake: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+plan:
+    generated: true
+    task_count: 7
+    acceptance_count: 12
+    acceptance_completed: 12
+confidence:
+    certain: 4
+    confident: 4
+    tentative: 0
+    unresolved: 0
+    score: 3.8
+    fuzzy: true
+    dimensions:
+        signal: 87.6
+        reversibility: 78.8
+        competence: 87.9
+        disambiguation: 83.8
+stage_metrics:
+    intake: {started_at: "2026-06-08T09:58:30Z", driver: fab-new, iterations: 1, completed_at: "2026-06-08T10:00:25Z"}
+    apply: {started_at: "2026-06-08T10:00:25Z", driver: fab-fff, iterations: 1, completed_at: "2026-06-08T10:04:45Z"}
+    review: {started_at: "2026-06-08T10:04:45Z", driver: fab-fff, iterations: 1, completed_at: "2026-06-08T10:07:35Z"}
+    hydrate: {started_at: "2026-06-08T10:07:35Z", driver: fab-fff, iterations: 1, completed_at: "2026-06-08T10:09:00Z"}
+    ship: {started_at: "2026-06-08T10:09:00Z", driver: fab-fff, iterations: 1}
+prs: []
+true_impact:
+    added: 0
+    deleted: 0
+    net: 0
+    excluding:
+        added: 0
+        deleted: 0
+        net: 0
+    computed_at: "2026-06-08T10:09:00Z"
+    computed_at_stage: hydrate
+# true_impact: lazily created on first apply-finish (no placeholder here).
+last_updated: 2026-06-08T10:09:00Z

--- a/fab/changes/260608-j6bs-shllai-readme-extraction-contract/intake.md
+++ b/fab/changes/260608-j6bs-shllai-readme-extraction-contract/intake.md
@@ -1,0 +1,136 @@
+# Intake: Conform repo to shll.ai README-extraction contract
+
+**Change**: 260608-j6bs-shllai-readme-extraction-contract
+**Created**: 2026-06-08
+**Status**: Draft
+
+## Origin
+
+One-shot task: structure this repo so shll.ai's daily mechanical pull renders run-kit's
+tool page cleanly. shll.ai pulls a slice of `README.md` plus the `docs/site/**` tree on a
+schedule — nothing is hand-copied and nothing is pushed. The job is producer-side
+conformance to the contract at
+https://github.com/sahil87/shll.ai/blob/main/docs/specs/readme-extraction-contract.md
+(§Producer conformance directive), Parts 1 and 2.
+
+> Task: conform this repo to shll.ai's README-extraction contract. Read the contract and
+> follow its §Producer conformance directive end-to-end. (1) Find this repo's row in the
+> per-tool table. (2) Do Part 1 — restructure README.md: head order, drop GitHub-footer
+> sections below the tail denylist, make all images absolute https URLs, render any mermaid
+> to a committed image, write any site-escaping link as an absolute URL. (3) Do Part 2 —
+> add a docs/site/**/*.md tree (install.md / workflows.md) following the four closed-set
+> rules. (4) Run the Verify checklist. Ship as a single PR. Do not touch shll.ai.
+
+**Interaction mode**: one-shot, with a single clarifying question answered.
+
+**Per-tool table row (run-kit)**: slug `run-kit`, URL space `/tools/run-kit/`, collector
+`content/run-kit/`, reserved static slugs already used = `overview`, `readme`, `commands`
+(so no `docs/site/` page may be named those three). `install` and `workflows` are
+explicitly allowed and belong to the tool repo.
+
+**Decision from conversation**: docs/site/ strategy = **Migrate wiki → docs/site/**. Move
+`docs/wiki/riff.md` content into `docs/site/workflows.md`, author `docs/site/install.md`
+(folding in Homebrew install + Tailscale HTTPS), and rewrite the README's two escaping
+links to point at `docs/site/*`. (User chose this over "new docs/site, keep wiki" and
+"minimal: links only".)
+
+## Why
+
+1. **Problem.** shll.ai renders the run-kit landing page by mechanically extracting a slice
+   of `README.md` and the `docs/site/**` tree. The current README has three traits that the
+   pull will mangle: a **relative logo image** (`assets/logo.svg`) that shll.ai will render
+   broken (it vendors zero image binaries), two **site-escaping relative links**
+   (`docs/wiki/riff.md`, `docs/wiki/tailscale.md`) that 404 on the site, and a
+   **`## Contributing` footer** that sits below the contract's tail denylist and will be
+   cut anyway — but is cleaner to remove from the canonical README intent.
+2. **Consequence if unfixed.** The published tool page shows a broken logo and two dead
+   "see the guide" links, and offers no `docs/site/` depth pages — the landing page reads
+   as half-finished next to sibling tools (idea, hop, fab-kit, wt) that conform.
+3. **Approach over alternatives.** Follow the contract verbatim rather than guessing: the
+   contract is the single source of truth for head order, tail cutoff, image/link rules,
+   and the docs/site closed-set rules. Migrating the existing `docs/wiki/` content into
+   `docs/site/` (rather than authoring net-new) reuses already-curated prose and gives the
+   richest page depth with one source of truth.
+
+## What Changes
+
+### Part 1 — README.md restructuring
+
+- **Absolute logo image.** Line 1's `<img src="assets/logo.svg">` becomes an absolute
+  `https://raw.githubusercontent.com/sahil87/run-kit/main/assets/logo.svg` URL. Head order
+  (`# H1` → `>` toolkit blockquote → badge run → prose) is **already correct** and is
+  preserved.
+- **Tail denylist.** Remove the `## Contributing` section (the only section at/below the
+  denylist: `Contributing|Development|Building|License|Acknowledgements`, case-insensitive).
+  `## Architecture` is NOT on the denylist and stays. The `just dev`/`just setup` developer
+  content currently under Contributing moves into `docs/site/install.md` (a "Development"
+  subsection) so it isn't lost — it just leaves the pulled README slice.
+- **Site-escaping relative links → docs/site links.** Rewrite `[riff guide](docs/wiki/riff.md)`
+  → `[riff guide](docs/site/workflows.md)` and `[Tailscale guide](docs/wiki/tailscale.md)`
+  → `[Tailscale guide](docs/site/install.md)`. The contract auto-rewrites `docs/site/<path>.md`
+  links to `/tools/run-kit/<path>` on the site, and they resolve to the real file on GitHub.
+- **No mermaid / no gh-mode tricks.** README already has neither — the ASCII "mental model"
+  block is plain text (kept), and there are no `#gh-dark-mode-only`/`#gh-light-mode-only`
+  fragments. No action needed; verified during Verify.
+- **External links already absolute.** `https://github.com/sahil87/wt`,
+  `https://github.com/sahil87/fab-kit`, the shll/Tailscale admin links, and the
+  `user-attachments` screenshots are already absolute `https://…`. No action.
+
+### Part 2 — docs/site/ tree
+
+- **`docs/site/install.md`** (reserved slug allowed) — install + access guide. Sections:
+  Homebrew install (`brew install sahil87/tap/rk`), upgrade (`rk update`), prerequisites /
+  `rk doctor`, Development (Node 20+/pnpm/Go 1.22+/`just setup`/`just dev`/`just prod` — the
+  migrated Contributing content), and **Tailscale HTTPS** (full content migrated from
+  `docs/wiki/tailscale.md`, including custom hostname + Funnel).
+- **`docs/site/workflows.md`** (reserved slug allowed) — the `rk riff` deep-dive, migrated
+  from `docs/wiki/riff.md`: pane array model, layouts table, presets, parallel `--count`,
+  wt passthrough, exit codes, common patterns.
+- **Closed-set conformance.** All images in both pages absolute `https://…`; every external
+  link absolute; every intra-site link relative-within-`docs/site/`; no `..` escape; no page
+  named `overview`/`readme`/`commands`.
+- **`docs/wiki/` retained.** The two wiki files stay in place (not deleted) so any existing
+  external/GitHub references keep working; `docs/site/` becomes the shll.ai-facing copy.
+
+### Verify (pre-PR)
+
+Run the contract's checklist: head order correct with no frontmatter/HTML-comment above the
+H1; no relative image anywhere (README + docs/site); README links point into `docs/site/`
+or are absolute; no gh-mode fragments; no reserved-slug page names; optional local extractor
+self-check if `extract-readme-cli.mjs` is reachable.
+
+## Affected Memory
+
+<!-- This change is docs/README structuring only — no spec-level product behavior changes.
+     No memory files are created, modified, or removed. -->
+
+- None — documentation/README restructuring only; no product behavior changes.
+
+## Impact
+
+- `README.md` — head image absolutized, two links repointed, `## Contributing` removed.
+- `docs/site/install.md` (new), `docs/site/workflows.md` (new).
+- `docs/wiki/riff.md`, `docs/wiki/tailscale.md` — unchanged (source for migration).
+- No code, API, or dependency changes. No `app/backend/`, `app/frontend/` touch.
+- Out of scope: the shll.ai repo (it pulls automatically); `help/run-kit.json` generation
+  (already emitted at build time per commit afe/230); deleting `docs/wiki/`.
+
+## Open Questions
+
+- None blocking. The one strategic choice (docs/site migration approach) was resolved in
+  conversation.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | run-kit's per-tool row: slug `run-kit`, reserved page names `overview`/`readme`/`commands`, `install`+`workflows` allowed | Read directly from the contract's per-tool table | S:98 R:90 A:95 D:95 |
+| 2 | Certain | Tail cutoff removes `## Contributing` only; `## Architecture` stays | Contract denylist is explicit (Contributing/Development/Building/License/Acknowledgements); Architecture not listed | S:95 R:80 A:95 D:90 |
+| 3 | Certain | Head order already conforms (`#`→`>`→badges→prose); only the logo `src` must be absolutized | Verified against current README.md and §1/§3 | S:95 R:85 A:95 D:90 |
+| 4 | Confident | Absolute logo URL = `raw.githubusercontent.com/sahil87/run-kit/main/assets/logo.svg` | Standard raw-content form for a committed repo asset; `main` is the default branch | S:80 R:75 A:80 D:75 |
+| 5 | Confident | docs/site strategy = migrate `docs/wiki/*` into `install.md`/`workflows.md`, rewrite README links to `docs/site/*` | Chosen by user in conversation over two alternatives | S:90 R:65 A:85 D:80 |
+| 6 | Confident | Migrated Contributing/`just` dev content lands in `docs/site/install.md` under a Development section (so it survives the tail cut) | Preserves real content while honoring the tail denylist; install page is the natural home | S:75 R:70 A:80 D:70 |
+| 7 | Confident | Keep `docs/wiki/` in place (don't delete) after migration | Avoids breaking any existing GitHub/external references; deletion is out of scope and separately reversible | S:70 R:75 A:75 D:75 |
+| 8 | Certain | No mermaid render needed; no gh-mode fragments to strip | Grepped README — neither present | S:98 R:90 A:98 D:95 |
+
+8 assumptions (4 certain, 4 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260608-j6bs-shllai-readme-extraction-contract/plan.md
+++ b/fab/changes/260608-j6bs-shllai-readme-extraction-contract/plan.md
@@ -1,0 +1,165 @@
+# Plan: Conform repo to shll.ai README-extraction contract
+
+**Change**: 260608-j6bs-shllai-readme-extraction-contract
+**Status**: In Progress
+**Intake**: `intake.md`
+
+## Requirements
+
+### README: Head & Image Conformance
+
+#### R1: Absolute logo image in the H1
+The README H1 logo image SHALL reference an absolute `https://…` URL, not a relative repo path. Head order (`# H1` → `>` toolkit blockquote → badges → prose) MUST be preserved unchanged.
+
+- **GIVEN** the README H1 `<img src="assets/logo.svg" …>`
+- **WHEN** the contract is applied
+- **THEN** the `src` becomes `https://raw.githubusercontent.com/sahil87/run-kit/main/assets/logo.svg`
+- **AND** nothing precedes the `#` H1 (no frontmatter, no HTML comment) and the `#`→`>`→badges→prose order is intact
+
+#### R2: No mermaid fences, no gh-mode fragments
+The README MUST contain no mermaid code fences and no `#gh-dark-mode-only` / `#gh-light-mode-only` URL fragments.
+
+- **GIVEN** the current README
+- **WHEN** verified via grep
+- **THEN** zero matches for `mermaid`, `gh-dark-mode-only`, `gh-light-mode-only` (no edit needed — confirm only)
+
+#### R3: Already-absolute links/images untouched
+All existing absolute `https://…` links and images (github.com/sahil87/*, user-attachments screenshots, Tailscale admin links) SHALL remain unchanged.
+
+- **GIVEN** the absolute URLs already in the README
+- **WHEN** the change is applied
+- **THEN** they are byte-for-byte unchanged
+
+### README: Tail Denylist & Link Repointing
+
+#### R4: Drop the Contributing section
+The README `## Contributing` section SHALL be removed entirely (it sits at/below the contract tail denylist: Contributing/Development/Building/License/Acknowledgements). `## Architecture` is NOT on the denylist and MUST be retained.
+
+- **GIVEN** the README ends with `## Architecture` then `## Contributing`
+- **WHEN** the change is applied
+- **THEN** `## Contributing` and its `just doctor`/`just setup`/`just dev`/`just prod` body are gone
+- **AND** `## Architecture` remains as the final section
+
+#### R5: Migrate developer content into docs/site/install.md
+The developer prerequisites and `just` recipes previously under `## Contributing` MUST be preserved in a `## Development` section of `docs/site/install.md` so the content is not lost.
+
+- **GIVEN** the Contributing body (Node 20+/pnpm/tmux/just/Go 1.22+/air/direnv prereqs + `just setup`/`just dev`/`just prod`)
+- **WHEN** the change is applied
+- **THEN** that content appears under a Development section in `docs/site/install.md`
+
+#### R6: Repoint site-escaping relative links
+The two `docs/wiki/*` relative links in the README SHALL be repointed into `docs/site/`.
+
+- **GIVEN** `[riff guide](docs/wiki/riff.md)` and `[Tailscale guide](docs/wiki/tailscale.md)`
+- **WHEN** the change is applied
+- **THEN** they become `[riff guide](docs/site/workflows.md)` and `[Tailscale guide](docs/site/install.md)` respectively
+- **AND** no `docs/wiki/` link remains in the README
+
+### docs/site Tree (closed-set rules)
+
+#### R7: docs/site/install.md authored
+A new `docs/site/install.md` SHALL exist with: Homebrew install (`brew install sahil87/tap/rk`), upgrade (`rk update`), prerequisites / `rk doctor`, a Development section (R5 content), and a Tailscale HTTPS section migrating the FULL content of `docs/wiki/tailscale.md` (quickstart, custom hostname, Funnel, all admin-console links kept absolute).
+
+- **GIVEN** the contract allows the `install` slug for the tool repo
+- **WHEN** the change is applied
+- **THEN** `docs/site/install.md` exists and covers all listed sections
+- **AND** every image is absolute `https://…`, every site-escaping link is absolute `https://…`, no `..` escape
+
+#### R8: docs/site/workflows.md authored
+A new `docs/site/workflows.md` SHALL exist migrating the FULL content of `docs/wiki/riff.md` (pane array model, layouts table, presets, parallel `--count`, wt passthrough, exit codes, common patterns).
+
+- **GIVEN** the contract allows the `workflows` slug for the tool repo
+- **WHEN** the change is applied
+- **THEN** `docs/site/workflows.md` exists with the full riff reference
+- **AND** every image is absolute, every site-escaping link is absolute, no `..` escape
+
+#### R9: Reserved-slug & wiki-retention rules
+No `docs/site/` page may be named `overview`, `readme`, or `commands`. `docs/wiki/` files MUST NOT be deleted.
+
+- **GIVEN** the reserved static slugs and wiki-retention decision
+- **WHEN** the change is applied
+- **THEN** docs/site contains only `install.md` and `workflows.md`
+- **AND** `docs/wiki/riff.md` and `docs/wiki/tailscale.md` remain in place
+
+### Non-Goals
+
+- Touching `app/backend/` or `app/frontend/` — docs-only change.
+- Deleting `docs/wiki/` — explicitly out of scope.
+- The shll.ai repo — it pulls automatically.
+- `help/run-kit.json` generation — already emitted at build time.
+
+### Design Decisions
+
+1. **Migrate wiki → docs/site rather than author net-new**: reuses curated prose, gives richest page depth, single source of truth — *Why*: user-chosen in intake — *Rejected*: "new docs/site, keep wiki separate" and "minimal: links only".
+2. **Tailscale link repoints to install.md, riff link repoints to workflows.md**: Tailscale content folds into the install/access guide; riff content is the workflows deep-dive — *Why*: matches the section homes chosen for each migration target.
+
+## Tasks
+
+### Phase 1: Setup
+
+- [x] T001 Create the `docs/site/` directory <!-- R7 R8 -->
+
+### Phase 2: docs/site authoring (migration targets — must exist before README links point at them)
+
+- [x] T002 Author `docs/site/workflows.md` migrating the full content of `docs/wiki/riff.md` (pane array model, layouts table, presets, parallel `--count`, wt passthrough, exit codes, common patterns); all links/images absolute, no `..` escape <!-- R8 -->
+- [x] T003 Author `docs/site/install.md` with Homebrew install, `rk update` upgrade, prerequisites/`rk doctor`, a `## Development` section (migrated Contributing prereqs + `just setup`/`just dev`/`just prod`), and a `## Tailscale HTTPS` section migrating the full content of `docs/wiki/tailscale.md` (quickstart, custom hostname, Funnel, admin links absolute) <!-- R7 R5 -->
+
+### Phase 3: README restructuring
+
+- [x] T004 In `README.md` line 1, absolutize the H1 logo `src` to `https://raw.githubusercontent.com/sahil87/run-kit/main/assets/logo.svg`; preserve head order <!-- R1 -->
+- [x] T005 In `README.md`, repoint `[riff guide](docs/wiki/riff.md)` → `docs/site/workflows.md` and `[Tailscale guide](docs/wiki/tailscale.md)` → `docs/site/install.md` <!-- R6 -->
+- [x] T006 In `README.md`, remove the `## Contributing` section entirely; keep `## Architecture` as the final section <!-- R4 -->
+
+### Phase 4: Verify
+
+- [x] T007 Run the contract Verify checklist: README head order intact, no relative image in README or docs/site, README links point into docs/site or absolute https, no `docs/wiki/` link in README, no gh-mode fragments, no reserved-slug page names, `docs/wiki/` retained <!-- R1 R2 R3 R6 R9 -->
+
+## Execution Order
+
+- T001 blocks T002 and T003 (directory must exist)
+- T002/T003 should precede T005 (links must point at existing files) but are otherwise independent of each other
+- T004/T005/T006 all edit README.md — sequential
+- T007 runs last
+
+## Acceptance
+
+### Functional Completeness
+
+- [x] A-001 R1: README H1 image `src` is `https://raw.githubusercontent.com/sahil87/run-kit/main/assets/logo.svg`; nothing precedes the `#` H1; `#`→`>`→badges→prose order intact
+- [x] A-002 R4: `## Contributing` is removed; `## Architecture` is retained as the final section
+- [x] A-003 R5: Contributing dev content (prereqs + `just setup`/`just dev`/`just prod`) is present under a Development section in `docs/site/install.md`
+- [x] A-004 R6: README links are `docs/site/workflows.md` (riff) and `docs/site/install.md` (Tailscale); no `docs/wiki/` link remains
+- [x] A-005 R7: `docs/site/install.md` exists with Homebrew install, `rk update`, prerequisites/`rk doctor`, Development, and full Tailscale HTTPS content (quickstart + custom hostname + Funnel)
+- [x] A-006 R8: `docs/site/workflows.md` exists with full riff reference (pane array, layouts table, presets, `--count`, wt passthrough, exit codes, common patterns)
+- [x] A-007 R9: docs/site contains only install.md and workflows.md; `docs/wiki/riff.md` and `docs/wiki/tailscale.md` still present
+
+### Behavioral Correctness
+
+- [x] A-008 R3: All pre-existing absolute URLs (github.com/sahil87/*, user-attachments screenshots, Tailscale admin links) are unchanged
+
+### Scenario Coverage
+
+- [x] A-009 R2: grep confirms zero `mermaid` / `gh-dark-mode-only` / `gh-light-mode-only` matches in README and docs/site
+- [x] A-010 R7 R8: grep confirms no relative image (`src="assets`, relative `![`) and no `..` escape in docs/site/**
+
+### Code Quality
+
+- [x] A-011 Pattern consistency: docs/site pages follow existing repo markdown style (heading levels, fenced code blocks, tables)
+- [x] A-012 No unnecessary duplication: migrated content reuses wiki prose rather than re-authoring; no content lost
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All acceptance items must pass before `/fab-continue` (hydrate)
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Absolute logo URL = `https://raw.githubusercontent.com/sahil87/run-kit/main/assets/logo.svg` | Specified verbatim in intake; standard raw-content form, `main` default branch | S:98 R:80 A:95 D:95 |
+| 2 | Certain | Tailscale link → install.md; riff link → workflows.md | Specified verbatim in intake Part 1 step 3 | S:98 R:85 A:95 D:95 |
+| 3 | Certain | install.md folds in the FULL tailscale.md content under a `## Tailscale HTTPS` section; workflows.md is the full riff.md migration | Specified verbatim in intake Part 2 | S:95 R:80 A:95 D:90 |
+| 4 | Confident | docs/site/install.md gets its own top-level intro + sectioned layout (Install / Prerequisites / Development / Tailscale HTTPS); install content (Homebrew, rk update, rk doctor) lifted from the README Quick start / Command reference | Intake lists the sections but not exact prose; README already contains the canonical command forms to reuse | S:80 R:70 A:85 D:75 |
+| 5 | Confident | Keep `docs/wiki/` files byte-for-byte (source of migration, not modified) | Intake says retain, not delete; no instruction to edit them | S:90 R:80 A:90 D:85 |
+
+5 assumptions (3 certain, 2 confident, 0 tentative).


### PR DESCRIPTION
## Meta

| ID | Type | Confidence | Plan | Review |
|----|------|-----------|------|--------|
| j6bs | docs | 3.8/5.0 | 7/7 tasks, 12/12 acceptance ✓ | ✓ 1 cycle |

**Pipeline**: [intake](https://github.com/sahil87/run-kit/blob/260608-j6bs-shllai-readme-extraction-contract/fab/changes/260608-j6bs-shllai-readme-extraction-contract/intake.md) ✓ → [apply](https://github.com/sahil87/run-kit/blob/260608-j6bs-shllai-readme-extraction-contract/fab/changes/260608-j6bs-shllai-readme-extraction-contract/plan.md) ✓ → review ✓ → hydrate ✓ → ship → review-pr

## Summary

Conforms the run-kit repo to shll.ai's README-extraction contract (§Producer conformance directive). shll.ai mechanically pulls a slice of `README.md` plus the `docs/site/**` tree daily to render the tool page; the current README would render a broken logo, two dead "see the guide" links, and offer no `docs/site/` depth pages. This is producer-side conformance only — docs-only, no code/API/dependency changes, and the shll.ai repo is untouched (it pulls automatically).

## Changes

### Part 1 — README.md restructuring
- Absolutize the H1 logo image: `assets/logo.svg` → `https://raw.githubusercontent.com/sahil87/run-kit/main/assets/logo.svg`.
- Remove the `## Contributing` section (the only section at/below the contract tail denylist); its `just dev`/`just setup` developer content migrates into `docs/site/install.md`.
- Repoint two site-escaping relative links: `[riff guide]` → `docs/site/workflows.md`, `[Tailscale guide]` → `docs/site/install.md`.
- Head order (`# H1` → toolkit blockquote → badges → prose) and `## Architecture` retained.

### Part 2 — docs/site/ tree
- **`docs/site/install.md`** (new): install + access guide — Homebrew install (`brew install sahil87/tap/rk`), `rk update`, prerequisites/`rk doctor`, a Development section (migrated Contributing content), and a full Tailscale HTTPS section (migrated from `docs/wiki/tailscale.md`).
- **`docs/site/workflows.md`** (new): the `rk riff` deep-dive (migrated from `docs/wiki/riff.md`).
- `docs/wiki/` retained unchanged.

## Verify
- Head order conforms — nothing precedes the `#` H1; `#` → `>` → badges → prose intact.
- All images absolute `https://…` (README + `docs/site/**`); no relative image anywhere.
- No site-escaping links — README links point into `docs/site/` or are absolute; no `docs/wiki/` link remains; no `..` escape in `docs/site/`.
- No reserved-slug pages — `docs/site/` contains only `install.md` and `workflows.md` (not `overview`/`readme`/`commands`).
- No mermaid and no gh-mode (`#gh-dark-mode-only`/`#gh-light-mode-only`) tricks.