### PR TITLE
feat: Confirm WebGL renderer is active + survive context loss

### DIFF
--- a/app/frontend/src/components/terminal-client.tsx
+++ b/app/frontend/src/components/terminal-client.tsx
@@ -46,6 +46,8 @@ export const clipboardProvider = {
 declare global {
   interface Window {
     __rkTerminals?: Record<string, import("@xterm/xterm").Terminal>;
+    /** Active renderer per windowId — "webgl" until a context-loss demotes it. */
+    __rkRenderer?: Record<string, "webgl" | "canvas">;
   }
 }
 
@@ -62,6 +64,17 @@ function unregisterTestTerminal(windowId: string) {
 // Shared encoder for measuring UTF-8 byte length on the inbound flush path
 // (allocated once, not per message).
 const textEncoder = new TextEncoder();
+
+/** Record which renderer is live for `windowId` (read by the latency harness). */
+function setActiveRenderer(windowId: string, renderer: "webgl" | "canvas") {
+  if (typeof window === "undefined") return;
+  (window.__rkRenderer ??= {})[windowId] = renderer;
+}
+
+function unsetActiveRenderer(windowId: string) {
+  if (typeof window === "undefined" || !window.__rkRenderer) return;
+  delete window.__rkRenderer[windowId];
+}
 
 type TerminalClientProps = {
   sessionName: string;
@@ -247,10 +260,30 @@ export function TerminalClient({
       // GPU-accelerated rendering (silent fallback to canvas). The module is
       // statically imported (resolved at chunk load), but WebGL context
       // creation can still throw at runtime — keep the guard around it.
+      //
+      // Two robustness additions over a bare load:
+      //  1. Record the active renderer ("webgl" | "canvas") on a window hook so
+      //     the latency harness can ASSERT WebGL is live — a silent canvas
+      //     fallback renders slower, and without this we'd never know it
+      //     happened (the whole point of the latency work is to not regress
+      //     blind).
+      //  2. Handle `onContextLoss`: a WebGL context can be lost AFTER successful
+      //     creation (tab backgrounding, GPU reset, driver hiccup). When that
+      //     happens the addon stops painting and the terminal FREEZES unless we
+      //     dispose it — disposing drops xterm back to its DOM/canvas renderer,
+      //     which keeps working. Correctness, not latency.
       try {
-        terminal.loadAddon(new WebglAddon());
+        const webgl = new WebglAddon();
+        webgl.onContextLoss(() => {
+          // Drop to the fallback renderer so output keeps flowing.
+          try { webgl.dispose(); } catch { /* already disposing */ }
+          setActiveRenderer(windowId, "canvas");
+        });
+        terminal.loadAddon(webgl);
+        setActiveRenderer(windowId, "webgl");
       } catch {
         // canvas renderer continues working
+        setActiveRenderer(windowId, "canvas");
       }
 
       // Keyboard input → current WebSocket (wsRef always points to latest)
@@ -325,6 +358,10 @@ export function TerminalClient({
         wsRef.current = null;
       }
       if (focusRef) focusRef.current = null;
+      // Note: __rkTerminals register/unregister moved to the dedicated
+      // windowId-keyed effect below. __rkRenderer is set at WebGL-load time in
+      // this init effect, so its cleanup stays here.
+      unsetActiveRenderer(windowId);
       xtermRef.current = null;
       fitAddonRef.current = null;
       try { terminal?.dispose(); } catch { /* WebGL addon may throw during teardown */ }

--- a/app/frontend/tests/e2e/echo-latency.spec.md
+++ b/app/frontend/tests/e2e/echo-latency.spec.md
@@ -13,11 +13,15 @@ just pw test echo-latency
 
 ## Why measure to the buffer, not the WS frame
 
-`terminal-client.tsx` batches incoming WebSocket data and flushes it to xterm
-once per `requestAnimationFrame`. That coalescing delay (up to ~1 frame) is
-part of what the user actually feels. The benchmark therefore stops the clock
-at **glyph-in-`term.buffer.active`** — after the rAF flush — rather than at
-"WS message received", which would understate latency by up to a frame.
+`terminal-client.tsx` writes inbound data to xterm via an **adaptive flush**:
+small chunks arriving while idle are written synchronously (so an echo paints
+this tick), while larger chunks or bursts coalesce into one write per
+`requestAnimationFrame`. Whatever path a given chunk takes, the render cost up
+to the painted glyph is part of what the user feels. The benchmark therefore
+stops the clock at **glyph-in-`term.buffer.active`** rather than at "WS message
+received", which would understate latency by the render tail. (Measuring this
+way is what let the adaptive flush show up as a real win — full-path p50 fell
+from ~40ms to ~10ms when the unconditional rAF wait was removed for echoes.)
 
 The WebGL renderer paints to a canvas that is **not DOM-readable**, so reading
 the parsed buffer is the only honest "glyph visible" signal available to a
@@ -25,6 +29,17 @@ Playwright driver. To reach the live `Terminal` instance the harness relies on
 a test-only registry: `terminal-client.tsx` registers each terminal on
 `window.__rkTerminals` (keyed by windowId) on mount and unregisters it on
 dispose. The registry is inert unless a test reads it.
+
+**Renderer confirmation.** The WebGL addon loads in a try/catch with a silent
+canvas fallback, and a live WebGL context can also be lost at runtime (tab
+backgrounding, GPU reset). Either way the renderer would be slower — making the
+latency numbers non-comparable — without any visible signal. So
+`terminal-client.tsx` records the active renderer on `window.__rkRenderer`
+(`"webgl"` until a context-loss demotes it to `"canvas"`), and the full-path
+test asserts it is `"webgl"`. A canvas fallback now fails the run loudly instead
+of quietly skewing the measurement. (The same context-loss handler also disposes
+the dead addon so the terminal drops to canvas and keeps rendering rather than
+freezing — a correctness fix independent of the benchmark.)
 
 Detection is **count-based on the cursor row**, not a fixed cell: the harness
 snapshots how many times `ch` appears on the cursor's row before the keystroke,
@@ -130,13 +145,15 @@ input path including the rAF render flush.
 3. `page.goto(/${server}/${windowId})`; wait for `.xterm-screen` visible.
 4. Poll until `window.__rkTerminals[windowId]` exists (terminal mounted +
    opened).
-5. Click `[role='application']` and focus `.xterm-helper-textarea` so
+5. **Assert `window.__rkRenderer[windowId] === "webgl"`** — fail loudly if the
+   renderer silently fell back to canvas (slower; non-comparable numbers).
+6. Click `[role='application']` and focus `.xterm-helper-textarea` so
    `keyboard.press` routes into xterm.
-6. **Warmup**: press Enter, then repeatedly press `w` (250ms cadence, up to 15s)
+7. **Warmup**: press Enter, then repeatedly press `w` (250ms cadence, up to 15s)
    until a `w` shows on the cursor row. This confirms the full input path is
    live and absorbs the cold-backend connect delay (relay attach + tmux select +
    cat start) instead of guessing with a fixed sleep.
-7. For each of 40 trials (char alternates `x`/`o`):
+8. For each of 40 trials (char alternates `x`/`o`):
    a. Press Enter (fresh line) and settle ~30ms so the newline echo lands.
    b. `measureEcho(page, windowId, ch, ECHO_DEADLINE_MS)`:
       - Snapshot the count of `ch` on the cursor row; clear `__rkSendAt` and
@@ -147,7 +164,7 @@ input path including the rAF render flush.
         a 5s deadline or if the keystroke produced no WebSocket send.
    c. Push three rows: `{ label: "full-path" }`, `{ label: "network" }`,
       `{ label: "render" }`.
-8. Assert 40 full-path samples were collected.
+9. Assert 40 full-path samples were collected.
 
 ### `baseline tmux-only echo distribution`
 

--- a/app/frontend/tests/e2e/echo-latency.spec.ts
+++ b/app/frontend/tests/e2e/echo-latency.spec.ts
@@ -408,6 +408,22 @@ test.describe("Echo latency benchmark", () => {
       )
       .toBe(true);
 
+    // Renderer confirmation: the WebGL addon loads in a try/catch with a silent
+    // canvas fallback. A canvas fallback renders measurably slower, so the
+    // latency numbers below are only meaningful if WebGL is actually live —
+    // assert it. (If a CI runner genuinely lacks a GPU/WebGL this will fail
+    // loudly, which is the right signal: the numbers from that box are not
+    // comparable to a WebGL run and shouldn't be silently trusted.)
+    const renderer = await page.evaluate(
+      (wid) => window.__rkRenderer?.[wid],
+      windowId,
+    );
+    expect(
+      renderer,
+      `expected WebGL renderer to be active (got ${renderer}); canvas fallback ` +
+        "renders slower and would make these latency numbers non-comparable",
+    ).toBe("webgl");
+
     // Focus the terminal for keyboard input. Click the terminal area (the
     // documented tap-to-focus path) then focus the helper textarea xterm reads
     // keystrokes from — belt and suspenders so keyboard.press routes into xterm.


### PR DESCRIPTION
**Stacked on #244** (base: `adaptive-flush`). PR #3 (final) of the render-latency series.

## Scope honesty up front

The original plan for PR #3 was "renderer confirmation + xterm tuning." After PR #2, the harness shows the render tail is **~9ms p50** — essentially **one unavoidable WebGL paint** plus detection granularity. There is no xterm-*tuning* lever left worth pulling: scrollback size and write-callback timing don't beat a single GPU paint, and chasing the number would be optimizing noise. So this PR drops the tuning half and keeps the two parts that have real value — making the renderer **observable** and **resilient**.

## What

1. **Renderer confirmation.** The WebGL addon loads in a `try/catch` with a silent canvas fallback. A canvas fallback renders slower and would make the latency numbers non-comparable — with no visible signal. Now `terminal-client.tsx` records the active renderer on `window.__rkRenderer` (`"webgl"` | `"canvas"`), and the echo harness **asserts `"webgl"`** — a silent fallback fails the run loudly instead of quietly skewing the measurement.

2. **Context-loss handling.** A live WebGL context can be lost *after* creation (tab backgrounding, GPU reset, driver hiccup). The addon then stops painting and the terminal **freezes**. `onContextLoss` now disposes the dead addon — dropping xterm to its canvas renderer, which keeps working — and demotes `__rkRenderer` to `"canvas"`. This is a **correctness fix**, independent of latency.

## Verification

- Harness asserts WebGL **is** active in headless Chromium (SwiftShader) — the diagnostic works; if it ever silently fell back, the run would now fail.
- Latency unchanged: full-path p50 ~9.5ms (this PR is robustness, not speed).
- `just test-frontend` — 550 unit tests pass.

## The series, end to end

| | full-path p50 | render p50 | notes |
|---|---|---|---|
| harness (#242) | 40.4ms | — | could now measure it |
| attribution (#243) | 40.4ms | 25.0ms | proved render dominates ~3:1 |
| **adaptive flush (#244)** | **9.6ms** | **9.3ms** | **−76% — the win** |
| renderer (this) | 9.5ms | 9.1ms | floored; made WebGL observable + resilient |

The render tail is now at its floor (one paint). Further latency work would mean predictive/local echo — only worth it for **remote** `rk serve`, where PR #1's `network` segment would dominate instead. The harness is set up to tell you exactly when that flips.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `just test-frontend` — 550 pass
- [x] `just test-e2e echo-latency` — all 3 pass; WebGL assertion green, latency stable, throughput healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)