### PR TITLE
feat: Keystroke→echo latency benchmark harness

### DIFF
--- a/app/frontend/src/components/terminal-client.tsx
+++ b/app/frontend/src/components/terminal-client.tsx
@@ -35,9 +35,13 @@ export const clipboardProvider = {
  * the live `Terminal` instance to poll `term.buffer.active` for the echoed
  * glyph (the WebGL canvas is not DOM-readable). We expose instances on
  * `window.__rkTerminals`, keyed by windowId, so a Playwright `page.evaluate`
- * can reach them. Inert in normal use — nothing reads the registry unless a
- * test driver does. Kept tiny and symmetric (register on create, unregister on
+ * can reach them. Kept tiny and symmetric (register on create, unregister on
  * dispose) so a stale handle never points at a disposed terminal.
+ *
+ * Gated on `import.meta.env.DEV`: this is populated ONLY in dev/e2e builds
+ * (Vite's dev server, which is what `just dev` / the e2e harness run against),
+ * never in a production `vite build`. So production bundles do not expose live
+ * Terminal instances on `window` at all — the helpers compile to no-ops there.
  */
 declare global {
   interface Window {
@@ -46,12 +50,12 @@ declare global {
 }
 
 function registerTestTerminal(windowId: string, terminal: import("@xterm/xterm").Terminal) {
-  if (typeof window === "undefined") return;
+  if (!import.meta.env.DEV || typeof window === "undefined") return;
   (window.__rkTerminals ??= {})[windowId] = terminal;
 }
 
 function unregisterTestTerminal(windowId: string) {
-  if (typeof window === "undefined" || !window.__rkTerminals) return;
+  if (!import.meta.env.DEV || typeof window === "undefined" || !window.__rkTerminals) return;
   delete window.__rkTerminals[windowId];
 }
 

--- a/app/frontend/src/components/terminal-client.tsx
+++ b/app/frontend/src/components/terminal-client.tsx
@@ -30,6 +30,31 @@ export const clipboardProvider = {
   },
 };
 
+/**
+ * Test-only terminal registry. The echo-latency e2e harness needs a handle to
+ * the live `Terminal` instance to poll `term.buffer.active` for the echoed
+ * glyph (the WebGL canvas is not DOM-readable). We expose instances on
+ * `window.__rkTerminals`, keyed by windowId, so a Playwright `page.evaluate`
+ * can reach them. Inert in normal use — nothing reads the registry unless a
+ * test driver does. Kept tiny and symmetric (register on create, unregister on
+ * dispose) so a stale handle never points at a disposed terminal.
+ */
+declare global {
+  interface Window {
+    __rkTerminals?: Record<string, import("@xterm/xterm").Terminal>;
+  }
+}
+
+function registerTestTerminal(windowId: string, terminal: import("@xterm/xterm").Terminal) {
+  if (typeof window === "undefined") return;
+  (window.__rkTerminals ??= {})[windowId] = terminal;
+}
+
+function unregisterTestTerminal(windowId: string) {
+  if (typeof window === "undefined" || !window.__rkTerminals) return;
+  delete window.__rkTerminals[windowId];
+}
+
 type TerminalClientProps = {
   sessionName: string;
   windowId: string;
@@ -192,6 +217,15 @@ export function TerminalClient({
       xtermRef.current = terminal;
       fitAddonRef.current = fitAddon;
 
+      // Test-only hook: register this Terminal instance on a window-level
+      // registry keyed by windowId so the echo-latency e2e harness can read
+      // `term.buffer.active` directly. The WebGL renderer paints to a canvas
+      // that is NOT DOM-readable, so reading the parsed buffer is the only
+      // honest way to detect "glyph visible" from a Playwright driver. This is
+      // a single ref assignment with no runtime cost; it is cleaned up on
+      // unmount alongside the terminal dispose below.
+      registerTestTerminal(windowId, terminal);
+
       // Clipboard addon — enriched clipboard support
       terminal.loadAddon(new ClipboardAddon(undefined, clipboardProvider));
 
@@ -287,6 +321,7 @@ export function TerminalClient({
         wsRef.current = null;
       }
       if (focusRef) focusRef.current = null;
+      unregisterTestTerminal(windowId);
       xtermRef.current = null;
       fitAddonRef.current = null;
       try { terminal?.dispose(); } catch { /* WebGL addon may throw during teardown */ }

--- a/app/frontend/src/components/terminal-client.tsx
+++ b/app/frontend/src/components/terminal-client.tsx
@@ -217,14 +217,10 @@ export function TerminalClient({
       xtermRef.current = terminal;
       fitAddonRef.current = fitAddon;
 
-      // Test-only hook: register this Terminal instance on a window-level
-      // registry keyed by windowId so the echo-latency e2e harness can read
-      // `term.buffer.active` directly. The WebGL renderer paints to a canvas
-      // that is NOT DOM-readable, so reading the parsed buffer is the only
-      // honest way to detect "glyph visible" from a Playwright driver. This is
-      // a single ref assignment with no runtime cost; it is cleaned up on
-      // unmount alongside the terminal dispose below.
-      registerTestTerminal(windowId, terminal);
+      // (The test-only registry is keyed on `windowId`, which can change while
+      // this terminal stays mounted — see the dedicated effect below, which
+      // re-keys register/unregister on windowId so the registry never goes
+      // stale. The init effect deliberately does NOT register here.)
 
       // Clipboard addon — enriched clipboard support
       terminal.loadAddon(new ClipboardAddon(undefined, clipboardProvider));
@@ -321,13 +317,27 @@ export function TerminalClient({
         wsRef.current = null;
       }
       if (focusRef) focusRef.current = null;
-      unregisterTestTerminal(windowId);
       xtermRef.current = null;
       fitAddonRef.current = null;
       try { terminal?.dispose(); } catch { /* WebGL addon may throw during teardown */ }
       setTerminalReady(false);
     };
   }, [wsRef, focusRef]);
+
+  // Test-only registry, keyed on the CURRENT windowId. The init effect runs
+  // mount-only (deps [wsRef, focusRef]), but `windowId` can change while this
+  // component stays mounted (it is rendered without a `key` in app.tsx, so a
+  // window switch re-renders rather than remounts). Registering here — keyed on
+  // [terminalReady, windowId] — re-keys the entry on every switch and cleans up
+  // the OLD id before adding the new one, so `window.__rkTerminals` never holds
+  // a stale handle. The echo-latency harness reads this to poll
+  // `term.buffer.active` (the WebGL canvas is not DOM-readable). Inert in normal
+  // use — nothing reads the registry unless a test driver does.
+  useEffect(() => {
+    if (!terminalReady || !xtermRef.current) return;
+    registerTestTerminal(windowId, xtermRef.current);
+    return () => unregisterTestTerminal(windowId);
+  }, [terminalReady, windowId]);
 
   // Scroll-lock: prevent xterm textarea from gaining focus when locked.
   // Instead of reactively blurring on focusin (which disrupts active touch

--- a/app/frontend/tests/e2e/echo-latency.spec.md
+++ b/app/frontend/tests/e2e/echo-latency.spec.md
@@ -36,7 +36,7 @@ prompt re-flowing the line or to cursor-column drift — the arrival of one more
 ## How the start timestamp is taken
 
 A real keystroke flows `keyboard.press` → xterm keydown → `onData` → `ws.send`
-(`terminal-client.tsx:219`). An init script (`INSTALL_SEND_STAMP`) wraps
+(TerminalClient's `terminal.onData` handler). An init script (`INSTALL_SEND_STAMP`) wraps
 `WebSocket.prototype.send` to stamp `window.__rkSendAt = performance.now()` on
 every single-character send. The measured latency is `firstVisible −
 __rkSendAt`, both `performance.now()` on the page clock — so start and finish

--- a/app/frontend/tests/e2e/echo-latency.spec.md
+++ b/app/frontend/tests/e2e/echo-latency.spec.md
@@ -1,0 +1,134 @@
+# echo-latency.spec.ts
+
+Benchmark file that measures **keystroke→echo latency** — the time from a
+keystroke leaving the browser to the echoed glyph becoming visible in the
+xterm.js buffer. It is an audit (like `sync-latency.spec.ts`): it records a
+p50/p95/p99 distribution and prints a summary in `afterAll`; it does **not**
+assert a latency budget, because localhost timing is too noisy for a stable
+perf gate. Run on demand:
+
+```
+just pw test echo-latency
+```
+
+## Why measure to the buffer, not the WS frame
+
+`terminal-client.tsx` batches incoming WebSocket data and flushes it to xterm
+once per `requestAnimationFrame`. That coalescing delay (up to ~1 frame) is
+part of what the user actually feels. The benchmark therefore stops the clock
+at **glyph-in-`term.buffer.active`** — after the rAF flush — rather than at
+"WS message received", which would understate latency by up to a frame.
+
+The WebGL renderer paints to a canvas that is **not DOM-readable**, so reading
+the parsed buffer is the only honest "glyph visible" signal available to a
+Playwright driver. To reach the live `Terminal` instance the harness relies on
+a test-only registry: `terminal-client.tsx` registers each terminal on
+`window.__rkTerminals` (keyed by windowId) on mount and unregisters it on
+dispose. The registry is inert unless a test reads it.
+
+Detection is **count-based on the cursor row**, not a fixed cell: the harness
+snapshots how many times `ch` appears on the cursor's row before the keystroke,
+then polls until that count increases. This is robust to a multi-line shell
+prompt re-flowing the line or to cursor-column drift — the arrival of one more
+`ch` on the active row is unambiguous. Trials alternate between two chars
+(`x`/`o`) and reset to a fresh line (Enter) each trial.
+
+## How the start timestamp is taken
+
+A real keystroke flows `keyboard.press` → xterm keydown → `onData` → `ws.send`
+(`terminal-client.tsx:219`). An init script (`INSTALL_SEND_STAMP`) wraps
+`WebSocket.prototype.send` to stamp `window.__rkSendAt = performance.now()` on
+every single-character send. The measured latency is `firstVisible −
+__rkSendAt`, both `performance.now()` on the page clock — so start and finish
+share one clock and only the sub-ms, unbatched keydown handler is excluded.
+This mirrors the `WebSocket.prototype.send` wrap pattern in
+`mobile-touch-scroll.spec.ts`.
+
+## Baseline and the run-kit tax
+
+A second test measures the **pure tmux echo** with no browser and no
+WebSocket: `tmux send-keys '<char>'` directly into the same `cat`, then poll
+`tmux capture-pane -p` until the char appears. The delta between the two
+distributions — `full-path p50 − baseline p50` — is the **run-kit tax**: the
+latency the web path adds over a local tmux echo. This makes the headline
+number meaningful across machines (it factors out tmux/hardware noise).
+
+**Baseline resolution caveat:** each `capture-pane` poll spawns a tmux
+subprocess (~10-20ms), which is itself the polling granularity. A true tmux
+echo faster than that floor is not separable from the measurement tool's own
+cost, so the baseline reads ~13ms even though the real tty echo is sub-ms. The
+baseline is therefore a conservative floor, and the reported run-kit tax is if
+anything an *under*-estimate of the web path's true added latency.
+
+## Shared setup
+
+- Per-file timeout raised to 90s (120s on CI) via `test.setTimeout` — the file
+  runs `FULL_PATH_TRIALS` + `BASELINE_TRIALS` (40 + 40) echo round-trips back
+  to back.
+- `beforeAll` creates session `e2e-echo-<ts>` (80×24) and starts `cat` in it
+  (`send-keys 'cat' Enter`). `cat` echoes every line of stdin verbatim — the
+  cleanest echo source, with no prompt / completion / PS1 noise.
+- `afterAll` sends `C-c` to break out of `cat`, kills the session, then prints
+  the summary table: full-path p50/p95/p99, baseline p50/p95/p99, and the
+  computed run-kit tax.
+- `resolveFirstWindowId(page)` polls `/api/sessions` for the session's first
+  window's stable `@N` id (the terminal route is keyed by window id, not
+  index), mirroring `mobile-touch-scroll.spec.ts`.
+- Trials alternate the two chars `x`/`o` and reset the line (Enter) each trial,
+  so global char-uniqueness is never needed — the count-based row detector
+  (see above) handles disambiguation.
+- A shared `samples` array collects `{ label, ms }` rows that `afterAll`
+  summarizes. `percentile()` does linear-interpolation percentiles; `summarize()`
+  formats the p50/p95/p99/min/max line.
+
+## Tests
+
+### `full-path keystroke→echo distribution`
+
+**What it proves:** A keystroke typed in the browser echoes back into the
+visible xterm buffer with a measurable latency; the test characterizes that
+latency as a p50/p95/p99 distribution over 40 trials, exercising the full
+input path including the rAF render flush.
+
+**Steps:**
+1. `page.addInitScript(INSTALL_SEND_STAMP)` — wrap `WebSocket.prototype.send`
+   before the app loads so the relay socket is wrapped at construction.
+2. `resolveFirstWindowId(page)` to get the deep-link `@N`.
+3. `page.goto(/${server}/${windowId})`; wait for `.xterm-screen` visible.
+4. Poll until `window.__rkTerminals[windowId]` exists (terminal mounted +
+   opened).
+5. Click `[role='application']` and focus `.xterm-helper-textarea` so
+   `keyboard.press` routes into xterm.
+6. **Warmup**: press Enter, then repeatedly press `w` (250ms cadence, up to 15s)
+   until a `w` shows on the cursor row. This confirms the full input path is
+   live and absorbs the cold-backend connect delay (relay attach + tmux select +
+   cat start) instead of guessing with a fixed sleep.
+7. For each of 40 trials (char alternates `x`/`o`):
+   a. Press Enter (fresh line) and settle ~30ms so the newline echo lands.
+   b. `measureEcho(page, windowId, ch, ECHO_DEADLINE_MS)`:
+      - Snapshot the count of `ch` on the cursor row; clear `window.__rkSendAt`.
+      - `keyboard.press(ch)` — a real keystroke through the genuine input path.
+      - rAF-poll the cursor row until the `ch` count increases, then return
+        `performance.now() − __rkSendAt`. Reject on a 5s deadline or if the
+        keystroke produced no WebSocket send.
+   c. Push `{ label: "full-path", ms }`.
+8. Assert 40 full-path samples were collected.
+
+### `baseline tmux-only echo distribution`
+
+**What it proves:** Establishes the latency floor — pure tmux echo with no
+browser or WebSocket — so the run-kit tax can be isolated. Characterizes it as
+a p50/p95/p99 distribution over 40 trials.
+
+**Steps:**
+1. Re-assert a fresh `cat`: `send-keys C-c` then `send-keys 'cat' Enter` and
+   settle ~500ms. The full-path test attached a browser relay to this session,
+   so its disconnect may have left `cat` in an unknown state; restarting it
+   makes the baseline independent of test ordering.
+2. For each of 40 trials (char alternates `x`/`o`):
+   a. `send-keys Enter` (fresh line); settle ~20ms so the newline echo lands.
+   b. Mark `performance.now()`, `tmux send-keys '<char>'`, then busy-poll
+      `capture-pane -p` (trailing blanks stripped) until the last non-empty line
+      ends with the char, or the 5s deadline passes.
+   c. Assert it landed; push `{ label: "baseline", ms }`.
+3. Assert 40 baseline samples were collected.

--- a/app/frontend/tests/e2e/echo-latency.spec.ts
+++ b/app/frontend/tests/e2e/echo-latency.spec.ts
@@ -1,0 +1,380 @@
+/**
+ * Keystroke→echo latency benchmark.
+ *
+ * Measures the time from a keystroke being dispatched in the browser to the
+ * echoed glyph becoming visible in the xterm.js buffer — the full perceived
+ * input path:
+ *
+ *   key dispatch → xterm onData → ws.send → WS frame → Go relay → tmux PTY
+ *   → tmux echo → relay → WS frame → ws.onmessage → requestAnimationFrame
+ *   flush → terminal.write → xterm parse → glyph in buffer.
+ *
+ * The clock stops at "glyph in buffer.active", NOT at "WS message received":
+ * terminal-client.tsx batches incoming data and flushes once per animation
+ * frame, so the rAF coalescing delay is part of what the user actually feels.
+ * Measuring to the buffer captures it; measuring to the WS frame would
+ * understate latency by up to a frame.
+ *
+ * A baseline loop measures the pure tmux echo (`send-keys` → `capture-pane`,
+ * no browser, no WebSocket) so the run-kit tax can be isolated from machine and
+ * tmux noise: tax ≈ full-path p50 − baseline p50.
+ *
+ * This is an AUDIT, like sync-latency.spec.ts — it records a p50/p95/p99
+ * distribution and prints a summary in afterAll; it does NOT assert a latency
+ * budget (localhost timing is too noisy for a stable perf gate). Run on demand:
+ *   just pw test echo-latency
+ */
+import { test, expect } from "@playwright/test";
+import { execSync } from "node:child_process";
+
+const TMUX_SERVER = process.env.E2E_TMUX_SERVER ?? "rk-test-e2e";
+const TEST_SESSION = `e2e-echo-${Date.now()}`;
+const port = Number(process.env.RK_PORT ?? "3333");
+const BASE = `http://localhost:${port}`;
+
+// Trial counts. Kept modest so the file stays well within the per-test budget
+// on a shared CI runner while still yielding a stable-enough distribution.
+const FULL_PATH_TRIALS = 40;
+const BASELINE_TRIALS = 40;
+// Per-keystroke echo deadline. Generous — a stalled echo should fail loudly
+// rather than silently skew the distribution toward the poll cap.
+const ECHO_DEADLINE_MS = 5_000;
+
+interface Sample {
+  label: string;
+  ms: number;
+}
+
+const samples: Sample[] = [];
+
+function tmux(cmd: string): void {
+  execSync(`tmux -L ${TMUX_SERVER} ${cmd}`, { stdio: "ignore" });
+}
+
+function tmuxCapture(): string {
+  return execSync(`tmux -L ${TMUX_SERVER} capture-pane -p -t ${TEST_SESSION}`, {
+    encoding: "utf8",
+  });
+}
+
+/** Percentile of a sample set (linear interpolation), p in [0,100]. */
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) return NaN;
+  const sorted = [...values].sort((a, b) => a - b);
+  if (sorted.length === 1) return sorted[0];
+  const rank = (p / 100) * (sorted.length - 1);
+  const lo = Math.floor(rank);
+  const hi = Math.ceil(rank);
+  if (lo === hi) return sorted[lo];
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (rank - lo);
+}
+
+function summarize(label: string, values: number[]): string {
+  const p50 = percentile(values, 50);
+  const p95 = percentile(values, 95);
+  const p99 = percentile(values, 99);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  return (
+    `  ${label.padEnd(22)} n=${String(values.length).padStart(3)}  ` +
+    `p50=${p50.toFixed(1)}ms  p95=${p95.toFixed(1)}ms  p99=${p99.toFixed(1)}ms  ` +
+    `min=${min.toFixed(1)}ms  max=${max.toFixed(1)}ms`
+  );
+}
+
+/**
+ * Resolve the first window's stable tmux id (`@N`) for TEST_SESSION from the
+ * backend snapshot. The terminal route is keyed by window id, not index, so a
+ * deep-link must carry `@N`. Polls because the session is created via the tmux
+ * CLI and surfaces in the snapshot asynchronously.
+ */
+async function resolveFirstWindowId(
+  page: import("@playwright/test").Page,
+): Promise<string> {
+  const deadline = Date.now() + 5_000;
+  let id: string | null = null;
+  while (Date.now() < deadline) {
+    const res = await page.request.get(
+      `${BASE}/api/sessions?server=${encodeURIComponent(TMUX_SERVER)}`,
+    );
+    if (res.ok()) {
+      const sessions = (await res.json()) as Array<{
+        name: string;
+        windows: Array<{ windowId: string }>;
+      }>;
+      const wid = sessions.find((s) => s.name === TEST_SESSION)?.windows[0]
+        ?.windowId;
+      if (wid) {
+        id = wid;
+        break;
+      }
+    }
+    await page.waitForTimeout(200);
+  }
+  expect(id, `first window for ${TEST_SESSION} not found`).not.toBeNull();
+  return id!;
+}
+
+/**
+ * Init script: wrap WebSocket.prototype.send so every relay send stamps the
+ * page-clock time of the most recent outbound byte on `window.__rkSendAt`. A
+ * real keystroke flows xterm keydown → onData → ws.send (terminal-client.tsx:
+ * 219), so this stamp is the moment the keystroke leaves the browser — the true
+ * start of the relay→tmux→echo→render round-trip. Stamping inside the real send
+ * path (rather than marking time in the test before keyboard.press) keeps start
+ * and finish on ONE clock and excludes only the sub-ms, unbatched keydown
+ * handler. Installed via addInitScript so it is in place before the app's
+ * WebSocket is constructed. Mirrors the prototype-wrap pattern in
+ * mobile-touch-scroll.spec.ts.
+ */
+const INSTALL_SEND_STAMP = () => {
+  const w = window as unknown as { __rkSendAt?: number };
+  const orig = WebSocket.prototype.send;
+  WebSocket.prototype.send = function (data: Parameters<WebSocket["send"]>[0]) {
+    // Only stamp single-character payloads — resize messages are JSON blobs and
+    // must not be mistaken for a keystroke.
+    if (typeof data === "string" && data.length === 1) {
+      w.__rkSendAt = performance.now();
+    }
+    return orig.call(this, data);
+  };
+};
+
+/**
+ * Dispatch one real keystroke and time how long until its glyph appears in the
+ * live xterm buffer. The keystroke goes through the genuine input path
+ * (keyboard.press → xterm keydown → onData → ws.send); the send-stamp wrapper
+ * records the page-clock start, and an rAF-driven poll of `term.buffer.active`
+ * records first-visible on the same clock.
+ *
+ * The poll reads the parsed buffer rather than the DOM: the WebGL renderer
+ * paints to a canvas that is not DOM-readable, so the buffer is the only honest
+ * "glyph visible" signal — and it sits AFTER the rAF flush in
+ * terminal-client.tsx, so the coalescing delay the user feels is included.
+ *
+ * Detection is **position-based, not content-based**: we read the cursor cell
+ * (`cursorY`, `cursorX`) BEFORE the keystroke — that is exactly the cell the
+ * echo will paint into — then poll that single cell until it holds `ch`. This
+ * sidesteps the fragility of scanning the viewport for a "unique" char: the
+ * viewport already contains noise (the word `cat`, prior echoes), and a single
+ * glyph is a poor global sentinel. Anchoring on the cursor cell means the same
+ * char can be reused every trial.
+ */
+async function measureEcho(
+  page: import("@playwright/test").Page,
+  windowId: string,
+  ch: string,
+  deadlineMs: number,
+): Promise<number> {
+  // Snapshot the cursor row's count of `ch` BEFORE the keystroke. The echo
+  // increments that count by one. Counting occurrences in the whole cursor row
+  // (rather than betting on an exact column) is robust to prompt-rendering noise
+  // and cursor drift: a fancy multi-line prompt can re-flow the line, but the
+  // arrival of one more `ch` on the active row is unambiguous. Also clear the
+  // prior send-stamp so we time THIS keystroke's send.
+  const before = await page.evaluate(
+    ({ windowId, ch }) => {
+      const term = window.__rkTerminals?.[windowId];
+      if (!term) throw new Error(`no registered terminal for ${windowId}`);
+      (window as unknown as { __rkSendAt?: number }).__rkSendAt = undefined;
+      const buf = term.buffer.active;
+      const row = buf.getLine(buf.baseY + buf.cursorY)?.translateToString(true) ?? "";
+      return row.split(ch).length - 1; // count of ch in the row
+    },
+    { windowId, ch },
+  );
+
+  // Real keystroke through the actual input path. The xterm helper textarea
+  // already holds focus from setup; press the key directly.
+  await page.keyboard.press(ch);
+
+  // Poll the cursor row on the page clock until the count of `ch` increases,
+  // then return (firstVisible − sendStamp). Both timestamps are
+  // performance.now() in the page context — no Node↔browser clock mixing.
+  return page.evaluate(
+    async ({ windowId, ch, before, deadlineMs }) => {
+      const term = window.__rkTerminals?.[windowId];
+      if (!term) throw new Error(`no registered terminal for ${windowId}`);
+
+      const echoLanded = (): boolean => {
+        const buf = term.buffer.active;
+        const row =
+          buf.getLine(buf.baseY + buf.cursorY)?.translateToString(true) ?? "";
+        return row.split(ch).length - 1 > before;
+      };
+
+      const startWait = performance.now();
+      return await new Promise<number>((resolve, reject) => {
+        const deadline = startWait + deadlineMs;
+        const tick = () => {
+          if (echoLanded()) {
+            const sentAt = (window as unknown as { __rkSendAt?: number }).__rkSendAt;
+            if (sentAt === undefined) {
+              reject(new Error("keystroke produced no WebSocket send"));
+              return;
+            }
+            resolve(performance.now() - sentAt);
+            return;
+          }
+          if (performance.now() > deadline) {
+            reject(new Error(`echo timeout for ${JSON.stringify(ch)}`));
+            return;
+          }
+          requestAnimationFrame(tick);
+        };
+        requestAnimationFrame(tick);
+      });
+    },
+    { windowId, ch, before, deadlineMs },
+  );
+}
+
+test.describe("Echo latency benchmark", () => {
+  // The file runs FULL_PATH_TRIALS + BASELINE_TRIALS echo round-trips back to
+  // back; give it ample headroom over the default per-test budget.
+  test.setTimeout(process.env.CI ? 120_000 : 90_000);
+
+  test.beforeAll(() => {
+    tmux(`new-session -d -s ${TEST_SESSION} -x 80 -y 24`);
+    // Run `cat` with no args: the tty echoes each typed char immediately and
+    // cat itself adds no prompt/completion/PS1 noise of its own — the cleanest
+    // echo source. (The shell prompt that launched cat sits above; trials work
+    // on cat's own input line below it.)
+    tmux(`send-keys -t ${TEST_SESSION} 'cat' Enter`);
+  });
+
+  test.afterAll(() => {
+    try {
+      // Break out of cat, then kill the session.
+      tmux(`send-keys -t ${TEST_SESSION} C-c`);
+    } catch { /* ok */ }
+    try {
+      tmux(`kill-session -t ${TEST_SESSION}`);
+    } catch { /* ok */ }
+
+    const full = samples.filter((s) => s.label === "full-path").map((s) => s.ms);
+    const base = samples.filter((s) => s.label === "baseline").map((s) => s.ms);
+
+    console.log("\n=== ECHO LATENCY BENCHMARK ===");
+    console.log("  keystroke → glyph-visible, p50/p95/p99\n");
+    if (full.length) console.log(summarize("full-path (browser)", full));
+    if (base.length) console.log(summarize("baseline (tmux only)", base));
+    if (full.length && base.length) {
+      const tax = percentile(full, 50) - percentile(base, 50);
+      console.log(
+        `\n  run-kit tax (full p50 − baseline p50): ${tax.toFixed(1)}ms` +
+          " — the cost the web path adds over a local tmux echo.",
+      );
+    }
+    console.log("=== END BENCHMARK ===\n");
+  });
+
+  test("full-path keystroke→echo distribution", async ({ page }) => {
+    // Install the send-stamp wrapper BEFORE the app loads so it wraps the relay
+    // WebSocket at construction time.
+    await page.addInitScript(INSTALL_SEND_STAMP);
+
+    const windowId = await resolveFirstWindowId(page);
+    await page.goto(`${BASE}/${TMUX_SERVER}/${encodeURIComponent(windowId)}`);
+    await expect(page.locator(".xterm-screen")).toBeVisible({ timeout: 10_000 });
+
+    // Wait until the terminal instance is registered (mounted + opened).
+    await expect
+      .poll(
+        () => page.evaluate((wid) => Boolean(window.__rkTerminals?.[wid]), windowId),
+        { timeout: 10_000 },
+      )
+      .toBe(true);
+
+    // Focus the terminal for keyboard input. Click the terminal area (the
+    // documented tap-to-focus path) then focus the helper textarea xterm reads
+    // keystrokes from — belt and suspenders so keyboard.press routes into xterm.
+    await page.locator("[role='application']").click();
+    await page.locator(".xterm-helper-textarea").focus();
+
+    // Warm up: the relay WebSocket must be OPEN and `cat` must be consuming
+    // stdin before any timing. Press a char and wait until it echoes — this
+    // both confirms the full input path is live and absorbs the connect delay,
+    // rather than guessing with a fixed sleep that may be too short on a cold
+    // backend (relay attach + tmux select + cat start).
+    await page.keyboard.press("Enter");
+    await expect
+      .poll(
+        async () => {
+          await page.keyboard.press("w");
+          return page.evaluate((wid) => {
+            const term = window.__rkTerminals?.[wid];
+            if (!term) return false;
+            const buf = term.buffer.active;
+            const row =
+              buf.getLine(buf.baseY + buf.cursorY)?.translateToString(true) ?? "";
+            return row.includes("w");
+          }, windowId);
+        },
+        { timeout: 15_000, intervals: [250] },
+      )
+      .toBe(true);
+
+    // Alternate between two chars so consecutive trials differ.
+    const CHARS = ["x", "o"];
+    for (let n = 0; n < FULL_PATH_TRIALS; n++) {
+      const ch = CHARS[n % CHARS.length];
+      // Reset to a fresh line before each trial so the row starts without `ch`,
+      // keeping the count-based detector unambiguous. Brief settle so the
+      // newline echo lands before we snapshot the pre-keystroke count.
+      await page.keyboard.press("Enter");
+      await page.waitForTimeout(30);
+      const ms = await measureEcho(page, windowId, ch, ECHO_DEADLINE_MS);
+      samples.push({ label: "full-path", ms });
+    }
+    expect(samples.filter((s) => s.label === "full-path").length).toBe(
+      FULL_PATH_TRIALS,
+    );
+  });
+
+  test("baseline tmux-only echo distribution", async ({ page }) => {
+    // Pure tmux echo: send a char via the tmux CLI directly into the same
+    // `cat`, then poll capture-pane until the current line shows it. No
+    // browser, no WebSocket — this is the floor the full path is measured
+    // against. Each trial resets to a fresh line (Enter), so the echoed char is
+    // the sole content of the last non-empty line — no global-uniqueness needed.
+    //
+    // Re-assert `cat` is running: the full-path test attached a browser relay
+    // to this session and its disconnect may have left cat in an unknown state.
+    // `q` Enter would quit a pager but is harmless to cat; instead we just
+    // ensure a fresh cat by sending C-c then `cat` Enter and letting it settle.
+    tmux(`send-keys -t ${TEST_SESSION} C-c`);
+    tmux(`send-keys -t ${TEST_SESSION} 'cat' Enter`);
+    await page.waitForTimeout(500);
+
+    const CHARS = ["x", "o"];
+    for (let n = 0; n < BASELINE_TRIALS; n++) {
+      const ch = CHARS[n % CHARS.length];
+      tmux(`send-keys -t ${TEST_SESSION} Enter`);
+      await page.waitForTimeout(20); // let the newline echo land
+      // Last line should now be empty; the next echoed char will be its tail.
+      const t0 = performance.now();
+      tmux(`send-keys -t ${TEST_SESSION} '${ch}'`);
+      let landed = false;
+      const deadline = t0 + ECHO_DEADLINE_MS;
+      // Each capture-pane subprocess costs ~10-20ms, which is itself the poll
+      // granularity here — there is no tight-loop storm to throttle, and a
+      // baseline below that resolution is not separable from the measurement
+      // tool's own cost (an honest limitation noted in the summary).
+      while (performance.now() < deadline) {
+        const lines = tmuxCapture().replace(/\n+$/, "").split("\n");
+        const last = lines[lines.length - 1] ?? "";
+        if (last.endsWith(ch)) {
+          landed = true;
+          break;
+        }
+      }
+      const ms = performance.now() - t0;
+      expect(landed, `baseline echo timeout for ${JSON.stringify(ch)}`).toBe(true);
+      samples.push({ label: "baseline", ms });
+    }
+    expect(samples.filter((s) => s.label === "baseline").length).toBe(
+      BASELINE_TRIALS,
+    );
+  });
+});

--- a/app/frontend/tests/e2e/echo-latency.spec.ts
+++ b/app/frontend/tests/e2e/echo-latency.spec.ts
@@ -118,8 +118,9 @@ async function resolveFirstWindowId(
 /**
  * Init script: wrap WebSocket.prototype.send so every relay send stamps the
  * page-clock time of the most recent outbound byte on `window.__rkSendAt`. A
- * real keystroke flows xterm keydown → onData → ws.send (terminal-client.tsx:
- * 219), so this stamp is the moment the keystroke leaves the browser — the true
+ * real keystroke flows xterm keydown → onData → ws.send (TerminalClient's
+ * `terminal.onData` handler), so this stamp is the moment the keystroke leaves
+ * the browser — the true
  * start of the relay→tmux→echo→render round-trip. Stamping inside the real send
  * path (rather than marking time in the test before keyboard.press) keeps start
  * and finish on ONE clock and excludes only the sub-ms, unbatched keydown
@@ -363,7 +364,9 @@ test.describe("Echo latency benchmark", () => {
       // tool's own cost (an honest limitation noted in the summary).
       while (performance.now() < deadline) {
         const lines = tmuxCapture().replace(/\n+$/, "").split("\n");
-        const last = lines[lines.length - 1] ?? "";
+        // Trim trailing whitespace on the candidate line: `capture-pane -p` can
+        // right-pad a row with spaces, which would defeat a bare `endsWith(ch)`.
+        const last = (lines[lines.length - 1] ?? "").replace(/\s+$/, "");
         if (last.endsWith(ch)) {
           landed = true;
           break;

--- a/app/frontend/tests/e2e/echo-latency.spec.ts
+++ b/app/frontend/tests/e2e/echo-latency.spec.ts
@@ -45,7 +45,19 @@ interface Sample {
   ms: number;
 }
 
-const samples: Sample[] = [];
+let samples: Sample[] = [];
+
+/**
+ * Drop any prior samples for `label`. Called at the start of each test so a
+ * Playwright retry (config has `retries: 1`) re-runs in the SAME worker process
+ * — and therefore against this persistent module-level array — without the
+ * failed attempt's partial samples lingering. Without this, a retry would
+ * double-count (failing the exact-count assertions) and skew the afterAll
+ * percentile summary.
+ */
+function resetSamples(label: string): void {
+  samples = samples.filter((s) => s.label !== label);
+}
 
 function tmux(cmd: string): void {
   execSync(`tmux -L ${TMUX_SERVER} ${cmd}`, { stdio: "ignore" });
@@ -271,6 +283,7 @@ test.describe("Echo latency benchmark", () => {
   });
 
   test("full-path keystroke→echo distribution", async ({ page }) => {
+    resetSamples("full-path"); // idempotent across a Playwright retry
     // Install the send-stamp wrapper BEFORE the app loads so it wraps the relay
     // WebSocket at construction time.
     await page.addInitScript(INSTALL_SEND_STAMP);
@@ -334,6 +347,7 @@ test.describe("Echo latency benchmark", () => {
   });
 
   test("baseline tmux-only echo distribution", async ({ page }) => {
+    resetSamples("baseline"); // idempotent across a Playwright retry
     // Pure tmux echo: send a char via the tmux CLI directly into the same
     // `cat`, then poll capture-pane until the current line shows it. No
     // browser, no WebSocket — this is the floor the full path is measured


### PR DESCRIPTION
## What

Adds a Playwright benchmark that measures **perceived terminal input latency** — the time from a keystroke leaving the browser to the echoed glyph appearing in the xterm.js buffer.

Run on demand:
```
just pw test echo-latency        # or: just test-e2e echo-latency
```

## Why

We wanted an objective, repeatable measure of run-kit's terminal latency vs. a local terminal, so render-side improvements can be seen to reduce a real number. The clock stops at **glyph-visible in `term.buffer.active`** — *after* the `requestAnimationFrame` flush in `terminal-client.tsx` — so the render-coalescing delay the user actually feels is captured (measuring to "WS frame received" would understate it by up to a frame).

## How

- **Full-path test**: a real `keyboard.press` flows through the genuine input path (xterm keydown → `onData` → `ws.send`). The start timestamp is stamped inside a wrapped `WebSocket.prototype.send` (init script), and an rAF poll of the xterm buffer records glyph-visible — both on one page clock. 40 trials → p50/p95/p99.
- **Baseline test**: pure `tmux send-keys → capture-pane` echo, no browser/WebSocket. The delta (`full p50 − baseline p50`) is the **run-kit tax**.
- Glyph detection is **count-based on the cursor row** (robust to a multi-line shell prompt re-flowing the line). Reads the parsed buffer because the WebGL canvas is not DOM-readable.
- `terminal-client.tsx` gains a minimal **test-only** `window.__rkTerminals` registry (register on mount, unregister on dispose) so the harness can reach the live `Terminal`. Inert in normal use — a single ref assignment.

Audit-style (like `sync-latency.spec.ts`): prints a summary, **no hard threshold** — localhost timing is too noisy for a stable perf gate.

## Observed (localhost)

```
full-path (browser)    p50 ~33-39ms  p95 ~50ms  min ~6ms
baseline (tmux only)   p50 ~13ms     (capture-pane subprocess-poll-bound floor)
run-kit tax            ~20-26ms
```

Full-path latency clusters near 2-3 animation frames (~16ms each) with a `min` near 6ms — the signature of the rAF batching being the dominant term. This confirms the **render tail, not the network hop, dominates local latency**.

### Caveats (documented in the .spec.md)
1. The baseline is tool-bound (~13ms = `capture-pane` subprocess cost), so the reported tax is **conservative** — if anything it under-states the web path's true added latency.
2. `terminal-client.tsx` is a production file; the hook is inert (a ref assignment) but is a deliberate test-purpose touch.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `just test-frontend` — 550 unit tests pass (component hook breaks nothing)
- [x] `just test-e2e echo-latency` — both tests pass, stable across runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)