### PR TITLE
fix: Run fab pane map version-independently (stale sibling project stripped PR fields)

### DIFF
--- a/app/backend/internal/sessions/sessions.go
+++ b/app/backend/internal/sessions/sessions.go
@@ -85,20 +85,26 @@ type paneMapEntry struct {
 // tmux socket the backend is querying; otherwise fab falls back to $TMUX or
 // the default socket.
 //
-// cmd.Dir is deliberately set to a NON-project directory (os.TempDir). The fab
-// router resolves which versioned fab-go binary to dispatch from the CWD's
-// fab/project/config.yaml; `pane map --all-sessions` is a CROSS-project,
-// cross-worktree query whose per-window data (change/stage/pr_url, each read
-// from the pane's own worktree .status.yaml) does NOT depend on CWD — only the
-// router's version selection does. Pinning that selection to any one project's
-// fab_version is wrong: a single project pinned to an older fab (one that
-// predates a field like pr_url) silently strips that field from EVERY window on
-// the server, even windows owned by projects on a newer fab. Running from a
-// neutral dir makes the router fall back to the globally-installed fab, so the
-// schema is always the newest the host's fab CLI supports and never downgraded
-// by a stale sibling project. (Inheriting the daemon's CWD is not enough — if
-// the daemon ever launches inside a fab project, that project's version would
-// re-pin; an explicit non-project dir is deterministic.)
+// cmd.Dir is deliberately set to a freshly-created, empty, private (0700) temp
+// directory. The fab router resolves which versioned fab-go binary to dispatch
+// from the CWD's fab/project/config.yaml; `pane map --all-sessions` is a
+// CROSS-project, cross-worktree query whose per-window data (change/stage/pr_url,
+// each read from the pane's own worktree .status.yaml) does NOT depend on CWD —
+// only the router's version selection does. Pinning that selection to any one
+// project's fab_version is wrong: a single project pinned to an older fab (one
+// that predates a field like pr_url) silently strips that field from EVERY
+// window on the server, even windows owned by projects on a newer fab. Running
+// from a project-free dir makes the router fall back to the globally-installed
+// fab, so the schema is always the newest the host's fab CLI supports and never
+// downgraded by a stale sibling project.
+//
+// We create our OWN empty dir rather than reuse os.TempDir(): the shared system
+// temp dir can already contain a fab/project/config.yaml (re-pinning the
+// version) and is world-writable on Unix, so another process could plant one
+// there — both would silently reintroduce the bug. A per-call MkdirTemp(0700)
+// dir is guaranteed project-free and not writable by others. If the dir can't
+// be created we fall back to running with the inherited CWD rather than failing
+// the whole pane-map (degraded, but better than no data).
 func fetchPaneMap(server string) (map[string]paneMapEntry, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -109,7 +115,11 @@ func fetchPaneMap(server string) (map[string]paneMapEntry, error) {
 	}
 	args = append(args, "pane", "map", "--json", "--all-sessions")
 	cmd := exec.CommandContext(ctx, "fab", args...)
-	cmd.Dir = os.TempDir()
+	// Project-free CWD so the fab router uses the global fab version (see above).
+	if neutralDir, err := os.MkdirTemp("", "rk-panemap-"); err == nil {
+		defer os.RemoveAll(neutralDir)
+		cmd.Dir = neutralDir
+	}
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()

--- a/app/backend/internal/sessions/sessions.go
+++ b/app/backend/internal/sessions/sessions.go
@@ -83,11 +83,23 @@ type paneMapEntry struct {
 // PATH and returns a lookup map keyed by "session:windowIndex". When server is
 // non-empty, it is passed as `-L <server>` so the subprocess targets the same
 // tmux socket the backend is querying; otherwise fab falls back to $TMUX or
-// the default socket. When repoRoot is non-empty, cmd.Dir is set to it so the
-// router can resolve the project's fab_version from fab/project/config.yaml;
-// otherwise the subprocess inherits the server's CWD. Returns nil map and an
-// error on failure.
-func fetchPaneMap(server, repoRoot string) (map[string]paneMapEntry, error) {
+// the default socket.
+//
+// cmd.Dir is deliberately set to a NON-project directory (os.TempDir). The fab
+// router resolves which versioned fab-go binary to dispatch from the CWD's
+// fab/project/config.yaml; `pane map --all-sessions` is a CROSS-project,
+// cross-worktree query whose per-window data (change/stage/pr_url, each read
+// from the pane's own worktree .status.yaml) does NOT depend on CWD — only the
+// router's version selection does. Pinning that selection to any one project's
+// fab_version is wrong: a single project pinned to an older fab (one that
+// predates a field like pr_url) silently strips that field from EVERY window on
+// the server, even windows owned by projects on a newer fab. Running from a
+// neutral dir makes the router fall back to the globally-installed fab, so the
+// schema is always the newest the host's fab CLI supports and never downgraded
+// by a stale sibling project. (Inheriting the daemon's CWD is not enough — if
+// the daemon ever launches inside a fab project, that project's version would
+// re-pin; an explicit non-project dir is deterministic.)
+func fetchPaneMap(server string) (map[string]paneMapEntry, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -97,9 +109,7 @@ func fetchPaneMap(server, repoRoot string) (map[string]paneMapEntry, error) {
 	}
 	args = append(args, "pane", "map", "--json", "--all-sessions")
 	cmd := exec.CommandContext(ctx, "fab", args...)
-	if repoRoot != "" {
-		cmd.Dir = repoRoot
-	}
+	cmd.Dir = os.TempDir()
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
@@ -161,7 +171,7 @@ var (
 // fetchPaneMapCached wraps fetchPaneMap with a per-server TTL cache.
 // Uses a double-check pattern after write lock acquisition to prevent thundering herd.
 // On fetch error, the stale cache entry for that server is preserved (if one exists).
-func fetchPaneMapCached(server, repoRoot string) (map[string]paneMapEntry, error) {
+func fetchPaneMapCached(server string) (map[string]paneMapEntry, error) {
 	paneMapCacheMu.RLock()
 	if entry, ok := paneMapCache[server]; ok && time.Since(entry.time) < paneMapCacheTTL {
 		cached := entry.data
@@ -178,7 +188,7 @@ func fetchPaneMapCached(server, repoRoot string) (map[string]paneMapEntry, error
 		return entry.data, nil
 	}
 
-	m, err := fetchPaneMap(server, repoRoot)
+	m, err := fetchPaneMap(server)
 	if err != nil {
 		// Preserve stale cache entry on error (graceful degradation).
 		if entry, ok := paneMapCache[server]; ok {
@@ -189,23 +199,6 @@ func fetchPaneMapCached(server, repoRoot string) (map[string]paneMapEntry, error
 
 	paneMapCache[server] = paneMapCacheEntry{data: m, time: time.Now()}
 	return m, nil
-}
-
-// findRepoRoot walks up from dir until it finds a directory containing
-// fab/project/config.yaml (the fab-project identity marker), returning that
-// directory. Returns "" if not found.
-func findRepoRoot(dir string) string {
-	for {
-		candidate := filepath.Join(dir, "fab/project/config.yaml")
-		if _, err := os.Stat(candidate); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return ""
-		}
-		dir = parent
-	}
 }
 
 // Per-entry git branch cache with separate positive/negative TTLs.
@@ -392,29 +385,13 @@ func FetchSessions(ctx context.Context, server string, provider ActiveWindowProv
 	}
 	wg.Wait()
 
-	// Derive repoRoot by walking up from the first available window's
-	// WorktreePath until we find a directory containing fab/project/config.yaml
-	// (the fab-project identity marker). WorktreePath is the pane's cwd which
-	// may be a subdirectory of the repo.
-	repoRoot := ""
-	for _, sd := range data {
-		for _, w := range sd.windows {
-			if w.WorktreePath != "" {
-				repoRoot = findRepoRoot(w.WorktreePath)
-				if repoRoot != "" {
-					break
-				}
-			}
-		}
-		if repoRoot != "" {
-			break
-		}
-	}
-
-	// Fetch pane-map once for all sessions. If refreshing the cache fails,
-	// fetchPaneMapCached may return a stale cached paneMap; if no data is
-	// available, windows keep empty fab fields (graceful degradation).
-	paneMap, _ := fetchPaneMapCached(server, repoRoot)
+	// Fetch pane-map once for all sessions. fetchPaneMap runs from a neutral
+	// (non-project) dir so the fab router dispatches the globally-installed fab
+	// version — `pane map` is a cross-project query and must not be pinned to
+	// any single window's project version (see fetchPaneMap doc). If refreshing
+	// the cache fails, fetchPaneMapCached may return a stale cached paneMap; if
+	// none is available, windows keep empty fab fields (graceful degradation).
+	paneMap, _ := fetchPaneMapCached(server)
 
 	// Collect all pane cwds for git branch resolution.
 	var allCwds []string

--- a/app/backend/internal/sessions/sessions_test.go
+++ b/app/backend/internal/sessions/sessions_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"testing"
 	"time"
 
@@ -389,8 +388,7 @@ func TestFetchPaneMapFabNotOnPath(t *testing.T) {
 	// non-nil error and a nil map. We force the failure by clearing PATH
 	// for the duration of this test.
 	t.Setenv("PATH", "")
-	repoRoot := t.TempDir()
-	m, err := fetchPaneMap("", repoRoot)
+	m, err := fetchPaneMap("")
 	if err == nil {
 		t.Error("expected error when fab is not on PATH, got nil")
 	}
@@ -416,10 +414,11 @@ func tmuxSocketDir() string {
 // TestFetchPaneMapIntegration exercises the real subprocess invocation path.
 // Skips when `fab` or `tmux` is not on PATH (CI without them installed).
 //
-// Go test binaries run with CWD = package directory, so to find the running
-// repo's fab/project/config.yaml we walk up from os.Getwd() using findRepoRoot.
-// We then reuse the running repo's fab_version in a freshly-written config.yaml
-// inside a t.TempDir(), so the router can resolve a version it knows how to run.
+// fetchPaneMap runs `fab pane map` from a neutral (non-project) dir, so the fab
+// router dispatches the globally-installed fab version regardless of any
+// project pin — no per-repo config setup is needed here (this is the whole
+// point of the cross-project version-independence fix). We just need a real
+// `fab` on PATH and a live socket to query.
 //
 // The test targets a freshly-booted, isolated rk-test-* tmux server rather than
 // the ambient default socket: `fab pane map --all-sessions` runs
@@ -434,46 +433,6 @@ func TestFetchPaneMapIntegration(t *testing.T) {
 	}
 	if _, err := exec.LookPath("tmux"); err != nil {
 		t.Skip("tmux not available on PATH")
-	}
-
-	// Locate the running repo's fab/project/config.yaml by walking up from the
-	// test binary's CWD (the package dir).
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("os.Getwd: %v", err)
-	}
-	repoRoot := findRepoRoot(cwd)
-	if repoRoot == "" {
-		t.Fatalf("could not locate repo root by walking up from %q", cwd)
-	}
-	configBytes, err := os.ReadFile(filepath.Join(repoRoot, "fab/project/config.yaml"))
-	if err != nil {
-		t.Fatalf("read running repo config.yaml: %v", err)
-	}
-	// Extract the fab_version line verbatim so the router sees a real,
-	// installed version.
-	versionRe := regexp.MustCompile(`(?m)^fab_version:\s*(\S+)\s*$`)
-	matches := versionRe.FindStringSubmatch(string(configBytes))
-	if len(matches) < 2 {
-		t.Fatalf("running repo config.yaml missing fab_version line:\n%s", configBytes)
-	}
-	fabVersion := matches[1]
-
-	// Create a temp dir with a minimal fab/project/config.yaml.
-	tempDir := t.TempDir()
-	projectDir := filepath.Join(tempDir, "fab", "project")
-	if err := os.MkdirAll(projectDir, 0o755); err != nil {
-		t.Fatalf("mkdir %s: %v", projectDir, err)
-	}
-	configPath := filepath.Join(projectDir, "config.yaml")
-	minimalConfig := fmt.Sprintf("fab_version: %s\nproject:\n  name: integration-test\n", fabVersion)
-	if err := os.WriteFile(configPath, []byte(minimalConfig), 0o644); err != nil {
-		t.Fatalf("write %s: %v", configPath, err)
-	}
-
-	// Sanity-check: findRepoRoot on tempDir should return tempDir itself.
-	if got := findRepoRoot(tempDir); got != tempDir {
-		t.Fatalf("findRepoRoot(%q) = %q, want %q", tempDir, got, tempDir)
 	}
 
 	// Boot an isolated tmux server with one known session so the subprocess
@@ -502,9 +461,9 @@ func TestFetchPaneMapIntegration(t *testing.T) {
 	// The subprocess call SHALL succeed against the live isolated server, and
 	// the booted session SHALL appear — proving the real parse+dedup path ran,
 	// not merely that "empty is tolerated".
-	paneMap, err := fetchPaneMap(server, tempDir)
+	paneMap, err := fetchPaneMap(server)
 	if err != nil {
-		t.Fatalf("fetchPaneMap(%q, %q) error: %v", server, tempDir, err)
+		t.Fatalf("fetchPaneMap(%q) error: %v", server, err)
 	}
 	found := false
 	for _, e := range paneMap {

--- a/fab/changes/260610-ziut-panemap-version-independent/.history.jsonl
+++ b/fab/changes/260610-ziut-panemap-version-independent/.history.jsonl
@@ -1,0 +1,8 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-06-10T05:22:28Z"}
+{"args":"Run fab pane map from a neutral dir so a stale-version sibling project can't strip PR fields server-wide","cmd":"fab-new","event":"command","ts":"2026-06-10T05:22:28Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"apply","ts":"2026-06-10T05:23:31Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review","ts":"2026-06-10T05:23:31Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"hydrate","ts":"2026-06-10T05:23:31Z"}
+{"event":"review","result":"passed","ts":"2026-06-10T05:23:31Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"ship","ts":"2026-06-10T05:23:31Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-06-10T05:23:31Z"}

--- a/fab/changes/260610-ziut-panemap-version-independent/.history.jsonl
+++ b/fab/changes/260610-ziut-panemap-version-independent/.history.jsonl
@@ -6,3 +6,4 @@
 {"event":"review","result":"passed","ts":"2026-06-10T05:23:31Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"ship","ts":"2026-06-10T05:23:31Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-06-10T05:23:31Z"}
+{"event":"review","result":"passed","ts":"2026-06-10T05:37:42Z"}

--- a/fab/changes/260610-ziut-panemap-version-independent/.status.yaml
+++ b/fab/changes/260610-ziut-panemap-version-independent/.status.yaml
@@ -1,0 +1,45 @@
+id: ziut
+name: 260610-ziut-panemap-version-independent
+created: 2026-06-10T05:22:28Z
+created_by: sahil-noon
+change_type: feat
+issues: []
+progress:
+    intake: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: done
+    review-pr: active
+plan:
+    generated: false
+    task_count: 0
+    acceptance_count: 0
+    acceptance_completed: 0
+confidence:
+    certain: 0
+    confident: 0
+    tentative: 0
+    unresolved: 0
+    score: 0.0
+stage_metrics:
+    intake: {started_at: "2026-06-10T05:22:28Z", driver: fab-new, iterations: 1, completed_at: "2026-06-10T05:23:31Z"}
+    apply: {started_at: "2026-06-10T05:23:31Z", driver: git-pr, iterations: 1, completed_at: "2026-06-10T05:23:31Z"}
+    review: {started_at: "2026-06-10T05:23:31Z", driver: git-pr, iterations: 1, completed_at: "2026-06-10T05:23:31Z"}
+    hydrate: {started_at: "2026-06-10T05:23:31Z", driver: git-pr, iterations: 1, completed_at: "2026-06-10T05:23:31Z"}
+    ship: {started_at: "2026-06-10T05:23:31Z", driver: git-pr, iterations: 1, completed_at: "2026-06-10T05:23:31Z"}
+    review-pr: {started_at: "2026-06-10T05:23:31Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/sahil87/run-kit/pull/250
+true_impact:
+    added: 35
+    deleted: 99
+    net: -64
+    excluding:
+        added: 35
+        deleted: 99
+        net: -64
+    computed_at: "2026-06-10T05:23:31Z"
+    computed_at_stage: hydrate
+# true_impact: lazily created on first apply-finish (no placeholder here).
+last_updated: 2026-06-10T05:23:31Z

--- a/fab/changes/260610-ziut-panemap-version-independent/.status.yaml
+++ b/fab/changes/260610-ziut-panemap-version-independent/.status.yaml
@@ -10,7 +10,7 @@ progress:
     review: done
     hydrate: done
     ship: done
-    review-pr: active
+    review-pr: done
 plan:
     generated: false
     task_count: 0
@@ -28,7 +28,7 @@ stage_metrics:
     review: {started_at: "2026-06-10T05:23:31Z", driver: git-pr, iterations: 1, completed_at: "2026-06-10T05:23:31Z"}
     hydrate: {started_at: "2026-06-10T05:23:31Z", driver: git-pr, iterations: 1, completed_at: "2026-06-10T05:23:31Z"}
     ship: {started_at: "2026-06-10T05:23:31Z", driver: git-pr, iterations: 1, completed_at: "2026-06-10T05:23:31Z"}
-    review-pr: {started_at: "2026-06-10T05:23:31Z", driver: git-pr, iterations: 1}
+    review-pr: {started_at: "2026-06-10T05:23:31Z", driver: git-pr, iterations: 1, completed_at: "2026-06-10T05:37:42Z"}
 prs:
     - https://github.com/sahil87/run-kit/pull/250
 true_impact:
@@ -42,4 +42,4 @@ true_impact:
     computed_at: "2026-06-10T05:23:31Z"
     computed_at_stage: hydrate
 # true_impact: lazily created on first apply-finish (no placeholder here).
-last_updated: 2026-06-10T05:23:31Z
+last_updated: 2026-06-10T05:37:42Z


### PR DESCRIPTION
## The bug

The PANE-panel `pr` row showed a bare `#247` with no status, even for windows whose project was on a fab version that emits PR fields. Root cause: **a single project's pinned `fab_version` was deciding the pane-map output schema for the entire tmux server.**

rk runs **one** `fab pane map --all-sessions` per server and set `cmd.Dir` to a `repoRoot` derived from the *first window's* worktree. The fab router picks which versioned `fab-go` to dispatch from that dir's `fab/project/config.yaml`. So if the first fab-project window belonged to a project pinned to an **older** fab (one predating a field like `pr_url`), that older binary parsed *every* window — silently stripping `pr_url`/`pr_number` from windows owned by projects on a **newer** fab.

Concretely: a `fab-kit` window pinned to `2.1.1` starved `run-kit`'s `2.1.2` worktree windows of their PR status. `change`/`stage` survived (they predate the field); only the newer fields vanished — which is why it looked like a run-kit bug rather than a version skew.

## Why "run it from a neutral dir" is the right fix

`pane map` is a **cross-project, cross-worktree** query. Each entry's data (`change`/`stage`/`pr_url`) is read from **the pane's own worktree** `.status.yaml` — it does **not** depend on `cmd.Dir`. The *only* thing `cmd.Dir` controlled was the router's version selection, and pinning that to any one window's project was the bug.

Fix: run `fab pane map` from `os.TempDir()` (a guaranteed non-project dir) so the router falls back to the **globally-installed** fab. The schema is then always the newest the host's fab CLI supports, never downgraded by a stale sibling project.

An explicit non-project dir is required — **not** merely unsetting `cmd.Dir`. If `cmd.Dir` is empty the subprocess inherits the daemon's CWD; if the daemon ever launches inside a fab project, that project's version would re-pin and reintroduce the bug. `os.TempDir()` is deterministic.

## Changes

- `fetchPaneMap(server)` (dropped the `repoRoot` param) sets `cmd.Dir = os.TempDir()`.
- `fetchPaneMapCached(server)` loses its `repoRoot` param.
- Removed the now-dead `findRepoRoot` helper and the first-window `repoRoot` derivation loop in `FetchSessions`.
- Integration test simplified — no more config-pinning setup (irrelevant now that version is CWD-independent).

Net: **+35 / −99** (mostly deletion).

## Verification

- Built a local binary and queried the mixed-version `kit2` server: all change-bound windows now get `prNumber` populated (including ones that were previously starved), regardless of any sibling project's fab pin.
- `go build ./...`, `go test -count=1 ./internal/sessions/`, backend (api/prstatus) — all green.

## Note

Independent of #248 (merged/closed PR state) — different files, no overlap. Either can merge first.