### PR TITLE
feat: Denser Sidebar Rows on Fine Pointers

### DIFF
--- a/app/frontend/src/components/sidebar/boards-section.tsx
+++ b/app/frontend/src/components/sidebar/boards-section.tsx
@@ -68,7 +68,7 @@ export function BoardsSection() {
                   onDrop={drag.onDrop}
                   onClick={() => navigate({ to: "/board/$name", params: { name: b.name } })}
                   aria-current={isActive ? "page" : undefined}
-                  className={`w-full flex items-center justify-between gap-2 px-2 py-1 text-left transition-colors min-h-[36px] ${
+                  className={`w-full flex items-center justify-between gap-2 px-2 py-px text-left transition-colors min-h-[24px] coarse:min-h-[36px] ${
                     isActive
                       ? "bg-bg-card text-text-primary font-medium"
                       : "text-text-secondary hover:text-text-primary hover:bg-bg-card/50"

--- a/app/frontend/src/components/sidebar/index.tsx
+++ b/app/frontend/src/components/sidebar/index.tsx
@@ -1500,7 +1500,14 @@ function ServerGroupInner(props: ServerGroupProps) {
               const sessionRowKey = `${server}:${session.name}`;
               const windowGroupId = `windows-${server}-${session.name}`;
               return (
-                <div key={session.name} className={`mb-1${isGhostSession ? " opacity-50 animate-pulse" : ""}`}>
+                <div
+                  key={session.name}
+                  // Stable per-session wrapper handle for tests (e.g.
+                  // sync-latency scopes window-row counts to one session) —
+                  // don't couple selectors to the spacing utility classes.
+                  data-session-group={session.name}
+                  className={`mb-1${isGhostSession ? " opacity-50 animate-pulse" : ""}`}
+                >
                   <SessionRow
                     server={server}
                     session={session}

--- a/app/frontend/src/components/sidebar/index.tsx
+++ b/app/frontend/src/components/sidebar/index.tsx
@@ -1500,7 +1500,7 @@ function ServerGroupInner(props: ServerGroupProps) {
               const sessionRowKey = `${server}:${session.name}`;
               const windowGroupId = `windows-${server}-${session.name}`;
               return (
-                <div key={session.name} className={`mb-2${isGhostSession ? " opacity-50 animate-pulse" : ""}`}>
+                <div key={session.name} className={`mb-1${isGhostSession ? " opacity-50 animate-pulse" : ""}`}>
                   <SessionRow
                     server={server}
                     session={session}

--- a/app/frontend/src/components/sidebar/session-row.tsx
+++ b/app/frontend/src/components/sidebar/session-row.tsx
@@ -150,7 +150,7 @@ function SessionRowInner({
       <div className="flex items-center gap-1.5 min-w-0 flex-1">
         <button
           onClick={() => onToggleCollapse(server, name)}
-          className="text-xs text-text-secondary hover:text-text-primary transition-colors shrink-0 min-h-[36px] flex items-center justify-center"
+          className="text-xs text-text-secondary hover:text-text-primary transition-colors shrink-0 min-h-[24px] coarse:min-h-[36px] flex items-center justify-center"
           aria-expanded={!isCollapsed}
           aria-label={`${isCollapsed ? "Expand" : "Collapse"} ${session.name}`}
         >
@@ -168,7 +168,7 @@ function SessionRowInner({
             e.stopPropagation();
             if (editingSession !== name) onDoubleClickName(server, name);
           }}
-          className="flex items-center gap-1 text-xs text-text-secondary hover:text-text-primary transition-colors py-1 min-h-[36px] min-w-0 flex-1"
+          className="flex items-center gap-1 text-xs text-text-secondary hover:text-text-primary transition-colors py-px min-h-[24px] coarse:min-h-[36px] min-w-0 flex-1"
           aria-label={`Navigate to ${session.name}`}
         >
           {editingSession === session.name ? (
@@ -206,7 +206,7 @@ function SessionRowInner({
               setShowColorPicker((v) => !v);
             }}
             aria-label={`Set color for ${session.name}`}
-            className="text-text-secondary hover:text-text-primary transition-opacity opacity-0 group-hover:opacity-100 coarse:opacity-100 px-0.5 min-h-[36px] flex items-center justify-center"
+            className="text-text-secondary hover:text-text-primary transition-opacity opacity-0 group-hover:opacity-100 coarse:opacity-100 px-0.5 min-h-[24px] coarse:min-h-[36px] flex items-center justify-center"
           >
             <PaletteIcon />
           </button>
@@ -214,14 +214,14 @@ function SessionRowInner({
         <button
           onClick={() => onCreateWindow(server, name)}
           aria-label={`New window in ${session.name}`}
-          className="text-text-secondary hover:text-text-primary transition-colors text-[16px] px-1 min-h-[36px] flex items-center justify-center"
+          className="text-text-secondary hover:text-text-primary transition-colors text-[16px] px-1 min-h-[24px] coarse:min-h-[36px] flex items-center justify-center"
         >
           +
         </button>
         <button
           onClick={(e) => onKillClick(server, name, session.windows.length, e.ctrlKey || e.metaKey)}
           aria-label={`Kill session ${session.name}`}
-          className="text-text-secondary hover:text-red-400 transition-colors text-[16px] px-1 min-h-[36px] flex items-center justify-center"
+          className="text-text-secondary hover:text-red-400 transition-colors text-[16px] px-1 min-h-[24px] coarse:min-h-[36px] flex items-center justify-center"
         >
           {"\u2715"}
         </button>

--- a/app/frontend/src/components/sidebar/window-row.tsx
+++ b/app/frontend/src/components/sidebar/window-row.tsx
@@ -183,12 +183,12 @@ function WindowRowInner({
     // border), tint the left border in accent color so the user sees which
     // windows belong to the board they're viewing.
     if (isSelected) {
-      style.borderLeft = `8px solid ${borderColor ?? "var(--color-accent)"}`;
+      style.borderLeft = `4px solid ${borderColor ?? "var(--color-accent)"}`;
     } else if (isPinnedToActiveBoard) {
-      style.borderLeft = "8px solid var(--color-accent)";
+      style.borderLeft = "4px solid var(--color-accent)";
     } else {
       // Always reserve left border space to prevent text shift between states.
-      style.borderLeft = "8px solid transparent";
+      style.borderLeft = "4px solid transparent";
     }
     return Object.keys(style).length > 0 ? style : undefined;
   }, [tint, uncoloredSelectedTint, isSelected, borderColor, isPinnedToActiveBoard]);
@@ -198,7 +198,9 @@ function WindowRowInner({
   const showPinIcon = !ghost && !!server;
   const buttonClass = useMemo(() => {
     const rightPad = showPinIcon ? "pr-[68px]" : "pr-11";
-    const base = `w-full text-left flex items-center justify-between gap-2 py-1 pl-2 ${rightPad} text-sm transition-colors min-h-[36px]`;
+    // Dense rows on fine pointers (24px); touch keeps the 36px target via the
+    // `coarse:` variant (context.md § Mobile Responsive Design).
+    const base = `w-full text-left flex items-center justify-between gap-2 py-px pl-2 ${rightPad} text-xs transition-colors min-h-[24px] coarse:min-h-[36px]`;
     if (isSelected) {
       // Colored selected uses tint.selected; uncolored selected borrows gray tint — both via buttonStyle.
       return `${base} text-text-primary font-medium`;
@@ -273,7 +275,7 @@ function WindowRowInner({
               onBlur={onRenameBlur}
               onClick={(e) => e.stopPropagation()}
               onMouseDown={(e) => e.stopPropagation()}
-              className="text-sm bg-transparent border border-accent rounded px-0.5 outline-none truncate w-full"
+              className="text-xs bg-transparent border border-accent rounded px-0.5 outline-none truncate w-full"
               aria-label="Rename window"
             />
           ) : (
@@ -310,7 +312,7 @@ function WindowRowInner({
               isPinnedToAny
                 ? "opacity-100 text-text-secondary hover:text-text-primary"
                 : "opacity-0 group-hover:opacity-100 coarse:opacity-100 focus-visible:opacity-100 text-text-secondary hover:text-text-primary"
-            } px-0.5 min-h-[36px] flex items-center justify-center`}
+            } px-0.5 min-h-[24px] coarse:min-h-[36px] flex items-center justify-center`}
           >
             <PinIcon filled={isPinnedToAny} />
           </button>
@@ -324,7 +326,7 @@ function WindowRowInner({
               e.stopPropagation();
               setShowColorPicker((v) => !v);
             }}
-            className="text-text-secondary hover:text-text-primary transition-opacity cursor-pointer opacity-0 group-hover:opacity-100 coarse:opacity-100 focus-visible:opacity-100 px-0.5 min-h-[36px] flex items-center justify-center"
+            className="text-text-secondary hover:text-text-primary transition-opacity cursor-pointer opacity-0 group-hover:opacity-100 coarse:opacity-100 focus-visible:opacity-100 px-0.5 min-h-[24px] coarse:min-h-[36px] flex items-center justify-center"
           >
             <PaletteIcon />
           </button>
@@ -336,7 +338,7 @@ function WindowRowInner({
             e.stopPropagation();
             if (!ghost) onKillClick(srv, session, win.windowId, e.ctrlKey || e.metaKey);
           }}
-          className="text-[14px] text-text-secondary hover:text-red-400 transition-opacity cursor-pointer opacity-0 group-hover:opacity-100 coarse:opacity-100 focus-visible:opacity-100 px-1 min-h-[36px] flex items-center justify-center"
+          className="text-[14px] text-text-secondary hover:text-red-400 transition-opacity cursor-pointer opacity-0 group-hover:opacity-100 coarse:opacity-100 focus-visible:opacity-100 px-1 min-h-[24px] coarse:min-h-[36px] flex items-center justify-center"
         >
           {"\u2715"}
         </button>

--- a/app/frontend/tests/e2e/sync-latency.spec.md
+++ b/app/frontend/tests/e2e/sync-latency.spec.md
@@ -76,13 +76,12 @@ expanded).
 1. `setup`.
 2. Assert session B is visible.
 3. If `New window in ${SESSION_B}` button is visible:
-   a. Scope to SESSION_B's window rows — the per-session `div.mb-2` wrapper
-      (unique to the session wrapper in `sidebar/index.tsx`) that `has`
-      SESSION_B's `Navigate to ` button — and count its `[data-window-id]`
-      rows (the stable window-row handle; real `@N` ids and `ghost-<id>`
-      rows alike). Anchoring on `div.mb-2` resolves to exactly SESSION_B's
-      wrapper, so no `.first()` is needed (a bare `div` filter would match
-      the whole-server container and over-count every session's rows).
+   a. Scope to SESSION_B's window rows — the per-session wrapper's stable
+      `data-session-group="${SESSION_B}"` handle (`sidebar/index.tsx`) —
+      and count its `[data-window-id]` rows (the stable window-row handle;
+      real `@N` ids and `ghost-<id>` rows alike). The attribute is keyed by
+      session name, so it selects exactly SESSION_B's wrapper without
+      relational `has` filtering.
    b. Start the timer, then click the `+` button. If a dialog appears (it
       doesn't for the current-server sidebar `+`, which is instant), click
       its `Create` button.

--- a/app/frontend/tests/e2e/sync-latency.spec.ts
+++ b/app/frontend/tests/e2e/sync-latency.spec.ts
@@ -169,25 +169,17 @@ test.describe("Sync Latency Audit", () => {
     const newWinBtn = sidebar.locator(`button[aria-label='New window in ${SESSION_B}']`);
 
     if (await newWinBtn.isVisible().catch(() => false)) {
-      // Scope to SESSION_B's window rows. The session wrapper has no
-      // `data-session` attribute, so we locate it relationally by anchoring on
-      // the per-session wrapper class `div.mb-2` (unique to the session
-      // wrapper at sidebar/index.tsx:1117) that `has` SESSION_B's
-      // `Navigate to ` button, then count its `[data-window-id]` descendants.
-      // `div.mb-2` + `.filter({ has })` resolves to exactly SESSION_B's
-      // wrapper, so `.first()` is deliberately NOT used: a bare
-      // `.locator("div").filter({ has }).first()` would resolve to the
-      // outermost matching ancestor — the whole-server Sessions container
-      // (index.tsx:731) — and over-count every session's rows.
+      // Scope to SESSION_B's window rows via the wrapper's stable
+      // `data-session-group` handle (sidebar/index.tsx) — keyed by session
+      // name, so it selects exactly SESSION_B's wrapper with no relational
+      // `.filter({ has })` anchoring.
       // `[data-window-id]` is the canonical, stable window-row handle (real
       // windows = tmux `@N`, ghost rows = `ghost-<optimisticId>`) — the same
       // one sidebar-window-sync.spec.ts selects by. The auto-derived window
       // name is unpredictable, so we detect "a new row appeared" by a count
       // increase rather than by name, mirroring test 1's session-level
       // row-count poll.
-      const sessionBGroup = sidebar
-        .locator("div.mb-2")
-        .filter({ has: page.locator(`button[aria-label='Navigate to ${SESSION_B}']`) });
+      const sessionBGroup = sidebar.locator(`[data-session-group="${SESSION_B}"]`);
       const winRows = sessionBGroup.locator("[data-window-id]");
       const beforeCount = await winRows.count();
 


### PR DESCRIPTION
## Summary

Sidebar rows (windows, sessions, boards) were sized to the 36px touch target on every pointer type, capping how many rows fit in the sessions panel. This moves the 36px minimum behind the `coarse:` variant (per the existing pointer-based sizing convention) and adopts IDE-tree density on fine pointers: 24px rows, `text-xs`, a 4px selected/pinned left border, and tighter session-block spacing — roughly 50% more rows visible on desktop, with touch devices unchanged.

## Changes

- `window-row.tsx` — row button 36px → `min-h-[24px] coarse:min-h-[36px]`, `text-sm` → `text-xs`, `py-1` → `py-px`; selected/pinned/reserved left border 8px → 4px; hover-reveal pin/palette/kill buttons follow the row height so they no longer overhang adjacent rows mid-hover
- `session-row.tsx` — chevron, name, palette, new-window, and kill controls get the same `min-h-[24px] coarse:min-h-[36px]` treatment
- `boards-section.tsx` — board rows likewise 36px → 24px on fine pointers
- `sidebar/index.tsx` — per-session block gap `mb-2` → `mb-1`

Verified: tsc, 1071 unit tests, targeted e2e (row-minimalism, sidebar-panels, mobile-layout, pr-status-sidebar, session-reorder), plus Playwright screenshots of cabin + terminal views (selected border, hover icons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)