### PR TITLE
fix: Wider Server Tiles to Fit Waiting Badge

### DIFF
--- a/app/frontend/src/components/sidebar/server-panel.tsx
+++ b/app/frontend/src/components/sidebar/server-panel.tsx
@@ -113,7 +113,10 @@ export function ServerPanel({
         scrollSnapType: "x mandatory",
       }
     : {
-        gridTemplateColumns: "repeat(auto-fill, minmax(72px, 1fr))",
+        // 88px floor (matching the mobile column width): the tile's count row
+        // must fit "N sess" plus the waiting rollup badge side by side — at the
+        // old 72px floor that pair exactly overflowed the padded content box.
+        gridTemplateColumns: "repeat(auto-fill, minmax(88px, 1fr))",
       };
 
   return (

--- a/app/frontend/src/components/sidebar/server-panel.tsx
+++ b/app/frontend/src/components/sidebar/server-panel.tsx
@@ -320,7 +320,11 @@ function ServerTile({
               tile's top-right (this is why the Cockpit tile's absolute top-right
               placement is not copied). WaitingBadge renders null at count <= 0,
               so the common (nothing-waiting) layout is unchanged. */}
-          <div className="flex items-center justify-between mt-0.5">
+          {/* h-4 reserves the badge's full height even when no badge renders:
+              the pill is taller than the count text, so without the reserve the
+              tile (and its whole grid row) would jump in height every time an
+              agent starts/stops waiting. */}
+          <div className="flex h-4 items-center justify-between mt-0.5">
             <div className="text-[10px] leading-tight text-text-secondary">
               {sessionCount} sess
             </div>


### PR DESCRIPTION
## Summary

When a server has waiting agents, the sidebar SERVER panel tile shows the yellow waiting-rollup badge on the same row as the "N sess" count. Two sizing problems: at the desktop grid's 72px tile floor the pair overflowed the padded content box, cramming the badge against the tile edge; and because the badge pill is taller than the count text, tiles (and their whole grid row) jumped in height every time an agent started or stopped waiting. This raises the desktop tile floor to 88px (matching the mobile column width) and reserves the badge's height in the count row permanently — tile dimensions are now constant whether or not the badge is visible.

## Changes

- `server-panel.tsx` — desktop grid `minmax(72px, 1fr)` → `minmax(88px, 1fr)`
- `server-panel.tsx` — count row gets a fixed `h-4` (the badge pill's exact height), so badge appearance/disappearance no longer resizes the tile

Verified: tsc, 1071 unit tests, server-panel-grid e2e (5/5), and a live before/after measurement with an injected waiting state — tile bounding box is byte-identical (97.5×47.75) with and without the badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)