### PR TITLE
fix: drop font-bold on sidebar braille/unicode spinners

### DIFF
--- a/app/frontend/src/components/sidebar/status-panel.tsx
+++ b/app/frontend/src/components/sidebar/status-panel.tsx
@@ -299,7 +299,7 @@ function WindowContent({ win }: { win: WindowInfo }) {
       {processLine && (
         <div className="truncate">
           <span className="text-text-secondary">run </span>
-          <BrailleSnake className={ICON_CLASS} />{" "}
+          <BrailleSnake className={`${ICON_CLASS} font-normal`} />{" "}
           <span className="text-text-secondary">{processLine}</span>
         </div>
       )}
@@ -308,7 +308,7 @@ function WindowContent({ win }: { win: WindowInfo }) {
       {agentLine && (
         <div className="truncate">
           <span className="text-text-secondary">agt </span>
-          <StarTwinkle className={ICON_CLASS} />{" "}
+          <StarTwinkle className={`${ICON_CLASS} font-normal`} />{" "}
           <span className="text-text-secondary">{agentLine}</span>
         </div>
       )}
@@ -316,7 +316,7 @@ function WindowContent({ win }: { win: WindowInfo }) {
       {/* fab */}
       {fabLine && (
         <CopyableRow prefix="fab" copied={copiedRow === "fab"} onCopy={() => handleCopy("fab", fabChange!.id)}>
-          <ClockSpinner className={ICON_CLASS} />{" "}
+          <ClockSpinner className={`${ICON_CLASS} font-normal`} />{" "}
           <span className="text-text-primary group-hover:text-accent">{fabLine}</span>
         </CopyableRow>
       )}


### PR DESCRIPTION
## Summary

The sidebar PANE panel's `run` row braille spinner rendered with a barely-visible empty dot — it looked like a faint smudge or border. Root cause: the shared `ICON_CLASS` applies `font-bold`, which fattens braille's raised dots until the empty-dot gap (the part that conveys the snake's motion) bloats and merges into its neighbors. `ICON_CLASS` is correct for the Nerd Font icon rows (`tmx`/`cwd`/`git`/`pr`) that have a real weight axis, but it hurt the three animated unicode/braille spinners that reuse it.

## Changes

- Append `font-normal` to the `BrailleSnake` (`run`), `StarTwinkle` (`agt`), and `ClockSpinner` (`fab`) call sites in `status-panel.tsx` — Tailwind's later utility overrides the inherited `font-bold`.
- `ICON_CLASS` itself is untouched, so the Nerd Font icon rows keep their bold treatment.

Verified: `tsc --noEmit` passes clean. A bold-vs-normal comparison at the real 14px size confirmed the empty-dot legibility recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)