### PR TITLE
fix: PID-liveness reconciler, unclipped waiting halo, lowercase pr register key

### DIFF
--- a/app/backend/cmd/rk/agent_setup.go
+++ b/app/backend/cmd/rk/agent_setup.go
@@ -41,9 +41,15 @@ const rkHookMarker = tmux.AgentStateOption
 // pane option via plain tmux with no rk/server dependency at hook-fire time. The
 // state is a fixed literal (one of the three known states) — NOT user input — so
 // there is no injection surface (Constitution §I).
+//
+// The trailing `$PPID` segment is the AGENT's pid: the harness runs the hook as
+// its own `sh -c` child, so the shell's parent IS the agent process. Readers use
+// it for the precise PID-liveness reconciler (docs/specs/agent-state.md § Reader
+// rules) — this is what makes wrapped launches (pane command "bash" while the
+// agent runs inside) report state correctly.
 func agentStateHookCommand(state string) string {
 	return fmt.Sprintf(
-		`sh -c '[ -n "$TMUX_PANE" ] || exit 0; tmux set-option -pt "$TMUX_PANE" %s "%s:$(date +%%s)" 2>/dev/null || true'`,
+		`sh -c '[ -n "$TMUX_PANE" ] || exit 0; tmux set-option -pt "$TMUX_PANE" %s "%s:$(date +%%s):$PPID" 2>/dev/null || true'`,
 		rkHookMarker, state,
 	)
 }

--- a/app/backend/cmd/rk/agent_setup_test.go
+++ b/app/backend/cmd/rk/agent_setup_test.go
@@ -251,8 +251,10 @@ func TestApplyAgentConfigConfirmWritesAndIsIdempotent(t *testing.T) {
 func TestAgentStateHookCommandShape(t *testing.T) {
 	cmd := agentStateHookCommand(agentStateWaiting)
 	// Must self-locate via $TMUX_PANE, no-op outside tmux, never fail the agent,
-	// carry the marker + state, and write the epoch suffix.
-	for _, want := range []string{`[ -n "$TMUX_PANE" ] || exit 0`, rkHookMarker, "waiting:", "date +%s", "|| true"} {
+	// carry the marker + state, and write the epoch + agent-pid segments (the
+	// pid — $PPID = the hook shell's parent, i.e. the agent — feeds the
+	// PID-liveness reconciler).
+	for _, want := range []string{`[ -n "$TMUX_PANE" ] || exit 0`, rkHookMarker, "waiting:", "date +%s", `:$PPID"`, "|| true"} {
 		if !strings.Contains(cmd, want) {
 			t.Errorf("hook command missing %q: %s", want, cmd)
 		}

--- a/app/backend/internal/tmux/tmux.go
+++ b/app/backend/internal/tmux/tmux.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"rk/internal/validate"
@@ -218,10 +219,12 @@ const (
 )
 
 // shellCommands is the set of plain-shell pane_current_command values that the
-// reconciler treats as "no agent" — a pane running one of these has no agent
-// regardless of a leftover @rk_agent_state value (the guppi auto-clear lesson:
-// an Esc-interrupted or killed agent can strand a stale `active`). See
-// docs/specs/agent-state.md § Reader rules.
+// LEGACY reconciler fallback treats as "no agent" — applied only to
+// two-segment @rk_agent_state values (no pid segment, older writers). A pane
+// running one of these has no agent regardless of a leftover value (the guppi
+// auto-clear lesson: a killed agent can strand a stale `active`). Pid-carrying
+// values use the precise PID-liveness reconciler instead (agentProcessAlive)
+// and never consult this set. See docs/specs/agent-state.md § Reader rules.
 var shellCommands = map[string]bool{
 	"bash": true,
 	"zsh":  true,
@@ -241,30 +244,49 @@ func isAgentState(s string) bool {
 	return s == AgentStateActive || s == AgentStateWaiting || s == AgentStateIdle
 }
 
+// agentProcessAlive reports whether the agent process with the given pid is
+// still alive, via the classic kill(pid, 0) liveness probe: no signal is sent,
+// only existence/permission is checked. EPERM counts as alive (the process
+// exists but belongs to another user). Package-level var so tests can stub it —
+// parsePanes stays deterministic without real processes.
+var agentProcessAlive = func(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return err == nil || err == syscall.EPERM
+}
+
 // parseAgentState parses a raw @rk_agent_state value of the form
-// "<state>:<epoch_seconds>" into a validated (state, epoch) pair. A value that
-// is empty, lacks the colon, carries an unknown state token, or has a
-// non-integer epoch yields ("", 0) — unknown. Splitting on the LAST colon is
-// defensive; the state tokens never contain a colon, so it is equivalent to a
-// first-colon split for valid input.
-func parseAgentState(raw string) (string, int64) {
+// "<state>:<epoch_seconds>[:<pid>]" into a validated (state, epoch, pid)
+// triple. The pid segment is optional (written by rk agent-setup's hooks as
+// $PPID — the agent process itself, since the hook runs as its `sh -c` child);
+// pid is 0 when the segment is absent (legacy two-segment writers). A value
+// that is empty, has the wrong segment count, carries an unknown state token,
+// a non-integer epoch, or a malformed/non-positive pid yields ("", 0, 0) —
+// unknown (malformed values are never partially trusted).
+func parseAgentState(raw string) (string, int64, int) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
-		return "", 0
+		return "", 0, 0
 	}
-	i := strings.LastIndex(raw, ":")
-	if i < 0 {
-		return "", 0
+	parts := strings.Split(raw, ":")
+	if len(parts) < 2 || len(parts) > 3 {
+		return "", 0, 0
 	}
-	state := raw[:i]
+	state := parts[0]
 	if !isAgentState(state) {
-		return "", 0
+		return "", 0, 0
 	}
-	epoch, err := strconv.ParseInt(raw[i+1:], 10, 64)
+	epoch, err := strconv.ParseInt(parts[1], 10, 64)
 	if err != nil {
-		return "", 0
+		return "", 0, 0
 	}
-	return state, epoch
+	pid := 0
+	if len(parts) == 3 {
+		pid, err = strconv.Atoi(parts[2])
+		if err != nil || pid <= 0 {
+			return "", 0, 0
+		}
+	}
+	return state, epoch, pid
 }
 
 // PaneInfo describes a single tmux pane within a window.
@@ -282,8 +304,10 @@ type PaneInfo struct {
 	CwdMissing bool `json:"cwdMissing,omitempty"`
 	// AgentState is the generic agent-lifecycle state from the pane's
 	// @rk_agent_state option (active|waiting|idle; empty = unknown), after the
-	// shell-command reconciler. AgentStateEpoch is the option's epoch-seconds
-	// suffix (0 = unknown), from which idle/waiting duration is computed rk-side.
+	// reconciler (PID liveness for pid-carrying values; shell-command fallback
+	// for legacy two-segment values). AgentStateEpoch is the option's
+	// epoch-seconds segment (0 = unknown), from which idle/waiting duration is
+	// computed rk-side.
 	AgentState      string `json:"agentState,omitempty"`
 	AgentStateEpoch int64  `json:"agentStateEpoch,omitempty"`
 }
@@ -519,11 +543,13 @@ func ListSessions(ctx context.Context, server string) ([]SessionInfo, error) {
 // grouping and not stored in PaneInfo. Lines with fewer than 7 fields are
 // silently skipped. Empty input returns nil.
 //
-// The @rk_agent_state field (field 6) is parsed into AgentState/AgentStateEpoch
-// via parseAgentState, then reconciled: a pane whose command is a plain shell is
-// treated as having no agent (both fields zeroed) regardless of a leftover option
-// value — the guppi auto-clear lesson that prevents a stranded `active` after an
-// Esc-interrupt/kill.
+// The @rk_agent_state field (field 6) is parsed into
+// AgentState/AgentStateEpoch (+ an optional agent pid) via parseAgentState,
+// then reconciled: pid-carrying values are trusted iff the agent process is
+// alive (kill-0 liveness — precise, wrapper-launch-proof); legacy two-segment
+// values fall back to the shell-command heuristic (a plain-shell pane has no
+// agent — the guppi auto-clear lesson that prevents a stranded `active` after
+// a kill).
 //
 // Accessible to same-package tests.
 func parsePanes(lines []string) map[int][]PaneInfo {
@@ -547,10 +573,21 @@ func parsePanes(lines []string) map[int][]PaneInfo {
 		}
 		isActive := strings.TrimSpace(parts[5]) == "1"
 		command := strings.TrimSpace(parts[4])
-		agentState, agentEpoch := parseAgentState(parts[6])
-		// Reconciler: a plain-shell pane has no agent regardless of a leftover
-		// @rk_agent_state value.
-		if isShellCommand(command) {
+		agentState, agentEpoch, agentPID := parseAgentState(parts[6])
+		// Reconciler. Primary form (pid-carrying values from current
+		// agent-setup hooks): PID liveness — the state is trusted iff the agent
+		// process is still alive, regardless of the pane's command name. This
+		// fixes the wrapped-launch false negative (an agent started via a
+		// non-exec'ing shell wrapper reports pane_current_command = "bash"
+		// while genuinely running) and precisely clears state from a
+		// killed/crashed agent. Legacy fallback (two-segment values, no pid):
+		// the original shell-command heuristic — a plain-shell pane has no
+		// agent regardless of a leftover value.
+		if agentPID > 0 {
+			if !agentProcessAlive(agentPID) {
+				agentState, agentEpoch = "", 0
+			}
+		} else if isShellCommand(command) {
 			agentState, agentEpoch = "", 0
 		}
 		p := PaneInfo{

--- a/app/backend/internal/tmux/tmux_test.go
+++ b/app/backend/internal/tmux/tmux_test.go
@@ -698,21 +698,50 @@ func TestParsePanes(t *testing.T) {
 		}
 	})
 
-	t.Run("shell command reconciler zeros a leftover agent state", func(t *testing.T) {
+	t.Run("legacy shell-command reconciler zeros a two-segment leftover state", func(t *testing.T) {
 		for _, shell := range []string{"bash", "zsh", "fish", "sh", "dash"} {
 			lines := []string{paneLineAgent(0, "%1", 0, "/tmp", shell, 1, "active:1751790000")}
 			p := parsePanes(lines)[0][0]
 			if p.AgentState != "" || p.AgentStateEpoch != 0 {
-				t.Errorf("shell %q: AgentState=%q epoch=%d, want empty/0 (reconciler)", shell, p.AgentState, p.AgentStateEpoch)
+				t.Errorf("shell %q: AgentState=%q epoch=%d, want empty/0 (legacy reconciler)", shell, p.AgentState, p.AgentStateEpoch)
 			}
 		}
 	})
 
-	t.Run("non-shell command keeps agent state", func(t *testing.T) {
+	t.Run("non-shell command keeps a two-segment state", func(t *testing.T) {
 		lines := []string{paneLineAgent(0, "%1", 0, "/tmp", "claude", 1, "active:1751790000")}
 		p := parsePanes(lines)[0][0]
 		if p.AgentState != "active" || p.AgentStateEpoch != 1751790000 {
 			t.Errorf("claude: AgentState=%q epoch=%d, want active/1751790000", p.AgentState, p.AgentStateEpoch)
+		}
+	})
+
+	t.Run("pid-carrying state survives a shell pane command when the process is alive", func(t *testing.T) {
+		// The wrapped-launch case: claude started via a non-exec'ing bash
+		// wrapper, so pane_current_command reads "bash" while the agent runs.
+		// PID liveness must win over the shell-name heuristic.
+		restore := agentProcessAlive
+		agentProcessAlive = func(pid int) bool { return pid == 4242 }
+		defer func() { agentProcessAlive = restore }()
+
+		lines := []string{paneLineAgent(0, "%1", 0, "/tmp", "bash", 1, "waiting:1751790000:4242")}
+		p := parsePanes(lines)[0][0]
+		if p.AgentState != "waiting" || p.AgentStateEpoch != 1751790000 {
+			t.Errorf("alive pid under bash: AgentState=%q epoch=%d, want waiting/1751790000", p.AgentState, p.AgentStateEpoch)
+		}
+	})
+
+	t.Run("pid-carrying state zeroed when the process is dead", func(t *testing.T) {
+		// A crashed/killed agent must clear even when the pane command looks
+		// agent-like — liveness is authoritative for pid-carrying values.
+		restore := agentProcessAlive
+		agentProcessAlive = func(int) bool { return false }
+		defer func() { agentProcessAlive = restore }()
+
+		lines := []string{paneLineAgent(0, "%1", 0, "/tmp", "claude", 1, "active:1751790000:4242")}
+		p := parsePanes(lines)[0][0]
+		if p.AgentState != "" || p.AgentStateEpoch != 0 {
+			t.Errorf("dead pid: AgentState=%q epoch=%d, want empty/0", p.AgentState, p.AgentStateEpoch)
 		}
 	})
 }
@@ -722,21 +751,28 @@ func TestParseAgentState(t *testing.T) {
 		raw       string
 		wantState string
 		wantEpoch int64
+		wantPID   int
 	}{
-		{"active:100", "active", 100},
-		{"waiting:200", "waiting", 200},
-		{"idle:300", "idle", 300},
-		{"", "", 0},
-		{"active", "", 0},
-		{"active:", "", 0},
-		{"active:x", "", 0},
-		{"bogus:100", "", 0},
-		{" idle:400 ", "idle", 400}, // surrounding whitespace trimmed
+		{"active:100", "active", 100, 0},
+		{"waiting:200", "waiting", 200, 0},
+		{"idle:300", "idle", 300, 0},
+		{"active:100:4242", "active", 100, 4242}, // pid-carrying form
+		{"waiting:200:1", "waiting", 200, 1},
+		{"", "", 0, 0},
+		{"active", "", 0, 0},
+		{"active:", "", 0, 0},
+		{"active:x", "", 0, 0},
+		{"bogus:100", "", 0, 0},
+		{"active:100:x", "", 0, 0},      // malformed pid → wholly unknown
+		{"active:100:0", "", 0, 0},      // non-positive pid → wholly unknown
+		{"active:100:-7", "", 0, 0},     // negative pid → wholly unknown
+		{"active:100:4242:9", "", 0, 0}, // too many segments
+		{" idle:400 ", "idle", 400, 0},  // surrounding whitespace trimmed
 	}
 	for _, c := range cases {
-		state, epoch := parseAgentState(c.raw)
-		if state != c.wantState || epoch != c.wantEpoch {
-			t.Errorf("parseAgentState(%q) = (%q, %d), want (%q, %d)", c.raw, state, epoch, c.wantState, c.wantEpoch)
+		state, epoch, pid := parseAgentState(c.raw)
+		if state != c.wantState || epoch != c.wantEpoch || pid != c.wantPID {
+			t.Errorf("parseAgentState(%q) = (%q, %d, %d), want (%q, %d, %d)", c.raw, state, epoch, pid, c.wantState, c.wantEpoch, c.wantPID)
 		}
 	}
 }

--- a/app/frontend/src/components/sidebar/status-panel.tsx
+++ b/app/frontend/src/components/sidebar/status-panel.tsx
@@ -198,12 +198,14 @@ function PrLinkRow({ prUrl, prNumber, copied, onCopy, children }: {
             before the segments therefore live as NBSPs INSIDE the prefix/icon
             spans, not as separate text nodes. CopyableRow renders `${prefix} `
             (3-char prefix + a gap space = 4 monospace advances before its
-            icon), so the at-rest prefix here is "PR"+NBSP+NBSP (also 4 advances)
+            icon), so the at-rest prefix here is "pr"+NBSP+NBSP (also 4 advances)
             to keep the icon/content column-aligned with tmx/cwd/git/fab and the
-            no-URL pr branch. The "copied \u2713"+NBSP feedback is 9 advances,
-            matching CopyableRow's "copied \u2713 " copied rendering. */}
+            no-URL pr branch. Lowercase "pr" \u2014 the register keys are one
+            lowercase vocabulary (tmx/cwd/git/out/agt/fab/pr). The
+            "copied \u2713"+NBSP feedback is 9 advances, matching CopyableRow's
+            "copied \u2713 " copied rendering. */}
         <span className="text-text-secondary shrink-0">
-          {copied ? "copied \u2713\u00a0" : "PR\u00a0\u00a0"}
+          {copied ? "copied \u2713\u00a0" : "pr\u00a0\u00a0"}
         </span>
         <span className={`${ICON_CLASS} shrink-0`} aria-hidden="true">{"\uf407\u00a0"}</span>
         <span data-testid="pr-line" className="min-w-0 truncate">
@@ -378,7 +380,7 @@ function WindowContent({ win }: { win: WindowInfo }) {
             {segmentSpans}
           </PrLinkRow>
         ) : (
-          <CopyableRow prefix={"PR\u00A0"} copied={copiedRow === "pr"} onCopy={() => handleCopy("pr", prText)}>
+          <CopyableRow prefix={"pr\u00A0"} copied={copiedRow === "pr"} onCopy={() => handleCopy("pr", prText)}>
             <span className={ICON_CLASS} aria-hidden="true">{"\uF407"}</span>
             {" "}
             <span data-testid="pr-line">

--- a/app/frontend/src/components/sidebar/window-row.tsx
+++ b/app/frontend/src/components/sidebar/window-row.tsx
@@ -250,7 +250,13 @@ function WindowRowInner({
         onMouseEnter={tint && !isSelected ? (e) => { (e.currentTarget as HTMLElement).style.backgroundColor = tint.hover; } : undefined}
         onMouseLeave={tint && !isSelected ? (e) => { (e.currentTarget as HTMLElement).style.backgroundColor = tint.base; } : undefined}
       >
-        <span className="flex items-center gap-1.5 truncate min-w-0">
+        {/* No `truncate` on this wrapper: the dot's waiting halo is a
+            box-shadow that paints OUTSIDE the 7px dot, and `truncate`'s
+            overflow-hidden clipped it into a half-moon at the span's left
+            edge. The name span below carries its own `truncate`, so text
+            ellipsis is unaffected; `min-w-0` stays so that inner truncation
+            keeps working inside the flex row. */}
+        <span className="flex items-center gap-1.5 min-w-0">
           {/* Unified status dot: PR status when the window is change-bound with
               a PR (purple/red/yellow/green/hollow per prDotState), else
               monochrome terminal activity (filled=active, hollow ring=idle). One

--- a/docs/specs/agent-state.md
+++ b/docs/specs/agent-state.md
@@ -34,12 +34,17 @@ is derived server-side.
 |----------|-------|
 | Name | `@rk_agent_state` |
 | Scope | tmux **pane** user option (`set-option -p`) |
-| Value | `"<state>:<epoch_seconds>"` |
+| Value | `"<state>:<epoch_seconds>[:<pid>]"` |
 | States | `active` \| `waiting` \| `idle` |
-| Example | `waiting:1751790000` |
+| Example | `waiting:1751790000:48213` |
 
-The epoch suffix is **mandatory** — readers compute idle/waiting duration from
-it.
+The epoch segment is **mandatory** — readers compute idle/waiting duration from
+it. The pid segment is the **agent process's pid** and SHOULD be written by all
+current writers (`$PPID` inside the hook's `sh -c` — the shell's parent IS the
+agent); it feeds the PID-liveness reconciler (Reader rule 3). Readers MUST
+tolerate its absence (legacy two-segment values). A malformed value — wrong
+segment count, unknown state, non-integer epoch, or a malformed/non-positive
+pid — is wholly unknown; readers never partially trust it.
 
 ### State semantics
 
@@ -62,15 +67,23 @@ Hook commands that write the option MUST:
 3. **Never fail the agent** — every path exits 0 (`… 2>/dev/null || true`); a
    broken hook must never break the agent's turn.
 4. **Depend on nothing but tmux** — write via plain
-   `tmux set-option -pt "$TMUX_PANE" @rk_agent_state "<state>:<epoch>"`. No `rk`
-   binary and no run-kit server need be running at hook-fire time.
+   `tmux set-option -pt "$TMUX_PANE" @rk_agent_state "<state>:<epoch>:<pid>"`.
+   No `rk` binary and no run-kit server need be running at hook-fire time.
+5. **Carry the agent pid** — `$PPID` inside the hook's `sh -c` is the agent
+   process (the harness runs hooks as its own shell children). This is what
+   lets readers trust state on *wrapped launches*, where
+   `#{pane_current_command}` reads as a shell while the agent runs inside it.
 
 Canonical command (one literal per state; nothing user-provided is
 interpolated):
 
 ```sh
-sh -c '[ -n "$TMUX_PANE" ] || exit 0; tmux set-option -pt "$TMUX_PANE" @rk_agent_state "<state>:$(date +%s)" 2>/dev/null || true'
+sh -c '[ -n "$TMUX_PANE" ] || exit 0; tmux set-option -pt "$TMUX_PANE" @rk_agent_state "<state>:$(date +%s):$PPID" 2>/dev/null || true'
 ```
+
+> **Migration**: updating the hook strings requires re-running `rk agent-setup`
+> (idempotent — rk-owned entries are replaced in place) and **restarting agent
+> sessions** (harnesses snapshot hook config at session start).
 
 ---
 
@@ -80,11 +93,21 @@ sh -c '[ -n "$TMUX_PANE" ] || exit 0; tmux set-option -pt "$TMUX_PANE" @rk_agent
    has no hooks installed).
 2. **Duration from epoch** — readers compute idle/waiting duration from the
    epoch suffix; they MAY apply staleness heuristics on top.
-3. **Shell-command reconciler** — a pane whose `#{pane_current_command}` is a
-   plain shell (`bash` \| `zsh` \| `fish` \| `sh` \| `dash`) is treated as having
-   **no agent**, regardless of a leftover option value. An Esc-interrupted or
-   killed agent can strand a stale `active`; the reconciler auto-clears it (the
-   guppi lesson).
+3. **Reconciler** — clears stranded state from dead agents, in two forms:
+   - **PID liveness (primary — pid-carrying values)**: the state is trusted iff
+     the agent process is alive (`kill(pid, 0)`; `ESRCH` = dead → treat as no
+     agent; `EPERM` counts as alive). The pane's command name is IRRELEVANT for
+     these values — a wrapped launch (`#{pane_current_command}` = `bash` while
+     the agent runs inside a non-exec'ing wrapper) reports correctly, and a
+     killed/crashed agent clears precisely.
+   - **Shell-command fallback (legacy two-segment values only)**: a pane whose
+     `#{pane_current_command}` is a plain shell (`bash` \| `zsh` \| `fish` \|
+     `sh` \| `dash`) is treated as having **no agent**, regardless of a leftover
+     option value (the guppi lesson). Known false negative: wrapped launches —
+     which is why the pid form is preferred.
+   An Esc-interrupted agent (alive, at rest) is corrected by the hooks
+   themselves (`Notification: idle_prompt` rewrites to `idle` after ~60s) — the
+   reconciler's job is only the dead-process case.
 4. **Window rollup** — a window with multiple panes rolls up to a single state
    with precedence `waiting > active > idle` (a split window with one waiting
    pane is a waiting window). A per-pane truth is preserved for future pane/board


### PR DESCRIPTION
Three small fixes from live dogfooding of the status pyramid (#318/#319):

## 1. PID-liveness reconciler (the missing `agt` line for wrapped launches)
The shell-command reconciler produced a **false negative** for agents launched through a non-exec'ing shell wrapper: `pane_current_command` reads `bash` while Claude genuinely runs inside, so a fresh `active:<epoch>` was suppressed — no `agt` register, no yellow dot (observed live on the operator's own session pane).

- `rk agent-setup` hooks now write `<state>:<epoch>:$PPID` — $PPID inside the hook's `sh -c` **is** the agent process.
- The reader reconciles pid-carrying values by `kill(pid, 0)` liveness (EPERM = alive) — pane command name becomes irrelevant; dead agents clear precisely; wrapped launches report correctly.
- Legacy two-segment values keep the shell-name fallback (readers tolerate both).
- `docs/specs/agent-state.md` schema + writer/reader rules updated (the cross-repo contract — fab-kit #472's readers should tolerate the optional third segment).

**Migration**: re-run `rk agent-setup` (idempotent) and restart agent sessions (hook config snapshots at session start).

## 2. Waiting halo no longer clipped
The window row's dot wrapper carried `truncate` (overflow-hidden), slicing the waiting halo box-shadow into a half-moon at the span's left edge. The wrapper drops `truncate` (the name span truncates itself; `min-w-0` kept).

## 3. `pr` register key lowercased
Completes the single lowercase register vocabulary: `tmx/cwd/git/out/agt/fab/pr`.

## Gates
`just test-backend` green (new parse/reconciler cases incl. alive-under-bash and dead-under-claude) · `just test-frontend` 979/979 · `tsc --noEmit` clean · e2e `pane-register-panel` 3/3 + `row-minimalism` 1/1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)