### PR TITLE
fix: Remove Empty-Wrapper Gap in Top-Bar Right Cluster

### DIFF
--- a/app/frontend/src/components/top-bar.tsx
+++ b/app/frontend/src/components/top-bar.tsx
@@ -473,17 +473,17 @@ export function TopBar({
           {/* Update chip — leads the L3 cluster. Self-contained (reads the
               update-notification state from SessionContext); renders nothing when
               no qualifying update is pending, when dismissed for the current
-              latest, or when the daemon reports the `dev` version. */}
-          <span className="hidden sm:flex">
-            <UpdateChip />
-          </span>
+              latest, or when the daemon reports the `dev` version. Carries its
+              own `hidden sm:flex` gating: a call-site wrapper span would remain
+              in this gap-3 flex row as an empty item while the chip renders
+              null, doubling the gap between its neighbors. */}
+          <UpdateChip />
 
           {/* Notification control — bell button + dropdown (enable / send test).
               Hides itself when push is unsupported (insecure context / no SW
-              support). */}
-          <span className="hidden sm:flex">
-            <NotificationControl />
-          </span>
+              support), and carries its own responsive gating for the same
+              empty-flex-item reason as UpdateChip. */}
+          <NotificationControl />
 
           {/* Theme toggle. */}
           <span className="hidden sm:flex">
@@ -1660,7 +1660,7 @@ function UpdateChip() {
   };
 
   return (
-    <span className="flex items-center">
+    <span className="hidden sm:flex items-center">
       <button
         type="button"
         onClick={handleUpdate}
@@ -1760,7 +1760,7 @@ function NotificationControl() {
     "w-full text-left text-xs text-text-secondary hover:text-text-primary transition-colors py-1.5 px-2 rounded hover:bg-bg-card disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-text-secondary";
 
   return (
-    <div ref={containerRef} className="relative inline-flex items-center">
+    <div ref={containerRef} className="relative hidden sm:inline-flex items-center">
       <button
         ref={triggerRef}
         type="button"

--- a/app/frontend/src/components/update-chip.test.tsx
+++ b/app/frontend/src/components/update-chip.test.tsx
@@ -110,6 +110,27 @@ describe("UpdateChip", () => {
     expect(screen.getByText("⬆ v0.7.0")).toBeInTheDocument();
   });
 
+  it("leaves no empty flex item in the top bar when hidden (gap regression)", () => {
+    // Self-hiding controls must carry their own responsive gating: an
+    // always-rendered call-site wrapper stays in the gap-3 flex row as an
+    // empty item while the child renders null, doubling the gap between
+    // its neighbors.
+    const { container } = renderChip({ daemonVersion: "0.5.3", updateAvailable: null });
+    const emptyHidden = Array.from(container.querySelectorAll(".hidden")).filter(
+      (el) => el.childNodes.length === 0,
+    );
+    expect(emptyHidden).toHaveLength(0);
+  });
+
+  it("carries the responsive `hidden sm:flex` gating on its own root", () => {
+    renderChip({
+      daemonVersion: "0.5.3",
+      updateAvailable: { current: "0.5.3", latest: "0.6.0" },
+    });
+    const root = screen.getByLabelText("Update run-kit to v0.6.0").parentElement;
+    expect(root).toHaveClass("hidden", "sm:flex");
+  });
+
   it("clicking the chip triggers updateNow and enters updating…", async () => {
     let resolveUpdate!: () => void;
     const updateNow = vi.fn(


### PR DESCRIPTION
## Summary

After #340, the top-bar right-cluster buttons lost their even spacing: a double gap appeared between the close button and the bell.

**Root cause**: `UpdateChip` and `NotificationControl` are self-hiding (they render `null` when there is no qualifying update / push is unsupported), but their call sites wrapped them in always-rendered `<span className="hidden sm:flex">` elements. An empty span in the `gap-3` flex row still collects the gap on both sides, so the row showed 2× spacing wherever a child rendered nothing — the *common* state for the update chip. The same latent flaw existed for the bell on plain-HTTP origins (push unsupported → null), just masked on HTTPS.

**Fix**: move the responsive `hidden sm:*` gating onto each component's own root element and drop the call-site wrappers, so a hidden control leaves no flex item behind. The font control's identical-looking root was left untouched — it never self-hides.

## Testing

- New regression test: renders the top bar with the chip hidden and asserts no empty `.hidden` flex items remain (verified it **fails** against the pre-fix `top-bar.tsx` from main, passes with the fix)
- New test: chip root carries `hidden sm:flex` so the below-`sm` gating survives the refactor
- `just test-frontend`: 63 files / 1092 tests pass; `tsc --noEmit` clean