### PR TITLE
fix: match PR status colors across dashboard, sidebar, and pane panel

### DIFF
--- a/app/frontend/src/components/pr-status-line.test.tsx
+++ b/app/frontend/src/components/pr-status-line.test.tsx
@@ -83,16 +83,18 @@ describe("PrStatusLine", () => {
     expect(line).toHaveTextContent("closed");
   });
 
-  it("uses the red token for failing checks", () => {
+  it("colors the failing-checks segment red (per-segment, not the whole line)", () => {
     render(
       <PrStatusLine
         win={makeWindow({ fabChange: "x", prNumber: 9, prState: "open", prChecks: "fail" })}
       />,
     );
-    expect(screen.getByTestId("pr-status-line").className).toContain("text-red-400");
+    // Container stays neutral; only the checks segment takes the red token.
+    expect(screen.getByTestId("pr-status-line").className).toContain("text-text-secondary");
+    expect(screen.getByText(/checks fail/).className).toContain("text-red-400");
   });
 
-  it("uses the red token when changes are requested", () => {
+  it("colors the changes-requested review segment red", () => {
     render(
       <PrStatusLine
         win={makeWindow({
@@ -103,7 +105,26 @@ describe("PrStatusLine", () => {
         })}
       />,
     );
-    expect(screen.getByTestId("pr-status-line").className).toContain("text-red-400");
+    expect(screen.getByText(/review: changes requested/).className).toContain("text-red-400");
+  });
+
+  it("colors the state word by GitHub state — merged is purple, matching the dot and panel", () => {
+    render(
+      <PrStatusLine
+        win={makeWindow({ fabChange: "x", prNumber: 9, prState: "merged", prChecks: "pass" })}
+      />,
+    );
+    expect(screen.getByText(/merged/).className).toContain("text-purple-400");
+  });
+
+  it("colors a passing-checks segment green on an open PR", () => {
+    render(
+      <PrStatusLine
+        win={makeWindow({ fabChange: "x", prNumber: 9, prState: "open", prChecks: "pass" })}
+      />,
+    );
+    expect(screen.getByText(/open/).className).toContain("text-accent-green");
+    expect(screen.getByText(/checks pass/).className).toContain("text-accent-green");
   });
 
   it("triggers refresh when the line (not the link) is clicked", () => {

--- a/app/frontend/src/components/pr-status-line.tsx
+++ b/app/frontend/src/components/pr-status-line.tsx
@@ -151,7 +151,7 @@ export function PrStatusLine({ win }: { win: WindowInfo }) {
 
   return (
     <div
-      className="flex items-center gap-1 text-xs text-text-secondary truncate"
+      className="flex items-center gap-1 text-xs text-text-secondary min-w-0 truncate"
       data-testid="pr-status-line"
       // Clicking the line (but not the link) kicks an on-demand refresh. This
       // is a best-effort progressive enhancement, NOT a semantic control — the
@@ -181,13 +181,16 @@ export function PrStatusLine({ win }: { win: WindowInfo }) {
         <span className="shrink-0">PR #{win.prNumber}</span>
       )}
       {win.prState && (
-        <span className={`shrink-0 ${PR_STATE_COLORS[win.prState]}`} aria-hidden="true">
-          {stateGlyph(win.prState)} {win.prState}
+        <span className={`shrink-0 ${PR_STATE_COLORS[win.prState]}`}>
+          {/* Glyph is decorative — the state word carries the meaning, so only
+              the glyph is hidden from screen readers (the line is the sole PR
+              signal on the dashboard, which has no accompanying dot). */}
+          <span aria-hidden="true">{stateGlyph(win.prState)}</span> {win.prState}
           {draftSuffix}
         </span>
       )}
       {summary.map((seg) => (
-        <span key={seg.text} className={`truncate ${seg.color}`}>
+        <span key={seg.text} className={`min-w-0 truncate ${seg.color}`}>
           {"·"} {seg.text}
         </span>
       ))}

--- a/app/frontend/src/components/pr-status-line.tsx
+++ b/app/frontend/src/components/pr-status-line.tsx
@@ -13,22 +13,59 @@ function stateGlyph(state: WindowInfo["prState"]): string {
   }
 }
 
-/** Human-readable checks/review summary, e.g. "checks pass" or "review: changes requested". */
-function summaryText(win: WindowInfo): string {
-  const parts: string[] = [];
+/**
+ * Colored checks/review segments for the live PR line, e.g. a green "checks
+ * pass" and a red "review: changes requested". Each segment carries its own
+ * color token from the shared vocabulary so the dashboard line matches the Pane
+ * panel segment-by-segment. Mirrors getPrSegments' rule: checks/review are
+ * historical once the PR is no longer open, so they're suppressed for a
+ * merged/closed PR (only the terminal state shows). `none`/absent is dropped.
+ */
+function summarySegments(win: WindowInfo): { text: string; color: string }[] {
+  const isOpen = !win.prState || win.prState === "open";
+  if (!isOpen) return [];
+  const parts: { text: string; color: string }[] = [];
   if (win.prChecks && win.prChecks !== "none") {
-    parts.push(`checks ${win.prChecks}`);
+    parts.push({ text: `checks ${win.prChecks}`, color: PR_CHECKS_COLORS[win.prChecks] });
   }
   if (win.prReview && win.prReview !== "none") {
-    parts.push(`review: ${win.prReview.replace(/_/g, " ")}`);
+    parts.push({ text: `review: ${win.prReview.replace(/_/g, " ")}`, color: PR_REVIEW_COLORS[win.prReview] });
   }
-  return parts.join(" · ");
+  return parts;
 }
 
 /** Fail-ish states get the red token; everything else uses the secondary token. */
 export function isFailish(win: WindowInfo): boolean {
   return win.prChecks === "fail" || win.prReview === "changes_requested";
 }
+
+/**
+ * Per-segment PR color vocabulary, shared by ALL three PR surfaces — the sidebar
+ * dot (via prDotState/PR_DOT_COLOR), the dashboard line (PrStatusLine, below),
+ * and the Pane panel segments (status-panel.tsx getPrSegments, which imports
+ * these). GitHub-style: open=green, merged=purple, closed=red; checks/review
+ * pass/approved=green, fail/changes_requested=red, pending/review_required=
+ * yellow. No new hex — `text-accent-green` is the theme token (themes.ts); the
+ * other four are the established PR Tailwind tokens. This is the single source
+ * of truth so a token rename touches one place and every surface stays in step.
+ */
+export const PR_STATE_COLORS: Record<NonNullable<WindowInfo["prState"]>, string> = {
+  open: "text-accent-green",
+  merged: "text-purple-400",
+  closed: "text-red-400",
+};
+
+export const PR_CHECKS_COLORS: Record<string, string> = {
+  pass: "text-accent-green",
+  fail: "text-red-400",
+  pending: "text-yellow-400",
+};
+
+export const PR_REVIEW_COLORS: Record<string, string> = {
+  approved: "text-accent-green",
+  changes_requested: "text-red-400",
+  review_required: "text-yellow-400",
+};
 
 /**
  * The five "traffic-light" states for the sidebar PR dot, generalizing the old
@@ -98,18 +135,23 @@ export const PR_DOT_LABEL: Record<PrDotState, string> = {
  * external link (new tab) whose click is stopped from bubbling so it never
  * selects/navigates the window. Clicking the rest of the line triggers a
  * best-effort `refreshPrStatus()` (the refreshed status arrives via SSE).
+ *
+ * Each segment is colored from the shared PR vocabulary (PR_STATE_COLORS /
+ * PR_CHECKS_COLORS / PR_REVIEW_COLORS) — the SAME tokens the sidebar dot and the
+ * Pane panel use — so a merged PR reads purple, a passing check green, a failing
+ * one red, on every surface. The container itself stays `text-text-secondary`
+ * (the default for `PR #<n>`, glyph, and separators); only the state and
+ * checks/review words take a state color.
  */
 export function PrStatusLine({ win }: { win: WindowInfo }) {
   if (!win.fabChange || !win.prNumber) return null;
 
-  const failish = isFailish(win);
-  const colorClass = failish ? "text-red-400" : "text-text-secondary";
-  const summary = summaryText(win);
+  const summary = summarySegments(win);
   const draftSuffix = win.prIsDraft ? " (draft)" : "";
 
   return (
     <div
-      className={`flex items-center gap-1 text-xs ${colorClass} truncate`}
+      className="flex items-center gap-1 text-xs text-text-secondary truncate"
       data-testid="pr-status-line"
       // Clicking the line (but not the link) kicks an on-demand refresh. This
       // is a best-effort progressive enhancement, NOT a semantic control — the
@@ -139,12 +181,16 @@ export function PrStatusLine({ win }: { win: WindowInfo }) {
         <span className="shrink-0">PR #{win.prNumber}</span>
       )}
       {win.prState && (
-        <span className="shrink-0" aria-hidden="true">
+        <span className={`shrink-0 ${PR_STATE_COLORS[win.prState]}`} aria-hidden="true">
           {stateGlyph(win.prState)} {win.prState}
           {draftSuffix}
         </span>
       )}
-      {summary && <span className="truncate">{"·"} {summary}</span>}
+      {summary.map((seg) => (
+        <span key={seg.text} className={`truncate ${seg.color}`}>
+          {"·"} {seg.text}
+        </span>
+      ))}
     </div>
   );
 }

--- a/app/frontend/src/components/sidebar/status-panel.tsx
+++ b/app/frontend/src/components/sidebar/status-panel.tsx
@@ -7,6 +7,7 @@ import { CollapsiblePanel } from "./collapsible-panel";
 import { ICON_CLASS } from "./icons";
 import { copyToClipboard } from "@/lib/clipboard";
 import { formatDuration, parseFabChange } from "@/lib/format";
+import { PR_STATE_COLORS, PR_CHECKS_COLORS, PR_REVIEW_COLORS } from "@/components/pr-status-line";
 import type { WindowInfo } from "@/types";
 
 type CopyableRowKey = "tmx" | "cwd" | "git" | "fab" | "pr";
@@ -70,24 +71,9 @@ function getAgentLine(win: WindowInfo): string | null {
 
 type PrSegment = { text: string; color: string };
 
-/** GitHub-style state colors: open=green, merged=purple, closed=red. */
-const PR_STATE_COLORS: Record<NonNullable<WindowInfo["prState"]>, string> = {
-  open: "text-accent-green",
-  merged: "text-purple-400",
-  closed: "text-red-400",
-};
-
-const PR_CHECKS_COLORS: Record<string, string> = {
-  pass: "text-accent-green",
-  fail: "text-red-400",
-  pending: "text-yellow-400",
-};
-
-const PR_REVIEW_COLORS: Record<string, string> = {
-  approved: "text-accent-green",
-  changes_requested: "text-red-400",
-  review_required: "text-yellow-400",
-};
+// PR segment color vocabulary (PR_STATE_COLORS / PR_CHECKS_COLORS /
+// PR_REVIEW_COLORS) is imported from pr-status-line.tsx — the single source of
+// truth shared with the sidebar dot and the dashboard PR line.
 
 /**
  * Build the PR status line for the pane panel as colored segments, e.g.


### PR DESCRIPTION
## Problem

The dashboard PR line (`PrStatusLine`) only had **two** colors — red for fail-ish, grey for everything else. So a **merged PR rendered grey on the dashboard** while the sidebar dot (added in #267) showed it **purple**. The three PR surfaces were not actually consistent, despite the claim that they shared one color story.

Follow-up to #267 (merged): #267's dot/precedence work shipped, but `PrStatusLine` — the dashboard's PR surface — never adopted the color vocabulary.

## Fix

- **Single source of truth**: lift the per-segment color maps (`PR_STATE_COLORS` / `PR_CHECKS_COLORS` / `PR_REVIEW_COLORS`) into `pr-status-line.tsx`, colocated with `prDotState` / `PR_DOT_COLOR`. `status-panel.tsx` now **imports** them instead of defining its own copies (removes the duplication a #267 review flagged).
- **Per-segment coloring**: `PrStatusLine` colors each segment by state — the state word by GitHub state (`merged`→purple, `open`→green, `closed`→red) and each checks/review segment by its own token (`pass`→green, `fail`→red, `pending`→yellow) — instead of a flat red/grey line. The container stays neutral for `PR #<n>` and separators.
- **Suppression alignment**: `PrStatusLine` now suppresses checks/review for merged/closed PRs (they're historical), matching what the pane panel already does.

All three surfaces — sidebar dot, dashboard line, pane panel — now share one color vocabulary. No new color tokens.

## Result

| Surface | Merged PR before | Merged PR after |
|---|---|---|
| Sidebar dot | 🟣 purple | 🟣 purple |
| Pane panel | 🟣 purple | 🟣 purple |
| **Dashboard line** | ⚪ grey | 🟣 **purple** |

## Tests

- `tsc --noEmit`: clean
- Scoped unit tests (`pr-status-line` / `window-row` / `status-panel`): **97 passed**
- Rewrote the two binary-line-color assertions into per-segment assertions; added merged→purple and open→green coverage.

Frontend-only. No backend change, no new color tokens.