### PR TITLE
feat: swatch popover 4×3 grid with Clear spanning bottom-right

### DIFF
--- a/app/frontend/src/components/swatch-popover.test.tsx
+++ b/app/frontend/src/components/swatch-popover.test.tsx
@@ -126,7 +126,7 @@ describe("SwatchPopover", () => {
     renderWithTheme(<SwatchPopover selectedColor="1+3" onSelect={onSelect} onClose={onClose} />);
 
     const listbox = screen.getByRole("listbox");
-    // In the 4-col grid, slot 6 ("o") + ArrowDown → Clear (no real swatch below it).
+    // In the 4-col grid, slot 6 ("1+3") + ArrowDown → Clear (no real swatch below it).
     fireEvent.keyDown(listbox, { key: "ArrowDown" });
     fireEvent.keyDown(listbox, { key: "Enter" });
     expect(onSelect).toHaveBeenLastCalledWith(null);

--- a/app/frontend/src/components/swatch-popover.test.tsx
+++ b/app/frontend/src/components/swatch-popover.test.tsx
@@ -119,6 +119,44 @@ describe("SwatchPopover", () => {
     expect(onSelect).toHaveBeenLastCalledWith(null);
   });
 
+  it("ArrowDown from the bottom swatch row lands on Clear; Enter clears", () => {
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    // Focus starts on the first blend (slot 6, "1+3") via selectedColor.
+    renderWithTheme(<SwatchPopover selectedColor="1+3" onSelect={onSelect} onClose={onClose} />);
+
+    const listbox = screen.getByRole("listbox");
+    // In the 4-col grid, slot 6 ("o") + ArrowDown → Clear (no real swatch below it).
+    fireEvent.keyDown(listbox, { key: "ArrowDown" });
+    fireEvent.keyDown(listbox, { key: "Enter" });
+    expect(onSelect).toHaveBeenLastCalledWith(null);
+  });
+
+  it("ArrowUp from Clear returns to the swatch above its left edge (orange)", () => {
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    renderWithTheme(<SwatchPopover onSelect={onSelect} onClose={onClose} />);
+
+    const listbox = screen.getByRole("listbox");
+    // Walk to Clear (10 ArrowRights from slot 0), then ArrowUp → slot 6 ("1+3"), Enter selects it.
+    for (let i = 0; i < PICKER_COLOR_VALUES.length; i++) {
+      fireEvent.keyDown(listbox, { key: "ArrowRight" });
+    }
+    fireEvent.keyDown(listbox, { key: "ArrowUp" });
+    fireEvent.keyDown(listbox, { key: "Enter" });
+    expect(onSelect).toHaveBeenLastCalledWith("1+3");
+  });
+
+  it("Clear renders inside the grid (col-span cell), still reachable by label", () => {
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    renderWithTheme(<SwatchPopover selectedColor="4" onSelect={onSelect} onClose={onClose} />);
+    const clear = screen.getByText("Clear");
+    expect(clear.className).toContain("col-span-2");
+    fireEvent.click(clear);
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+
   it("Space selects the focused blend swatch", () => {
     const onSelect = vi.fn();
     const onClose = vi.fn();

--- a/app/frontend/src/components/swatch-popover.tsx
+++ b/app/frontend/src/components/swatch-popover.tsx
@@ -75,7 +75,7 @@ export function SwatchPopover({ selectedColor, onSelect, onClose }: SwatchPopove
           const next = i + GRID_COLS;
           if (next < colorCount) return next; // lands on a real swatch
           // Past the last swatch row: any downward move lands on Clear, which
-          // occupies the right half of the final row (cols CLEAR_COL..3).
+          // occupies the right half of the final row (cols `colorCount % GRID_COLS`..3).
           return clearIndex;
         });
       } else if (e.key === "ArrowUp") {
@@ -86,7 +86,7 @@ export function SwatchPopover({ selectedColor, onSelect, onClose }: SwatchPopove
             // Step up one row, same column → the swatch directly above Clear's left edge.
             const clearCol = colorCount % GRID_COLS;
             const clearRow = Math.floor(colorCount / GRID_COLS);
-            return (clearRow - 1) * GRID_COLS + clearCol; // 10 swatches → slot 6 ("o")
+            return (clearRow - 1) * GRID_COLS + clearCol; // 10 swatches → slot 6 ("1+3", orange)
           }
           const prev = i - GRID_COLS;
           return prev >= 0 ? prev : i;

--- a/app/frontend/src/components/swatch-popover.tsx
+++ b/app/frontend/src/components/swatch-popover.tsx
@@ -9,8 +9,11 @@ type SwatchPopoverProps = {
   onClose: () => void;
 };
 
-/** Grid columns — must match the Tailwind `grid-cols-3` below for nav math. */
-const GRID_COLS = 3;
+/** Grid columns — must match the Tailwind `grid-cols-4` below for nav math.
+ *  Layout: 10 swatches fill rows 0-1 (cols 0-3) + row 2 cols 0-1; Clear is the
+ *  11th item, occupying the remaining cells of the final row as a `col-span`
+ *  cell (bottom-right). With 10 swatches that's row 2, cols 2-3. */
+const GRID_COLS = 4;
 
 export function SwatchPopover({ selectedColor, onSelect, onClose }: SwatchPopoverProps) {
   const { theme } = useTheme();
@@ -68,17 +71,22 @@ export function SwatchPopover({ selectedColor, onSelect, onClose }: SwatchPopove
       } else if (e.key === "ArrowDown") {
         e.preventDefault();
         setFocusIndex((i) => {
-          if (i >= clearIndex) return i; // already on Clear
+          if (i >= clearIndex) return i; // already on Clear (last row)
           const next = i + GRID_COLS;
-          // Drop past the last grid row → land on Clear.
-          return next < colorCount ? next : clearIndex;
+          if (next < colorCount) return next; // lands on a real swatch
+          // Past the last swatch row: any downward move lands on Clear, which
+          // occupies the right half of the final row (cols CLEAR_COL..3).
+          return clearIndex;
         });
       } else if (e.key === "ArrowUp") {
         e.preventDefault();
         setFocusIndex((i) => {
           if (i >= clearIndex) {
-            // From Clear, jump back into the last occupied swatch in the grid.
-            return colorCount - 1;
+            // Clear occupies the final row starting at column `colorCount % GRID_COLS`.
+            // Step up one row, same column → the swatch directly above Clear's left edge.
+            const clearCol = colorCount % GRID_COLS;
+            const clearRow = Math.floor(colorCount / GRID_COLS);
+            return (clearRow - 1) * GRID_COLS + clearCol; // 10 swatches → slot 6 ("o")
           }
           const prev = i - GRID_COLS;
           return prev >= 0 ? prev : i;
@@ -104,7 +112,7 @@ export function SwatchPopover({ selectedColor, onSelect, onClose }: SwatchPopove
       onKeyDown={handleKeyDown}
       className="bg-bg-primary border border-border rounded-md shadow-lg p-1.5 z-50 w-max"
     >
-      <div className="grid grid-cols-3 gap-1">
+      <div className="grid grid-cols-4 gap-1">
         {PICKER_COLOR_VALUES.map((value, i) => {
           const tint = rowTints.get(value);
           const fallback = colorValueToHex(value, theme.palette) ?? theme.palette.foreground;
@@ -134,17 +142,18 @@ export function SwatchPopover({ selectedColor, onSelect, onClose }: SwatchPopove
             </button>
           );
         })}
+        {/* Clear — bottom-right, spanning the final row's remaining cells. */}
+        <button
+          role="option"
+          aria-selected={selectedColor == null}
+          onClick={() => onSelect(null)}
+          className={`col-span-2 h-5 text-[10px] text-text-secondary hover:text-text-primary rounded-sm transition-colors flex items-center justify-center ${
+            focusIndex === clearIndex ? "ring-1 ring-text-secondary" : ""
+          }`}
+        >
+          Clear
+        </button>
       </div>
-      <button
-        role="option"
-        aria-selected={selectedColor == null}
-        onClick={() => onSelect(null)}
-        className={`mt-1 w-full text-[10px] text-text-secondary hover:text-text-primary py-0.5 rounded-sm transition-colors ${
-          focusIndex === clearIndex ? "ring-1 ring-text-secondary" : ""
-        }`}
-      >
-        Clear
-      </button>
     </div>
   );
 }


### PR DESCRIPTION
## What

Reflows the sidebar color picker (`SwatchPopover`) from a **3-column** grid to a **4-column** grid, and moves **Clear into the grid** as a `col-span-2` cell in the bottom-right.

**Before** — `grid-cols-3`, 10 swatches as 3/3/3/1 (ragged last row, one lone swatch), Clear a separate full-width text button below the grid.

**After** — `grid-cols-4`, 10 swatches as 4/4/2, Clear spanning the final row's remaining two cells (bottom-right), keeping its readable label:

```
┌───┬───┬───┬───┐
│ 1 │ 2 │ 3 │ 4 │
├───┼───┼───┼───┤
│ 5 │ 6 │ o │ p │
├───┼───┼───┼───────┐
│ s │ l │  Clear    │  ← col-span-2
└───┴───┴───────────┘
```

## Why

The 3-column layout was inherited from the original 6-swatch picker (6 + Clear = a clean 3×3); when the palette expanded to 10 (#271) the grid was left at 3 columns and just reflowed, leaving an orphan swatch and a detached Clear. 4 columns packs 10 swatches into a tidy 4/4/2, and a spanning Clear fills the bottom-right with no orphan gap.

## Keyboard nav

The 2D arrow-key math was reworked for the new geometry:
- **ArrowDown** from the bottom swatch row → Clear.
- **ArrowUp** from Clear → the swatch directly above its left edge (orange). Clear's row/column is **derived** from the swatch count + `GRID_COLS`, so the math survives a future palette-size change rather than hard-coding slot indices.
- **ArrowLeft/Right** stay linear (clamped), preserving the existing traversal test.

Keyboard reachability of every swatch + Clear is a Constitution §V (Keyboard-First) requirement.

## Tests

- Added: ArrowDown→Clear, ArrowUp-from-Clear→orange (the changed geometry), and a `col-span-2` Clear structural assertion.
- Frontend suite green: **745/745** (44 files). Typecheck clean.

Frontend-only; no backend/API/SSE change.