### PR TITLE
fix: Sidebar PR status shows wrong state when PR numbers collide across repos

### DIFF
--- a/app/backend/api/pr_status_test.go
+++ b/app/backend/api/pr_status_test.go
@@ -26,6 +26,9 @@ func TestAttachPRStatusChangeBoundGate(t *testing.T) {
 		prStatus: stubSnapshotter{snap: map[string]prstatus.PRStatus{
 			"u386": {Number: 386, URL: "u386", State: "open", Checks: "pass", ReviewDecision: "approved"},
 			"u999": {Number: 999, URL: "u999", State: "merged", Checks: "fail"},
+			// Poisoned empty key: the collector never produces one, but the
+			// gate must still refuse to join an empty PrURL against it.
+			"": {State: "closed"},
 		}},
 	}
 
@@ -41,6 +44,9 @@ func TestAttachPRStatusChangeBoundGate(t *testing.T) {
 			// change-bound window with no PrURL (e.g. a stale fab that emits
 			// pr_number only) → no attach — the join key is the URL
 			{Index: 3, FabChange: "260610-z", PrNumber: intp(386), PrURL: nil},
+			// change-bound window with an EMPTY PrURL → gate treats it as
+			// missing; must not match an empty snapshot key
+			{Index: 4, FabChange: "260610-w", PrNumber: intp(7), PrURL: strp("")},
 		},
 	}}
 
@@ -58,6 +64,9 @@ func TestAttachPRStatusChangeBoundGate(t *testing.T) {
 	}
 	if ws[3].PrState != "" {
 		t.Errorf("window 3 (no PrURL) must stay empty: %+v", ws[3])
+	}
+	if ws[4].PrState != "" {
+		t.Errorf("window 4 (empty PrURL) must stay empty: %+v", ws[4])
 	}
 }
 

--- a/app/backend/api/pr_status_test.go
+++ b/app/backend/api/pr_status_test.go
@@ -13,19 +13,19 @@ import (
 
 // stubSnapshotter implements PRStatusSnapshotter with a canned map.
 type stubSnapshotter struct {
-	snap map[int]prstatus.PRStatus
+	snap map[string]prstatus.PRStatus
 }
 
-func (s stubSnapshotter) Snapshot() map[int]prstatus.PRStatus { return s.snap }
+func (s stubSnapshotter) Snapshot() map[string]prstatus.PRStatus { return s.snap }
 
 func intp(n int) *int       { return &n }
 func strp(s string) *string { return &s }
 
 func TestAttachPRStatusChangeBoundGate(t *testing.T) {
 	hub := &sseHub{
-		prStatus: stubSnapshotter{snap: map[int]prstatus.PRStatus{
-			386: {Number: 386, URL: "u386", State: "open", Checks: "pass", ReviewDecision: "approved"},
-			999: {Number: 999, URL: "u999", State: "merged", Checks: "fail"},
+		prStatus: stubSnapshotter{snap: map[string]prstatus.PRStatus{
+			"u386": {Number: 386, URL: "u386", State: "open", Checks: "pass", ReviewDecision: "approved"},
+			"u999": {Number: 999, URL: "u999", State: "merged", Checks: "fail"},
 		}},
 	}
 
@@ -34,12 +34,13 @@ func TestAttachPRStatusChangeBoundGate(t *testing.T) {
 		Windows: []tmux.WindowInfo{
 			// change-bound window with a matching PR → attach
 			{Index: 0, FabChange: "260610-x", PrNumber: intp(386), PrURL: strp("u386")},
-			// scratch window (no FabChange) WITH a PrNumber → gate blocks attach
+			// scratch window (no FabChange) WITH a PrURL → gate blocks attach
 			{Index: 1, FabChange: "", PrNumber: intp(999), PrURL: strp("u999")},
 			// change-bound window whose PR is not in the snapshot → no attach
-			{Index: 2, FabChange: "260610-y", PrNumber: intp(123)},
-			// change-bound window with no PrNumber → no attach
-			{Index: 3, FabChange: "260610-z", PrNumber: nil},
+			{Index: 2, FabChange: "260610-y", PrNumber: intp(123), PrURL: strp("u123")},
+			// change-bound window with no PrURL (e.g. a stale fab that emits
+			// pr_number only) → no attach — the join key is the URL
+			{Index: 3, FabChange: "260610-z", PrNumber: intp(386), PrURL: nil},
 		},
 	}}
 
@@ -50,20 +51,50 @@ func TestAttachPRStatusChangeBoundGate(t *testing.T) {
 		t.Errorf("window 0 (change-bound, matched) not enriched: %+v", ws[0])
 	}
 	if ws[1].PrState != "" || ws[1].PrChecks != "" || ws[1].PrReview != "" {
-		t.Errorf("window 1 (scratch) must NOT be enriched despite PrNumber: %+v", ws[1])
+		t.Errorf("window 1 (scratch) must NOT be enriched despite PrURL: %+v", ws[1])
 	}
 	if ws[2].PrState != "" {
 		t.Errorf("window 2 (no snapshot match) must stay empty: %+v", ws[2])
 	}
 	if ws[3].PrState != "" {
-		t.Errorf("window 3 (no PrNumber) must stay empty: %+v", ws[3])
+		t.Errorf("window 3 (no PrURL) must stay empty: %+v", ws[3])
+	}
+}
+
+func TestAttachPRStatusSameNumberDifferentRepos(t *testing.T) {
+	// Regression: two change-bound windows whose PRs share a number but live in
+	// different repos must each get THEIR OWN state. The old number-keyed join
+	// showed an open idea#18 as merged because shll#18 (same number) had merged.
+	hub := &sseHub{
+		prStatus: stubSnapshotter{snap: map[string]prstatus.PRStatus{
+			"https://github.com/sahil87/idea/pull/18": {Number: 18, URL: "https://github.com/sahil87/idea/pull/18", State: "open", Checks: "pass"},
+			"https://github.com/sahil87/shll/pull/18": {Number: 18, URL: "https://github.com/sahil87/shll/pull/18", State: "merged", Checks: "none"},
+		}},
+	}
+
+	sess := []sessions.ProjectSession{{
+		Name: "dev",
+		Windows: []tmux.WindowInfo{
+			{Index: 0, FabChange: "260612-a", PrNumber: intp(18), PrURL: strp("https://github.com/sahil87/idea/pull/18")},
+			{Index: 1, FabChange: "260612-b", PrNumber: intp(18), PrURL: strp("https://github.com/sahil87/shll/pull/18")},
+		},
+	}}
+
+	hub.attachPRStatus(sess)
+	ws := sess[0].Windows
+
+	if ws[0].PrState != "open" {
+		t.Errorf("idea#18 window state = %q, want open: %+v", ws[0].PrState, ws[0])
+	}
+	if ws[1].PrState != "merged" {
+		t.Errorf("shll#18 window state = %q, want merged: %+v", ws[1].PrState, ws[1])
 	}
 }
 
 func TestAttachPRStatusNilCollectorNoop(t *testing.T) {
 	hub := &sseHub{prStatus: nil}
 	sess := []sessions.ProjectSession{{
-		Windows: []tmux.WindowInfo{{FabChange: "x", PrNumber: intp(1)}},
+		Windows: []tmux.WindowInfo{{FabChange: "x", PrNumber: intp(1), PrURL: strp("u1")}},
 	}}
 	hub.attachPRStatus(sess) // must not panic
 	if sess[0].Windows[0].PrState != "" {
@@ -74,10 +105,10 @@ func TestAttachPRStatusNilCollectorNoop(t *testing.T) {
 func TestAttachPRStatusResetsStaleFields(t *testing.T) {
 	// A window carrying stale PR fields whose PR dropped from the snapshot must
 	// be cleared (wholesale-rebuild + reset semantics).
-	hub := &sseHub{prStatus: stubSnapshotter{snap: map[int]prstatus.PRStatus{}}}
+	hub := &sseHub{prStatus: stubSnapshotter{snap: map[string]prstatus.PRStatus{}}}
 	sess := []sessions.ProjectSession{{
 		Windows: []tmux.WindowInfo{
-			{FabChange: "x", PrNumber: intp(386), PrState: "open", PrChecks: "pass", PrReview: "approved", PrIsDraft: true},
+			{FabChange: "x", PrNumber: intp(386), PrURL: strp("u386"), PrState: "open", PrChecks: "pass", PrReview: "approved", PrIsDraft: true},
 		},
 	}}
 	hub.attachPRStatus(sess)

--- a/app/backend/api/sse.go
+++ b/app/backend/api/sse.go
@@ -342,9 +342,9 @@ func (h *sseHub) broadcastBoardChanged(server string, payload boardChangedPayloa
 // in-memory collector snapshot. It is a PURE read of prStatus.Snapshot() — NO
 // network/gh call — preserving the SSE hot path's zero-network-call guarantee.
 //
-// Gate: status is attached only to a window that has BOTH a non-nil PrURL
-// (from the pane-map enrichment) AND a non-empty FabChange (the change-bound
-// gate). The join is by canonical PR URL, never by bare PR number — numbers
+// Gate: status is attached only to a window that has BOTH a non-empty PrURL
+// (from the pane-map enrichment; nil and "" both fail the gate) AND a
+// non-empty FabChange (the change-bound gate). The join is by canonical PR URL, never by bare PR number — numbers
 // are only unique per repo, so a number join can pick up an unrelated repo's
 // PR state. The four display fields are always reset first so a window that
 // lost its PR (merged/closed → dropped from the snapshot) clears cleanly even
@@ -362,7 +362,7 @@ func (h *sseHub) attachPRStatus(sess []sessions.ProjectSession) {
 			w := &windows[wi]
 			// Reset display fields so stale values never linger.
 			w.PrState, w.PrChecks, w.PrReview, w.PrIsDraft = "", "", "", false
-			if w.FabChange == "" || w.PrURL == nil {
+			if w.FabChange == "" || w.PrURL == nil || *w.PrURL == "" {
 				continue
 			}
 			if st, ok := snap[*w.PrURL]; ok {

--- a/app/backend/api/sse.go
+++ b/app/backend/api/sse.go
@@ -43,13 +43,14 @@ func (prodBoardEntriesFetcher) ListBoardEntries(ctx context.Context, server stri
 	return tmux.ListBoardEntries(ctx, server)
 }
 
-// PRStatusSnapshotter supplies the current in-memory PR-status map, keyed by PR
-// number. Injected into the SSE hub so the poll path can attach live PR status
+// PRStatusSnapshotter supplies the current in-memory PR-status map, keyed by
+// canonical PR URL (PR numbers are only unique per repo — see prstatus.Collector).
+// Injected into the SSE hub so the poll path can attach live PR status
 // to change-bound windows via a PURE in-memory read — the hot path makes no
 // network call. Implemented by *prstatus.Collector; a one-method interface lets
 // tests stub it and lets the hub degrade gracefully (nil → no PR fields).
 type PRStatusSnapshotter interface {
-	Snapshot() map[int]prstatus.PRStatus
+	Snapshot() map[string]prstatus.PRStatus
 }
 
 // boardEventName is the SSE event type for board-membership changes. Matches
@@ -341,11 +342,13 @@ func (h *sseHub) broadcastBoardChanged(server string, payload boardChangedPayloa
 // in-memory collector snapshot. It is a PURE read of prStatus.Snapshot() — NO
 // network/gh call — preserving the SSE hot path's zero-network-call guarantee.
 //
-// Gate: status is attached only to a window that has BOTH a non-nil PrNumber
+// Gate: status is attached only to a window that has BOTH a non-nil PrURL
 // (from the pane-map enrichment) AND a non-empty FabChange (the change-bound
-// gate). The four display fields are always reset first so a window that lost
-// its PR (merged/closed → dropped from the snapshot) clears cleanly even on a
-// cached result slice (the cache stores the same slice by reference).
+// gate). The join is by canonical PR URL, never by bare PR number — numbers
+// are only unique per repo, so a number join can pick up an unrelated repo's
+// PR state. The four display fields are always reset first so a window that
+// lost its PR (merged/closed → dropped from the snapshot) clears cleanly even
+// on a cached result slice (the cache stores the same slice by reference).
 //
 // No-op when no collector is wired (nil prStatus) — degrades gracefully.
 func (h *sseHub) attachPRStatus(sess []sessions.ProjectSession) {
@@ -359,10 +362,10 @@ func (h *sseHub) attachPRStatus(sess []sessions.ProjectSession) {
 			w := &windows[wi]
 			// Reset display fields so stale values never linger.
 			w.PrState, w.PrChecks, w.PrReview, w.PrIsDraft = "", "", "", false
-			if w.FabChange == "" || w.PrNumber == nil {
+			if w.FabChange == "" || w.PrURL == nil {
 				continue
 			}
-			if st, ok := snap[*w.PrNumber]; ok {
+			if st, ok := snap[*w.PrURL]; ok {
 				w.PrState = st.State
 				w.PrChecks = st.Checks
 				w.PrReview = st.ReviewDecision

--- a/app/backend/internal/prstatus/prstatus.go
+++ b/app/backend/internal/prstatus/prstatus.go
@@ -51,9 +51,13 @@ type PRStatus struct {
 }
 
 // Collector holds the latest PR-status snapshot, refreshed in the background.
+// The map is keyed by canonical PR URL, NOT by PR number: numbers are only
+// unique per repository, and the batched query spans ALL of the viewer's repos,
+// so two open PRs can share a number (e.g. repoA#18 and repoB#18) and a
+// number-keyed map would let one silently clobber the other.
 type Collector struct {
 	mu       sync.RWMutex
-	byNumber map[int]PRStatus
+	byURL    map[string]PRStatus
 	interval time.Duration
 
 	// ghExec runs the batched gh query and returns its raw stdout. It is a
@@ -71,7 +75,7 @@ type Collector struct {
 // Call Start to begin the background goroutine.
 func NewCollector(interval time.Duration) *Collector {
 	return &Collector{
-		byNumber:  make(map[int]PRStatus),
+		byURL:     make(map[string]PRStatus),
 		interval:  interval,
 		ghExec:    defaultGhExec,
 		available: ghAvailable,
@@ -97,13 +101,13 @@ func (c *Collector) Start(ctx context.Context) {
 	}()
 }
 
-// Snapshot returns a deep copy of the current PR-status map. Callers may read
-// it freely without holding the lock.
-func (c *Collector) Snapshot() map[int]PRStatus {
+// Snapshot returns a deep copy of the current PR-status map, keyed by
+// canonical PR URL. Callers may read it freely without holding the lock.
+func (c *Collector) Snapshot() map[string]PRStatus {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	out := make(map[int]PRStatus, len(c.byNumber))
-	for k, v := range c.byNumber {
+	out := make(map[string]PRStatus, len(c.byURL))
+	for k, v := range c.byURL {
 		out[k] = v
 	}
 	return out
@@ -116,7 +120,7 @@ func (c *Collector) RefreshNow(ctx context.Context) {
 	c.refresh(ctx)
 }
 
-// refresh performs ONE batched gh call and rebuilds byNumber wholesale.
+// refresh performs ONE batched gh call and rebuilds byURL wholesale.
 //
 // Failure modes (all leave the last-good map untouched, return without error):
 //   - ghExec is nil (gh unavailable / collector not wired) → no-op
@@ -143,10 +147,10 @@ func (c *Collector) refresh(ctx context.Context) {
 		return
 	}
 
-	next := make(map[int]PRStatus, len(prs))
+	next := make(map[string]PRStatus, len(prs))
 	now := time.Now()
 	for _, p := range prs {
-		next[p.Number] = PRStatus{
+		next[p.URL] = PRStatus{
 			Number:         p.Number,
 			URL:            p.URL,
 			State:          mapState(p.State, p.IsDraft),
@@ -160,7 +164,7 @@ func (c *Collector) refresh(ctx context.Context) {
 	// REPLACE wholesale: a PR absent from the new result (merged/closed/no
 	// longer OPEN) is gone next cycle. This is the cleanup mechanism.
 	c.mu.Lock()
-	c.byNumber = next
+	c.byURL = next
 	c.mu.Unlock()
 }
 

--- a/app/backend/internal/prstatus/prstatus.go
+++ b/app/backend/internal/prstatus/prstatus.go
@@ -150,6 +150,13 @@ func (c *Collector) refresh(ctx context.Context) {
 	next := make(map[string]PRStatus, len(prs))
 	now := time.Now()
 	for _, p := range prs {
+		// URL is the map key: a node with an empty URL (malformed/partial gh
+		// JSON — url unmarshals to "" without error) must be skipped, or every
+		// such node would collide on the "" key and could attach a wrong
+		// status downstream.
+		if p.URL == "" {
+			continue
+		}
 		next[p.URL] = PRStatus{
 			Number:         p.Number,
 			URL:            p.URL,

--- a/app/backend/internal/prstatus/prstatus_test.go
+++ b/app/backend/internal/prstatus/prstatus_test.go
@@ -50,7 +50,7 @@ func TestRefreshBuildsSnapshot(t *testing.T) {
 	c.refresh(context.Background())
 
 	snap := c.Snapshot()
-	got, ok := snap[386]
+	got, ok := snap["https://example/pull/386"]
 	if !ok {
 		t.Fatalf("PR #386 missing from snapshot: %v", snap)
 	}
@@ -79,7 +79,7 @@ func TestRefreshWholesaleRebuildDropsAbsentPR(t *testing.T) {
 	)
 	c := newTestCollector(func(context.Context) ([]byte, error) { return out, nil })
 	c.refresh(context.Background())
-	if snap := c.Snapshot(); len(snap) != 2 || snap[100].Number != 100 || snap[200].Number != 200 {
+	if snap := c.Snapshot(); len(snap) != 2 || snap["u100"].Number != 100 || snap["u200"].Number != 200 {
 		t.Fatalf("first cycle snapshot = %v, want #100 and #200", snap)
 	}
 
@@ -90,10 +90,10 @@ func TestRefreshWholesaleRebuildDropsAbsentPR(t *testing.T) {
 	out = ghJSON(ghFixture(200, "u200", "OPEN", false, "SUCCESS", ""))
 	c.refresh(context.Background())
 	snap := c.Snapshot()
-	if _, ok := snap[100]; ok {
+	if _, ok := snap["u100"]; ok {
 		t.Error("PR #100 should be gone after wholesale rebuild")
 	}
-	if _, ok := snap[200]; !ok {
+	if _, ok := snap["u200"]; !ok {
 		t.Error("PR #200 should remain")
 	}
 	if len(snap) != 1 {
@@ -113,14 +113,14 @@ func TestRefreshStaleWhileRevalidateOnError(t *testing.T) {
 
 	// First refresh: good data.
 	c.refresh(context.Background())
-	if _, ok := c.Snapshot()[386]; !ok {
+	if _, ok := c.Snapshot()["u386"]; !ok {
 		t.Fatal("PR #386 missing after first refresh")
 	}
 
 	// Second refresh: gh errors — last-good map MUST be kept.
 	c.refresh(context.Background())
 	snap := c.Snapshot()
-	if got, ok := snap[386]; !ok || got.ReviewDecision != "approved" {
+	if got, ok := snap["u386"]; !ok || got.ReviewDecision != "approved" {
 		t.Errorf("stale-while-revalidate failed: snapshot = %v", snap)
 	}
 }
@@ -169,7 +169,7 @@ func TestRefreshBadJSONKeepsLastGood(t *testing.T) {
 	})
 	c.refresh(context.Background())
 	c.refresh(context.Background())
-	if _, ok := c.Snapshot()[7]; !ok {
+	if _, ok := c.Snapshot()["u7"]; !ok {
 		t.Error("bad JSON should keep last-good map")
 	}
 }
@@ -238,7 +238,7 @@ func TestDraftAndEnumCollapseEndToEnd(t *testing.T) {
 	c.refresh(context.Background())
 	snap := c.Snapshot()
 
-	p11 := snap[11]
+	p11 := snap["u11"]
 	if !p11.IsDraft {
 		t.Error("#11 should be draft")
 	}
@@ -247,15 +247,40 @@ func TestDraftAndEnumCollapseEndToEnd(t *testing.T) {
 	}
 	// #12 is a non-draft open PR with passing checks and an approval — exercises
 	// the SUCCESS→pass and APPROVED→approved collapses.
-	p12 := snap[12]
+	p12 := snap["u12"]
 	if p12.State != "open" || p12.IsDraft || p12.Checks != "pass" || p12.ReviewDecision != "approved" {
 		t.Errorf("#12 collapse wrong: %+v", p12)
 	}
 	// #13 is merged — the query now includes MERGED so a landed PR shows its
 	// terminal state (checks/review are "none"/none for the empty fixture).
-	p13 := snap[13]
+	p13 := snap["u13"]
 	if p13.State != "merged" {
 		t.Errorf("#13 should be merged, got %+v", p13)
+	}
+}
+
+func TestRefreshCrossRepoSameNumberNoCollision(t *testing.T) {
+	// PR numbers are only unique per repository. Two PRs sharing a number but
+	// living in different repos must BOTH survive the rebuild under their own
+	// URL keys — a number-keyed map let one clobber the other (the bug where an
+	// open repoA#18 displayed as merged because repoB#18 had merged).
+	c := newTestCollector(func(context.Context) ([]byte, error) {
+		return ghJSON(
+			ghFixture(18, "https://github.com/sahil87/idea/pull/18", "OPEN", false, "SUCCESS", "") + "," +
+				ghFixture(18, "https://github.com/sahil87/shll/pull/18", "MERGED", false, "", ""),
+		), nil
+	})
+	c.refresh(context.Background())
+	snap := c.Snapshot()
+
+	if len(snap) != 2 {
+		t.Fatalf("snapshot size = %d, want 2 (one per URL): %v", len(snap), snap)
+	}
+	if got := snap["https://github.com/sahil87/idea/pull/18"].State; got != "open" {
+		t.Errorf("idea#18 state = %q, want open", got)
+	}
+	if got := snap["https://github.com/sahil87/shll/pull/18"].State; got != "merged" {
+		t.Errorf("shll#18 state = %q, want merged", got)
 	}
 }
 
@@ -265,8 +290,8 @@ func TestSnapshotIsCopy(t *testing.T) {
 	})
 	c.refresh(context.Background())
 	snap := c.Snapshot()
-	delete(snap, 1) // mutate the copy
-	if _, ok := c.Snapshot()[1]; !ok {
+	delete(snap, "u1") // mutate the copy
+	if _, ok := c.Snapshot()["u1"]; !ok {
 		t.Error("mutating the snapshot must not affect the collector's map")
 	}
 }

--- a/app/backend/internal/prstatus/prstatus_test.go
+++ b/app/backend/internal/prstatus/prstatus_test.go
@@ -284,6 +284,29 @@ func TestRefreshCrossRepoSameNumberNoCollision(t *testing.T) {
 	}
 }
 
+func TestRefreshSkipsEmptyURL(t *testing.T) {
+	// A node with an empty URL (malformed/partial gh JSON) must be dropped —
+	// inserting it would make unrelated empty-URL nodes collide on the "" key.
+	c := newTestCollector(func(context.Context) ([]byte, error) {
+		return ghJSON(
+			ghFixture(1, "", "MERGED", false, "", "") + "," +
+				ghFixture(2, "u2", "OPEN", false, "SUCCESS", ""),
+		), nil
+	})
+	c.refresh(context.Background())
+	snap := c.Snapshot()
+
+	if _, ok := snap[""]; ok {
+		t.Error("empty-URL node must not be inserted under the \"\" key")
+	}
+	if len(snap) != 1 {
+		t.Errorf("snapshot size = %d, want 1 (only the valid node): %v", len(snap), snap)
+	}
+	if _, ok := snap["u2"]; !ok {
+		t.Error("valid node u2 should remain present")
+	}
+}
+
 func TestSnapshotIsCopy(t *testing.T) {
 	c := newTestCollector(func(context.Context) ([]byte, error) {
 		return ghJSON(ghFixture(1, "u1", "OPEN", false, "SUCCESS", "")), nil


### PR DESCRIPTION
## Problem

The sidebar pane line showed `sahil87/idea#18` as **merged** while the PR is actually open.

The `prstatus.Collector` fetches the viewer's 100 most-recently-updated PRs across **all** repos in one batched GraphQL call, but cached them in a map keyed by **bare PR number**. PR numbers are only unique per repository — `sahil87/idea#18` (open) and `sahil87/shll#18` (merged) both landed on key `18`, and the rebuild loop let the later node clobber the earlier one. The SSE join (`attachPRStatus`) then looked up the window's PR by number and attached the unrelated repo's state.

## Fix

Key the snapshot by **canonical PR URL** and join on the window's `PrURL` — both sides already carried the URL (the GraphQL query returns `url`; `fab pane map` emits `pr_url` next to `pr_number`), so no extra data is fetched.

- `internal/prstatus`: `byNumber map[int]PRStatus` → `byURL map[string]PRStatus`; `Snapshot()` returns the URL-keyed map
- `api/sse.go`: `PRStatusSnapshotter` interface updated; `attachPRStatus` gates on `PrURL != nil` and joins on `*w.PrURL`

A window lacking `pr_url` (e.g. a stale fab pane-map schema that predates the field) now gets no PR status instead of risking a wrong match.

## Tests

- New regression `TestRefreshCrossRepoSameNumberNoCollision`: two PRs sharing a number survive the rebuild under their own URL keys
- New regression `TestAttachPRStatusSameNumberDifferentRepos`: two change-bound windows with same-numbered PRs in different repos each get their own state
- Existing prstatus/attach tests re-keyed by URL; gate test now covers the `PrURL == nil` case
- `just test-backend` passes