### PR TITLE
fix: resolve agent pid via comm-validated ancestor walk in agent-setup hooks

### DIFF
--- a/app/backend/cmd/rk/agent_setup.go
+++ b/app/backend/cmd/rk/agent_setup.go
@@ -39,18 +39,22 @@ const rkHookMarker = tmux.AgentStateOption
 // agentStateHookCommand builds the fixed, self-contained hook command for a
 // given state. It is a no-op outside tmux, never fails the agent, and writes the
 // pane option via plain tmux with no rk/server dependency at hook-fire time. The
-// state is a fixed literal (one of the three known states) — NOT user input — so
-// there is no injection surface (Constitution §I).
+// state and comm are fixed registry literals (never user input), so there is no
+// injection surface (Constitution §I).
 //
-// The trailing `$PPID` segment is the AGENT's pid: the harness runs the hook as
-// its own `sh -c` child, so the shell's parent IS the agent process. Readers use
-// it for the precise PID-liveness reconciler (docs/specs/agent-state.md § Reader
-// rules) — this is what makes wrapped launches (pane command "bash" while the
-// agent runs inside) report state correctly.
-func agentStateHookCommand(state string) string {
+// The pid segment is resolved by a bounded, comm-validated ancestor walk (up to
+// 3 hops from $PPID) rather than raw $PPID: harnesses spawn hook commands
+// through an EPHEMERAL intermediate shell that exits the moment the hook
+// finishes (measured with Claude Code — a raw $PPID recorded that dead wrapper,
+// so the reader's liveness check suppressed every value). The walk climbs until
+// the process name equals the agent's comm (e.g. "claude"), which is the pid
+// the PID-liveness reconciler actually needs. If the walk cannot validate an
+// ancestor, the pid segment is omitted — a two-segment value that degrades to
+// the reader's legacy shell-name fallback, never a wrong pid.
+func agentStateHookCommand(state, comm string) string {
 	return fmt.Sprintf(
-		`sh -c '[ -n "$TMUX_PANE" ] || exit 0; tmux set-option -pt "$TMUX_PANE" %s "%s:$(date +%%s):$PPID" 2>/dev/null || true'`,
-		rkHookMarker, state,
+		`sh -c '[ -n "$TMUX_PANE" ] || exit 0; p=$PPID; i=0; while [ $i -lt 3 ] && [ -n "$p" ] && [ "$(ps -o comm= -p "$p" 2>/dev/null)" != "%s" ]; do p=$(ps -o ppid= -p "$p" 2>/dev/null | tr -d " "); i=$((i+1)); done; [ "$(ps -o comm= -p "$p" 2>/dev/null)" = "%s" ] || p=""; tmux set-option -pt "$TMUX_PANE" %s "%s:$(date +%%s)${p:+:$p}" 2>/dev/null || true'`,
+		comm, comm, rkHookMarker, state,
 	)
 }
 
@@ -64,10 +68,12 @@ type agentHook struct {
 }
 
 // agentConfig is one agent's install target: a display name, the user-global
-// settings file to merge into, and the ordered event→state hook mapping.
+// settings file to merge into, the agent process's comm name (for the hook's
+// pid-resolution walk), and the ordered event→state hook mapping.
 type agentConfig struct {
 	name         string
 	settingsPath string
+	comm         string // process name of the agent binary, e.g. "claude"
 	hooks        []agentHook
 }
 
@@ -91,6 +97,7 @@ func agentRegistry(home string) []agentConfig {
 		{
 			name:         "Claude Code",
 			settingsPath: filepath.Join(home, claudeSettingsRelPath),
+			comm:         "claude",
 			hooks: []agentHook{
 				{event: "UserPromptSubmit", state: agentStateActive},
 				{event: "PreToolUse", state: agentStateActive},
@@ -155,7 +162,7 @@ func applyAgentConfig(out io.Writer, reader *bufio.Reader, ac agentConfig, unins
 	if uninstall {
 		unmergeHooks(next)
 	} else {
-		mergeHooks(next, ac.hooks)
+		mergeHooks(next, ac.hooks, ac.comm)
 	}
 
 	beforeJSON := mustMarshalIndent(current)
@@ -253,7 +260,7 @@ func writeSettings(path string, m map[string]any) error {
 // preserved. The Claude hooks shape is:
 //
 //	hooks → <Event> → [ { matcher?, hooks: [ {type:"command", command} ] } ]
-func mergeHooks(settings map[string]any, hooks []agentHook) {
+func mergeHooks(settings map[string]any, hooks []agentHook, comm string) {
 	hooksRoot := asMap(settings["hooks"])
 	if hooksRoot == nil {
 		hooksRoot = map[string]any{}
@@ -273,7 +280,7 @@ func mergeHooks(settings map[string]any, hooks []agentHook) {
 
 	// Now append the fresh rk entries.
 	for _, h := range hooks {
-		hooksRoot[h.event] = append(asSlice(hooksRoot[h.event]), rkHookEntry(h))
+		hooksRoot[h.event] = append(asSlice(hooksRoot[h.event]), rkHookEntry(h, comm))
 	}
 
 	settings["hooks"] = hooksRoot
@@ -304,12 +311,12 @@ func unmergeHooks(settings map[string]any) {
 
 // rkHookEntry builds the Claude hook-entry object for one agentHook: an optional
 // matcher plus a single command handler.
-func rkHookEntry(h agentHook) map[string]any {
+func rkHookEntry(h agentHook, comm string) map[string]any {
 	entry := map[string]any{
 		"hooks": []any{
 			map[string]any{
 				"type":    "command",
-				"command": agentStateHookCommand(h.state),
+				"command": agentStateHookCommand(h.state, comm),
 			},
 		},
 	}

--- a/app/backend/cmd/rk/agent_setup_test.go
+++ b/app/backend/cmd/rk/agent_setup_test.go
@@ -51,7 +51,7 @@ func TestMergeHooksAddsEntriesAndPreservesExisting(t *testing.T) {
 		},
 	}
 
-	mergeHooks(existing, claudeHooks())
+	mergeHooks(existing, claudeHooks(), "claude")
 
 	// Non-hook config preserved.
 	if existing["model"] != "opus" {
@@ -82,11 +82,11 @@ func TestMergeHooksAddsEntriesAndPreservesExisting(t *testing.T) {
 
 func TestMergeHooksIdempotent(t *testing.T) {
 	settings := map[string]any{}
-	mergeHooks(settings, claudeHooks())
+	mergeHooks(settings, claudeHooks(), "claude")
 	first, _ := json.Marshal(settings)
 
 	// A second merge must not add duplicates and must produce identical output.
-	mergeHooks(settings, claudeHooks())
+	mergeHooks(settings, claudeHooks(), "claude")
 	second, _ := json.Marshal(settings)
 
 	if string(first) != string(second) {
@@ -108,7 +108,7 @@ func TestUnmergeHooksRemovesOnlyRkEntries(t *testing.T) {
 			},
 		},
 	}
-	mergeHooks(settings, claudeHooks())
+	mergeHooks(settings, claudeHooks(), "claude")
 	unmergeHooks(settings)
 
 	if got := countRkEntries(settings); got != 0 {
@@ -128,7 +128,7 @@ func TestUnmergeHooksDropsEmptyEventAndRoot(t *testing.T) {
 	// When rk owns the ONLY entries, uninstall must remove empty event arrays and
 	// the now-empty hooks object entirely.
 	settings := map[string]any{}
-	mergeHooks(settings, claudeHooks())
+	mergeHooks(settings, claudeHooks(), "claude")
 	unmergeHooks(settings)
 
 	if _, ok := settings["hooks"]; ok {
@@ -249,12 +249,13 @@ func TestApplyAgentConfigConfirmWritesAndIsIdempotent(t *testing.T) {
 }
 
 func TestAgentStateHookCommandShape(t *testing.T) {
-	cmd := agentStateHookCommand(agentStateWaiting)
+	cmd := agentStateHookCommand(agentStateWaiting, "claude")
 	// Must self-locate via $TMUX_PANE, no-op outside tmux, never fail the agent,
-	// carry the marker + state, and write the epoch + agent-pid segments (the
-	// pid — $PPID = the hook shell's parent, i.e. the agent — feeds the
-	// PID-liveness reconciler).
-	for _, want := range []string{`[ -n "$TMUX_PANE" ] || exit 0`, rkHookMarker, "waiting:", "date +%s", `:$PPID"`, "|| true"} {
+	// carry the marker + state, resolve the agent pid via the bounded
+	// comm-validated ancestor walk (raw $PPID records the harness's ephemeral
+	// hook-wrapper shell, which is dead by read time), and omit the pid segment
+	// when the walk fails (${p:+:$p} → two-segment legacy degrade).
+	for _, want := range []string{`[ -n "$TMUX_PANE" ] || exit 0`, rkHookMarker, "waiting:", "date +%s", `ps -o comm= -p "$p"`, `!= "claude"`, "${p:+:$p}", "|| true"} {
 		if !strings.Contains(cmd, want) {
 			t.Errorf("hook command missing %q: %s", want, cmd)
 		}

--- a/app/frontend/src/components/sidebar/collapsible-panel.tsx
+++ b/app/frontend/src/components/sidebar/collapsible-panel.tsx
@@ -287,7 +287,14 @@ export function CollapsiblePanel({
           </span>
           <TypedLabel text={title} className="font-bold uppercase tracking-wide" />
           {headerRight && (
-            <span className="ml-auto flex items-center gap-1 min-w-0 truncate">
+            /* No `truncate` here: the Pane panel's headerRight leads with a
+               StatusDot whose waiting halo is a box-shadow painting OUTSIDE
+               the dot — an overflow-hidden wrapper clips it into a half-moon
+               (same fix as the window-row dot wrapper). Every headerRight
+               consumer ellipsizes its own text (Pane/Host/Server carry inner
+               `truncate` spans; Boards is a fixed count), so `min-w-0` alone
+               is enough. */
+            <span className="ml-auto flex items-center gap-1 min-w-0">
               {headerRight}
             </span>
           )}

--- a/docs/specs/agent-state.md
+++ b/docs/specs/agent-state.md
@@ -69,16 +69,23 @@ Hook commands that write the option MUST:
 4. **Depend on nothing but tmux** — write via plain
    `tmux set-option -pt "$TMUX_PANE" @rk_agent_state "<state>:<epoch>:<pid>"`.
    No `rk` binary and no run-kit server need be running at hook-fire time.
-5. **Carry the agent pid** — `$PPID` inside the hook's `sh -c` is the agent
-   process (the harness runs hooks as its own shell children). This is what
-   lets readers trust state on *wrapped launches*, where
-   `#{pane_current_command}` reads as a shell while the agent runs inside it.
+5. **Carry the agent pid, resolved by a comm-validated ancestor walk** — NOT
+   raw `$PPID`: harnesses spawn hook commands through an *ephemeral*
+   intermediate shell that exits when the hook finishes (measured with Claude
+   Code — raw `$PPID` recorded that dead wrapper, so liveness suppressed every
+   value). The hook walks up from `$PPID` (bounded, 3 hops) until the process
+   name equals the agent's comm (a per-agent registry literal, e.g. `claude`),
+   and omits the pid segment entirely if the walk cannot validate an ancestor —
+   a two-segment value that degrades to the reader's legacy fallback, never a
+   wrong pid. This is what lets readers trust state on *wrapped launches*,
+   where `#{pane_current_command}` reads as a shell while the agent runs
+   inside it.
 
-Canonical command (one literal per state; nothing user-provided is
-interpolated):
+Canonical command (state and comm are fixed registry literals; nothing
+user-provided is interpolated):
 
 ```sh
-sh -c '[ -n "$TMUX_PANE" ] || exit 0; tmux set-option -pt "$TMUX_PANE" @rk_agent_state "<state>:$(date +%s):$PPID" 2>/dev/null || true'
+sh -c '[ -n "$TMUX_PANE" ] || exit 0; p=$PPID; i=0; while [ $i -lt 3 ] && [ -n "$p" ] && [ "$(ps -o comm= -p "$p" 2>/dev/null)" != "claude" ]; do p=$(ps -o ppid= -p "$p" 2>/dev/null | tr -d " "); i=$((i+1)); done; [ "$(ps -o comm= -p "$p" 2>/dev/null)" = "claude" ] || p=""; tmux set-option -pt "$TMUX_PANE" @rk_agent_state "<state>:$(date +%s)${p:+:$p}" 2>/dev/null || true'
 ```
 
 > **Migration**: updating the hook strings requires re-running `rk agent-setup`


### PR DESCRIPTION
Follow-up to #320, found live: after re-running `rk agent-setup` + restarting claude, the option was written as `active:<epoch>:1645918` — **but that pid was already dead** (the actual claude: 1642463, two hops up). The harness spawns hook commands through an *ephemeral intermediate shell* that exits when the hook finishes, so raw `$PPID` recorded the wrapper, the PID-liveness reconciler correctly said "dead", and every value was suppressed — still no `agt` line.

## Fix
The hook resolves the pid with a **bounded, comm-validated ancestor walk**: climb from `$PPID` (max 3 hops) until `ps -o comm=` equals the agent's registry literal (`claude`); if the walk can't validate an ancestor, the pid segment is **omitted** — a two-segment value that degrades to the legacy shell-name fallback, never a wrong pid.

Verified against reality before baking in: the walk resolves the true claude pid both when spawned directly and under a nested wrapper shell.

- `comm` threaded through the per-agent registry (`agentConfig.comm`) → `mergeHooks` → `rkHookEntry` → command builder; it's a fixed literal, no injection surface.
- `docs/specs/agent-state.md` writer rule 5 + canonical command updated with the measured rationale.
- Shape test asserts the walk pieces + the `${p:+:$p}` degrade.

**Migration** (unchanged): re-run `rk agent-setup`, restart agent sessions.

Gates: `just test-backend` green (cmd/rk + internal/tmux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)