### PR TITLE
chore: Colorize sidebar PR status line, brighten and extend panel icons

### DIFF
--- a/app/frontend/src/components/sidebar/host-panel.tsx
+++ b/app/frontend/src/components/sidebar/host-panel.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { CollapsiblePanel } from "./collapsible-panel";
+import { ICON_CLASS } from "./icons";
 import { sparkline } from "@/lib/sparkline";
 import { gaugeBar, gaugeColor, formatMemory } from "@/lib/gauge";
 import { useMetrics } from "@/contexts/session-context";
@@ -50,6 +51,7 @@ export function HostPanel({ isConnected }: HostPanelProps) {
           {/* CPU sparkline — label+pct fixed, sparkline clips oldest (left) data on narrow panels */}
           <div className="flex items-baseline gap-[1ch]">
             <span className="text-text-secondary shrink-0">cpu</span>
+            <span className={`${ICON_CLASS} shrink-0`} aria-hidden="true">{"\uF2DB"}</span>
             <div className="text-accent flex-1 min-w-0 overflow-hidden" dir="rtl">
               <span className="whitespace-nowrap" dir="ltr">{sparkline(metrics.cpu.samples)}</span>
             </div>
@@ -62,6 +64,8 @@ export function HostPanel({ isConnected }: HostPanelProps) {
           {/* Disk + Uptime */}
           <div className="text-text-secondary truncate">
             <span>dsk </span>
+            <span className={ICON_CLASS} aria-hidden="true">{"\uF0A0"}</span>
+            {" "}
             <span>{formatDisk(metrics.disk.used, metrics.disk.total)}</span>
             <span> &middot; up </span>
             <span>{formatUptime(metrics.uptime)}</span>
@@ -104,6 +108,7 @@ function MemoryLine({ used, total }: { used: number; total: number }) {
   return (
     <div className="flex items-baseline gap-[1ch]">
       <span className="text-text-secondary shrink-0">mem</span>
+      <span className={`${ICON_CLASS} shrink-0`} aria-hidden="true">{"\u{F035B}"}</span>
       <div ref={gaugeRef} className="flex-1 min-w-0 overflow-hidden whitespace-nowrap">
         <span className={color}>{gaugeBar(ratio, charCount)}</span>
       </div>
@@ -132,6 +137,8 @@ function LoadLine({
   return (
     <div className="truncate">
       <span className="text-text-secondary">ld&nbsp; </span>
+      <span className={ICON_CLASS} aria-hidden="true">{"\uF0E4"}</span>
+      {" "}
       <span className={p1 > 90 ? redClass : "text-text-primary"}>{p1}%</span>
       <span className="text-text-secondary"> </span>
       <span className={p5 > 90 ? redClass : "text-text-primary"}>{p5}%</span>

--- a/app/frontend/src/components/sidebar/icons.ts
+++ b/app/frontend/src/components/sidebar/icons.ts
@@ -1,0 +1,4 @@
+/** Icon column treatment shared by the sidebar info panels (Pane, Host):
+ *  brighter token, bold weight, +2px size. leading-none keeps the taller
+ *  glyph inside the row's 16px line box (no row-height change). */
+export const ICON_CLASS = "text-accent-bright font-bold text-[14px] leading-none";

--- a/app/frontend/src/components/sidebar/status-panel.test.tsx
+++ b/app/frontend/src/components/sidebar/status-panel.test.tsx
@@ -397,9 +397,37 @@ describe("StatusPanel copy behavior", () => {
         prReview: "approved",
       });
       render(<StatusPanel window={win} nowSeconds={0} />);
-      expect(
-        screen.getByText("#241 · open · checks pass · review: approved"),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("pr-line")).toHaveTextContent(
+        "#241 · open · checks pass · review: approved",
+      );
+    });
+
+    it("colors the segments by state: open/pass/approved are green", () => {
+      const win = makeWindow({
+        fabChange: "260610-596o-pr-status-sidebar",
+        prNumber: 241,
+        prState: "open",
+        prChecks: "pass",
+        prReview: "approved",
+      });
+      render(<StatusPanel window={win} nowSeconds={0} />);
+      expect(screen.getByText("open").className).toContain("text-accent-green");
+      expect(screen.getByText("checks pass").className).toContain("text-accent-green");
+      expect(screen.getByText("review: approved").className).toContain("text-accent-green");
+      expect(screen.getByText("#241").className).toContain("text-text-primary");
+    });
+
+    it("colors pending checks yellow and a draft state neutral", () => {
+      const win = makeWindow({
+        fabChange: "260610-596o-pr-status-sidebar",
+        prNumber: 241,
+        prState: "open",
+        prIsDraft: true,
+        prChecks: "pending",
+      });
+      render(<StatusPanel window={win} nowSeconds={0} />);
+      expect(screen.getByText("checks pending").className).toContain("text-yellow-400");
+      expect(screen.getByText("open (draft)").className).toContain("text-text-secondary");
     });
 
     it("hides the pr row when the window is not change-bound", () => {
@@ -451,7 +479,9 @@ describe("StatusPanel copy behavior", () => {
       render(<StatusPanel window={win} nowSeconds={0} />);
       // Merged PRs show "#247 · merged" only — checks/review are historical
       // once a PR lands, so they're suppressed.
-      expect(screen.getByText("#247 · merged")).toBeInTheDocument();
+      expect(screen.getByTestId("pr-line")).toHaveTextContent("#247 · merged");
+      expect(screen.queryByText(/checks/)).toBeNull();
+      expect(screen.getByText("merged").className).toContain("text-purple-400");
     });
 
     it("shows the terminal state and suppresses checks/review for a closed PR", () => {
@@ -465,10 +495,10 @@ describe("StatusPanel copy behavior", () => {
       });
       render(<StatusPanel window={win} nowSeconds={0} />);
       // Closed PRs show "#247 · closed" only — same suppression as merged.
-      expect(screen.getByText("#247 · closed")).toBeInTheDocument();
+      expect(screen.getByTestId("pr-line")).toHaveTextContent("#247 · closed");
     });
 
-    it("does not apply the red token to a closed PR with a hidden failed check", () => {
+    it("suppresses a hidden failed check for a closed PR; only the state is red", () => {
       const win = makeWindow({
         fabChange: "260610-596o-x",
         prNumber: 247,
@@ -476,10 +506,12 @@ describe("StatusPanel copy behavior", () => {
         prChecks: "fail",
       });
       render(<StatusPanel window={win} nowSeconds={0} />);
-      // The failure text is suppressed for a terminal-state PR, so the row must
-      // stay neutral (no text-red-400) rather than red on a hidden reason.
-      const value = screen.getByText("#247 · closed");
-      expect(value.className).not.toContain("text-red-400");
+      // The failure text is suppressed for a terminal-state PR — the red on the
+      // state segment refers to "closed" itself (GitHub convention), never to a
+      // hidden failure reason, which must not leak into other segments.
+      expect(screen.queryByText(/checks/)).toBeNull();
+      expect(screen.getByText("closed").className).toContain("text-red-400");
+      expect(screen.getByText("#247").className).not.toContain("text-red-400");
     });
 
     it("renders an open-in-new-tab link to the PR URL", () => {
@@ -512,7 +544,7 @@ describe("StatusPanel copy behavior", () => {
       expect(screen.queryByRole("link")).toBeNull();
     });
 
-    it("applies the red token when checks fail", () => {
+    it("applies the red token to the failing checks segment", () => {
       const win = makeWindow({
         fabChange: "260610-596o-x",
         prNumber: 241,
@@ -520,8 +552,10 @@ describe("StatusPanel copy behavior", () => {
         prChecks: "fail",
       });
       render(<StatusPanel window={win} nowSeconds={0} />);
-      const value = screen.getByText("#241 · open · checks fail");
-      expect(value.className).toContain("text-red-400");
+      expect(screen.getByTestId("pr-line")).toHaveTextContent("#241 · open · checks fail");
+      expect(screen.getByText("checks fail").className).toContain("text-red-400");
+      // The failure is scoped to its segment — the still-open state stays green.
+      expect(screen.getByText("open").className).toContain("text-accent-green");
     });
   });
 });

--- a/app/frontend/src/components/sidebar/status-panel.tsx
+++ b/app/frontend/src/components/sidebar/status-panel.tsx
@@ -3,6 +3,7 @@ import { BrailleSnake } from "@/components/braille-snake";
 import { ClockSpinner } from "@/components/clock-spinner";
 import { StarTwinkle } from "@/components/star-twinkle";
 import { CollapsiblePanel } from "./collapsible-panel";
+import { ICON_CLASS } from "./icons";
 import { copyToClipboard } from "@/lib/clipboard";
 import { formatDuration, parseFabChange } from "@/lib/format";
 import type { WindowInfo } from "@/types";
@@ -67,33 +68,57 @@ function getAgentLine(win: WindowInfo): string | null {
   return win.agentState;
 }
 
-/**
- * Build the PR status line for the pane panel, e.g. "#241 · open · checks pass"
- * for an open PR, or "#241 · merged" once it lands. Returns null unless the
- * window is change-bound (`fabChange`) AND carries a `prNumber` — the same gate
- * the sidebar/dashboard PR surface uses. For a merged/closed PR the checks and
- * review parts are suppressed (they're historical once the PR is no longer
- * open); only the terminal state is shown.
- */
-function getPrLine(win: WindowInfo): string | null {
-  if (!win.fabChange || !win.prNumber) return null;
-  const parts = [`#${win.prNumber}`];
-  if (win.prState) parts.push(`${win.prState}${win.prIsDraft ? " (draft)" : ""}`);
-  const isOpen = !win.prState || win.prState === "open";
-  if (isOpen && win.prChecks && win.prChecks !== "none") parts.push(`checks ${win.prChecks}`);
-  if (isOpen && win.prReview && win.prReview !== "none") parts.push(`review: ${win.prReview.replace(/_/g, " ")}`);
-  return parts.join(" · ");
-}
+type PrSegment = { text: string; color: string };
+
+/** GitHub-style state colors: open=green, merged=purple, closed=red. */
+const PR_STATE_COLORS: Record<NonNullable<WindowInfo["prState"]>, string> = {
+  open: "text-accent-green",
+  merged: "text-purple-400",
+  closed: "text-red-400",
+};
+
+const PR_CHECKS_COLORS: Record<string, string> = {
+  pass: "text-accent-green",
+  fail: "text-red-400",
+  pending: "text-yellow-400",
+};
+
+const PR_REVIEW_COLORS: Record<string, string> = {
+  approved: "text-accent-green",
+  changes_requested: "text-red-400",
+  review_required: "text-yellow-400",
+};
 
 /**
- * Fail-ish PR states get the red token (mirrors the dashboard PrStatusLine).
- * Gated on the PR being open: getPrLine suppresses the checks/review text for a
- * merged/closed PR (it's historical once landed), so coloring the row red on a
- * now-hidden failure would be misleading — a terminal-state row stays neutral.
+ * Build the PR status line for the pane panel as colored segments, e.g.
+ * "#241 · open · checks pass" for an open PR, or "#241 · merged" once it
+ * lands. Returns null unless the window is change-bound (`fabChange`) AND
+ * carries a `prNumber` — the same gate the sidebar/dashboard PR surface uses.
+ * For a merged/closed PR the checks and review parts are suppressed (they're
+ * historical once the PR is no longer open); only the terminal state is shown.
+ * A draft PR keeps the neutral token for its state — draft is "not ready",
+ * not a healthy green.
  */
-function prIsFailish(win: WindowInfo): boolean {
+function getPrSegments(win: WindowInfo): PrSegment[] | null {
+  if (!win.fabChange || !win.prNumber) return null;
+  const segments: PrSegment[] = [{ text: `#${win.prNumber}`, color: "text-text-primary" }];
+  if (win.prState) {
+    segments.push({
+      text: `${win.prState}${win.prIsDraft ? " (draft)" : ""}`,
+      color: win.prIsDraft ? "text-text-secondary" : PR_STATE_COLORS[win.prState],
+    });
+  }
   const isOpen = !win.prState || win.prState === "open";
-  return isOpen && (win.prChecks === "fail" || win.prReview === "changes_requested");
+  if (isOpen && win.prChecks && win.prChecks !== "none") {
+    segments.push({ text: `checks ${win.prChecks}`, color: PR_CHECKS_COLORS[win.prChecks] });
+  }
+  if (isOpen && win.prReview && win.prReview !== "none") {
+    segments.push({
+      text: `review: ${win.prReview.replace(/_/g, " ")}`,
+      color: PR_REVIEW_COLORS[win.prReview],
+    });
+  }
+  return segments;
 }
 
 export function WindowPanel({ window: win, nowSeconds }: WindowPanelProps) {
@@ -177,15 +202,15 @@ function WindowContent({ win, nowSeconds }: { win: WindowInfo; nowSeconds: numbe
     : null;
   const processLine = getProcessLine(win, nowSeconds);
   const agentLine = getAgentLine(win);
-  const prLine = getPrLine(win);
-  const prFailish = prIsFailish(win);
+  const prSegments = getPrSegments(win);
+  const prText = prSegments?.map((s) => s.text).join(" · ") ?? "";
 
   return (
     <div className="flex flex-col gap-0 text-xs">
       {/* tmx */}
       {paneId ? (
         <CopyableRow prefix="tmx" copied={copiedRow === "tmx"} onCopy={() => handleCopy("tmx", paneId)}>
-          <span className="text-accent" aria-hidden="true">{"\uF489"}</span>
+          <span className={ICON_CLASS} aria-hidden="true">{"\uF489"}</span>
           {" "}
           <span className="text-text-secondary group-hover:text-accent">
             pane {activePaneIndex + 1}/{paneCount}{paneId && ` ${paneId}`}
@@ -194,7 +219,7 @@ function WindowContent({ win, nowSeconds }: { win: WindowInfo; nowSeconds: numbe
       ) : (
         <div className="truncate">
           <span className="text-text-secondary">tmx </span>
-          <span className="text-accent" aria-hidden="true">{"\uF489"}</span>
+          <span className={ICON_CLASS} aria-hidden="true">{"\uF489"}</span>
           {" "}
           <span className="text-text-secondary">
             pane {activePaneIndex + 1}/{paneCount}
@@ -204,7 +229,7 @@ function WindowContent({ win, nowSeconds }: { win: WindowInfo; nowSeconds: numbe
 
       {/* cwd */}
       <CopyableRow prefix="cwd" copied={copiedRow === "cwd"} onCopy={() => handleCopy("cwd", activePaneCwd)} title={activePaneCwd}>
-        <span className="text-accent" aria-hidden="true">{"\uF413"}</span>
+        <span className={ICON_CLASS} aria-hidden="true">{"\uF413"}</span>
         {" "}
         <span className="text-text-secondary group-hover:text-accent">{cwd}</span>
       </CopyableRow>
@@ -212,7 +237,7 @@ function WindowContent({ win, nowSeconds }: { win: WindowInfo; nowSeconds: numbe
       {/* git */}
       {gitBranch && (
         <CopyableRow prefix="git" copied={copiedRow === "git"} onCopy={() => handleCopy("git", gitBranch)}>
-          <span className="text-accent" aria-hidden="true">{"\uF418"}</span>
+          <span className={ICON_CLASS} aria-hidden="true">{"\uF418"}</span>
           {" "}
           <span className="text-text-primary group-hover:text-accent">{gitBranch}</span>
         </CopyableRow>
@@ -223,20 +248,25 @@ function WindowContent({ win, nowSeconds }: { win: WindowInfo; nowSeconds: numbe
           PR URL is present, a hover-revealed open link (right-aligned, always
           shown on touch) opens the PR in a new tab — the open + copy affordances
           are split the same way the sidebar window row splits its row-body
-          action from its hover action buttons. Gated via getPrLine. */}
-      {prLine && (
+          action from its hover action buttons. Gated via getPrSegments. */}
+      {prSegments && (
         <div className="group/pr relative">
           <CopyableRow
             prefix={"pr\u00A0"}
             copied={copiedRow === "pr"}
-            onCopy={() => handleCopy("pr", win.prUrl ?? prLine)}
+            onCopy={() => handleCopy("pr", win.prUrl ?? prText)}
             title={win.prUrl ?? undefined}
             className={win.prUrl ? "pr-6" : undefined}
           >
-            <span className="text-accent" aria-hidden="true">{"\uF407"}</span>
+            <span className={ICON_CLASS} aria-hidden="true">{"\uF407"}</span>
             {" "}
-            <span className={`${prFailish ? "text-red-400" : "text-text-secondary"} group-hover:text-accent`}>
-              {prLine}
+            <span data-testid="pr-line">
+              {prSegments.map((seg, i) => (
+                <span key={seg.text}>
+                  {i > 0 && <span className="text-text-secondary group-hover:text-accent">{" \u00B7 "}</span>}
+                  <span className={`${seg.color} group-hover:text-accent`}>{seg.text}</span>
+                </span>
+              ))}
             </span>
           </CopyableRow>
           {win.prUrl && (
@@ -259,7 +289,7 @@ function WindowContent({ win, nowSeconds }: { win: WindowInfo; nowSeconds: numbe
       {processLine && (
         <div className="truncate">
           <span className="text-text-secondary">run </span>
-          <BrailleSnake className="text-accent" />{" "}
+          <BrailleSnake className={ICON_CLASS} />{" "}
           <span className="text-text-secondary">{processLine}</span>
         </div>
       )}
@@ -268,7 +298,7 @@ function WindowContent({ win, nowSeconds }: { win: WindowInfo; nowSeconds: numbe
       {agentLine && (
         <div className="truncate">
           <span className="text-text-secondary">agt </span>
-          <StarTwinkle className="text-accent" />{" "}
+          <StarTwinkle className={ICON_CLASS} />{" "}
           <span className="text-text-secondary">{agentLine}</span>
         </div>
       )}
@@ -276,7 +306,7 @@ function WindowContent({ win, nowSeconds }: { win: WindowInfo; nowSeconds: numbe
       {/* fab */}
       {fabLine && (
         <CopyableRow prefix="fab" copied={copiedRow === "fab"} onCopy={() => handleCopy("fab", fabChange!.id)}>
-          <ClockSpinner className="text-accent" />{" "}
+          <ClockSpinner className={ICON_CLASS} />{" "}
           <span className="text-text-primary group-hover:text-accent">{fabLine}</span>
         </CopyableRow>
       )}

--- a/app/frontend/src/contexts/theme-context.test.tsx
+++ b/app/frontend/src/contexts/theme-context.test.tsx
@@ -402,7 +402,7 @@ describe("ThemeProvider", () => {
   });
 
   describe("CSS custom properties", () => {
-    it("applies all 8 CSS custom properties via deriveUIColors to document.documentElement.style", () => {
+    it("applies all 9 CSS custom properties via deriveUIColors to document.documentElement.style", () => {
       render(
         <ThemeProvider>
           <TestConsumer />
@@ -418,6 +418,7 @@ describe("ThemeProvider", () => {
       expect(style.getPropertyValue("--color-text-secondary")).toBe(derived.textSecondary);
       expect(style.getPropertyValue("--color-border")).toBe(derived.border);
       expect(style.getPropertyValue("--color-accent")).toBe(derived.accent);
+      expect(style.getPropertyValue("--color-accent-bright")).toBe(derived.accentBright);
       expect(style.getPropertyValue("--color-accent-green")).toBe(derived.accentGreen);
     });
 

--- a/app/frontend/src/contexts/theme-context.tsx
+++ b/app/frontend/src/contexts/theme-context.tsx
@@ -71,10 +71,10 @@ function readPreference(): { preference: string; themeDark: string; themeLight: 
 function applyThemeToDOM(theme: Theme): void {
   const root = document.documentElement;
 
-  // Derive the 8 UI colors from the full palette
+  // Derive the 9 UI colors from the full palette
   const uiColors: UIColors = deriveUIColors(theme.palette, theme.category);
 
-  // Set all 8 CSS custom properties
+  // Set all 9 CSS custom properties
   const colorKeys = Object.keys(COLOR_CSS_MAP) as (keyof UIColors)[];
   for (const key of colorKeys) {
     root.style.setProperty(COLOR_CSS_MAP[key], uiColors[key]);

--- a/app/frontend/src/globals.css
+++ b/app/frontend/src/globals.css
@@ -34,6 +34,7 @@
   --color-text-secondary: #7a8394;
   --color-border: #454d66;
   --color-accent: #5b8af0;
+  --color-accent-bright: #82a8f7;
   --color-accent-green: #22c55e;
   --font-mono: "MonaspiceNe Nerd Font Mono", monospace;
 }
@@ -47,6 +48,7 @@ html[data-theme="dark"] {
   --color-text-secondary: #7a8394;
   --color-border: #454d66;
   --color-accent: #5b8af0;
+  --color-accent-bright: #82a8f7;
   --color-accent-green: #22c55e;
 }
 
@@ -59,6 +61,9 @@ html[data-theme="light"] {
   --color-text-secondary: #6b7280;
   --color-border: #d1d5db;
   --color-accent: #4a7ae8;
+  /* "bright" means more salient than accent, relative to the theme background:
+     lighter on dark, darker + more saturated on light (lighter would wash out). */
+  --color-accent-bright: #3b66d6;
   --color-accent-green: #16a34a;
 }
 

--- a/app/frontend/src/themes.test.ts
+++ b/app/frontend/src/themes.test.ts
@@ -105,10 +105,11 @@ describe("themes", () => {
   });
 
   describe("COLOR_CSS_MAP", () => {
-    it("maps all 8 color keys to CSS custom property names", () => {
-      expect(Object.keys(COLOR_CSS_MAP)).toHaveLength(8);
+    it("maps all 9 color keys to CSS custom property names", () => {
+      expect(Object.keys(COLOR_CSS_MAP)).toHaveLength(9);
       expect(COLOR_CSS_MAP.bgPrimary).toBe("--color-bg-primary");
       expect(COLOR_CSS_MAP.accent).toBe("--color-accent");
+      expect(COLOR_CSS_MAP.accentBright).toBe("--color-accent-bright");
     });
   });
 });
@@ -148,13 +149,28 @@ describe("deriveUIColors", () => {
     expect(ui.border).not.toBe(theme.palette.background);
   });
 
-  it("all 8 keys are valid hex", () => {
+  it("all 9 keys are valid hex", () => {
     for (const theme of THEMES) {
       const ui = deriveUIColors(theme.palette, theme.category);
       const keys = Object.keys(ui) as (keyof UIColors)[];
-      expect(keys).toHaveLength(8);
+      expect(keys).toHaveLength(9);
       for (const key of keys) {
         expect(ui[key]).toMatch(HEX_RE);
+      }
+    }
+  });
+
+  it("derives accentBright lighter than accent on dark, darker on light", () => {
+    const luminance = (hex: string) => {
+      const n = parseInt(hex.slice(1), 16);
+      return ((n >> 16) & 0xff) + ((n >> 8) & 0xff) + (n & 0xff);
+    };
+    for (const theme of THEMES) {
+      const ui = deriveUIColors(theme.palette, theme.category);
+      if (theme.category === "dark") {
+        expect(luminance(ui.accentBright)).toBeGreaterThan(luminance(ui.accent));
+      } else {
+        expect(luminance(ui.accentBright)).toBeLessThan(luminance(ui.accent));
       }
     }
   });

--- a/app/frontend/src/themes.ts
+++ b/app/frontend/src/themes.ts
@@ -25,6 +25,7 @@ export type UIColors = {
   textSecondary: string;
   border: string;
   accent: string;
+  accentBright: string;
   accentGreen: string;
 };
 
@@ -47,6 +48,7 @@ export const COLOR_CSS_MAP: Record<keyof UIColors, string> = {
   textSecondary: "--color-text-secondary",
   border: "--color-border",
   accent: "--color-accent",
+  accentBright: "--color-accent-bright",
   accentGreen: "--color-accent-green",
 };
 
@@ -147,9 +149,10 @@ export function saturateHex(hex: string, factor: number): string {
 
 // ── Derivation functions ─────────────────────────────────────────────────────
 
-/** Derive the 8 UI CSS colors from a full theme palette. */
+/** Derive the 9 UI CSS colors from a full theme palette. */
 export function deriveUIColors(palette: ThemePalette, category: "dark" | "light"): UIColors {
   const isDark = category === "dark";
+  const accent = palette.ansi[4];
   return {
     bgPrimary: palette.background,
     bgCard: isDark ? lightenHex(palette.background, 8) : darkenHex(palette.background, 3),
@@ -157,7 +160,10 @@ export function deriveUIColors(palette: ThemePalette, category: "dark" | "light"
     textPrimary: palette.foreground,
     textSecondary: blendHex(palette.foreground, palette.ansi[8], 0.3),
     border: blendHex(palette.foreground, palette.background, 0.25),
-    accent: palette.ansi[4],
+    accent,
+    // "bright" = more salient than accent relative to the theme background:
+    // lighter on dark, darker + more saturated on light (lighter would wash out).
+    accentBright: isDark ? lightenHex(accent, 25) : saturateHex(darkenHex(accent, 12), 1.15),
     accentGreen: palette.ansi[2],
   };
 }


### PR DESCRIPTION
## Summary

The Pane panel's PR status line now renders as semantically colored segments (GitHub-style: open=green, merged=purple, closed=red; checks and review states in green/red/yellow) instead of a single gray string. Sidebar info-row icons are more prominent — a new `--color-accent-bright` theme token (salience-relative per theme: lighter on dark, darker/more saturated on light), bold weight, and a +2px size bump — and the Host panel's four rows (cpu, mem, dsk, ld) gain matching icons via a shared `ICON_CLASS`, uniform with the Pane panel.