### PR TITLE
fix: render failed status-dot as a dotted ring (was a 4-dash flower)

### DIFF
--- a/app/frontend/src/components/sidebar/window-row.test.tsx
+++ b/app/frontend/src/components/sidebar/window-row.test.tsx
@@ -219,7 +219,7 @@ describe("WindowRow", () => {
   // Triage signals: a failed fab stage colors the separate stage TEXT red
   // (window-row's own text, unchanged by the lifecycle dot). The DOT now follows
   // the lifecycle journey (hue=phase, shape=status) — a failed stage/PR renders
-  // a dashed ring in the phase hue + a red CENTER dot, never a whole-dot red.
+  // a dotted ring in the phase hue + a red CENTER dot, never a whole-dot red.
   describe("triage signals", () => {
     it("colors the stage text red when fabDisplayState is failed", () => {
       const win = makeWindow({
@@ -247,9 +247,9 @@ describe("WindowRow", () => {
       expect(stage.className).not.toContain("text-red-400");
     });
 
-    it("renders a failed fab stage as a dashed ring + red CENTER dot (no whole-dot red)", () => {
+    it("renders a failed fab stage as a dotted ring + red CENTER dot (no whole-dot red)", () => {
       // The lifecycle dot replaces the old whole-dot red tint: a failed stage
-      // keeps its phase hue (review→amber) with a dashed border and only a small
+      // keeps its phase hue (review→amber) with a dotted border and only a small
       // red center child. Requires a fabChange (else it's the tmux fallback).
       const win = makeWindow({
         windowId: "@0",
@@ -262,7 +262,7 @@ describe("WindowRow", () => {
       const dot = screen.getByLabelText("review — failed");
       expect(dot.className).toContain("text-amber-400");
       expect(dot.className).not.toContain("text-red-400"); // whole-dot red is gone
-      expect(dot.getAttribute("style")).toContain("dashed");
+      expect(dot.getAttribute("style")).toContain("dotted");
       expect(dot.querySelector("span")!.className).toContain("bg-red-400"); // red center only
     });
 
@@ -292,7 +292,7 @@ describe("WindowRow", () => {
       expect(dot.className).toContain("rounded-none");
     });
 
-    it("renders a purple dashed-ring + red center when prChecks is fail", () => {
+    it("renders a purple dotted-ring + red center when prChecks is fail", () => {
       const win = makeWindow({
         windowId: "@0",
         index: 0,
@@ -305,7 +305,7 @@ describe("WindowRow", () => {
       const dot = screen.getByLabelText("PR — failing");
       expect(dot).toBeInTheDocument();
       expect(dot.className).toContain("text-purple-400");
-      expect(dot.getAttribute("style")).toContain("dashed");
+      expect(dot.getAttribute("style")).toContain("dotted");
       expect(dot.querySelector("span")!.className).toContain("bg-red-400");
     });
 

--- a/app/frontend/src/components/status-dot.test.tsx
+++ b/app/frontend/src/components/status-dot.test.tsx
@@ -132,13 +132,13 @@ describe("StatusDot — rendering shapes", () => {
     expect(dot.textContent).toBe("");
   });
 
-  it("renders a dashed ring + a red center dot for a failed stage (NOT a whole-dot red)", () => {
+  it("renders a dotted ring + a red center dot for a failed stage (NOT a whole-dot red)", () => {
     render(<StatusDot win={makeWindow({ fabChange: "x", fabStage: "review", fabDisplayState: "failed" })} />);
     const dot = screen.getByLabelText("review — failed");
-    // Outer ring stays in the phase hue (amber), dashed border, transparent fill.
+    // Outer ring stays in the phase hue (amber), dotted border, transparent fill.
     expect(dot.className).toContain("text-amber-400");
     expect(dot.className).not.toContain("text-red-400");
-    expect(dot.getAttribute("style")).toContain("dashed");
+    expect(dot.getAttribute("style")).toContain("dotted");
     expect(dot.getAttribute("style")).toContain("transparent");
     // The ONLY red is the small center child dot.
     const center = dot.querySelector("span");
@@ -190,11 +190,11 @@ describe("StatusDot — PR phase (purple, same shape language)", () => {
     expect(dot.getAttribute("style")).toContain("transparent");
   });
 
-  it("failing → purple dashed ring + red center", () => {
+  it("failing → purple dotted ring + red center", () => {
     render(<StatusDot win={prWin({ prState: "open", prChecks: "fail" })} />);
     const dot = screen.getByLabelText("PR — failing");
     expect(dot.className).toContain("text-purple-400");
-    expect(dot.getAttribute("style")).toContain("dashed");
+    expect(dot.getAttribute("style")).toContain("dotted");
     expect(dot.querySelector("span")!.className).toContain("bg-red-400");
   });
 

--- a/app/frontend/src/components/status-dot.tsx
+++ b/app/frontend/src/components/status-dot.tsx
@@ -14,18 +14,20 @@ import type { WindowInfo } from "@/types";
  *   - SHAPE = status (health), ONE vocabulary across fab stages AND PR:
  *       ring          → pending (PR: checks running)
  *       solid         → active / ready (PR: open / healthy)
- *       failed        → dashed ring in phase hue + a small RED center dot
+ *       failed        → dotted ring in phase hue + a small RED center dot
  *                       (PR: checks fail / changes requested)
  *       done          → filled sharp-cornered square in phase hue (PR: merged)
  *       skipped       → gray hollow ring (PR: closed unmerged)
  *
  * Red is used in exactly ONE way across the whole system: the small center dot
- * inside a `failed` dashed ring — never as a whole-dot color (this removes the
+ * inside a `failed` dotted ring — never as a whole-dot color (this removes the
  * old `fabDisplayState === "failed"` red tint and the old solid-red PR fail).
  *
- * Every shape renders at one uniform 7px footprint (`DOT_SIZE`) so the filled
- * square and the hollow circles read as the same size in the dense sidebar; the
- * square is distinguished by its sharp (`rounded-none`) corners, not by being bigger.
+ * Every shape EXCEPT `failed` renders at one uniform 7px footprint (`DOT_SIZE`)
+ * so the filled square and the hollow circles read as the same size in the dense
+ * sidebar; the square is distinguished by its sharp (`rounded-none`) corners, not
+ * by being bigger. The `failed` dot is the lone exception — a slightly larger 9px
+ * footprint so its dotted bead-ring stays legible (see the failed branch below).
  *
  * The dot always carries `role="img"` + `aria-label` + `title` composed from
  * phase + status (e.g. "apply — active", "PR — merged", "review — failed",
@@ -33,10 +35,11 @@ import type { WindowInfo } from "@/types";
  * never the sole channel (colorblind a11y + keyboard-first constitution).
  */
 
-// Every shape renders at one uniform footprint so the filled square and the
-// hollow circles read as the same size in the dense sidebar (a filled 8px
-// square next to a hollow 6px ring looks much bigger). 7px is the middle ground
-// that still leaves the dashed failed-ring + red center legible.
+// Every shape EXCEPT `failed` renders at one uniform footprint so the filled
+// square and the hollow circles read as the same size in the dense sidebar (a
+// filled 8px square next to a hollow 6px ring looks much bigger). The `failed`
+// dot is the one exception — it uses a slightly larger 9px footprint so its
+// dotted bead-ring has room to read (see the failed branch below).
 const DOT_SIZE = "w-[7px] h-[7px]";
 
 /** Human word for the SHAPE/status axis used in the accessible label. */
@@ -103,15 +106,22 @@ export function StatusDot({ win }: { win: WindowInfo }) {
   }
 
   if (state.shape === "failed") {
-    // Dashed ring in the phase hue with a small red center dot. Same DOT_SIZE as
-    // the other shapes; the red center (`w-1 h-1`) reads inside the 7px ring.
+    // Dotted ring in the phase hue with a small red center dot. A CSS `dashed`
+    // border can't control its dash count — at the 7px DOT_SIZE a browser fits
+    // only ~4 dashes, which read as flower petals rather than the intended fine
+    // dashed ring. A `dotted` border at a slightly larger 9px footprint with a
+    // thin 1.2px stroke renders as a delicate bead ring instead. The failed dot
+    // is the ONE shape that breaks the uniform DOT_SIZE — the extra ~2px buys a
+    // legible bead count; every other shape stays at 7px. The 3px red center
+    // sits inside the 9px ring's ~6.6px hole (vs the old 4px center, which
+    // overflowed the 7px ring).
     return (
       <span
         {...common}
-        className={`relative inline-flex items-center justify-center ${DOT_SIZE} rounded-full shrink-0 ${color}`}
-        style={{ border: "1.8px dashed currentColor", backgroundColor: "transparent" }}
+        className={`relative inline-flex items-center justify-center w-[9px] h-[9px] rounded-full shrink-0 ${color}`}
+        style={{ border: "1.2px dotted currentColor", backgroundColor: "transparent" }}
       >
-        <span aria-hidden="true" className="w-1 h-1 rounded-full bg-red-400" />
+        <span aria-hidden="true" className="w-[3px] h-[3px] rounded-full bg-red-400" />
       </span>
     );
   }

--- a/docs/img/status-dot-matrix.svg
+++ b/docs/img/status-dot-matrix.svg
@@ -44,8 +44,8 @@
   <circle cx="300" cy="133" r="5" fill="none" stroke="#60a5fa" stroke-width="1.8"/>
   <!-- active: solid -->
   <circle cx="400" cy="133" r="5" fill="#60a5fa"/>
-  <!-- failed: dashed ring + red center -->
-  <circle cx="500" cy="133" r="6" fill="none" stroke="#60a5fa" stroke-width="1.8" stroke-dasharray="3 2"/>
+  <!-- failed: dotted ring + red center -->
+  <circle cx="500" cy="133" r="6" fill="none" stroke="#60a5fa" stroke-width="1.8" stroke-linecap="round" stroke-dasharray="0.1 3"/>
   <circle cx="500" cy="133" r="2.2" fill="#f87171"/>
   <!-- done: rounded square -->
   <rect x="594" y="127" width="12" height="12" rx="3" fill="#60a5fa"/>
@@ -58,7 +58,7 @@
   <text class="stage" x="60" y="202">apply · review · hydrate</text>
   <circle cx="300" cy="197" r="5" fill="none" stroke="#fbbf24" stroke-width="1.8"/>
   <circle cx="400" cy="197" r="5" fill="#fbbf24"/>
-  <circle cx="500" cy="197" r="6" fill="none" stroke="#fbbf24" stroke-width="1.8" stroke-dasharray="3 2"/>
+  <circle cx="500" cy="197" r="6" fill="none" stroke="#fbbf24" stroke-width="1.8" stroke-linecap="round" stroke-dasharray="0.1 3"/>
   <circle cx="500" cy="197" r="2.2" fill="#f87171"/>
   <rect x="594" y="191" width="12" height="12" rx="3" fill="#fbbf24"/>
   <circle cx="700" cy="197" r="5" fill="none" stroke="#787c99" stroke-width="1.8"/>
@@ -69,7 +69,7 @@
   <text class="stage" x="60" y="266">ship · review-pr</text>
   <circle cx="300" cy="261" r="5" fill="none" stroke="#9ece6a" stroke-width="1.8"/>
   <circle cx="400" cy="261" r="5" fill="#9ece6a"/>
-  <circle cx="500" cy="261" r="6" fill="none" stroke="#9ece6a" stroke-width="1.8" stroke-dasharray="3 2"/>
+  <circle cx="500" cy="261" r="6" fill="none" stroke="#9ece6a" stroke-width="1.8" stroke-linecap="round" stroke-dasharray="0.1 3"/>
   <circle cx="500" cy="261" r="2.2" fill="#f87171"/>
   <rect x="594" y="255" width="12" height="12" rx="3" fill="#9ece6a"/>
   <circle cx="700" cy="261" r="5" fill="none" stroke="#787c99" stroke-width="1.8"/>
@@ -80,7 +80,7 @@
   <text class="stage" x="60" y="330">PR</text>
   <circle cx="300" cy="325" r="5" fill="none" stroke="#c084fc" stroke-width="1.8"/>
   <circle cx="400" cy="325" r="5" fill="#c084fc"/>
-  <circle cx="500" cy="325" r="6" fill="none" stroke="#c084fc" stroke-width="1.8" stroke-dasharray="3 2"/>
+  <circle cx="500" cy="325" r="6" fill="none" stroke="#c084fc" stroke-width="1.8" stroke-linecap="round" stroke-dasharray="0.1 3"/>
   <circle cx="500" cy="325" r="2.2" fill="#f87171"/>
   <rect x="594" y="319" width="12" height="12" rx="3" fill="#c084fc"/>
   <circle cx="700" cy="325" r="5" fill="none" stroke="#787c99" stroke-width="1.8"/>
@@ -110,9 +110,9 @@
   <text class="sub" x="46" y="482" font-size="10.5">ring = pending</text>
   <circle cx="174" cy="478" r="5" fill="#787c99"/>
   <text class="sub" x="186" y="482" font-size="10.5">solid = active / ready</text>
-  <circle cx="350" cy="478" r="6" fill="none" stroke="#787c99" stroke-width="1.8" stroke-dasharray="3 2"/>
+  <circle cx="350" cy="478" r="6" fill="none" stroke="#787c99" stroke-width="1.8" stroke-linecap="round" stroke-dasharray="0.1 3"/>
   <circle cx="350" cy="478" r="2.2" fill="#f87171"/>
-  <text class="sub" x="362" y="482" font-size="10.5">dashed ring + red center = failed</text>
+  <text class="sub" x="362" y="482" font-size="10.5">dotted ring + red center = failed</text>
   <rect x="574" y="472" width="12" height="12" rx="3" fill="#787c99"/>
   <text class="sub" x="592" y="482" font-size="10.5">rounded square = done</text>
 

--- a/docs/site/status-dot.md
+++ b/docs/site/status-dot.md
@@ -58,7 +58,7 @@ ONE shape vocabulary across **all** phases (fab stages AND PR):
 |--------------------------------------------|-------|-----------|
 | `pending` (PR: checks running) | ring | hollow circle, 1.8px solid border in phase hue, transparent fill |
 | `active` / `ready` (PR: open / healthy) | solid circle | filled circle in phase hue |
-| `failed` (PR: checks fail / changes requested) | **dashed ring + red center** | dashed 1.8px border in phase hue, transparent fill, with a small **red** (`bg-red-400`) dot centered inside |
+| `failed` (PR: checks fail / changes requested) | **dotted ring + red center** | dotted 1.2px border in phase hue on a slightly larger 9px footprint, transparent fill, with a small **red** (`bg-red-400`) dot centered inside |
 | `done` (PR: merged) | square | filled sharp-cornered square (`rounded-none`) in phase hue |
 | `skipped` (PR: closed unmerged) | gray ring | hollow ring forced to gray (`text-text-secondary`) |
 
@@ -79,21 +79,21 @@ journey:
 
 | Stage (hue) | pending | active/ready | failed | done | skipped |
 |-------------|---------|--------------|--------|------|---------|
-| intake (blue) | blue ring | blue solid | blue dashed-ring + red center | blue square | gray ring |
-| apply/review/hydrate (amber) | amber ring | amber solid | amber dashed-ring + red center | amber square | gray ring |
-| ship/review-pr (green) | green ring | green solid | green dashed-ring + red center | green square | gray ring |
-| PR (purple) | purple ring (checks pending) | purple solid (open/healthy) | purple dashed-ring + red center (failing) | purple square (merged) | gray ring (closed) |
+| intake (blue) | blue ring | blue solid | blue dotted-ring + red center | blue square | gray ring |
+| apply/review/hydrate (amber) | amber ring | amber solid | amber dotted-ring + red center | amber square | gray ring |
+| ship/review-pr (green) | green ring | green solid | green dotted-ring + red center | green square | gray ring |
+| PR (purple) | purple ring (checks pending) | purple solid (open/healthy) | purple dotted-ring + red center (failing) | purple square (merged) | gray ring (closed) |
 | plain (gray) | — | gray solid (active) | — | — | gray ring (idle) |
 
 ## Red is used in exactly one way
 
-Across the entire system, **red appears only as the small center dot inside a `failed` dashed
+Across the entire system, **red appears only as the small center dot inside a `failed` dotted
 ring** — never as a whole-dot color. This deliberately removes two earlier special cases:
 
 - the merged `StatusDot`'s `fabDisplayState === "failed"` whole-dot red tint, and
 - the old PR dot's solid-red `fail` state.
 
-Both now render as a **dashed ring in their phase hue + a red center dot**.
+Both now render as a **dotted ring in their phase hue + a red center dot**.
 
 ## Accessibility
 


### PR DESCRIPTION
## Summary

The failed StatusDot rendered as a pink "flower" in the sidebar instead of the intended dashed ring from the design doc. Root cause: a CSS `dashed` border on a 7px circle fits only ~4 dashes (the browser controls the count), so they read as flower petals — and the 4px red center overflowed the thin ring. CSS gives no control over dash count, so this switches to a `dotted` border on a slightly larger 9px footprint, which renders as a clean bead ring at the dense sidebar size.

## Changes

- **`status-dot.tsx`** — failed branch: `1.8px dashed` @ 7px → `1.2px dotted` @ 9px; red center `4px → 3px` (now fits the ring's ~6.6px inner hole). The failed dot is the one deliberate exception to the uniform 7px `DOT_SIZE`; comments updated to document why.
- **`status-dot.test.tsx` / `window-row.test.tsx`** — 4 assertions + names/comments: `"dashed"` → `"dotted"`.
- **`docs/site/status-dot.md`** — spec language "dashed ring" → "dotted ring"; the CSS detail row now documents `dotted 1.2px @ 9px`.
- **`docs/img/status-dot-matrix.svg`** — all 5 failed cells + legend: dashed `stroke-dasharray="3 2"` → round-capped dotted (`stroke-linecap="round" stroke-dasharray="0.1 3"`).

### Verification
- `just check` (tsc --noEmit) — clean
- Full frontend Vitest suite — 790/790 pass
- Frontend-only change (no Go touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)