### PR TITLE
fix: unify status-dot sizes so the done square doesn't dominate the circles

### DIFF
--- a/app/frontend/src/components/status-dot.tsx
+++ b/app/frontend/src/components/status-dot.tsx
@@ -23,15 +23,21 @@ import type { WindowInfo } from "@/types";
  * inside a `failed` dashed ring — never as a whole-dot color (this removes the
  * old `fabDisplayState === "failed"` red tint and the old solid-red PR fail).
  *
- * `failed` and `done` render slightly larger (8px vs the 6px ring/solid) so the
- * dashed border shows enough dashes (with a clearly visible red center) and the
- * rounded square reads unambiguously as a square next to the circles.
+ * Every shape renders at one uniform 7px footprint (`DOT_SIZE`) so the filled
+ * square and the hollow circles read as the same size in the dense sidebar; the
+ * square is distinguished by its shape (`rounded-[1px]`), not by being bigger.
  *
  * The dot always carries `role="img"` + `aria-label` + `title` composed from
  * phase + status (e.g. "apply — active", "PR — merged", "review — failed",
  * "intake — pending"), or "active"/"idle" for the tmux fallback — color is
  * never the sole channel (colorblind a11y + keyboard-first constitution).
  */
+
+// Every shape renders at one uniform footprint so the filled square and the
+// hollow circles read as the same size in the dense sidebar (a filled 8px
+// square next to a hollow 6px ring looks much bigger). 7px is the middle ground
+// that still leaves the dashed failed-ring + red center legible.
+const DOT_SIZE = "w-[7px] h-[7px]";
 
 /** Human word for the SHAPE/status axis used in the accessible label. */
 const SHAPE_LABEL: Record<DotShape, string> = {
@@ -83,25 +89,26 @@ export function StatusDot({ win }: { win: WindowInfo }) {
   const common = { role: "img" as const, "aria-label": label, title: label };
 
   if (state.shape === "done") {
-    // Square (barely-softened corners) — slightly larger so it reads clearly as
-    // a square next to the circles. A larger radius (e.g. 3px on this ~8px box)
-    // rounds the corners enough to look like a circle, so keep it ~1px.
+    // Square (barely-softened corners). A larger radius (e.g. 3px on this 7px
+    // box) rounds the corners enough to look like a circle, so keep it ~1px.
+    // Same DOT_SIZE as every other shape so the square doesn't visually dominate
+    // the circles in the dense sidebar.
     return (
       <span
         {...common}
-        className={`w-2 h-2 rounded-[1px] shrink-0 ${color}`}
+        className={`${DOT_SIZE} rounded-[1px] shrink-0 ${color}`}
         style={{ backgroundColor: "currentColor" }}
       />
     );
   }
 
   if (state.shape === "failed") {
-    // Dashed ring in the phase hue with a small red center dot. Larger (8px) so
-    // the dashed border shows enough dashes and the red center is legible.
+    // Dashed ring in the phase hue with a small red center dot. Same DOT_SIZE as
+    // the other shapes; the red center (`w-1 h-1`) reads inside the 7px ring.
     return (
       <span
         {...common}
-        className={`relative inline-flex items-center justify-center w-2 h-2 rounded-full shrink-0 ${color}`}
+        className={`relative inline-flex items-center justify-center ${DOT_SIZE} rounded-full shrink-0 ${color}`}
         style={{ border: "1.8px dashed currentColor", backgroundColor: "transparent" }}
       >
         <span aria-hidden="true" className="w-1 h-1 rounded-full bg-red-400" />
@@ -113,7 +120,7 @@ export function StatusDot({ win }: { win: WindowInfo }) {
     return (
       <span
         {...common}
-        className={`w-1.5 h-1.5 rounded-full shrink-0 ${color}`}
+        className={`${DOT_SIZE} rounded-full shrink-0 ${color}`}
         style={{ border: "none", backgroundColor: "currentColor" }}
       />
     );
@@ -124,7 +131,7 @@ export function StatusDot({ win }: { win: WindowInfo }) {
   return (
     <span
       {...common}
-      className={`w-1.5 h-1.5 rounded-full shrink-0 ${color}`}
+      className={`${DOT_SIZE} rounded-full shrink-0 ${color}`}
       style={{ border: "1.8px solid currentColor", backgroundColor: "transparent" }}
     />
   );

--- a/docs/memory/run-kit/ui-patterns.md
+++ b/docs/memory/run-kit/ui-patterns.md
@@ -144,13 +144,13 @@ A copyable metadata row appended after `fab` in `WindowPanel`, following the sam
 
 | Shape (`DotShape`) | fab `fabDisplayState` / PR equivalent | Rendering |
 |--------------------|----------------------------------------|-----------|
-| `ring` | `pending` (PR: checks running) | hollow circle, `1.8px solid currentColor` border in phase hue, transparent fill, `w-1.5 h-1.5` (~6px) |
-| `solid` | `active`/`ready` (PR: open/healthy) | filled circle (`backgroundColor: currentColor`, `border: none`) in phase hue, `w-1.5 h-1.5` |
-| `failed` | `failed` (PR: checks fail / changes requested) | **dashed ring** (`1.8px dashed currentColor`, transparent) in phase hue + a centered small **red** `bg-red-400` dot (`w-1 h-1`), at `w-2 h-2` (~8px) |
-| `done` | `done` (PR: merged) | filled **rounded square** (`rounded-[1px]`, `backgroundColor: currentColor`) in phase hue, at `w-2 h-2` |
+| `ring` | `pending` (PR: checks running) | hollow circle, `1.8px solid currentColor` border in phase hue, transparent fill |
+| `solid` | `active`/`ready` (PR: open/healthy) | filled circle (`backgroundColor: currentColor`, `border: none`) in phase hue |
+| `failed` | `failed` (PR: checks fail / changes requested) | **dashed ring** (`1.8px dashed currentColor`, transparent) in phase hue + a centered small **red** `bg-red-400` dot (`w-1 h-1`) |
+| `done` | `done` (PR: merged) | filled **rounded square** (`rounded-[1px]`, `backgroundColor: currentColor`) in phase hue |
 | `skipped` | `skipped` (PR: closed unmerged) | gray hollow ring (hue FORCED to `text-text-secondary`) |
 
-`failed` and `done` render at **8px** (`w-2 h-2`) so the dashed ring shows enough dashes (with a legible red center) and the square reads unambiguously as a square next to the 6px circles; `ring`/`solid` stay ~6px.
+All shapes render at one uniform 7px footprint (`DOT_SIZE = "w-[7px] h-[7px]"`), so the filled square and the hollow circles read as the same size in the dense sidebar — the square is distinguished by its `rounded-[1px]` shape, not by being larger (a filled square at a bigger box-size visually dominates the hollow rings). The `failed` red center stays `w-1 h-1` inside the 7px ring.
 
 **Shape mappings**:
 - `fabShape(displayState)`: `pending`→`ring`; `active`,`ready`→`solid`; `failed`→`failed`; `done`→`done`; `skipped`→`skipped`; unknown/absent→`solid` (a live fab window with a future/unrecognized state still reads as a live dot, not gone).

--- a/docs/specs/status-dot.md
+++ b/docs/specs/status-dot.md
@@ -60,9 +60,9 @@ ONE shape vocabulary across **all** phases (fab stages AND PR):
 | `done` (PR: merged) | rounded square | filled rounded square (`rounded-[1px]`) in phase hue |
 | `skipped` (PR: closed unmerged) | gray ring | hollow ring forced to gray (`text-text-secondary`) |
 
-The `failed` and `done` shapes render slightly larger (8px vs the 6px ring/solid) so the dashed
-border shows enough dashes (with a clearly visible red center) and the square reads unambiguously as
-a square next to the circles.
+All shapes render at one uniform 7px footprint, so the filled square and the hollow circles read as
+the same size in the dense sidebar — the square is distinguished by its shape (`rounded-[1px]`), not
+by being larger. (A filled square at a larger box-size visually dominates the hollow rings.)
 
 ### tmux fallback
 


### PR DESCRIPTION
## What

Follow-up to #277. The lifecycle `StatusDot` rendered its `done`/`failed` shapes at **8px** (`w-2 h-2`) while `ring`/`solid` were **6px** (`w-1.5 h-1.5`). A *filled* 8px square next to a *hollow* 6px ring looks markedly bigger, so the green `done` square visually dominated the sidebar (it read as an oversized circle rather than a peer of the other dots).

Render every shape at one uniform **7px** footprint (`DOT_SIZE = "w-[7px] h-[7px]"`). The square is now distinguished purely by its `rounded-[1px]` shape, not by size — matching the proportions shown in the design preview.

## Changes

- `status-dot.tsx` — introduce `DOT_SIZE`; apply it to all four shape branches (was `w-2 h-2` for done/failed, `w-1.5 h-1.5` for ring/solid). The `failed` red center stays `w-1 h-1` inside the 7px ring.
- `docs/specs/status-dot.md`, `docs/memory/run-kit/ui-patterns.md` — updated the sizing notes (uniform 7px, no 6/8px split).

Frontend-only; no behavior change beyond dot geometry. Type check clean; 778 frontend unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)