### PR TITLE
feat: top-bar notification control + Cmd+K test notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,16 @@ key persisted under `~/.rk/`). It is **fail-silent**: if the server is
 unreachable or returns an error it exits 0 and prints nothing, so it never
 stalls a calling script or agent loop.
 
-**Opt in from the browser**: open the command palette (`Cmd+K`) and run
-**Notifications: Enable push**. This requests notification permission and
-subscribes the current device. There is no settings page — the palette is the
-opt-in gesture.
+**Opt in from the browser**: click the **bell icon** in the top bar (or open the
+command palette with `Cmd+K` and run **Notifications: Enable push**). This
+requests notification permission and subscribes the current device. There is no
+settings page — the bell dropdown and the palette are the opt-in gestures. The
+bell dropdown also offers **Send test notification** (a local test that bypasses
+the server) and a **Notifications help** link.
+
+See the [notifications guide](docs/site/notifications.md) for setup and the
+common "it says sent but nothing appears" troubleshooting (almost always an
+OS-level notification block — e.g. macOS Focus mode).
 
 > **Secure-context requirement**: Web Push (service worker + `PushManager`)
 > only works in a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) —

--- a/app/frontend/src/components/top-bar.test.tsx
+++ b/app/frontend/src/components/top-bar.test.tsx
@@ -483,6 +483,15 @@ describe("TopBar", () => {
       expect(sendTestNotification).toHaveBeenCalledTimes(1);
     });
 
+    it("includes a Notifications help link to the GitHub guide (new tab)", async () => {
+      await renderWithState("default");
+      act(() => fireEvent.click(screen.getByLabelText("Notifications off")));
+      const help = screen.getByText("Notifications help…").closest("a")!;
+      expect(help).toHaveAttribute("href", expect.stringContaining("docs/site/notifications.md"));
+      expect(help).toHaveAttribute("target", "_blank");
+      expect(help).toHaveAttribute("rel", "noopener noreferrer");
+    });
+
     it("closes the dropdown on Escape and returns focus to the bell", async () => {
       await renderWithState("subscribed");
       const trigger = screen.getByLabelText("Notifications on");

--- a/app/frontend/src/components/top-bar.test.tsx
+++ b/app/frontend/src/components/top-bar.test.tsx
@@ -15,6 +15,17 @@ vi.mock("@/api/client", async () => {
   };
 });
 
+// Drive the NotificationControl deterministically: mock the push lib so each
+// test picks the reported state without touching real serviceWorker / Notification.
+const getPushState = vi.fn();
+const enablePushSubscription = vi.fn();
+const sendTestNotification = vi.fn();
+vi.mock("@/lib/push", () => ({
+  getPushState: (...a: unknown[]) => getPushState(...a),
+  enablePushSubscription: (...a: unknown[]) => enablePushSubscription(...a),
+  sendTestNotification: (...a: unknown[]) => sendTestNotification(...a),
+}));
+
 const nowSeconds = Math.floor(Date.now() / 1000);
 
 const fabWindow: WindowInfo = {
@@ -81,6 +92,13 @@ function renderTopBar(overrides: Partial<React.ComponentProps<typeof TopBar>> = 
 
 describe("TopBar", () => {
   beforeEach(() => {
+    // NotificationControl's hook calls getPushState() on mount; default it to a
+    // resolved promise so every render is safe even in tests that don't touch
+    // notifications (afterEach's restoreAllMocks would otherwise leave it
+    // returning undefined → `undefined.then` on the next render).
+    getPushState.mockResolvedValue("default");
+    enablePushSubscription.mockResolvedValue("subscribed");
+    sendTestNotification.mockResolvedValue(true);
     // ThemeProvider needs matchMedia
     vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({
       matches: true,
@@ -396,5 +414,83 @@ describe("TopBar", () => {
     });
     expect(btn).not.toBeDisabled();
     expect(btn.querySelector("svg[viewBox='7 10 50 44']")).toBeFalsy();
+  });
+
+  describe("NotificationControl", () => {
+    beforeEach(() => {
+      getPushState.mockReset().mockResolvedValue("default");
+      enablePushSubscription.mockReset().mockResolvedValue("subscribed");
+      sendTestNotification.mockReset().mockResolvedValue(true);
+    });
+
+    /** Render and flush the mount-time getPushState() promise. */
+    async function renderWithState(state: string) {
+      getPushState.mockResolvedValue(state);
+      let utils!: ReturnType<typeof renderTopBar>;
+      await act(async () => {
+        utils = renderTopBar();
+        await Promise.resolve();
+      });
+      return utils;
+    }
+
+    it("renders the bell trigger labeled 'off' when not subscribed", async () => {
+      await renderWithState("default");
+      expect(screen.getByLabelText("Notifications off")).toBeInTheDocument();
+      expect(screen.queryByLabelText("Notifications on")).not.toBeInTheDocument();
+    });
+
+    it("renders the bell labeled 'on' when subscribed", async () => {
+      await renderWithState("subscribed");
+      expect(screen.getByLabelText("Notifications on")).toBeInTheDocument();
+    });
+
+    it("hides itself entirely when push is unsupported", async () => {
+      await renderWithState("unsupported");
+      expect(screen.queryByLabelText("Notifications off")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Notifications on")).not.toBeInTheDocument();
+    });
+
+    it("opens a dropdown with Enable + (disabled) Test when not subscribed", async () => {
+      await renderWithState("default");
+      act(() => fireEvent.click(screen.getByLabelText("Notifications off")));
+      expect(screen.getByText("Enable notifications")).toBeInTheDocument();
+      // Test is present but disabled until subscribed.
+      expect(screen.getByText("Send test notification").closest("button")).toBeDisabled();
+    });
+
+    it("calls enablePushSubscription when Enable is clicked", async () => {
+      await renderWithState("default");
+      act(() => fireEvent.click(screen.getByLabelText("Notifications off")));
+      await act(async () => {
+        fireEvent.click(screen.getByText("Enable notifications"));
+        await Promise.resolve();
+      });
+      expect(enablePushSubscription).toHaveBeenCalledTimes(1);
+    });
+
+    it("enables the Test action and calls sendTestNotification when subscribed", async () => {
+      await renderWithState("subscribed");
+      act(() => fireEvent.click(screen.getByLabelText("Notifications on")));
+      // No Enable item when already subscribed.
+      expect(screen.queryByText("Enable notifications")).not.toBeInTheDocument();
+      const testBtn = screen.getByText("Send test notification").closest("button")!;
+      expect(testBtn).not.toBeDisabled();
+      await act(async () => {
+        fireEvent.click(testBtn);
+        await Promise.resolve();
+      });
+      expect(sendTestNotification).toHaveBeenCalledTimes(1);
+    });
+
+    it("closes the dropdown on Escape and returns focus to the bell", async () => {
+      await renderWithState("subscribed");
+      const trigger = screen.getByLabelText("Notifications on");
+      act(() => fireEvent.click(trigger));
+      expect(screen.getByText("Send test notification")).toBeInTheDocument();
+      act(() => fireEvent.keyDown(document, { key: "Escape" }));
+      expect(screen.queryByText("Send test notification")).not.toBeInTheDocument();
+      expect(trigger).toHaveFocus();
+    });
   });
 });

--- a/app/frontend/src/components/top-bar.test.tsx
+++ b/app/frontend/src/components/top-bar.test.tsx
@@ -445,6 +445,12 @@ describe("TopBar", () => {
       expect(screen.getByLabelText("Notifications on")).toBeInTheDocument();
     });
 
+    it("announces the blocked state distinctly to screen readers when denied", async () => {
+      await renderWithState("denied");
+      expect(screen.getByLabelText("Notifications blocked")).toBeInTheDocument();
+      expect(screen.queryByLabelText("Notifications off")).not.toBeInTheDocument();
+    });
+
     it("hides itself entirely when push is unsupported", async () => {
       await renderWithState("unsupported");
       expect(screen.queryByLabelText("Notifications off")).not.toBeInTheDocument();

--- a/app/frontend/src/components/top-bar.tsx
+++ b/app/frontend/src/components/top-bar.tsx
@@ -682,6 +682,11 @@ function TerminalFontControl() {
 const BELL_ON = "\uF0F3";
 const BELL_OFF = "\uF1F6";
 
+// Notifications help page (rendered by GitHub). Opens in a new tab from the
+// bell dropdown \u2014 the canonical "it says sent but nothing shows" guide.
+const NOTIFICATIONS_HELP_URL =
+  "https://github.com/sahil87/run-kit/blob/main/docs/site/notifications.md";
+
 /**
  * Top-bar notification control: a bell icon button (filled when subscribed,
  * bell-slash otherwise) opening a small dropdown to enable push and send a
@@ -792,10 +797,21 @@ function NotificationControl() {
             Send test notification
           </button>
           {denied && (
-            <div className="px-2 py-1 text-[11px] text-text-secondary select-none border-t border-border mt-0.5 pt-1.5">
+            <div className="px-2 py-1 text-[11px] text-text-secondary select-none">
               Re-allow notifications for this site in your browser/OS settings.
             </div>
           )}
+          <a
+            href={NOTIFICATIONS_HELP_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            role="menuitem"
+            onClick={() => setOpen(false)}
+            title="Open the notifications setup & troubleshooting guide on GitHub"
+            className={`${menuItemClass} border-t border-border mt-0.5 pt-1.5`}
+          >
+            Notifications help…
+          </a>
         </div>
       )}
     </div>

--- a/app/frontend/src/components/top-bar.tsx
+++ b/app/frontend/src/components/top-bar.tsx
@@ -6,6 +6,7 @@ import { useChromeState, useChromeDispatch, TERMINAL_FONT_BOUNDS } from "@/conte
 import { useTheme, useThemeActions } from "@/contexts/theme-context";
 import { useOptimisticAction } from "@/hooks/use-optimistic-action";
 import { useToast } from "@/components/toast";
+import { usePushSubscription } from "@/hooks/use-push-subscription";
 import { splitWindow, closePane } from "@/api/client";
 import type { ProjectSession, WindowInfo } from "@/types";
 import type { BreadcrumbDropdownItem } from "@/contexts/chrome-context";
@@ -241,6 +242,13 @@ export function TopBar({
               all modes. */}
           <span className="hidden sm:flex">
             <FixedWidthToggle />
+          </span>
+
+          {/* Notification control — bell button + dropdown (enable / send test).
+              Route-agnostic; hides itself when push is unsupported (insecure
+              context / no SW support). */}
+          <span className="hidden sm:flex">
+            <NotificationControl />
           </span>
 
           {/* Theme is the rightmost icon button (before the connection dot +
@@ -663,6 +671,131 @@ function TerminalFontControl() {
             </svg>
             Reset
           </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Nerd Font bell glyphs (same icon system as the sidebar status panel):
+// U+F0F3 bell (notifications on), U+F1F6 bell-slash (off / available).
+const BELL_ON = "\uF0F3";
+const BELL_OFF = "\uF1F6";
+
+/**
+ * Top-bar notification control: a bell icon button (filled when subscribed,
+ * bell-slash otherwise) opening a small dropdown to enable push and send a
+ * local test notification. Self-contained — calls `usePushSubscription`
+ * directly (no props threaded through TopBar), mirroring TerminalFontControl /
+ * ThemeToggle. Renders nothing when push is unsupported (insecure context or no
+ * service-worker support) so the bell never appears where it can't work.
+ */
+function NotificationControl() {
+  const { state, enable, sendTest } = usePushSubscription();
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("keydown", handleKey, { capture: true });
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("keydown", handleKey, { capture: true });
+    };
+  }, [open]);
+
+  // No bell at all where push can't work — keeps the affordance honest.
+  if (state === "unsupported") return null;
+
+  const subscribed = state === "subscribed";
+  const denied = state === "denied";
+
+  const statusLabel = subscribed
+    ? "Notifications: on"
+    : denied
+      ? "Blocked in browser settings"
+      : "Notifications: off";
+  const ariaLabel = subscribed ? "Notifications on" : "Notifications off";
+
+  const menuItemClass =
+    "w-full text-left text-xs text-text-secondary hover:text-text-primary transition-colors py-1.5 px-2 rounded hover:bg-bg-card disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-text-secondary";
+
+  return (
+    <div ref={containerRef} className="relative inline-flex items-center">
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="true"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        title={statusLabel}
+        className={`min-w-[24px] min-h-[24px] coarse:min-w-[36px] coarse:min-h-[36px] rounded border transition-colors flex items-center justify-center leading-none ${
+          open
+            ? "border-accent text-accent bg-accent/10"
+            : subscribed
+              ? "border-border text-accent-bright hover:border-text-secondary"
+              : "border-border text-text-secondary hover:border-text-secondary"
+        }`}
+      >
+        <span aria-hidden="true" className="text-[13px] font-bold">
+          {subscribed ? BELL_ON : BELL_OFF}
+        </span>
+      </button>
+      {open && (
+        <div
+          role="menu"
+          aria-label="Notifications"
+          className="absolute top-full right-0 mt-1 min-w-[180px] bg-bg-primary border border-border rounded-lg shadow-2xl p-1.5 z-50 flex flex-col gap-0.5"
+        >
+          <div className="px-2 py-1 text-[11px] text-text-secondary select-none">
+            {statusLabel}
+          </div>
+          {!subscribed && (
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setOpen(false);
+                void enable();
+              }}
+              className={menuItemClass}
+            >
+              Enable notifications
+            </button>
+          )}
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setOpen(false);
+              void sendTest();
+            }}
+            disabled={!subscribed}
+            title={subscribed ? "Send a local test notification" : "Enable notifications first"}
+            className={menuItemClass}
+          >
+            Send test notification
+          </button>
+          {denied && (
+            <div className="px-2 py-1 text-[11px] text-text-secondary select-none border-t border-border mt-0.5 pt-1.5">
+              Re-allow notifications for this site in your browser/OS settings.
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/app/frontend/src/components/top-bar.tsx
+++ b/app/frontend/src/components/top-bar.tsx
@@ -734,7 +734,11 @@ function NotificationControl() {
     : denied
       ? "Blocked in browser settings"
       : "Notifications: off";
-  const ariaLabel = subscribed ? "Notifications on" : "Notifications off";
+  const ariaLabel = subscribed
+    ? "Notifications on"
+    : denied
+      ? "Notifications blocked"
+      : "Notifications off";
 
   const menuItemClass =
     "w-full text-left text-xs text-text-secondary hover:text-text-primary transition-colors py-1.5 px-2 rounded hover:bg-bg-card disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-text-secondary";

--- a/app/frontend/src/hooks/use-push-subscription.ts
+++ b/app/frontend/src/hooks/use-push-subscription.ts
@@ -1,21 +1,30 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { PaletteAction } from "@/components/command-palette";
 import { useToast } from "@/components/toast";
-import { enablePushSubscription, getPushState, type PushState } from "@/lib/push";
+import {
+  enablePushSubscription,
+  getPushState,
+  sendTestNotification,
+  type PushState,
+} from "@/lib/push";
 
 /**
- * Push opt-in, surfaced as command-palette actions (Cmd+K) per Constitution
- * §V Keyboard-First and §IV Minimal Surface Area — no new route/settings page.
- *
- * The visible affordance is terminal-themed (a text label that reflects state),
- * NOT a bell icon (explicit user decision). `pushActions` returns at most one
- * entry: the enable command when not yet subscribed.
+ * Push opt-in + test, surfaced both as command-palette actions (Cmd+K, per
+ * Constitution §V Keyboard-First / §IV Minimal Surface Area) and as the
+ * top-bar `NotificationControl` button+dropdown. Both surfaces are backed by
+ * the same `enable` / `sendTest` handlers and `state` here, so they never drift.
  */
-export function usePushSubscription(): { state: PushState; actions: PaletteAction[] } {
+export function usePushSubscription(): {
+  state: PushState;
+  enable: () => Promise<void>;
+  sendTest: () => Promise<void>;
+  actions: PaletteAction[];
+} {
   const [state, setState] = useState<PushState>("default");
   const { addToast } = useToast();
 
-  // Resolve the initial state once on mount (without prompting the user).
+  // Resolve the initial state once on mount (without prompting the user). The
+  // underlying getPushState() is timeout-guarded, so this never hangs.
   useEffect(() => {
     let cancelled = false;
     getPushState().then((s) => {
@@ -45,27 +54,44 @@ export function usePushSubscription(): { state: PushState; actions: PaletteActio
     }
   }, [addToast]);
 
-  const actions = useMemo<PaletteAction[]>(() => {
-    if (state === "subscribed") {
-      // Already on — surface a terminal-themed "enabled" marker, no action.
-      return [
-        {
-          id: "push-enabled",
-          label: "Notifications: Enabled ✓",
-          onSelect: () => {},
-        },
-      ];
+  const sendTest = useCallback(async () => {
+    const shown = await sendTestNotification();
+    if (shown) {
+      addToast("Test notification sent — check your desktop", "info");
+    } else if (Notification?.permission === "denied") {
+      addToast("Notifications blocked — enable them in your browser settings", "error");
+    } else {
+      addToast("Enable notifications first", "error");
     }
-    return [
-      {
+  }, [addToast]);
+
+  const actions = useMemo<PaletteAction[]>(() => {
+    const list: PaletteAction[] = [];
+    if (state === "subscribed") {
+      // Already on — a no-op marker + a test action.
+      list.push({
+        id: "push-enabled",
+        label: "Notifications: Enabled ✓",
+        onSelect: () => {},
+      });
+      list.push({
+        id: "push-test",
+        label: "Notifications: Send test notification",
+        onSelect: () => {
+          void sendTest();
+        },
+      });
+    } else {
+      list.push({
         id: "push-enable",
         label: "Notifications: Enable push",
         onSelect: () => {
           void enable();
         },
-      },
-    ];
-  }, [state, enable]);
+      });
+    }
+    return list;
+  }, [state, enable, sendTest]);
 
-  return { state, actions };
+  return { state, enable, sendTest, actions };
 }

--- a/app/frontend/src/lib/push.test.ts
+++ b/app/frontend/src/lib/push.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { registerServiceWorker, enablePushSubscription, getPushState } from "./push";
+import {
+  registerServiceWorker,
+  enablePushSubscription,
+  getPushState,
+  sendTestNotification,
+} from "./push";
 
 // Mock the API client so the subscribe flow does not hit the network.
 const getVapidPublicKey = vi.fn();
@@ -46,7 +51,8 @@ function installServiceWorker(opts: {
       opts.subscribeResult ?? { toJSON: () => ({ endpoint: "https://e", keys: {} }) },
     ),
   };
-  const registration = { pushManager };
+  const showNotification = vi.fn().mockResolvedValue(undefined);
+  const registration = { pushManager, showNotification };
   Object.defineProperty(globalThis.navigator, "serviceWorker", {
     value: {
       register: vi.fn().mockResolvedValue(registration),
@@ -61,7 +67,7 @@ function installServiceWorker(opts: {
     writable: true,
     configurable: true,
   });
-  return { registration, pushManager };
+  return { registration, pushManager, showNotification };
 }
 
 function removeServiceWorker() {
@@ -181,5 +187,35 @@ describe("getPushState", () => {
     installServiceWorker({ existingSub: { toJSON: () => ({}) } });
     setNotificationPermission("granted");
     expect(await getPushState()).toBe("subscribed");
+  });
+});
+
+describe("sendTestNotification", () => {
+  afterEach(() => {
+    removeServiceWorker();
+  });
+
+  it("returns false (no-op) when push is unsupported", async () => {
+    removeServiceWorker();
+    Object.defineProperty(globalThis, "Notification", { value: undefined, writable: true, configurable: true });
+    expect(await sendTestNotification()).toBe(false);
+  });
+
+  it("returns false without calling showNotification when permission is not granted", async () => {
+    const { showNotification } = installServiceWorker();
+    setNotificationPermission("default");
+    expect(await sendTestNotification()).toBe(false);
+    expect(showNotification).not.toHaveBeenCalled();
+  });
+
+  it("calls registration.showNotification and returns true when granted", async () => {
+    const { showNotification } = installServiceWorker();
+    setNotificationPermission("granted");
+    expect(await sendTestNotification()).toBe(true);
+    expect(showNotification).toHaveBeenCalledTimes(1);
+    expect(showNotification).toHaveBeenCalledWith(
+      "RunKit",
+      expect.objectContaining({ body: expect.any(String) }),
+    );
   });
 });

--- a/app/frontend/src/lib/push.ts
+++ b/app/frontend/src/lib/push.ts
@@ -59,17 +59,69 @@ function urlBase64ToUint8Array(base64: string): Uint8Array<ArrayBuffer> {
   return out;
 }
 
-/** Report the current push subscription state without prompting the user. */
+/**
+ * Resolve to the ready (active) service-worker registration, or null if no
+ * worker activates within `timeoutMs`. `navigator.serviceWorker.ready` never
+ * rejects and never resolves until a worker is active — so on a page where the
+ * worker never registers/activates (e.g. a subpath where `/sw.js` isn't
+ * reachable) it would hang forever. The timeout guards every caller that only
+ * needs a best-effort read of the current state.
+ */
+async function readyRegistration(
+  timeoutMs = 3000,
+): Promise<ServiceWorkerRegistration | null> {
+  if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) {
+    return null;
+  }
+  return Promise.race([
+    navigator.serviceWorker.ready.catch(() => null),
+    new Promise<null>((resolve) => setTimeout(() => resolve(null), timeoutMs)),
+  ]);
+}
+
+/**
+ * Report the current push subscription state without prompting the user. The
+ * `serviceWorker.ready` wait is timeout-guarded so this can never hang the
+ * caller (e.g. a top-bar indicator querying state on mount).
+ */
 export async function getPushState(): Promise<PushState> {
   if (!isPushSupported()) return "unsupported";
   if (Notification.permission === "denied") return "denied";
   if (Notification.permission !== "granted") return "default";
+  const reg = await readyRegistration();
+  if (!reg) return "default";
   try {
-    const reg = await navigator.serviceWorker.ready;
     const sub = await reg.pushManager.getSubscription();
     return sub ? "subscribed" : "default";
   } catch {
     return "default";
+  }
+}
+
+/**
+ * Show a local test notification straight from the active service worker,
+ * bypassing the server and the browser's push service entirely. This isolates
+ * the OS-delivery leg: if a real `rk notify` reports `sent:N` but nothing
+ * appears, a successful test here proves the SW + OS path works and the gap is
+ * push-delivery-specific; a failing test points at an OS-level notification
+ * block (macOS Focus / blocked site permission) instead.
+ *
+ * Returns true if `showNotification` was invoked, false if a prerequisite was
+ * missing (unsupported, permission not granted, no active worker). Never throws.
+ */
+export async function sendTestNotification(): Promise<boolean> {
+  if (!isPushSupported()) return false;
+  if (Notification.permission !== "granted") return false;
+  const reg = await readyRegistration();
+  if (!reg) return false;
+  try {
+    await reg.showNotification("RunKit", {
+      body: "Test notification — if you can see this, delivery works.",
+      icon: "/generated-icons/icon-192.png",
+    });
+    return true;
+  } catch {
+    return false;
   }
 }
 
@@ -101,7 +153,9 @@ export async function enablePushSubscription(): Promise<PushState> {
     // before we touch pushManager.
     const reg = await registerServiceWorker();
     if (!reg) return "default";
-    await navigator.serviceWorker.ready;
+    // Guard the activation wait — a worker that never activates would otherwise
+    // hang the opt-in flow indefinitely. `reg` is still usable for subscribe.
+    await readyRegistration();
 
     let sub = await reg.pushManager.getSubscription();
     if (!sub) {

--- a/app/frontend/src/lib/push.ts
+++ b/app/frontend/src/lib/push.ts
@@ -73,10 +73,20 @@ async function readyRegistration(
   if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) {
     return null;
   }
-  return Promise.race([
-    navigator.serviceWorker.ready.catch(() => null),
-    new Promise<null>((resolve) => setTimeout(() => resolve(null), timeoutMs)),
-  ]);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<null>((resolve) => {
+    timer = setTimeout(() => resolve(null), timeoutMs);
+  });
+  try {
+    return await Promise.race([
+      navigator.serviceWorker.ready.catch(() => null),
+      timeout,
+    ]);
+  } finally {
+    // Clear the timer when readiness wins so the common (fast) path doesn't
+    // leave a dangling 3s timeout on every call (e.g. mount-time polling).
+    clearTimeout(timer);
+  }
 }
 
 /**

--- a/docs/site/notifications.md
+++ b/docs/site/notifications.md
@@ -1,0 +1,92 @@
+# Notifications — Setup & Troubleshooting
+
+> [← Back to the README](../../README.md)
+
+RunKit can send **Web Push** notifications — real OS-level banners that reach you
+even when the RunKit tab is closed. They're delivered by the browser's push
+service waking a service worker, so they work in the background. This page
+covers turning them on and fixing the common "I enabled it but nothing shows up"
+case.
+
+## Quick start
+
+1. Open RunKit over a **secure context** — `https://…` or `http://localhost` /
+   `http://127.0.0.1`. Web Push will not work over plain `http://` to a LAN IP
+   (the browser blocks service workers + `PushManager` outside a secure context).
+2. Click the **bell icon** in the top bar (next to the theme toggle) → **Enable
+   notifications**, and accept the browser's permission prompt. The bell fills in
+   when you're subscribed.
+   - Equivalent: `Cmd+K` → **Notifications: Enable push**.
+3. Click the bell again → **Send test notification**. A banner should appear.
+   - Equivalent: `Cmd+K` → **Notifications: Send test notification**.
+4. Fire one from any shell on the box:
+   ```sh
+   rk notify "hello from the box"
+   ```
+
+## "It says it sent, but I see nothing"
+
+This is the most common case, and it is almost never a RunKit bug — the message
+reached the browser's push service but the **OS suppressed the notification**.
+The **Send test notification** button is the fastest way to confirm this: it
+fires a notification *locally from the service worker*, bypassing the server and
+the push service entirely. If the test button shows nothing, the problem is the
+OS / browser notification permission, not delivery.
+
+### macOS
+
+1. **System Settings → Notifications → your browser** (e.g. Google Chrome).
+   - "Allow notifications" = **on**.
+   - Alert style = **Banners** or **Alerts** (not "None").
+2. **Turn off Focus / Do Not Disturb** — Control Center (menu bar, top right).
+   A Focus mode silently swallows notifications and is the single most common
+   culprit.
+3. **In the browser**: Settings → Privacy & Security → Site Settings →
+   Notifications → confirm the RunKit site is **Allowed**.
+
+### Windows
+
+1. **Settings → System → Notifications** → your browser is **on**.
+2. Turn off **Focus assist / Do not disturb**.
+3. In the browser: Site Settings → Notifications → RunKit site **Allowed**.
+
+### Browser-level (all platforms)
+
+If you previously clicked **Block** on the permission prompt, the site is stuck
+denied and re-running "Enable" does nothing. Re-allow it: click the lock/tune
+icon in the address bar → Site settings → set **Notifications** to **Allow**,
+then reload and enable again.
+
+## Requirements & caveats
+
+- **Secure context required.** Service workers and `PushManager` only run over
+  HTTPS or `localhost`/`127.0.0.1`. Hitting RunKit at a plain `http://<lan-ip>`
+  URL will silently fail to subscribe. Tailscale HTTPS (`https://*.ts.net`) and a
+  TLS reverse proxy both qualify.
+- **iOS** delivers Web Push only to a PWA **added to the Home Screen** — never a
+  plain Safari tab.
+- **Reverse proxies / subpaths.** The service worker registers at the origin
+  root (`/sw.js`). If you serve RunKit under a subpath (e.g. `/runkit/`), make
+  sure your proxy exposes `/sw.js` and `/api/*` at the origin root (the same host
+  RunKit is reached on) — otherwise registration or subscription can fail even
+  though the page loads.
+- **One feed per subscription.** Each browser that opts in is its own
+  subscription; `rk notify` fans out to all of them. Subscriptions that have
+  expired or been revoked are pruned automatically on the next send (you'll see
+  `pruned` count in `/api/notify`'s response).
+
+## How it works (for the curious)
+
+```
+rk notify "msg"
+  → POST /api/notify              (local RunKit server)
+  → webpush-go signs with VAPID   (server-held private key)
+  → browser push service (e.g. FCM)
+  → wakes the service worker (public/sw.js)
+  → showNotification()            (OS banner — tab can be closed)
+```
+
+The server reports `{"sent": N, "pruned": M}` — `sent` counts subscriptions the
+push service accepted. `sent: 0` with no subscriptions means nobody has opted in
+yet; a non-zero `sent` with no visible banner means the OS suppressed it (see
+above). The whole chain is fail-silent: a notify failure never blocks the caller.


### PR DESCRIPTION
## Summary

Follow-up to the merged Web Push feature (#270). Adds a real top-bar **notification control** (bell icon button + dropdown) for managing Web Push, a client-side **test notification** reachable from both the dropdown and `Cmd+K`, and a **troubleshooting help page** linked from the dropdown.

Motivated by a live debugging session: a real `rk notify` reported `sent:1` (server + push service worked) but no OS notification appeared — the gap was OS-level delivery (macOS Focus mode), with no easy in-app way to test it, see subscription state, or learn how to fix it. This adds all three.

## What changed

1. **Top-bar `NotificationControl`** (`top-bar.tsx`) — a Nerd Font bell button (filled `U+F0F3` when subscribed, bell-slash `U+F1F6` otherwise), styled like the neighboring `TerminalFontControl`/`ThemeToggle`. Sits **alongside** the existing SSE connection dot (kept as a separate signal, not merged). Hides itself entirely when push is unsupported. Dropdown: status line + **Enable notifications** + **Send test notification** (disabled until subscribed) + **Notifications help…** link.

2. **Client-side test send** (`lib/push.ts` `sendTestNotification`) — a local `registration.showNotification()` that **bypasses the server and the push service**, isolating the OS-delivery leg. A successful test proves SW + OS work; a failing one points at an OS-level block.

3. **`Cmd+K` parity** (`use-push-subscription.ts`) — adds `Notifications: Send test notification` to the command palette (when subscribed).

4. **Hardening** — `getPushState()` / `enablePushSubscription()` wrap the `serviceWorker.ready` wait with a **3s timeout** so the indicator can never hang.

5. **Help page** (`docs/site/notifications.md`) — setup + the common "it says sent but nothing appears" troubleshooting (macOS/Windows notification settings, secure-context requirement, iOS PWA caveat, subpath-proxy caveat, how the chain works). Linked from the bell dropdown (opens the GitHub-rendered page in a new tab) and from the README's Push notifications section.

## Design notes

- Honors Constitution §IV (no new route/settings page — the control lives in the existing top bar) and §V (keyboard-first — `Cmd+K` test action).
- The original intake rejected a bell as the *palette label*; a labeled top-bar button with a tooltip is a different context where a bell is the clearest meaning (decided with the maintainer).
- The help link uses the `blob/main/...` GitHub URL, so it resolves once this merges to `main` (matching how the README references `docs/site/` pages by repo path).

## Tests

- `lib/push.test.ts`: `sendTestNotification` cases (unsupported / ungranted no-ops, granted → `showNotification` called).
- `top-bar.test.tsx`: `NotificationControl` block — state glyph (on/off), hidden-when-unsupported, dropdown actions (enable / test enabled+disabled), help-link href/target/rel, Escape-to-close + focus return.
- Full frontend suite: **789 passing**, `tsc --noEmit` clean, production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)