### PR TITLE
feat: Show merged/closed PR state in the pane line

### DIFF
--- a/app/backend/internal/prstatus/prstatus.go
+++ b/app/backend/internal/prstatus/prstatus.go
@@ -177,13 +177,19 @@ func ghAvailable(ctx context.Context) bool {
 	return cmd.Run() == nil
 }
 
-// ghQuery is the GraphQL query fetching every open PR authored by the user
-// across all repos in a single call. statusCheckRollup.state is GitHub's
-// pre-collapsed rollup enum (SUCCESS|FAILURE|PENDING|ERROR|EXPECTED) so we get
-// the rollup for free without iterating individual check runs.
+// ghQuery is the GraphQL query fetching the user's most-recently-updated PRs
+// across all repos in a single call — OPEN, MERGED, and CLOSED, ordered by
+// UPDATED_AT desc and capped at $limit. Including MERGED/CLOSED lets the pane
+// line show a "merged"/"closed" state instead of a bare PR number after a PR
+// lands. The recency ordering + $limit cap IS the eviction mechanism: a stale
+// merged PR ages out of the top-$limit window and drops from the next wholesale
+// rebuild, so the in-memory snapshot stays bounded without separate pruning.
+// A just-merged PR is recently updated, so it sits near the top and is always
+// included. statusCheckRollup.state is GitHub's pre-collapsed rollup enum
+// (SUCCESS|FAILURE|PENDING|ERROR|EXPECTED) so we get the rollup for free.
 const ghQuery = `query($limit: Int!) {
   viewer {
-    pullRequests(first: $limit, states: OPEN, orderBy: {field: UPDATED_AT, direction: DESC}) {
+    pullRequests(first: $limit, states: [OPEN, MERGED, CLOSED], orderBy: {field: UPDATED_AT, direction: DESC}) {
       nodes {
         number
         url
@@ -262,15 +268,18 @@ func parsePRs(out []byte) ([]ghPR, error) {
 
 // --- enum collapse --------------------------------------------------------------
 
-// mapState collapses GitHub's PR state to the display state. The GraphQL query
-// fetches `states: OPEN` only — a PR that merges or closes drops out of the next
-// wholesale rebuild rather than being shown (this is the cleanup mechanism), so
-// the snapshot only ever carries open PRs and this returns "open" for them. The
-// draft flag is surfaced separately via PRStatus.IsDraft; a draft PR is still
-// "open". Non-OPEN inputs (never produced by the current query) also map to
-// "open" as a safe default.
-func mapState(_ string, _ bool) string {
-	return "open"
+// mapState collapses GitHub's PR state to the display state open|merged|closed.
+// The draft flag is surfaced separately via PRStatus.IsDraft; a draft PR is
+// still "open". An unexpected/empty state defaults to "open".
+func mapState(ghState string, _ bool) string {
+	switch ghState {
+	case "MERGED":
+		return "merged"
+	case "CLOSED":
+		return "closed"
+	default: // OPEN (and any unexpected value)
+		return "open"
+	}
 }
 
 // mapChecks collapses GitHub's statusCheckRollup state to pass|fail|pending|none.

--- a/app/backend/internal/prstatus/prstatus_test.go
+++ b/app/backend/internal/prstatus/prstatus_test.go
@@ -83,8 +83,9 @@ func TestRefreshWholesaleRebuildDropsAbsentPR(t *testing.T) {
 		t.Fatalf("first cycle snapshot = %v, want #100 and #200", snap)
 	}
 
-	// Second cycle: #100 merged/closed → absent from --state open result.
-	// Wholesale rebuild must drop it (no eviction logic).
+	// Second cycle: #100 has aged out of the top-$limit UPDATED_AT window, so
+	// it's absent from the fetch. Wholesale rebuild must drop it (this recency
+	// window IS the eviction mechanism — no separate pruning logic).
 	out = ghJSON(ghFixture(200, "u200", "OPEN", false, "SUCCESS", ""))
 	c.refresh(context.Background())
 	snap := c.Snapshot()
@@ -212,12 +213,11 @@ func TestMapState(t *testing.T) {
 	}{
 		{"OPEN", false, "open"},
 		{"OPEN", true, "open"}, // draft is surfaced via IsDraft, still "open"
-		// The collector queries states: OPEN only, so merged/closed PRs never
-		// reach mapState — they drop out of the wholesale rebuild instead. Any
-		// non-OPEN input therefore maps to the "open" safe default.
-		{"MERGED", false, "open"},
-		{"CLOSED", false, "open"},
-		{"WAT", false, "open"},
+		// The collector queries states: [OPEN, MERGED, CLOSED] so the line can
+		// show a terminal state after a PR lands.
+		{"MERGED", false, "merged"},
+		{"CLOSED", false, "closed"},
+		{"WAT", false, "open"}, // unexpected → safe "open" default
 	}
 	for _, tc := range cases {
 		if got := mapState(tc.in, tc.draft); got != tc.want {
@@ -230,7 +230,8 @@ func TestDraftAndEnumCollapseEndToEnd(t *testing.T) {
 	c := newTestCollector(func(context.Context) ([]byte, error) {
 		return ghJSON(
 			ghFixture(11, "u11", "OPEN", true, "FAILURE", "CHANGES_REQUESTED") + "," +
-				ghFixture(12, "u12", "OPEN", false, "SUCCESS", "APPROVED"),
+				ghFixture(12, "u12", "OPEN", false, "SUCCESS", "APPROVED") + "," +
+				ghFixture(13, "u13", "MERGED", false, "", ""),
 		), nil
 	})
 	c.refresh(context.Background())
@@ -244,11 +245,16 @@ func TestDraftAndEnumCollapseEndToEnd(t *testing.T) {
 		t.Errorf("#11 collapse wrong: %+v", p11)
 	}
 	// #12 is a non-draft open PR with passing checks and an approval — exercises
-	// the SUCCESS→pass and APPROVED→approved collapses. (Merged/closed states
-	// are unreachable: the query is states: OPEN.)
+	// the SUCCESS→pass and APPROVED→approved collapses.
 	p12 := snap[12]
 	if p12.State != "open" || p12.IsDraft || p12.Checks != "pass" || p12.ReviewDecision != "approved" {
 		t.Errorf("#12 collapse wrong: %+v", p12)
+	}
+	// #13 is merged — the query now includes MERGED so a landed PR shows its
+	// terminal state (checks/review are "none"/none for the empty fixture).
+	p13 := snap[13]
+	if p13.State != "merged" {
+		t.Errorf("#13 should be merged, got %+v", p13)
 	}
 }
 

--- a/app/backend/internal/prstatus/prstatus_test.go
+++ b/app/backend/internal/prstatus/prstatus_test.go
@@ -83,9 +83,10 @@ func TestRefreshWholesaleRebuildDropsAbsentPR(t *testing.T) {
 		t.Fatalf("first cycle snapshot = %v, want #100 and #200", snap)
 	}
 
-	// Second cycle: #100 has aged out of the top-$limit UPDATED_AT window, so
-	// it's absent from the fetch. Wholesale rebuild must drop it (this recency
-	// window IS the eviction mechanism — no separate pruning logic).
+	// Second cycle: #100 is simply absent from the fetch result. Whatever the
+	// real-world reason (e.g. it aged out of the top-$limit UPDATED_AT window),
+	// the wholesale rebuild must drop it — there is no separate pruning logic,
+	// so "not in the latest fetch" is the entire eviction mechanism.
 	out = ghJSON(ghFixture(200, "u200", "OPEN", false, "SUCCESS", ""))
 	c.refresh(context.Background())
 	snap := c.Snapshot()

--- a/app/frontend/src/components/pr-status-line.test.tsx
+++ b/app/frontend/src/components/pr-status-line.test.tsx
@@ -61,6 +61,28 @@ describe("PrStatusLine", () => {
     expect(line).toHaveTextContent("review: approved");
   });
 
+  it("renders the merged glyph and state for a merged PR", () => {
+    render(
+      <PrStatusLine
+        win={makeWindow({ fabChange: "260610-x", prNumber: 386, prState: "merged" })}
+      />,
+    );
+    const line = screen.getByTestId("pr-status-line");
+    expect(line).toHaveTextContent("\u2713"); // ✓
+    expect(line).toHaveTextContent("merged");
+  });
+
+  it("renders the closed glyph and state for a closed PR", () => {
+    render(
+      <PrStatusLine
+        win={makeWindow({ fabChange: "260610-x", prNumber: 386, prState: "closed" })}
+      />,
+    );
+    const line = screen.getByTestId("pr-status-line");
+    expect(line).toHaveTextContent("\u2717"); // ✗
+    expect(line).toHaveTextContent("closed");
+  });
+
   it("uses the red token for failing checks", () => {
     render(
       <PrStatusLine

--- a/app/frontend/src/components/pr-status-line.tsx
+++ b/app/frontend/src/components/pr-status-line.tsx
@@ -1,15 +1,16 @@
 import { refreshPrStatus } from "@/api/client";
 import type { WindowInfo } from "@/types";
 
-/**
- * State glyph. The collector only fetches OPEN PRs (states: OPEN — the
- * wholesale-rebuild cleanup means merged/closed PRs simply drop out of the
- * snapshot rather than being displayed), so `prState` is always "open" in
- * practice and the glyph is the open dot. Kept as a function for the (unused)
- * non-open fallback so the call site reads uniformly.
- */
-function stateGlyph(_state: WindowInfo["prState"]): string {
-  return "●";
+/** State glyph: open=●, merged=✓, closed=✗. Falls back to ● for unknown. */
+function stateGlyph(state: WindowInfo["prState"]): string {
+  switch (state) {
+    case "merged":
+      return "✓";
+    case "closed":
+      return "✗";
+    default:
+      return "●";
+  }
 }
 
 /** Human-readable checks/review summary, e.g. "checks pass" or "review: changes requested". */

--- a/app/frontend/src/components/sidebar/status-panel.test.tsx
+++ b/app/frontend/src/components/sidebar/status-panel.test.tsx
@@ -439,6 +439,21 @@ describe("StatusPanel copy behavior", () => {
       );
     });
 
+    it("shows the terminal state and suppresses checks/review for a merged PR", () => {
+      const win = makeWindow({
+        fabChange: "260610-596o-x",
+        prNumber: 247,
+        prUrl: "https://github.com/sahil87/run-kit/pull/247",
+        prState: "merged",
+        prChecks: "pass",
+        prReview: "approved",
+      });
+      render(<StatusPanel window={win} nowSeconds={0} />);
+      // Merged PRs show "#247 · merged" only — checks/review are historical
+      // once a PR lands, so they're suppressed.
+      expect(screen.getByText("#247 · merged")).toBeInTheDocument();
+    });
+
     it("renders an open-in-new-tab link to the PR URL", () => {
       const win = makeWindow({
         fabChange: "260610-596o-x",

--- a/app/frontend/src/components/sidebar/status-panel.test.tsx
+++ b/app/frontend/src/components/sidebar/status-panel.test.tsx
@@ -454,6 +454,34 @@ describe("StatusPanel copy behavior", () => {
       expect(screen.getByText("#247 · merged")).toBeInTheDocument();
     });
 
+    it("shows the terminal state and suppresses checks/review for a closed PR", () => {
+      const win = makeWindow({
+        fabChange: "260610-596o-x",
+        prNumber: 247,
+        prUrl: "https://github.com/sahil87/run-kit/pull/247",
+        prState: "closed",
+        prChecks: "fail",
+        prReview: "changes_requested",
+      });
+      render(<StatusPanel window={win} nowSeconds={0} />);
+      // Closed PRs show "#247 · closed" only — same suppression as merged.
+      expect(screen.getByText("#247 · closed")).toBeInTheDocument();
+    });
+
+    it("does not apply the red token to a closed PR with a hidden failed check", () => {
+      const win = makeWindow({
+        fabChange: "260610-596o-x",
+        prNumber: 247,
+        prState: "closed",
+        prChecks: "fail",
+      });
+      render(<StatusPanel window={win} nowSeconds={0} />);
+      // The failure text is suppressed for a terminal-state PR, so the row must
+      // stay neutral (no text-red-400) rather than red on a hidden reason.
+      const value = screen.getByText("#247 · closed");
+      expect(value.className).not.toContain("text-red-400");
+    });
+
     it("renders an open-in-new-tab link to the PR URL", () => {
       const win = makeWindow({
         fabChange: "260610-596o-x",

--- a/app/frontend/src/components/sidebar/status-panel.tsx
+++ b/app/frontend/src/components/sidebar/status-panel.tsx
@@ -85,9 +85,15 @@ function getPrLine(win: WindowInfo): string | null {
   return parts.join(" · ");
 }
 
-/** Fail-ish PR states get the red token (mirrors the dashboard PrStatusLine). */
+/**
+ * Fail-ish PR states get the red token (mirrors the dashboard PrStatusLine).
+ * Gated on the PR being open: getPrLine suppresses the checks/review text for a
+ * merged/closed PR (it's historical once landed), so coloring the row red on a
+ * now-hidden failure would be misleading — a terminal-state row stays neutral.
+ */
 function prIsFailish(win: WindowInfo): boolean {
-  return win.prChecks === "fail" || win.prReview === "changes_requested";
+  const isOpen = !win.prState || win.prState === "open";
+  return isOpen && (win.prChecks === "fail" || win.prReview === "changes_requested");
 }
 
 export function WindowPanel({ window: win, nowSeconds }: WindowPanelProps) {

--- a/app/frontend/src/components/sidebar/status-panel.tsx
+++ b/app/frontend/src/components/sidebar/status-panel.tsx
@@ -68,17 +68,20 @@ function getAgentLine(win: WindowInfo): string | null {
 }
 
 /**
- * Build the PR status line for the pane panel, e.g. "#241 · open · checks pass".
- * Returns null unless the window is change-bound (`fabChange`) AND carries a
- * `prNumber` — the same gate the sidebar/dashboard PR surface uses. State is
- * always "open" in practice (the collector queries states: OPEN only).
+ * Build the PR status line for the pane panel, e.g. "#241 · open · checks pass"
+ * for an open PR, or "#241 · merged" once it lands. Returns null unless the
+ * window is change-bound (`fabChange`) AND carries a `prNumber` — the same gate
+ * the sidebar/dashboard PR surface uses. For a merged/closed PR the checks and
+ * review parts are suppressed (they're historical once the PR is no longer
+ * open); only the terminal state is shown.
  */
 function getPrLine(win: WindowInfo): string | null {
   if (!win.fabChange || !win.prNumber) return null;
   const parts = [`#${win.prNumber}`];
   if (win.prState) parts.push(`${win.prState}${win.prIsDraft ? " (draft)" : ""}`);
-  if (win.prChecks && win.prChecks !== "none") parts.push(`checks ${win.prChecks}`);
-  if (win.prReview && win.prReview !== "none") parts.push(`review: ${win.prReview.replace(/_/g, " ")}`);
+  const isOpen = !win.prState || win.prState === "open";
+  if (isOpen && win.prChecks && win.prChecks !== "none") parts.push(`checks ${win.prChecks}`);
+  if (isOpen && win.prReview && win.prReview !== "none") parts.push(`review: ${win.prReview.replace(/_/g, " ")}`);
   return parts.join(" · ");
 }
 

--- a/fab/changes/260610-nls0-pr-status-merged-closed/.history.jsonl
+++ b/fab/changes/260610-nls0-pr-status-merged-closed/.history.jsonl
@@ -1,0 +1,8 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-06-10T05:14:19Z"}
+{"args":"Show merged/closed PR state in the pane line (broaden collector query to OPEN+MERGED+CLOSED, recency-windowed)","cmd":"fab-new","event":"command","ts":"2026-06-10T05:14:19Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"apply","ts":"2026-06-10T05:15:01Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review","ts":"2026-06-10T05:15:01Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"hydrate","ts":"2026-06-10T05:15:01Z"}
+{"event":"review","result":"passed","ts":"2026-06-10T05:15:01Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"ship","ts":"2026-06-10T05:15:01Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-06-10T05:15:01Z"}

--- a/fab/changes/260610-nls0-pr-status-merged-closed/.history.jsonl
+++ b/fab/changes/260610-nls0-pr-status-merged-closed/.history.jsonl
@@ -6,3 +6,4 @@
 {"event":"review","result":"passed","ts":"2026-06-10T05:15:01Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"ship","ts":"2026-06-10T05:15:01Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-06-10T05:15:01Z"}
+{"event":"review","result":"passed","ts":"2026-06-10T05:42:41Z"}

--- a/fab/changes/260610-nls0-pr-status-merged-closed/.status.yaml
+++ b/fab/changes/260610-nls0-pr-status-merged-closed/.status.yaml
@@ -10,7 +10,7 @@ progress:
     review: done
     hydrate: done
     ship: done
-    review-pr: active
+    review-pr: done
 plan:
     generated: false
     task_count: 0
@@ -28,7 +28,7 @@ stage_metrics:
     review: {started_at: "2026-06-10T05:15:01Z", driver: git-pr, iterations: 1, completed_at: "2026-06-10T05:15:01Z"}
     hydrate: {started_at: "2026-06-10T05:15:01Z", driver: git-pr, iterations: 1, completed_at: "2026-06-10T05:15:01Z"}
     ship: {started_at: "2026-06-10T05:15:01Z", driver: git-pr, iterations: 1, completed_at: "2026-06-10T05:15:01Z"}
-    review-pr: {started_at: "2026-06-10T05:15:01Z", driver: git-pr, iterations: 1}
+    review-pr: {started_at: "2026-06-10T05:15:01Z", driver: git-pr, iterations: 1, completed_at: "2026-06-10T05:42:41Z"}
 prs:
     - https://github.com/sahil87/run-kit/pull/248
 true_impact:
@@ -42,4 +42,4 @@ true_impact:
     computed_at: "2026-06-10T05:15:01Z"
     computed_at_stage: hydrate
 # true_impact: lazily created on first apply-finish (no placeholder here).
-last_updated: 2026-06-10T05:15:01Z
+last_updated: 2026-06-10T05:42:41Z

--- a/fab/changes/260610-nls0-pr-status-merged-closed/.status.yaml
+++ b/fab/changes/260610-nls0-pr-status-merged-closed/.status.yaml
@@ -1,0 +1,45 @@
+id: nls0
+name: 260610-nls0-pr-status-merged-closed
+created: 2026-06-10T05:14:19Z
+created_by: sahil-noon
+change_type: feat
+issues: []
+progress:
+    intake: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: done
+    review-pr: active
+plan:
+    generated: false
+    task_count: 0
+    acceptance_count: 0
+    acceptance_completed: 0
+confidence:
+    certain: 0
+    confident: 0
+    tentative: 0
+    unresolved: 0
+    score: 0.0
+stage_metrics:
+    intake: {started_at: "2026-06-10T05:14:19Z", driver: fab-new, iterations: 1, completed_at: "2026-06-10T05:15:01Z"}
+    apply: {started_at: "2026-06-10T05:15:01Z", driver: git-pr, iterations: 1, completed_at: "2026-06-10T05:15:01Z"}
+    review: {started_at: "2026-06-10T05:15:01Z", driver: git-pr, iterations: 1, completed_at: "2026-06-10T05:15:01Z"}
+    hydrate: {started_at: "2026-06-10T05:15:01Z", driver: git-pr, iterations: 1, completed_at: "2026-06-10T05:15:01Z"}
+    ship: {started_at: "2026-06-10T05:15:01Z", driver: git-pr, iterations: 1, completed_at: "2026-06-10T05:15:01Z"}
+    review-pr: {started_at: "2026-06-10T05:15:01Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/sahil87/run-kit/pull/248
+true_impact:
+    added: 74
+    deleted: 40
+    net: 34
+    excluding:
+        added: 74
+        deleted: 40
+        net: 34
+    computed_at: "2026-06-10T05:15:01Z"
+    computed_at_stage: hydrate
+# true_impact: lazily created on first apply-finish (no placeholder here).
+last_updated: 2026-06-10T05:15:01Z


### PR DESCRIPTION
## Summary

The PANE panel `pr` row showed a bare `#247` once a PR merged — no indication it had landed. This broadens the PR-status collector to surface `merged`/`closed` state, so the line reads `#247 · merged` after a PR lands (and `#247 · open · checks pass · review: approved` while it's open).

## Why

The collector queried `states: OPEN` only — by design, as the original wholesale-rebuild cleanup ("merged PRs just drop off"). But `prNumber` still flows from `fab pane map` (which reads the URL from `.status.yaml` regardless of merge state), so a merged PR rendered a bare number with no status — ambiguous between "merged" and "status not fetched yet".

## How (eviction stays free)

The naive fix — query all merged/closed PRs — would let them accumulate unboundedly and break the self-pruning cache. Instead the query stays `first: $limit` ordered by `UPDATED_AT desc`, just with the state filter widened to `[OPEN, MERGED, CLOSED]`:

- A **just-merged** PR is recently updated → near the top of the window → always included.
- A **stale** merged/closed PR ages out of the top-`$limit` window → drops from the next wholesale rebuild.

So the recency window + `$limit` cap **is** the eviction mechanism — no separate pruning logic, the in-memory snapshot stays bounded. (Note: merged/closed PRs now consume window slots, so the `limit=100` cap does more work than under open-only.)

## Changes

- `prstatus.go`: query `states: [OPEN, MERGED, CLOSED]`; `mapState` regains `merged`/`closed` branches.
- `pr-status-line.tsx` (dashboard): `stateGlyph` regains `✓` (merged) / `✗` (closed).
- `status-panel.tsx` (pane panel): `getPrLine` shows the terminal state and **suppresses checks/review** for a merged/closed PR (historical once landed) — `#247 · merged`, not `#247 · merged · checks pass · review: approved`.

## Tests

- `prstatus_test.go`: `mapState` MERGED→merged / CLOSED→closed; end-to-end collapse test gains a merged fixture; wholesale-rebuild eviction comment updated to the recency-window rationale.
- `status-panel.test.tsx`: +1 — merged PR shows `#247 · merged` with checks/review suppressed.
- Gates: `go build ./...` + backend (prstatus/api/sessions), `tsc --noEmit`, frontend 41/41, e2e `pr-status-sidebar` 2/2 — all green.