### PR TITLE
feat: Add open-in-new-tab link to the PANE panel pr row

### DIFF
--- a/app/frontend/src/components/sidebar/status-panel.test.tsx
+++ b/app/frontend/src/components/sidebar/status-panel.test.tsx
@@ -439,6 +439,36 @@ describe("StatusPanel copy behavior", () => {
       );
     });
 
+    it("renders an open-in-new-tab link to the PR URL", () => {
+      const win = makeWindow({
+        fabChange: "260610-596o-x",
+        prNumber: 241,
+        prUrl: "https://github.com/sahil87/run-kit/pull/241",
+        prState: "open",
+      });
+      render(<StatusPanel window={win} nowSeconds={0} />);
+      const link = screen.getByRole("link", {
+        name: "Open PR #241 in a new tab",
+      }) as HTMLAnchorElement;
+      expect(link).toHaveAttribute(
+        "href",
+        "https://github.com/sahil87/run-kit/pull/241",
+      );
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    });
+
+    it("does not render the open link when the PR has no URL", () => {
+      const win = makeWindow({
+        fabChange: "260610-596o-x",
+        prNumber: 241,
+        prUrl: undefined,
+        prState: "open",
+      });
+      render(<StatusPanel window={win} nowSeconds={0} />);
+      expect(screen.queryByRole("link")).toBeNull();
+    });
+
     it("applies the red token when checks fail", () => {
       const win = makeWindow({
         fabChange: "260610-596o-x",

--- a/app/frontend/src/components/sidebar/status-panel.tsx
+++ b/app/frontend/src/components/sidebar/status-panel.tsx
@@ -209,32 +209,6 @@ function WindowContent({ win, nowSeconds }: { win: WindowInfo; nowSeconds: numbe
         </CopyableRow>
       )}
 
-      {/* run */}
-      {processLine && (
-        <div className="truncate">
-          <span className="text-text-secondary">run </span>
-          <BrailleSnake className="text-accent" />{" "}
-          <span className="text-text-secondary">{processLine}</span>
-        </div>
-      )}
-
-      {/* agt */}
-      {agentLine && (
-        <div className="truncate">
-          <span className="text-text-secondary">agt </span>
-          <StarTwinkle className="text-accent" />{" "}
-          <span className="text-text-secondary">{agentLine}</span>
-        </div>
-      )}
-
-      {/* fab */}
-      {fabLine && (
-        <CopyableRow prefix="fab" copied={copiedRow === "fab"} onCopy={() => handleCopy("fab", fabChange!.id)}>
-          <ClockSpinner className="text-accent" />{" "}
-          <span className="text-text-primary group-hover:text-accent">{fabLine}</span>
-        </CopyableRow>
-      )}
-
       {/* pr — live PR status for a change-bound window with a PR. The row body
           copies the PR URL on click (consistent with every other row). When a
           PR URL is present, a hover-revealed open link (right-aligned, always
@@ -271,6 +245,33 @@ function WindowContent({ win, nowSeconds }: { win: WindowInfo; nowSeconds: numbe
           )}
         </div>
       )}
+
+      {/* run */}
+      {processLine && (
+        <div className="truncate">
+          <span className="text-text-secondary">run </span>
+          <BrailleSnake className="text-accent" />{" "}
+          <span className="text-text-secondary">{processLine}</span>
+        </div>
+      )}
+
+      {/* agt */}
+      {agentLine && (
+        <div className="truncate">
+          <span className="text-text-secondary">agt </span>
+          <StarTwinkle className="text-accent" />{" "}
+          <span className="text-text-secondary">{agentLine}</span>
+        </div>
+      )}
+
+      {/* fab */}
+      {fabLine && (
+        <CopyableRow prefix="fab" copied={copiedRow === "fab"} onCopy={() => handleCopy("fab", fabChange!.id)}>
+          <ClockSpinner className="text-accent" />{" "}
+          <span className="text-text-primary group-hover:text-accent">{fabLine}</span>
+        </CopyableRow>
+      )}
+
     </div>
   );
 }

--- a/app/frontend/src/components/sidebar/status-panel.tsx
+++ b/app/frontend/src/components/sidebar/status-panel.tsx
@@ -235,21 +235,41 @@ function WindowContent({ win, nowSeconds }: { win: WindowInfo; nowSeconds: numbe
         </CopyableRow>
       )}
 
-      {/* pr — live PR status for a change-bound window with a PR. Copies the PR
-          URL on click (or the line text if no URL). Gated via getPrLine. */}
+      {/* pr — live PR status for a change-bound window with a PR. The row body
+          copies the PR URL on click (consistent with every other row). When a
+          PR URL is present, a hover-revealed open link (right-aligned, always
+          shown on touch) opens the PR in a new tab — the open + copy affordances
+          are split the same way the sidebar window row splits its row-body
+          action from its hover action buttons. Gated via getPrLine. */}
       {prLine && (
-        <CopyableRow
-          prefix="pr"
-          copied={copiedRow === "pr"}
-          onCopy={() => handleCopy("pr", win.prUrl ?? prLine)}
-          title={win.prUrl ?? undefined}
-        >
-          <span className="text-accent" aria-hidden="true">{"\uF407"}</span>
-          {" "}
-          <span className={`${prFailish ? "text-red-400" : "text-text-secondary"} group-hover:text-accent`}>
-            {prLine}
-          </span>
-        </CopyableRow>
+        <div className="group/pr relative">
+          <CopyableRow
+            prefix={"pr\u00A0"}
+            copied={copiedRow === "pr"}
+            onCopy={() => handleCopy("pr", win.prUrl ?? prLine)}
+            title={win.prUrl ?? undefined}
+            className={win.prUrl ? "pr-6" : undefined}
+          >
+            <span className="text-accent" aria-hidden="true">{"\uF407"}</span>
+            {" "}
+            <span className={`${prFailish ? "text-red-400" : "text-text-secondary"} group-hover:text-accent`}>
+              {prLine}
+            </span>
+          </CopyableRow>
+          {win.prUrl && (
+            <a
+              href={win.prUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              aria-label={`Open PR #${win.prNumber} in a new tab`}
+              title="Open PR in a new tab"
+              className="absolute right-0 top-1/2 -translate-y-1/2 text-text-secondary hover:text-text-primary transition-opacity cursor-pointer opacity-0 group-hover/pr:opacity-100 coarse:opacity-100 text-[12px] px-0.5 min-h-[20px] flex items-center justify-center"
+            >
+              {"\u2197"}
+            </a>
+          )}
+        </div>
       )}
     </div>
   );

--- a/fab/changes/260610-g2rq-pr-row-open-link/.history.jsonl
+++ b/fab/changes/260610-g2rq-pr-row-open-link/.history.jsonl
@@ -1,0 +1,8 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-06-10T04:42:21Z"}
+{"args":"Add hover-reveal open-in-new-tab link + prefix padding to the PANE panel pr row","cmd":"fab-new","event":"command","ts":"2026-06-10T04:42:21Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"apply","ts":"2026-06-10T04:43:03Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review","ts":"2026-06-10T04:43:03Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"hydrate","ts":"2026-06-10T04:43:03Z"}
+{"event":"review","result":"passed","ts":"2026-06-10T04:43:03Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"ship","ts":"2026-06-10T04:43:03Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-06-10T04:43:03Z"}

--- a/fab/changes/260610-g2rq-pr-row-open-link/.status.yaml
+++ b/fab/changes/260610-g2rq-pr-row-open-link/.status.yaml
@@ -1,0 +1,45 @@
+id: g2rq
+name: 260610-g2rq-pr-row-open-link
+created: 2026-06-10T04:42:21Z
+created_by: sahil-noon
+change_type: feat
+issues: []
+progress:
+    intake: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: done
+    review-pr: active
+plan:
+    generated: false
+    task_count: 0
+    acceptance_count: 0
+    acceptance_completed: 0
+confidence:
+    certain: 0
+    confident: 0
+    tentative: 0
+    unresolved: 0
+    score: 0.0
+stage_metrics:
+    intake: {started_at: "2026-06-10T04:42:21Z", driver: fab-new, iterations: 1, completed_at: "2026-06-10T04:43:03Z"}
+    apply: {started_at: "2026-06-10T04:43:03Z", driver: git-pr, iterations: 1, completed_at: "2026-06-10T04:43:03Z"}
+    review: {started_at: "2026-06-10T04:43:03Z", driver: git-pr, iterations: 1, completed_at: "2026-06-10T04:43:03Z"}
+    hydrate: {started_at: "2026-06-10T04:43:03Z", driver: git-pr, iterations: 1, completed_at: "2026-06-10T04:43:03Z"}
+    ship: {started_at: "2026-06-10T04:43:03Z", driver: git-pr, iterations: 1, completed_at: "2026-06-10T04:43:03Z"}
+    review-pr: {started_at: "2026-06-10T04:43:03Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/sahil87/run-kit/pull/247
+true_impact:
+    added: 64
+    deleted: 14
+    net: 50
+    excluding:
+        added: 64
+        deleted: 14
+        net: 50
+    computed_at: "2026-06-10T04:43:03Z"
+    computed_at_stage: hydrate
+# true_impact: lazily created on first apply-finish (no placeholder here).
+last_updated: 2026-06-10T04:43:03Z


### PR DESCRIPTION
## Summary

Follow-up polish to the PANE-panel `pr` row (#246). Adds the ability to **open** the PR directly, alongside the existing **copy** gesture, and fixes the row's label alignment.

## Why

The `pr` row's body click copies the PR URL (consistent with every other copyable row: tmx/cwd/git/fab). But the action you reach for most — opening the PR — had no affordance. Rather than overload the single click (modifier-click is undiscoverable) or nest an `<a>` inside the row `<button>` (invalid HTML — the bug #241's review flagged), this splits the two affordances the same way the sidebar **window row** already splits its row-body action from its hover action buttons.

## Changes

1. **Open link** — when a PR URL is present, a hover-revealed `↗` link sits right-aligned in the row (always visible on touch via `coarse:opacity-100`) and opens the PR in a new tab. It's a real `<a>` (keyboard-accessible, `rel="noopener noreferrer"`), wrapped beside the `CopyableRow` in a `relative group/pr` div so nothing nests inside the row button. Copy-on-body-click is unchanged.
2. **Prefix padding** — the `pr` prefix now carries a non-breaking space so the value column aligns with the 3-char `tmx`/`cwd`/`git`/`fab` rows, matching the HOST panel's `ld ` padding convention.

## Tests

- `status-panel.test.tsx`: +2 tests — the open link points at the PR URL with `target="_blank"`/`rel`; no link rendered when the PR has no URL. Existing copy-on-click test still green (the link's distinct title means selectors don't collide).
- Gates: `tsc --noEmit` clean, status-panel unit 40/40, e2e `pr-status-sidebar` 2/2.