### PR TITLE
fix: make the done status dot a sharp square (rounded-none)

### DIFF
--- a/app/frontend/src/components/sidebar/window-row.test.tsx
+++ b/app/frontend/src/components/sidebar/window-row.test.tsx
@@ -289,7 +289,7 @@ describe("WindowRow", () => {
       const dot = screen.getByLabelText("PR — merged");
       expect(dot).toBeInTheDocument();
       expect(dot.className).toContain("text-purple-400");
-      expect(dot.className).toContain("rounded-[1px]");
+      expect(dot.className).toContain("rounded-none");
     });
 
     it("renders a purple dashed-ring + red center when prChecks is fail", () => {

--- a/app/frontend/src/components/status-dot.test.tsx
+++ b/app/frontend/src/components/status-dot.test.tsx
@@ -149,7 +149,7 @@ describe("StatusDot — rendering shapes", () => {
   it("renders a rounded square (not a circle) for a done stage", () => {
     render(<StatusDot win={makeWindow({ fabChange: "x", fabStage: "ship", fabDisplayState: "done" })} />);
     const dot = screen.getByLabelText("ship — done");
-    expect(dot.className).toContain("rounded-[1px]");
+    expect(dot.className).toContain("rounded-none");
     expect(dot.className).not.toContain("rounded-full");
     expect(dot.className).toContain("text-accent-green");
     expect(dot.getAttribute("style")).toContain("background-color: currentcolor");
@@ -173,7 +173,7 @@ describe("StatusDot — PR phase (purple, same shape language)", () => {
     render(<StatusDot win={prWin({ prState: "merged", prChecks: "fail" })} />);
     const dot = screen.getByLabelText("PR — merged");
     expect(dot.className).toContain("text-purple-400");
-    expect(dot.className).toContain("rounded-[1px]");
+    expect(dot.className).toContain("rounded-none");
   });
 
   it("open/healthy → purple solid circle", () => {

--- a/app/frontend/src/components/status-dot.tsx
+++ b/app/frontend/src/components/status-dot.tsx
@@ -16,7 +16,7 @@ import type { WindowInfo } from "@/types";
  *       solid         → active / ready (PR: open / healthy)
  *       failed        → dashed ring in phase hue + a small RED center dot
  *                       (PR: checks fail / changes requested)
- *       done          → filled rounded square in phase hue (PR: merged)
+ *       done          → filled sharp-cornered square in phase hue (PR: merged)
  *       skipped       → gray hollow ring (PR: closed unmerged)
  *
  * Red is used in exactly ONE way across the whole system: the small center dot
@@ -25,7 +25,7 @@ import type { WindowInfo } from "@/types";
  *
  * Every shape renders at one uniform 7px footprint (`DOT_SIZE`) so the filled
  * square and the hollow circles read as the same size in the dense sidebar; the
- * square is distinguished by its shape (`rounded-[1px]`), not by being bigger.
+ * square is distinguished by its sharp (`rounded-none`) corners, not by being bigger.
  *
  * The dot always carries `role="img"` + `aria-label` + `title` composed from
  * phase + status (e.g. "apply — active", "PR — merged", "review — failed",
@@ -89,14 +89,14 @@ export function StatusDot({ win }: { win: WindowInfo }) {
   const common = { role: "img" as const, "aria-label": label, title: label };
 
   if (state.shape === "done") {
-    // Square (barely-softened corners). A larger radius (e.g. 3px on this 7px
-    // box) rounds the corners enough to look like a circle, so keep it ~1px.
-    // Same DOT_SIZE as every other shape so the square doesn't visually dominate
-    // the circles in the dense sidebar.
+    // Sharp-cornered square (no rounding). At 7px even a 1px radius softens the
+    // corners enough to blur the square-vs-circle distinction, so render fully
+    // square (`rounded-none`) to keep `done` visually distinct from the round
+    // shapes. Same DOT_SIZE as every other shape so it doesn't dominate.
     return (
       <span
         {...common}
-        className={`${DOT_SIZE} rounded-[1px] shrink-0 ${color}`}
+        className={`${DOT_SIZE} rounded-none shrink-0 ${color}`}
         style={{ backgroundColor: "currentColor" }}
       />
     );

--- a/docs/memory/run-kit/ui-patterns.md
+++ b/docs/memory/run-kit/ui-patterns.md
@@ -147,10 +147,10 @@ A copyable metadata row appended after `fab` in `WindowPanel`, following the sam
 | `ring` | `pending` (PR: checks running) | hollow circle, `1.8px solid currentColor` border in phase hue, transparent fill |
 | `solid` | `active`/`ready` (PR: open/healthy) | filled circle (`backgroundColor: currentColor`, `border: none`) in phase hue |
 | `failed` | `failed` (PR: checks fail / changes requested) | **dashed ring** (`1.8px dashed currentColor`, transparent) in phase hue + a centered small **red** `bg-red-400` dot (`w-1 h-1`) |
-| `done` | `done` (PR: merged) | filled **rounded square** (`rounded-[1px]`, `backgroundColor: currentColor`) in phase hue |
+| `done` | `done` (PR: merged) | filled **sharp-cornered square** (`rounded-none`, `backgroundColor: currentColor`) in phase hue |
 | `skipped` | `skipped` (PR: closed unmerged) | gray hollow ring (hue FORCED to `text-text-secondary`) |
 
-All shapes render at one uniform 7px footprint (`DOT_SIZE = "w-[7px] h-[7px]"`), so the filled square and the hollow circles read as the same size in the dense sidebar — the square is distinguished by its `rounded-[1px]` shape, not by being larger (a filled square at a bigger box-size visually dominates the hollow rings). The `failed` red center stays `w-1 h-1` inside the 7px ring.
+All shapes render at one uniform 7px footprint (`DOT_SIZE = "w-[7px] h-[7px]"`), so the filled square and the hollow circles read as the same size in the dense sidebar — the square is distinguished by its sharp `rounded-none` corners, not by being larger (at 7px even a 1px radius blurs the square-vs-circle distinction; a filled square at a bigger box-size visually dominates the hollow rings). The `failed` red center stays `w-1 h-1` inside the 7px ring.
 
 **Shape mappings**:
 - `fabShape(displayState)`: `pending`→`ring`; `active`,`ready`→`solid`; `failed`→`failed`; `done`→`done`; `skipped`→`skipped`; unknown/absent→`solid` (a live fab window with a future/unrecognized state still reads as a live dot, not gone).

--- a/docs/specs/status-dot.md
+++ b/docs/specs/status-dot.md
@@ -57,12 +57,13 @@ ONE shape vocabulary across **all** phases (fab stages AND PR):
 | `pending` (PR: checks running) | ring | hollow circle, 1.8px solid border in phase hue, transparent fill |
 | `active` / `ready` (PR: open / healthy) | solid circle | filled circle in phase hue |
 | `failed` (PR: checks fail / changes requested) | **dashed ring + red center** | dashed 1.8px border in phase hue, transparent fill, with a small **red** (`bg-red-400`) dot centered inside |
-| `done` (PR: merged) | rounded square | filled rounded square (`rounded-[1px]`) in phase hue |
+| `done` (PR: merged) | square | filled sharp-cornered square (`rounded-none`) in phase hue |
 | `skipped` (PR: closed unmerged) | gray ring | hollow ring forced to gray (`text-text-secondary`) |
 
 All shapes render at one uniform 7px footprint, so the filled square and the hollow circles read as
-the same size in the dense sidebar — the square is distinguished by its shape (`rounded-[1px]`), not
-by being larger. (A filled square at a larger box-size visually dominates the hollow rings.)
+the same size in the dense sidebar — the square is distinguished by its sharp (`rounded-none`)
+corners, not by being larger. (At 7px even a 1px radius blurs the square-vs-circle distinction; a
+filled square at a larger box-size visually dominates the hollow rings.)
 
 ### tmux fallback
 


### PR DESCRIPTION
## What

Follow-up to #277/#278. At the uniform 7px footprint, even a 1px corner radius on the `done` square softens it enough that it still reads as a small circle rather than a square — so `done` wasn't visually distinct from the round shapes in the sidebar.

Drop the rounding entirely (`rounded-[1px]` → `rounded-none`) so the square has fully sharp corners and is unambiguously distinct.

## Changes

- `status-dot.tsx` — `done` shape `rounded-[1px]` → `rounded-none`
- `status-dot.test.tsx`, `window-row.test.tsx` — updated the 3 corner-radius assertions
- `docs/specs/status-dot.md`, `docs/memory/run-kit/ui-patterns.md` — updated the doc references

Frontend-only; geometry-only change. Type check clean; frontend unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)