### PR TITLE
feat: Adaptive terminal write flush — immediate echo, batch under load

### DIFF
--- a/app/frontend/src/components/terminal-client.tsx
+++ b/app/frontend/src/components/terminal-client.tsx
@@ -461,10 +461,42 @@ export function TerminalClient({
     const wsProto =
       window.location.protocol === "https:" ? "wss:" : "ws:";
 
-    // Write batching: accumulate WebSocket data and flush once per animation frame
+    // Adaptive write flushing.
+    //
+    // The naive strategy — buffer every inbound chunk and flush once per
+    // requestAnimationFrame — adds up to a full frame (~16ms) of latency to a
+    // lone keystroke echo for no benefit: there is nothing to coalesce when one
+    // small chunk arrives in an idle frame. (Latency attribution showed this
+    // rAF tail dominates perceived input latency ~3:1 over the network hop.)
+    //
+    // Instead: write SMALL chunks that arrive while idle straight to the
+    // terminal, synchronously, so an echo paints on the same tick. Fall back to
+    // rAF-coalescing only under load — i.e. once a chunk is large, or once we
+    // are already buffering — so a flood (`cat largefile`, a build log) still
+    // batches into one write per frame and does not melt the renderer.
+    //
+    // Ordering safety (terminal bytes are order-sensitive): the moment ANYTHING
+    // is buffered, every subsequent chunk also buffers until the buffer drains.
+    // An immediate write therefore only happens when the buffer is empty AND no
+    // flush is pending, so a synchronous write can never jump ahead of buffered
+    // bytes.
     let textBuffer = "";
     let binaryBuffers: Uint8Array[] = [];
     let flushRafId: number | null = null;
+    // At most ONE immediate (synchronous) write per animation frame. The flag is
+    // reset on each rAF tick. This is the flood guard: the first small idle
+    // chunk in a frame paints immediately (interactive echo), but a burst of
+    // small chunks within the same frame coalesces — without it, a program
+    // emitting one byte at a time would write synchronously on every message.
+    let wroteImmediatelyThisFrame = false;
+    let frameResetRafId: number | null = null;
+
+    // A chunk larger than this is treated as "under load" and coalesced rather
+    // than written immediately. A keystroke echo is a handful of bytes; a paste,
+    // a program's burst output, or a redraw is far larger (the relay reads the
+    // PTY in 4KB chunks). The threshold trades a little extra latency on medium
+    // chunks for protection against synchronous-write storms.
+    const IMMEDIATE_WRITE_MAX_BYTES = 64;
 
     function flushToTerminal() {
       flushRafId = null;
@@ -476,6 +508,37 @@ export function TerminalClient({
         terminal.write(buf);
       }
       binaryBuffers = [];
+    }
+
+    /** True while we are coalescing — a flush is pending or data is buffered. */
+    function isBuffering(): boolean {
+      return flushRafId !== null || textBuffer !== "" || binaryBuffers.length > 0;
+    }
+
+    function scheduleFlush() {
+      if (flushRafId === null) {
+        flushRafId = requestAnimationFrame(flushToTerminal);
+      }
+    }
+
+    /** Decide whether an inbound chunk of `len` bytes can be written now. */
+    function canWriteImmediately(len: number): boolean {
+      return (
+        !isBuffering() &&
+        !wroteImmediatelyThisFrame &&
+        len <= IMMEDIATE_WRITE_MAX_BYTES
+      );
+    }
+
+    /** Mark that an immediate write happened; arm a one-shot frame reset. */
+    function markImmediateWrite() {
+      wroteImmediatelyThisFrame = true;
+      if (frameResetRafId === null) {
+        frameResetRafId = requestAnimationFrame(() => {
+          frameResetRafId = null;
+          wroteImmediatelyThisFrame = false;
+        });
+      }
     }
 
     function connect() {
@@ -500,13 +563,27 @@ export function TerminalClient({
           needsReset = false;
           terminal.reset();
         }
+
         if (typeof event.data === "string") {
+          // Idle + small + first-this-frame → write now so an echo paints this
+          // tick. Otherwise (buffering, large chunk, or already wrote this
+          // frame) coalesce into the next frame.
+          if (canWriteImmediately(event.data.length)) {
+            terminal.write(event.data);
+            markImmediateWrite();
+            return;
+          }
           textBuffer += event.data;
+          scheduleFlush();
         } else {
-          binaryBuffers.push(new Uint8Array(event.data));
-        }
-        if (!flushRafId) {
-          flushRafId = requestAnimationFrame(flushToTerminal);
+          const chunk = new Uint8Array(event.data);
+          if (canWriteImmediately(chunk.length)) {
+            terminal.write(chunk);
+            markImmediateWrite();
+            return;
+          }
+          binaryBuffers.push(chunk);
+          scheduleFlush();
         }
       };
 
@@ -516,6 +593,11 @@ export function TerminalClient({
           cancelAnimationFrame(flushRafId);
           flushRafId = null;
         }
+        if (frameResetRafId) {
+          cancelAnimationFrame(frameResetRafId);
+          frameResetRafId = null;
+        }
+        wroteImmediatelyThisFrame = false;
         try { flushToTerminal(); } catch { /* terminal may be disposed */ }
 
         if (cancelled) return;
@@ -541,6 +623,7 @@ export function TerminalClient({
     return () => {
       cancelled = true;
       if (flushRafId) cancelAnimationFrame(flushRafId);
+      if (frameResetRafId) cancelAnimationFrame(frameResetRafId);
       if (reconnectTimer) clearTimeout(reconnectTimer);
       if (wsRef.current) {
         wsRef.current.close();

--- a/app/frontend/src/components/terminal-client.tsx
+++ b/app/frontend/src/components/terminal-client.tsx
@@ -59,6 +59,10 @@ function unregisterTestTerminal(windowId: string) {
   delete window.__rkTerminals[windowId];
 }
 
+// Shared encoder for measuring UTF-8 byte length on the inbound flush path
+// (allocated once, not per message).
+const textEncoder = new TextEncoder();
+
 type TerminalClientProps = {
   sessionName: string;
   windowId: string;
@@ -521,6 +525,19 @@ export function TerminalClient({
       }
     }
 
+    /**
+     * UTF-8 byte length of a string, computed only when necessary. Bounds:
+     * UTF-8 bytes ≥ UTF-16 code units (every code unit is ≥1 byte), and ≤ 4×
+     * code units. So if `4 * length <= MAX` it is definitely within the
+     * threshold, and if `length > MAX` it is definitely over — neither needs an
+     * encode. Only the ambiguous middle band pays for `TextEncoder`.
+     */
+    function textByteLength(s: string): number {
+      if (s.length * 4 <= IMMEDIATE_WRITE_MAX_BYTES) return s.length; // ≤ threshold for sure
+      if (s.length > IMMEDIATE_WRITE_MAX_BYTES) return s.length; // ≥ threshold for sure (loose, but > MAX)
+      return textEncoder.encode(s).length;
+    }
+
     /** Decide whether an inbound chunk of `len` bytes can be written now. */
     function canWriteImmediately(len: number): boolean {
       return (
@@ -568,7 +585,15 @@ export function TerminalClient({
           // Idle + small + first-this-frame → write now so an echo paints this
           // tick. Otherwise (buffering, large chunk, or already wrote this
           // frame) coalesce into the next frame.
-          if (canWriteImmediately(event.data.length)) {
+          //
+          // Measure the threshold in UTF-8 BYTES, not String.length (UTF-16
+          // code units): a multibyte string can be ≤64 code units yet >64 bytes,
+          // which would wrongly take the immediate path and weaken the flood
+          // guard. textByteLength only encodes when the cheap code-unit upper
+          // bound (each UTF-16 unit is ≤3 UTF-8 bytes within the BMP, 4 across a
+          // surrogate pair) leaves the result ambiguous, so the hot path for a
+          // tiny ASCII echo stays allocation-free.
+          if (canWriteImmediately(textByteLength(event.data))) {
             terminal.write(event.data);
             markImmediateWrite();
             return;

--- a/app/frontend/tests/e2e/echo-latency.spec.md
+++ b/app/frontend/tests/e2e/echo-latency.spec.md
@@ -96,12 +96,15 @@ anything an *under*-estimate of the web path's true added latency.
 - `beforeAll` creates session `e2e-echo-<ts>` (80×24) and starts `cat` in it
   (`send-keys 'cat' Enter`). `cat` echoes every line of stdin verbatim — the
   cleanest echo source, with no prompt / completion / PS1 noise.
-- `afterAll` sends `C-c` to break out of `cat`, kills the session, then prints
-  the summary table: full-path p50/p95/p99, baseline p50/p95/p99, and the
-  computed run-kit tax.
-- `resolveFirstWindowId(page)` polls `/api/sessions` for the session's first
-  window's stable `@N` id (the terminal route is keyed by window id, not
-  index), mirroring `mobile-touch-scroll.spec.ts`.
+- The throughput guard uses its own `BURST_SESSION` (`e2e-burst-<ts>`) so its
+  flood doesn't disturb the echo session.
+- `afterAll` sends `C-c` to break out of `cat`, kills both sessions, then prints
+  the summary table: full-path / network / render / baseline p50/p95/p99, the
+  computed run-kit tax, the attribution verdict, and the throughput time.
+- `resolveFirstWindowId(page, session?)` polls `/api/sessions` for the named
+  session's first window's stable `@N` id (the terminal route is keyed by window
+  id, not index), mirroring `mobile-touch-scroll.spec.ts`. Defaults to the echo
+  session; the throughput test passes `BURST_SESSION`.
 - Trials alternate the two chars `x`/`o` and reset the line (Enter) each trial,
   so global char-uniqueness is never needed — the count-based row detector
   (see above) handles disambiguation.
@@ -164,3 +167,32 @@ a p50/p95/p99 distribution over 40 trials.
       ends with the char, or the 5s deadline passes.
    c. Assert it landed; push `{ label: "baseline", ms }`.
 3. Assert 40 baseline samples were collected.
+
+### `throughput guard — burst output renders fully and fast`
+
+**What it proves:** Optimizing echo latency (the adaptive flush in
+`terminal-client.tsx`, which writes small idle chunks immediately instead of
+always waiting for a `requestAnimationFrame`) did **not** regress burst
+rendering. A large, countable flood must still render completely and quickly via
+the under-load coalescing path — no dropped/garbled output, no renderer melt.
+
+**Steps:**
+1. Create a dedicated `BURST_SESSION` (so the flood doesn't disturb the echo
+   session's interactive `cat`).
+2. `resolveFirstWindowId(page, BURST_SESSION)`, navigate, wait for
+   `.xterm-screen` and the registered terminal handle; focus the terminal.
+3. Mark `performance.now()`, then `keyboard.type("seq 1 N\n")` (N =
+   `THROUGHPUT_LINES`, 20000). `seq` emits predictable output whose final line
+   `N` is a unique end-marker; the relay delivers it as many multi-KB frames,
+   exercising the coalescing branch.
+4. In-page `requestAnimationFrame` loop tracks `term.buffer.active.length`;
+   quiescence = the end-marker line is present in the last rows of scrollback
+   AND the line count has been stable for ~150ms. Returns the in-page elapsed
+   time, or rejects past the 30s deadline.
+5. Assert wall-clock under the deadline; push `{ label: "throughput", ms }` (the
+   in-page quiescence time) for the summary.
+
+**Why this lives in the same file:** the echo tests and this guard are two sides
+of the same trade-off. Keeping them together means a future change that shaves
+echo latency at the cost of flood performance fails *here*, in the same run that
+shows the latency win — they can't drift apart.

--- a/app/frontend/tests/e2e/echo-latency.spec.ts
+++ b/app/frontend/tests/e2e/echo-latency.spec.ts
@@ -29,6 +29,10 @@ import { execSync } from "node:child_process";
 
 const TMUX_SERVER = process.env.E2E_TMUX_SERVER ?? "rk-test-e2e";
 const TEST_SESSION = `e2e-echo-${Date.now()}`;
+// Dedicated session for the throughput test — it runs a burst command rather
+// than the interactive `cat`, so it gets its own window to avoid disturbing the
+// echo session.
+const BURST_SESSION = `e2e-burst-${Date.now()}`;
 const port = Number(process.env.RK_PORT ?? "3333");
 const BASE = `http://localhost:${port}`;
 
@@ -39,6 +43,14 @@ const BASELINE_TRIALS = 40;
 // Per-keystroke echo deadline. Generous — a stalled echo should fail loudly
 // rather than silently skew the distribution toward the poll cap.
 const ECHO_DEADLINE_MS = 5_000;
+
+// Throughput guard: number of lines a burst command emits. `seq 1 N` produces
+// predictable, countable output whose final line (`N`) is a unique end-marker.
+// Large enough that the relay delivers it as many multi-KB frames — exercising
+// the coalescing (under-load) branch of the adaptive flush, the path that must
+// NOT regress when echo latency is optimized.
+const THROUGHPUT_LINES = 20_000;
+const THROUGHPUT_DEADLINE_MS = 30_000;
 
 interface Sample {
   label: string;
@@ -95,13 +107,14 @@ function summarize(label: string, values: number[]): string {
 }
 
 /**
- * Resolve the first window's stable tmux id (`@N`) for TEST_SESSION from the
+ * Resolve the first window's stable tmux id (`@N`) for `session` from the
  * backend snapshot. The terminal route is keyed by window id, not index, so a
  * deep-link must carry `@N`. Polls because the session is created via the tmux
  * CLI and surfaces in the snapshot asynchronously.
  */
 async function resolveFirstWindowId(
   page: import("@playwright/test").Page,
+  session: string = TEST_SESSION,
 ): Promise<string> {
   const deadline = Date.now() + 5_000;
   let id: string | null = null;
@@ -114,7 +127,7 @@ async function resolveFirstWindowId(
         name: string;
         windows: Array<{ windowId: string }>;
       }>;
-      const wid = sessions.find((s) => s.name === TEST_SESSION)?.windows[0]
+      const wid = sessions.find((s) => s.name === session)?.windows[0]
         ?.windowId;
       if (wid) {
         id = wid;
@@ -123,7 +136,7 @@ async function resolveFirstWindowId(
     }
     await page.waitForTimeout(200);
   }
-  expect(id, `first window for ${TEST_SESSION} not found`).not.toBeNull();
+  expect(id, `first window for ${session} not found`).not.toBeNull();
   return id!;
 }
 
@@ -327,6 +340,9 @@ test.describe("Echo latency benchmark", () => {
     try {
       tmux(`kill-session -t ${TEST_SESSION}`);
     } catch { /* ok */ }
+    try {
+      tmux(`kill-session -t ${BURST_SESSION}`);
+    } catch { /* ok */ }
 
     const pick = (label: string) =>
       samples.filter((s) => s.label === label).map((s) => s.ms);
@@ -334,6 +350,7 @@ test.describe("Echo latency benchmark", () => {
     const network = pick("network");
     const render = pick("render");
     const base = pick("baseline");
+    const throughput = pick("throughput");
 
     console.log("\n=== ECHO LATENCY BENCHMARK ===");
     console.log("  keystroke → glyph-visible, p50/p95/p99\n");
@@ -355,7 +372,14 @@ test.describe("Echo latency benchmark", () => {
       console.log(
         `  attribution (p50): network=${np.toFixed(1)}ms, render=${rp.toFixed(1)}ms` +
           ` → ${dominant} dominates. Render is the rAF-flush + xterm-parse tail` +
-          " (the PR-#2 adaptive-flush target).",
+          " (the adaptive-flush target).",
+      );
+    }
+    if (throughput.length) {
+      console.log(
+        `\n  throughput guard: ${THROUGHPUT_LINES} lines rendered to quiescence in` +
+          ` ${throughput[0].toFixed(0)}ms — the under-load coalescing path. Echo` +
+          " latency must drop WITHOUT this regressing.",
       );
     }
     console.log("=== END BENCHMARK ===\n");
@@ -482,5 +506,96 @@ test.describe("Echo latency benchmark", () => {
     expect(samples.filter((s) => s.label === "baseline").length).toBe(
       BASELINE_TRIALS,
     );
+  });
+
+  test("throughput guard — burst output renders fully and fast", async ({ page }) => {
+    // Flood the terminal with a large, countable burst (`seq 1 N`) and measure
+    // time-to-quiescence plus that the final line landed. This exercises the
+    // adaptive flush's UNDER-LOAD branch: the relay delivers seq's output as
+    // many multi-KB frames, which must coalesce into ~one write per frame rather
+    // than writing synchronously per frame. The guard's job is to prove the
+    // echo-latency optimization did not trade away burst-render performance —
+    // it asserts both completeness (no dropped/garbled output) and a sane bound.
+    tmux(`new-session -d -s ${BURST_SESSION} -x 80 -y 24`);
+
+    const windowId = await resolveFirstWindowId(page, BURST_SESSION);
+    await page.goto(`${BASE}/${TMUX_SERVER}/${encodeURIComponent(windowId)}`);
+    await expect(page.locator(".xterm-screen")).toBeVisible({ timeout: 10_000 });
+    await expect
+      .poll(
+        () => page.evaluate((wid) => Boolean(window.__rkTerminals?.[wid]), windowId),
+        { timeout: 10_000 },
+      )
+      .toBe(true);
+
+    await page.locator("[role='application']").click();
+    await page.locator(".xterm-helper-textarea").focus();
+    await page.waitForTimeout(1_000); // relay open + shell ready
+
+    // Issue the burst. The unique end-marker is the final line `N` on its own.
+    const endMarker = String(THROUGHPUT_LINES);
+    const t0 = performance.now();
+    await page.keyboard.type(`seq 1 ${THROUGHPUT_LINES}\n`);
+
+    // Quiescence = the terminal's scrollback line count stops growing AND the
+    // end-marker is present in the buffer. Poll the registered Terminal's
+    // buffer; the WebGL canvas is not DOM-readable (same rationale as measureEcho).
+    const elapsed = await page.evaluate(
+      async ({ windowId, endMarker, deadlineMs }) => {
+        const term = window.__rkTerminals?.[windowId];
+        if (!term) throw new Error(`no registered terminal for ${windowId}`);
+        const t0 = performance.now();
+        const deadline = t0 + deadlineMs;
+
+        const endMarkerPresent = (): boolean => {
+          const buf = term.buffer.active;
+          // Scan the last rows of scrollback for the marker on its own line.
+          const total = buf.length;
+          for (let y = Math.max(0, total - term.rows * 2); y < total; y++) {
+            const line = buf.getLine(y)?.translateToString(true).trim();
+            if (line === endMarker) return true;
+          }
+          return false;
+        };
+
+        return await new Promise<number>((resolve, reject) => {
+          let lastLen = -1;
+          let stableSince = 0;
+          const tick = () => {
+            const now = performance.now();
+            const len = term.buffer.active.length;
+            if (len !== lastLen) {
+              lastLen = len;
+              stableSince = now;
+            }
+            // Done when the end-marker is in the buffer and growth has settled
+            // for ~150ms (a few frames with no new lines).
+            if (endMarkerPresent() && now - stableSince > 150) {
+              resolve(now - t0);
+              return;
+            }
+            if (now > deadline) {
+              reject(
+                new Error(
+                  `throughput timeout: endMarker=${endMarkerPresent()}, len=${len}`,
+                ),
+              );
+              return;
+            }
+            requestAnimationFrame(tick);
+          };
+          requestAnimationFrame(tick);
+        });
+      },
+      { windowId, endMarker, deadlineMs: THROUGHPUT_DEADLINE_MS },
+    );
+    const wall = performance.now() - t0;
+
+    // Correctness: the final line of the burst rendered (no truncation/garble).
+    // Timing: recorded for the summary and bounded by the deadline (the
+    // page.evaluate above already rejects past it). We record `elapsed` (the
+    // in-page quiescence time) as the comparable metric across runs.
+    samples.push({ label: "throughput", ms: elapsed });
+    expect(wall).toBeLessThan(THROUGHPUT_DEADLINE_MS);
   });
 });

--- a/app/frontend/tests/e2e/echo-latency.spec.ts
+++ b/app/frontend/tests/e2e/echo-latency.spec.ts
@@ -509,6 +509,7 @@ test.describe("Echo latency benchmark", () => {
   });
 
   test("throughput guard — burst output renders fully and fast", async ({ page }) => {
+    resetSamples("throughput"); // idempotent across a Playwright retry
     // Flood the terminal with a large, countable burst (`seq 1 N`) and measure
     // time-to-quiescence plus that the final line landed. This exercises the
     // adaptive flush's UNDER-LOAD branch: the relay delivers seq's output as
@@ -530,7 +531,33 @@ test.describe("Echo latency benchmark", () => {
 
     await page.locator("[role='application']").click();
     await page.locator(".xterm-helper-textarea").focus();
-    await page.waitForTimeout(1_000); // relay open + shell ready
+
+    // Warm up with a marker-based poll instead of a fixed sleep — the relay
+    // WebSocket must be OPEN and the shell consuming input before the burst, and
+    // a fixed sleep is flaky on a cold/slow runner (consistent with the
+    // full-path test, which avoids fixed sleeps for the same reason). Press `z`
+    // until it echoes on the cursor row, then clear the line so the marker isn't
+    // mistaken for burst output.
+    await expect
+      .poll(
+        async () => {
+          await page.keyboard.press("z");
+          return page.evaluate((wid) => {
+            const term = window.__rkTerminals?.[wid];
+            if (!term) return false;
+            const buf = term.buffer.active;
+            const row =
+              buf.getLine(buf.baseY + buf.cursorY)?.translateToString(true) ?? "";
+            return row.includes("z");
+          }, windowId);
+        },
+        { timeout: 15_000, intervals: [250] },
+      )
+      .toBe(true);
+    // Clear the typed warmup marker(s) from the prompt line WITHOUT executing
+    // them (Ctrl-U kills the line in the shell's line editor) so the burst
+    // command runs from a clean prompt.
+    await page.keyboard.press("Control+u");
 
     // Issue the burst. The unique end-marker is the final line `N` on its own.
     const endMarker = String(THROUGHPUT_LINES);


### PR DESCRIPTION
**Stacked on #243** (base: `latency-attribution`). PR #2 of the render-latency series — **this is the actual latency win.**

## What

The relay's inbound data path buffered every chunk and flushed once per `requestAnimationFrame`. For a lone keystroke echo that adds up to a full frame (~16ms) of latency for no benefit — there's nothing to coalesce when one small chunk arrives in an idle frame. PR #1's attribution proved this rAF tail dominates perceived input latency ~3:1 over the network hop.

**Adaptive flush:** write small chunks that arrive while idle straight to the terminal **synchronously** (echo paints this tick); fall back to rAF-coalescing only **under load**.

## How

A chunk is written immediately iff: nothing is buffered, no immediate write has happened yet this frame, and the chunk is ≤64 bytes. Otherwise it buffers and flushes on the next frame.

- **Flood guard:** at most one immediate write per animation frame (the flag resets on each rAF tick). So a burst of small chunks coalesces — without it, a program emitting one byte at a time would write synchronously on every message.
- **Large chunks coalesce:** the relay reads the PTY in 4KB chunks (`relay.go`), so `cat largefile` output is always > 64 bytes → buffered → one write/frame.
- **Ordering safety** (terminal bytes are order-sensitive): the moment anything is buffered, every subsequent chunk also buffers until it drains. An immediate write can therefore never jump ahead of buffered bytes.
- rAF cleanup wired through `onclose` and effect teardown.

## Throughput guard (the safety net)

Added a third harness test: `seq 1 20000` → measure time-to-quiescence + assert the end-marker line rendered. This exercises the under-load coalescing path, so an echo-latency win can **never** silently trade away burst rendering. The echo tests and this guard live in the same file on purpose — they're two sides of one trade-off and can't drift apart.

## Result (localhost, vs PR #1)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| **full-path p50** | 40.4ms | **9.6ms** | **−76%** |
| render p50 | 25.0ms | **9.3ms** | **−63%** |
| throughput (20k lines) | — | **164ms** to quiescence, end-marker present | ✓ |

The run-kit tax is now *below* the `capture-pane`-bound baseline floor — the web path's added latency is faster than our baseline measurement tool can resolve (a sign that baseline metric has served its purpose).

The residual ~9ms render is xterm parse + a single paint, not multi-frame coalescing — that's the floor for this approach and the PR #3 (renderer tuning) target.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `just test-frontend` — 550 unit tests pass (terminal-client unchanged in behavior for the buffered path)
- [x] frontend `vite build` succeeds
- [x] `just test-e2e echo-latency` — all 3 tests pass; latency dropped 76%, throughput healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)