### PR TITLE
fix: board page not filling viewport height

### DIFF
--- a/app/frontend/src/components/board/board-page.tsx
+++ b/app/frontend/src/components/board/board-page.tsx
@@ -698,8 +698,11 @@ function BoardPageContent({ name }: { name: string }) {
     />
   );
 
+  // `h-full` is load-bearing: Shell sizes to `height: 100%` (260707-4vq2), so
+  // this wrapper must span AppLayout's `flex-1` content region or the whole
+  // board collapses to content height.
   return (
-    <div className="bg-bg-primary text-text-primary">
+    <div className="h-full bg-bg-primary text-text-primary">
       <Shell sidebarChildren={sidebarElement}>
         {/* Sidebar grid area (desktop only — Shell removes it on mobile). The
             board route shares the unified Sidebar with AppShell; drag-resize

--- a/app/frontend/tests/e2e/boards-pin-flow.spec.md
+++ b/app/frontend/tests/e2e/boards-pin-flow.spec.md
@@ -23,7 +23,9 @@ backend and frontend agree on.
 
 **What it proves:** Pinning a real tmux window through the HTTP API moves
 the system into a state where (1) `GET /api/boards` lists the new board,
-(2) `/board/<name>` renders the pinned window's pane header, and (3)
+(2) `/board/<name>` renders the pinned window's pane header inside a
+full-viewport-height shell (regression guard: a missing `h-full` on the
+board page's wrapper collapses the Shell grid to content height), and (3)
 clicking the pane-header unpin button leaves the route on its empty-state
 copy.
 
@@ -36,6 +38,9 @@ copy.
 4. Navigate directly to `/board/<name>` (waitUntil `domcontentloaded` to
    skip waiting for every WebSocket child to settle).
 5. Assert `win-a` is visible (pane-header content).
-6. Click the pane-header `Unpin…` button.
-7. Poll `GET /api/boards` until the board disappears from the listing
+6. Assert the bottom bar (`footer`) sits at the viewport bottom — the
+   Shell fills the full height (Shell is `height: 100%`, so the board
+   wrapper must carry `h-full`).
+7. Click the pane-header `Unpin…` button.
+8. Poll `GET /api/boards` until the board disappears from the listing
    (empty boards are removed per spec — `Empty board cannot exist`).

--- a/app/frontend/tests/e2e/boards-pin-flow.spec.ts
+++ b/app/frontend/tests/e2e/boards-pin-flow.spec.ts
@@ -67,6 +67,18 @@ test.describe("Boards: Pin flow", () => {
       timeout: 10_000,
     });
 
+    // Regression: the board Shell must fill the viewport. Shell sizes to
+    // `height: 100%`, so a missing `h-full` on the board page's wrapper
+    // collapses the grid to content height and the bottom bar floats
+    // mid-page instead of sitting at the viewport bottom.
+    const viewport = page.viewportSize();
+    expect(viewport).toBeTruthy();
+    const bottomBar = await page.locator("footer").boundingBox();
+    expect(bottomBar).toBeTruthy();
+    expect(bottomBar!.y + bottomBar!.height).toBeGreaterThanOrEqual(
+      viewport!.height - 2,
+    );
+
     // Unpin via the pane-header button — verify it's reachable, then assert
     // the API state via the listing endpoint. (We click rather than calling
     // the API directly to exercise the rendered unpin button; we don't poll


### PR DESCRIPTION
## Summary

PR #326 changed Shell to size via `height: 100%`, which requires a definite-height parent chain. The board page wraps Shell in a plain `div` with no height, so the percentage resolved to auto and the whole board grid collapsed to content height — panes hugged the top of the viewport and the bottom bar floated mid-page. Adds `h-full` to the board page's wrapper so it spans AppLayout's `flex-1` content region, and a regression assertion in the boards-pin-flow e2e that the bottom bar sits at the viewport bottom (verified failing at 516px without the fix, passing with it).