### PR TITLE
feat: Brand Logo Kickstart Spin on Hover

### DIFF
--- a/app/frontend/src/components/top-bar.tsx
+++ b/app/frontend/src/components/top-bar.tsx
@@ -233,7 +233,7 @@ export function TopBar({
             title="Cockpit"
             className={`flex items-center gap-2 shrink-0 rk-brand-glitch ${LINK_CRUMB_CLASS}`}
           >
-            <img src="/icon.svg" alt="Run Kit" width={20} height={20} />
+            <img src="/icon.svg" alt="Run Kit" width={20} height={20} className="rk-brand-logo" />
             {/* [text-decoration:inherit] — the anchor is a flex container and
                 text-decoration does not propagate into flex items, so an
                 underline-based LINK_CRUMB_CLASS would silently skip the

--- a/app/frontend/src/globals.css
+++ b/app/frontend/src/globals.css
@@ -104,7 +104,8 @@ summary {
 
 /* ── Hover-animation vocabulary (change 260703-5ilm; boot sweep 260704-pr0p) ──
    One motion treatment per element category, so motion carries meaning:
-     glitch      = brand (rk-brand-glitch)
+     glitch      = brand (rk-brand-glitch; the logo inside additionally
+                   kickstart-spins — rk-brand-logo)
      boot sweep  = top-bar page heading (JS, in top-bar.tsx — one inverse-video
                    cursor sweeps the `PageType: name` string: TypedLabel-style
                    over the prefix, decode glyph churn over the name; reuses the
@@ -175,6 +176,18 @@ summary {
 .rk-brand-glitch:hover {
   animation: rk-glitch 300ms steps(2) 1;
   color: var(--color-accent-green);
+}
+
+/* The logo rides the glitch with a kickstart spin: four full turns in 600ms,
+   launched at full speed and decelerating into the landing. 1440° is a 360°
+   multiple so the hexagon always lands aligned; at this speed the launch reads
+   as flicker (the glitch's texture) and the decelerating tail is where the
+   rotation becomes visible. Scoped to the logo — the wordmark only glitches. */
+@keyframes rk-brand-spin {
+  to { transform: rotate(1440deg); }
+}
+.rk-brand-glitch:hover .rk-brand-logo {
+  animation: rk-brand-spin 600ms cubic-bezier(0.16, 0.84, 0.32, 1) 1;
 }
 
 /* Blink for the SectionHeading reserved caret (.rk-bracket-caret) on hover. */
@@ -275,6 +288,7 @@ summary {
   .rk-glint::after,
   .rk-glint:hover::after { animation: none; opacity: 0; }
   .rk-brand-glitch:hover { animation: none; }
+  .rk-brand-glitch:hover .rk-brand-logo { animation: none; }
   /* (typed-label sweep is skipped in JS — no CSS gate needed) */
   .rk-bracket-group .rk-bracket,
   .rk-bracket-group:hover .rk-bracket-open,


### PR DESCRIPTION
## Summary

Hovering the top-bar brand crumb now spins the hexagon logo four full turns (1440°) in 600ms with an ease-out kickstart — launching at full speed and decelerating into an aligned landing — layered on the existing `rk-glitch` RGB-split treatment. The spin targets the logo only (`rk-brand-logo`); the wordmark keeps the glitch, and the animation is zeroed under `prefers-reduced-motion` alongside the rest of the hover vocabulary.