### PR TITLE
docs: Window Views Spec, Desktop-View Plan, Web-View-Lens Intake

### DIFF
--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -30,6 +30,7 @@
 | [Short-Term Goal](short-term-goal.md) | Minimum viable product requirements and priorities |
 | [Status Pyramid](status-pyramid.md) | Precedence model for status signals — tier ladder (PR > fab > agent > tmux), channel model (hue/shape/animation), attention overlay, decision table, rollups |
 | [Themes](themes.md) | Theme system architecture: ANSI palettes, derivation, tmux integration, import script |
+| [Window Views](window-views.md) | Rows are substrates, views are lenses — the parallel-view model (tty/web/chat/desktop): derived availability vs per-viewer choice, the shared switcher contract, two-species taxonomy, migration map for iframe / desktop (PR #71) / chat |
 
 ## Wiki
 

--- a/docs/specs/window-views.md
+++ b/docs/specs/window-views.md
@@ -1,0 +1,172 @@
+# Window Views — Rows Are Substrates, Views Are Lenses
+
+> The model for every "parallel view" of a tmux window run-kit renders: what a
+> window row *is*, what a view *is*, how view availability is derived, and how
+> view choice is expressed. This spec unifies three features that grew up with
+> three unrelated mechanisms — iframe windows (`@rk_type=iframe`), desktop
+> streaming (PR #71), and the agent chat view
+> ([`fab/plans/sahil/agent-chat-view.md`](../../fab/plans/sahil/agent-chat-view.md)).
+> Sections marked **[current]** describe shipped behavior; **[target]** is the
+> design intent this spec commits to.
+>
+> Companions: [`agent-state.md`](agent-state.md) defines `@rk_chat` (the chat
+> view's capability signal); [`status-pyramid.md`](status-pyramid.md) is
+> untouched by this model — status signals describe the substrate, never the
+> lens.
+
+---
+
+## The Problem [current]
+
+Three features each render "a second output of the same underlying thing", and
+each invented its own typing and view-state machinery:
+
+| Feature | Availability signal | View choice | Who sees a flip |
+|---------|--------------------|-------------|-----------------|
+| iframe window | `@rk_type=iframe` + `@rk_url` window options | server-side mutation — the `>_` button POSTs `@rk_type: null` | everyone; the window's identity changes globally |
+| desktop (PR #71, unmerged) | `desktop:` window-name prefix + `@rk_vnc_port` | fixed at creation — the relay sniffs the type and branches, so the tty is unreachable | everyone, permanently |
+| chat (planned) | `@rk_chat` pane option | client-side `?view=chat` + localStorage, per-viewer | just you |
+
+Three conventions for "what kind of thing is this window", three for "which
+view am I in". Left alone, every future projection (log viewer, diff viewer,
+…) would invent a fourth.
+
+---
+
+## The Model [target]
+
+Separate **what runs** from **what you can look at**:
+
+1. **A window row is a substrate** — a supervised process in a tmux pane.
+   Rows never exist purely to display something; if there is no process worth
+   supervising, it should not be a window (see § Two Species).
+2. **A view is a lens** — a renderer over one derivable output of that
+   process. The tty is a lens. An iframe of the HTTP service the pane serves
+   is a lens. The parsed agent transcript is a lens. The VNC framebuffer is a
+   lens.
+3. **Availability is derived; choice is per-viewer.** Which lenses a window
+   offers is a *capability set* computed from pane/window options and
+   derivable facts (Constitution II/X). Which lens *you* are looking through
+   is client-side view state — never a server-side mutation, never part of
+   the window's identity.
+
+### The View Registry
+
+| View | Available when | Renderer | Status |
+|------|---------------|----------|--------|
+| `tty` | always | xterm.js `TerminalClient` | **[current]** |
+| `web` | `@rk_url` set (later: a listening HTTP port derived to be owned by the pane's process subtree) | `IframeWindow` (proxy iframe + URL bar) | **[current]** as a window *type*; **[target]** as a lens — change `260714-t97o-web-view-lens` |
+| `chat` | `@rk_chat` pane option present | chat renderer | **[target]** — [`agent-chat-view.md`](../../fab/plans/sahil/agent-chat-view.md) changes 2–3 |
+| `desktop` | VNC-port window option present (set by the desktop launcher, reconciler-cleared) | noVNC canvas | **[target]** — [`fab/plans/sahil/desktop-view.md`](../../fab/plans/sahil/desktop-view.md) |
+
+The registry is open-ended: a new projection adds a row here, a capability
+signal, and a renderer — it does not add a window type, a name convention, or
+a route.
+
+---
+
+## Rules
+
+### R1 — Availability is derived, never declared as identity
+
+A lens's capability signal is a pane/window option or a request-time
+derivation. `@rk_type` as a *mutable identity* is retired; it survives only as
+a creation-time **default-view hint** (§ Migration). No window-name prefixes
+(`desktop:`) — names belong to users.
+
+### R2 — Choice is per-viewer, in the URL
+
+View state lives in a `?view=` search param on the existing
+`/$server/$window` route (Constitution IV: no new routes). Unknown or
+unavailable values fall back to `tty`. Deep links (push notifications, Cockpit
+tiles) address a lens by URL. Last-chosen view per window persists in
+localStorage as a **value-bearing key** (stores the view name; absent = the
+window's default view). *This supersedes the chat plan's key-present
+`board-autofit`-style convention — value-bearing generalizes past two states;
+chat change 3 should read this spec at pickup.*
+
+### R3 — The tty is always reachable
+
+Every window offers `tty`, whatever else it offers. A desktop window's tty
+shows the Xvfb/x11vnc supervisor logs; a headless codex-server pane's tty
+shows the server logs. Watching the raw process is the run-kit ethos — no
+lens may hide it, and no relay may sniff-and-branch it away.
+
+### R4 — One switcher UX, shared by all lenses
+
+A segmented chip in the top-bar right cluster's **L1 tier** (terminal-route
+tier), rendered only when the capability set exceeds `{tty}`: two states
+render `[tty|chat]`-style, more render as a compact segmented group. Active
+segment inverse-video. Palette parity (`View: Terminal` / `View: Web` / …)
+and a keyboard shortcut are mandatory (Constitution V). The center page
+heading follows the lens: `Terminal: <window>`, `Web: <window>`,
+`Chat: <window>`, `Desktop: <window>`. Whichever change ships first
+(`web-view-lens` or chat change 3) builds the generalized switcher; the other
+reuses it.
+
+### R5 — Default view is a derived hint, not a lock
+
+A window MAY carry a default lens (e.g. `@rk_type=iframe` legacy windows
+default to `web`; a headless codex-server pane defaults to `chat`). The
+default applies only when the URL carries no `?view=` and localStorage has no
+entry. It never removes the switcher.
+
+Capabilities are **orthogonal and stack**: nothing prevents one window from
+offering `web` + `chat` + `desktop` simultaneously (an agent pane in a window
+with `@rk_url` set, say). The switcher simply grows segments (R4); the only
+question stacking raises is which *default* wins when several hints apply, and
+the registry's fixed order answers it: `desktop > chat > web > tty` (a
+desktop window's tty is supervisor logs; a chat hint is more specific to the
+pane's process than a URL hint). The user's own choice — URL param, then
+localStorage — always outranks any hint.
+
+### R6 — The connection dot reports the current lens's health
+
+"Dot-everywhere = per-page live-data health" extends per-lens: tty → relay WS,
+web → n/a (falls back to SSE health), chat → chat stream, desktop → VNC WS.
+
+### R7 — Substrate state stays global; view state stays local
+
+Mutating the *content address* of a lens (e.g. editing `@rk_url` in the web
+view's URL bar) is substrate state — shared, POSTed, visible to everyone.
+Switching *which lens you look through* is view state — local, URL-carried.
+The current `>_` button conflates these; the retrofit separates them.
+
+---
+
+## Two Species (and the residual case)
+
+**Pane-coupled projections** — chat, desktop, and `web` on the row that
+actually serves the port: the pane's process genuinely has multiple outputs.
+This is the model's home turf.
+
+**Row-less surfaces wearing a window costume** [current] — an iframe window
+created from the Cockpit SERVICES zone has an inert shell pane; the tmux
+window exists only to give a URL identity, a sidebar seat, and
+board-pinnability. Two-step exit path:
+
+1. **[target, near]** Derive port → owning pane (listening-services collector
+   already probes; `rk agent-hook` already walks pid ancestry) and surface the
+   `web` lens on the *owning* row. Cockpit "Open in window" deep-links to
+   `/$server/$window?view=web` when an owner derives; synthetic-window
+   creation remains the fallback for non-derivable services.
+2. **[target, far]** External URLs (staging sites, other hosts) are the honest
+   residual — no pane can own them. If demand persists, they become board-level
+   **URL tiles** persisted like `board_order` in settings.yaml, and synthetic
+   iframe windows retire entirely. Until then, the synthetic window stays as
+   the compat shim.
+
+Boards, later: a board pin generalizes from *window* to *(window, view)* pair
+— "pin the same window twice, tty and chat side by side". Out of scope for
+every current change; noted so nobody designs against it.
+
+---
+
+## Migration Map
+
+| Feature | From [current] | To [target] | Vehicle |
+|---------|---------------|-------------|---------|
+| iframe | `@rk_type` mutation flips the view for everyone; render gate `rkType === "iframe" && rkUrl` | `web` lens: `?view=web`, chip, no type mutation; `@rk_type=iframe` demoted to default-view hint; `@rk_url` stays global substrate state | change `260714-t97o-web-view-lens` (drafted) |
+| desktop | PR #71: name-prefix typing, relay sniffing, tty unreachable, bitrotted against current main | `desktop` lens per [`desktop-view.md`](../../fab/plans/sahil/desktop-view.md); supersede PR #71, salvage its components | new change stack (planned) |
+| chat | planned as `?view=chat` | already conforms; adopt R2's value-bearing localStorage + R4's shared switcher | chat plan changes 1–4 (change 1 in progress) |
+| Cockpit "Open in window" | creates a synthetic iframe window | deep-link to owning row's `?view=web` when derivable; synthetic fallback | follow-up after `web-view-lens` |

--- a/fab/changes/260714-t97o-web-view-lens/.history.jsonl
+++ b/fab/changes/260714-t97o-web-view-lens/.history.jsonl
@@ -1,0 +1,3 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-07-14T09:43:29Z"}
+{"args":"Retrofit iframe viewing to the window-views lens model: per-viewer ?view=web, tty always reachable, no @rk_type mutation on view switch","cmd":"fab-new","event":"command","ts":"2026-07-14T09:43:29Z"}
+{"delta":"+4.7","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-07-14T09:46:49Z"}

--- a/fab/changes/260714-t97o-web-view-lens/.status.yaml
+++ b/fab/changes/260714-t97o-web-view-lens/.status.yaml
@@ -1,0 +1,36 @@
+id: t97o
+name: 260714-t97o-web-view-lens
+created: 2026-07-14T09:43:29Z
+created_by: Sahil Ahuja
+change_type: feat
+issues: []
+progress:
+    intake: ready
+    apply: pending
+    review: pending
+    hydrate: pending
+    ship: pending
+    review-pr: pending
+plan:
+    generated: false
+    task_count: 0
+    acceptance_count: 0
+    acceptance_completed: 0
+confidence:
+    certain: 4
+    confident: 5
+    tentative: 0
+    unresolved: 0
+    score: 4.7
+    fuzzy: true
+    dimensions:
+        signal: 75.6
+        reversibility: 79.4
+        competence: 84.4
+        disambiguation: 79.4
+stage_metrics:
+    intake: {started_at: "2026-07-14T09:43:29Z", driver: fab-new, iterations: 1}
+prs: []
+change_type_source: explicit
+# true_impact: lazily created on first stage-finish that computes it (no placeholder here).
+last_updated: 2026-07-14T09:46:49Z

--- a/fab/changes/260714-t97o-web-view-lens/intake.md
+++ b/fab/changes/260714-t97o-web-view-lens/intake.md
@@ -1,0 +1,187 @@
+# Intake: Web View Lens — Iframe Viewing Retrofit
+
+**Change**: 260714-t97o-web-view-lens
+**Created**: 2026-07-14
+
+## Origin
+
+> Retrofit iframe viewing to the window-views lens model: per-viewer `?view=web`, tty always reachable, no `@rk_type` mutation on view switch.
+
+Drafted during a `/fab-discuss` session (2026-07-14) that produced
+[`docs/specs/window-views.md`](../../../docs/specs/window-views.md) (in the same PR as this
+intake). The discussion identified that run-kit's three "parallel view" features — iframe
+windows, desktop streaming (PR #71), the planned agent chat view — each invented a different
+typing/view-state mechanism, and committed to a unifying model: **rows are substrates, views
+are derived lenses**. This change is the first executable step: bring the shipped iframe
+feature under that model. Interaction mode: conversational; the user endorsed the model and
+asked for this intake to be executable by another agent. Read the spec before planning — it
+is the authority for every rule cited below (R1–R7).
+
+## Why
+
+**Problem.** The iframe feature treats "which view am I in" as *window identity*: the `>_`
+button in `IframeWindow` calls `updateWindowType(server, windowId, "")`, POSTing a mutation
+of the `@rk_type` window option. Consequences:
+
+1. **The flip is global** — every connected viewer's rendering changes, and the window's
+   identity changes in tmux, when one person just wanted to peek at the logs.
+2. **The tty is second-class** — getting back to the terminal *destroys* the web view state
+   (`@rk_url` remains, but the window must be re-typed to see the iframe again), violating
+   spec R3 (tty always reachable) and R7 (substrate state vs view state).
+3. **Divergence compounds** — the chat view (planned, `?view=chat`) and desktop view
+   (PR #71) will otherwise ship two *more* mechanisms. The spec's R4 requires one shared
+   switcher; somebody must build it first, and this change is sequenced before chat
+   change 3.
+
+**If we don't fix it:** three parallel-view conventions harden in shipped code, the chat
+plan's switcher gets built chat-shaped instead of general, and PR #71's successor has no
+pattern to conform to.
+
+**Why this approach:** per-viewer URL-carried view state is already the committed decision
+in the chat plan's decision log and spec R2; retrofitting iframe first is the smallest
+shipped-code change that forces the shared machinery (view resolution, switcher chip,
+palette parity, heading behavior) into existence.
+
+## What Changes
+
+Frontend-only. No Go changes expected: the sessions payload already carries `rkType`/`rkUrl`
+per window, and the window-option POST endpoints stay (the URL bar still uses
+`updateWindowUrl`).
+
+### 1. View state & resolution
+
+- Add a validated `view` search param to `terminalRoute` in
+  `app/frontend/src/router.tsx` (TanStack Router `validateSearch`). Accepted value today:
+  `"web"`. Unknown values are dropped (treated as absent), not errored.
+- New pure helper module `app/frontend/src/lib/window-view.ts`:
+  - `availableViews(win): ViewName[]` — `["tty"]`, plus `"web"` when `win.rkUrl` is
+    non-empty. Availability is decoupled from `rkType` (spec R1): an iframe-*typed* window
+    with no URL offers only `tty` (this matches the current render gate, which already
+    requires BOTH).
+  - `defaultView(win): ViewName` — `"web"` when `win.rkType === "iframe"` and `rkUrl` is
+    set, else `"tty"` (spec R5: `@rk_type=iframe` is demoted from identity to
+    creation-time default-view hint; no data migration, existing windows keep working).
+  - `resolveView(searchView, stored, win): ViewName` — precedence: URL param (if that view
+    is available) → localStorage (if available) → `defaultView(win)`. Anything unavailable
+    falls through to `tty`.
+- **localStorage**: value-bearing key per window, e.g.
+  `runkit-window-view:{server}:{windowId}` storing the view name; absent = default (spec
+  R2 — value-bearing, NOT the key-present `board-autofit` convention; the spec explicitly
+  supersedes the chat plan's localStorage detail). Written on every explicit view switch;
+  follow the try/catch-noop localStorage pattern in
+  `app/frontend/src/contexts/chrome-context.tsx`.
+- Switching views updates the URL search param (`navigate` with `search`) so the state is
+  copy-paste shareable and deep-linkable (push-notification-ready, same seam the chat plan
+  banks on).
+- Navigating to a *different* window drops the param; each window resolves its own
+  last-view/default.
+
+### 2. View switcher UI (the generalized machinery — chat change 3 reuses this)
+
+- Segmented chip in the top-bar right cluster's **L1 tier** (terminal-route-only tier in
+  `app/frontend/src/components/top-bar.tsx`, where splits + fixed-width live). Rendered
+  only when `availableViews(win).length > 1`. Two-state form `[tty|web]`, active segment
+  inverse-video, house hover vocabulary (CRT glint, `rk-*` classes), reduced-motion safe.
+  Build it as a generic `ViewSwitcher` taking the available-view list — chat/desktop add
+  segments, not components.
+- **Palette parity** (Constitution V): `View: Terminal` / `View: Web` actions in
+  `app/frontend/src/components/command-palette.tsx` registration (AppShell terminal-route
+  actions), visible only when the corresponding view is available and not current. The
+  existing `toggle-iframe-terminal` palette action is replaced by these (it currently
+  mutates `@rk_type`).
+- **Keyboard shortcut** to cycle views on the current window (pick a free binding at plan
+  time from the existing shortcut registry; document it in the palette entry per
+  code-review.md).
+- **Center heading follows the lens** (spec R4): `Terminal: <window>` in tty view,
+  `Web: <window>` in web view. Same static-prefix-span treatment (hidden below `sm`);
+  window rename affordance (click-to-edit heading) works identically in both views.
+
+### 3. IframeWindow decoupling
+
+In `app/frontend/src/components/iframe-window.tsx`:
+
+- The `>_` button becomes a *view switch* (sets `?view=tty` + localStorage) — it no longer
+  calls `updateWindowType`. Remove that import/usage; keep the component's URL bar +
+  refresh unchanged.
+- The URL bar's Enter-commit keeps calling `updateWindowUrl` (global substrate state, spec
+  R7 — everyone SHOULD see the new address; this is the window's content address, not a
+  view preference).
+- In `app/frontend/src/app.tsx`, the render branch stops keying on
+  `rkType === "iframe" && rkUrl` and instead renders by `resolveView(...)`:
+  `web` → `IframeWindow`, else `TerminalClient`.
+
+### 4. Window-switch transition integration (load-bearing, easy to miss)
+
+`app.tsx` keeps a `switchTransitionRef` whose `iframeIds` set classifies transition targets:
+iframe-rendering targets use the **ungated** capture path (no first-write receipt seam),
+terminal targets gate on `ws.onmessage` receipt (see the comment block around
+`app.tsx:822`). This classification MUST now be computed from the *effective resolved view*
+of each window (localStorage + default — the URL param is not yet known for a
+navigation target), not from raw `rkType && rkUrl`. A window whose effective view is `tty`
+has a receipt seam even if iframe-typed; a window resolving to `web` does not. Getting this
+wrong reintroduces the blank-pane/hang class of bugs documented in memory — treat it as its
+own task with its own test.
+
+### 5. Explicitly unchanged (compat surface)
+
+- `create-iframe-window` palette flow and `createWindow(..., "iframe", url)` — synthetic
+  iframe windows still get created exactly as today (they now mean "default view = web").
+- Cockpit SERVICES "Open in window" — still creates the synthetic window. The
+  deep-link-to-owning-row upgrade is a follow-up per the spec's Migration Map, NOT this
+  change.
+- Backend endpoints, `@rk_type`/`@rk_url` option plumbing, board rendering (boards render
+  panes, not lenses — board lens pins are out of scope per spec).
+- Port→pane ownership derivation — separate follow-up change.
+
+### 6. Tests & companions
+
+- **Vitest**: `lib/window-view.test.ts` covering `availableViews`/`defaultView`/
+  `resolveView` precedence + fallback matrix; switcher chip render gating; palette action
+  visibility.
+- **Playwright e2e** (via `just test-e2e`/`just pw` only — port 3020 isolation) + sibling
+  `.spec.md` companion (constitution): chip appears only on web-capable windows; flipping
+  to tty and back preserves the window and never POSTs an option mutation; deep link
+  `?view=web` cold-loads into the iframe; `?view=web` on a window with no `rkUrl` falls
+  back to terminal; legacy `@rk_type=iframe` window defaults to web with the chip present;
+  last-view persistence across a window switch away and back. Verify 375px and desktop
+  viewports.
+
+## Affected Memory
+
+- `run-kit/ui-patterns`: (modify) view switcher chip + `?view=` search param + heading-follows-lens + value-bearing localStorage convention + transition-classification change; iframe section rewritten from "window type" to "web lens"
+- `run-kit/architecture`: (modify) note that `@rk_type` is a default-view hint, not identity; no API changes
+
+## Impact
+
+- `app/frontend/src/router.tsx` — search param validation on `terminalRoute`
+- `app/frontend/src/lib/window-view.ts` (+ test) — new
+- `app/frontend/src/app.tsx` — render branch, transition classification, palette actions
+- `app/frontend/src/components/top-bar.tsx` (+ test) — ViewSwitcher chip, heading prefix
+- `app/frontend/src/components/iframe-window.tsx` (+ test) — `>_` decoupling
+- `app/frontend/src/components/command-palette.tsx` — action registration (via app.tsx)
+- `app/frontend/tests/` — new e2e spec + `.spec.md`
+- No Go changes; no new routes; no new dependencies.
+
+Blast radius: the terminal route's render path and window-switch transition — regressions
+here surface as blank panes or stuck transitions, which the e2e suite must catch.
+
+## Open Questions
+
+- Which keyboard binding cycles views? (Resolve at plan time against the live shortcut
+  registry — low stakes, must not collide with existing terminal-route shortcuts.)
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | View choice is per-viewer via `?view=` search param; switching never mutates `@rk_type` | Spec R2/R7, committed in discussion and endorsed by user; chat plan decision log already chose the same seam | S:90 R:70 A:95 D:95 |
+| 2 | Certain | tty view is always reachable on every window, including iframe-typed ones | Spec R3; core of the model | S:90 R:80 A:95 D:95 |
+| 3 | Certain | Web availability = `rkUrl` non-empty; `@rk_type=iframe` demoted to default-view hint; no data migration | Spec R1/R5; matches current render gate's AND-condition so no existing window changes behavior | S:80 R:75 A:90 D:85 |
+| 4 | Certain | Switcher chip in L1 top-bar tier with palette parity + keyboard shortcut; heading follows lens | Spec R4 + chat plan decision log (Constitution V makes parity mandatory) | S:85 R:80 A:85 D:80 |
+| 5 | Confident | localStorage is value-bearing per window (stores view name; absent = default), superseding chat plan's key-present convention | Spec R2 explicitly supersedes; generalizes past two states for desktop/chat | S:75 R:85 A:80 D:70 |
+| 6 | Confident | This change builds the generalized ViewSwitcher; chat change 3 reuses it | Spec R4 "whichever ships first builds it"; this change is sequenced first | S:70 R:75 A:75 D:70 |
+| 7 | Confident | Scope excludes port→pane derivation, Cockpit deep-link upgrade, board lens pins, URL tiles | Spec Migration Map sequences them as follow-ups; keeps this change one-PR-sized | S:70 R:85 A:80 D:75 |
+| 8 | Confident | Navigating to a different window drops `?view`; each window resolves its own last-view/default | Simplest semantics; per-window persistence covers the intent; easily revisited | S:55 R:85 A:75 D:65 |
+| 9 | Confident | Frontend-only — no Go changes (payload already carries `rkType`/`rkUrl`; option endpoints unchanged) | Verified against `api/windows.go` + `internal/tmux/tmux.go` during discussion | S:65 R:80 A:85 D:80 |
+
+9 assumptions (4 certain, 5 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260714-t97o-web-view-lens/intake.md
+++ b/fab/changes/260714-t97o-web-view-lens/intake.md
@@ -61,6 +61,9 @@ per window, and the window-option POST endpoints stay (the URL bar still uses
   - `defaultView(win): ViewName` — `"web"` when `win.rkType === "iframe"` and `rkUrl` is
     set, else `"tty"` (spec R5: `@rk_type=iframe` is demoted from identity to
     creation-time default-view hint; no data migration, existing windows keep working).
+    Structure the helper as spec R5's *hint precedence* (`desktop > chat > web > tty`)
+    with only `web` implemented — capabilities are orthogonal and stack, so desktop/chat
+    later add a hint to this ordered list, not a new code path.
   - `resolveView(searchView, stored, win): ViewName` — precedence: URL param (if that view
     is available) → localStorage (if available) → `defaultView(win)`. Anything unavailable
     falls through to `tty`.

--- a/fab/plans/sahil/desktop-view.md
+++ b/fab/plans/sahil/desktop-view.md
@@ -1,0 +1,207 @@
+# Plan: Desktop View (GUI streaming as a lens, superseding PR #71)
+
+**Authored**: 2026-07-14
+**Author**: discussion session with Claude (`/fab-discuss`)
+**Executor**: agents picking up changes one by one, each via the normal fab pipeline
+**Status**: Plan only — no changes drafted yet (change 1 of the stack is drafted separately)
+
+## Goal
+
+Web-based desktop (GUI) streaming in run-kit — Xvfb + x11vnc + noVNC — delivered as a
+**`desktop` lens on a normal window row** per
+[`docs/specs/window-views.md`](../../../docs/specs/window-views.md), not as a special
+window type. This plan supersedes **PR #71**
+(`260323-a805-web-based-remote-desktop`): same proven stack, different integration
+model, rebuilt against current main.
+
+## Why supersede PR #71 instead of rebasing it
+
+PR #71 validated the hard parts. It also predates both the window-views model and four
+months of main. Two independent reasons to restart:
+
+**Model conflicts** (each violates a spec rule):
+
+1. **Name-prefix typing** — window type derived from a `desktop:` window-name prefix.
+   Violates R1 (capability signals are options/derivations, names belong to users).
+2. **Relay sniffing** — `/relay/{session}/{window}` auto-detects the window type and
+   branches to a VNC proxy, making the tty **unreachable** for desktop windows. Violates
+   R3: the pane runs the Xvfb/x11vnc supervisor, and watching that raw process is the
+   run-kit ethos (and the debugging seam when VNC breaks).
+3. **Fixed-at-creation view** — no way to flip between desktop and logs; view is
+   identity. Violates R2/R5 (per-viewer `?view=desktop`, default-view hint only).
+
+**Bitrot** (a rebase would fight all of it): the PR edits `dashboard.tsx` (deleted —
+SessionTiles replaced it), `breadcrumb-dropdown.tsx` (gone — universal top-bar heading
+redesign), `top-bar.tsx` (rewritten twice: 3-column grid, RootTopBar/AppLayout root
+mount), and predates unified StatusDot, name-optional window creation, and the
+(server, owning session)-keyed relay identity.
+
+**What PR #71 got right — salvage as reference, cherry-pick judiciously:**
+
+- The stack: Xvfb + WM detection + x11vnc **inside a tmux window** — tmux supervises,
+  so desktops survive rk restarts (Constitution VI). Keep exactly this shape.
+- Dynamic display/port allocation via `net.Listen(":0")` — no collisions.
+- VNC port stored in a tmux window option — derivable, no DB (Constitution II).
+- `DesktopClient` (noVNC canvas, `scaleViewport` client-side scaling), the desktop
+  bottom bar (clipboard paste, resolution picker, fullscreen), `novnc.d.ts` typings.
+- Resolution-change endpoint concept (`POST`, Constitution IX).
+
+Branch `260323-a805-web-based-remote-desktop` stays available as the reference
+implementation; close the PR with a comment linking this plan.
+
+## Decision log (committed by this plan — intakes should treat these as Certain)
+
+- **Desktop is a lens, not a type.** A desktop window is a normal window whose pane
+  runs the display supervisor; `?view=desktop` renders noVNC, `?view=tty` (spec R3)
+  shows the supervisor logs. Default view is `desktop` (spec R5 derived hint — same
+  pattern as the chat plan's headless codex-server default).
+- **Capability signal**: `@rk_desktop = <vnc-port>` window option, set by the launcher
+  once x11vnc is listening, cleared by liveness reconciliation when the supervisor dies
+  (mirror the `@rk_agent_state` reconciler pattern; a stale option must not leave a
+  dead `[tty|desktop]` chip). Port ownership is verifiable at read time (the option is
+  a hint; the probe is the truth — Constitution X spirit).
+- **Explicit relay addressing, no sniffing**: the existing tty relay is untouched for
+  every window; VNC gets its own WebSocket endpoint (e.g. `/relay-vnc/{server}/{window}`,
+  resolved from `@rk_desktop`). The frontend picks the endpoint from the resolved view.
+- **Creation**: the unified window-creation endpoint accepts a desktop kind (POST body
+  field, like the existing `rkType`/`rkUrl` creation path — NOT a name convention). The
+  pane command is the supervisor script/binary invocation; entry points are the `▾`
+  switcher's `+ New Window` flow and a palette action, current-model equivalents of
+  PR #71's three entry points.
+- **Host-dependency probe**: `Xvfb`/`x11vnc`/WM presence is probed server-side
+  (`exec.LookPath`, no shell strings — Constitution I); creation affordances hide (or
+  error cleanly) when absent. run-kit gains no hard dependency.
+- **Security**: x11vnc binds localhost-only (`-localhost`); the browser reaches it only
+  through rk's authenticated WS proxy, same trust boundary as the terminal relay and
+  `/proxy/{port}/`. Session/window inputs validated per Constitution I.
+- **Switcher/UX machinery is inherited**, not built here: chip, palette parity,
+  shortcut, heading (`Desktop: <window>`), localStorage — all from
+  `260714-t97o-web-view-lens` (spec R4). This stack adds a segment, not a component.
+- **Connection dot** in desktop view = VNC WS health (spec R6).
+
+## The change stack
+
+Linear dependency order. Each row becomes one fab change / one PR.
+Agents: fill in your row when you create the change; mark Done when the PR merges.
+
+| # | Slug (suggested) | Depends on | Change folder | PR | Status |
+|---|------------------|-----------|---------------|----|--------|
+| 1 | `web-view-lens` | — | `260714-t97o-web-view-lens` | | drafted (intake ready) |
+| 2 | `desktop-capability-backend` | 1 merged | | | not started |
+| 3 | `desktop-view-frontend` | 2 | | | not started |
+| 4 | `desktop-resolution-clipboard` (optional polish) | 3 | | | not started |
+
+---
+
+### Change 2 — `desktop-capability-backend`
+
+**Purpose**: everything Go — a desktop window can be created, carries a live
+`@rk_desktop` capability, and its VNC socket is reachable over an rk WebSocket.
+
+**Scope**:
+- Supervisor launcher (script under `scripts/` or a `rk desktop-launch` subcommand —
+  decide at intake; the pane command must be transparent in the tty view): allocate
+  display + port (`net.Listen(":0")` pattern from PR #71), start Xvfb → WM → x11vnc
+  `-localhost`, stamp `@rk_desktop=<port>`, clear on exit (trap). Restarts inside the
+  same pane re-stamp.
+- Liveness reconciliation for `@rk_desktop` (sessions enrichment seam — same place
+  agent-state reconciles): option present but port not listening → treat as absent,
+  optionally clear.
+- Unified creation endpoint: desktop kind on the existing window-creation POST
+  (`api/windows.go`), name-optional like every window.
+- `/relay-vnc/{server}/{window}` WS endpoint (`api/relay.go` sibling): resolve
+  `@rk_desktop`, proxy binary WS ⇄ TCP to the VNC port. Timeouts, connection cleanup on
+  client disconnect (code-review.md rules), no orphaned sockets.
+- Host-dep probe surfaced to the frontend (e.g. a `desktopAvailable` capability on an
+  existing GET — no new route).
+- Surface `@rk_desktop` in the sessions payload + SSE (per-window field, like
+  `rkType`/`rkUrl`).
+
+**Salvage**: PR #71's `relay.go` VNC proxy code, window/option plumbing in `tmux.go`,
+`validate.go` additions — as reference; the option name, no-sniffing relay, and
+reconciler are new.
+
+**Acceptance**: `curl`-level — create a desktop window on a test tmux server, see
+`@rk_desktop` stamped within seconds, WS dial to `/relay-vnc/...` reaches the VNC
+handshake (RFB banner); kill x11vnc → capability disappears from the payload; `rk serve`
+restart mid-session loses nothing. Go tests for allocation, option lifecycle, proxy
+teardown. Zero frontend work.
+
+---
+
+### Change 3 — `desktop-view-frontend`
+
+**Purpose**: the user-facing desktop lens.
+
+**Scope**:
+- noVNC dependency (re-verify current package/API at pickup — PR #71 used
+  `scaleViewport`; the typings in its `novnc.d.ts` are a starting point).
+- `DesktopClient` renderer mounted when `resolveView(...) === "desktop"` (machinery from
+  change 1): connect to `/relay-vnc/...`, client-side scaling with aspect ratio,
+  clipboard paste, fullscreen toggle (bottom-bar treatment per PR #71's
+  `desktop-bottom-bar.tsx`, restyled to current house vocabulary).
+- `desktop` registered in `availableViews` (gate: `@rk_desktop` present) +
+  `defaultView` (desktop-capable → default `desktop`); chip shows `[tty|desktop]`;
+  palette `View: Desktop`; heading `Desktop: <window>`.
+- Creation UX: `+ New Window` flow gains a desktop option when `desktopAvailable`;
+  palette action.
+- Connection dot ⇒ VNC WS health in desktop view.
+- Vitest for view-registry integration; Playwright e2e gated on host capability (skip
+  cleanly when Xvfb absent — CI may not have it; the ungated assertions are chip/palette
+  gating off a mocked payload). `.spec.md` companions, 375px + desktop viewports
+  (mobile: canvas scales, tmux 80-col overflow rule doesn't apply here).
+
+**Acceptance**: flip `[tty|desktop]` on a live desktop window and watch supervisor logs
+in tty view while the desktop keeps running; deep link `?view=desktop` cold-loads; a
+non-desktop window never shows the segment; dead supervisor → segment disappears, tty
+still fine.
+
+---
+
+### Change 4 (optional) — `desktop-resolution-clipboard`
+
+**Purpose**: quality-of-life once the lens is real.
+
+**Scope**: resolution-change endpoint (POST; PR #71 restarted Xvfb at the new size —
+evaluate `xrandr` on a virtual display first, since an Xvfb restart kills every X client:
+if xrandr works, prefer it; either way surface the destructive case in the UI), resolution
+picker, richer clipboard (read back from guest), mobile ergonomics pass
+(`useVisualViewport` interplay).
+
+---
+
+## Pickup protocol (for the agent taking the next change)
+
+1. Read this plan in full, plus: `docs/specs/window-views.md` (the authority),
+   `fab/project/constitution.md`, the `ui-patterns` / `architecture` / `tmux-sessions`
+   memory files, and the change-1 intake
+   (`fab/changes/260714-t97o-web-view-lens/intake.md`).
+2. Skim PR #71's branch (`260323-a805-web-based-remote-desktop`) for the salvage list —
+   reference material, not a merge base.
+3. Check the tracking table + `fab change list` — take the lowest-numbered change whose
+   dependencies are **merged to main**.
+4. Draft via `/fab-new <slug>`; reference this plan in the intake. Treat the Decision
+   log as Certain in SRAD scoring; the per-change "decide at intake" items are where
+   clarification effort goes.
+5. Fill in your row in the tracking table in the same PR; mark Done when the PR merges.
+6. Run the normal pipeline (`/fab-fff` or stage-by-stage `/fab-continue`).
+
+## Out of scope (entire plan)
+
+- Desktop lenses on board panes (boards render tty panes; `(window, view)` pins are a
+  spec-flagged future).
+- Audio, GPU acceleration, multi-monitor, session recording.
+- Any VNC exposure that bypasses rk's WS proxy.
+- Windows/macOS host support (Xvfb is X11/Linux; probe simply reports unavailable).
+
+## Risk register
+
+| # | Risk | Mitigation |
+|---|------|------------|
+| 1 | Host deps (Xvfb/x11vnc/WM) missing or version-drifted | Server-side probe gates all affordances; zero hard dependency; document install hints in README |
+| 2 | e2e can't run the X stack on CI | Capability-gated e2e (clean skip); proxy + option lifecycle covered by Go tests; chip/palette gating covered against mocked payloads |
+| 3 | noVNC package drift since PR #71 (2026-03) | Change 3 starts with a verification pass; typings re-derived |
+| 4 | WS⇄TCP proxy leaks connections | code-review.md rules apply (timeouts, cleanup on disconnect); teardown is an explicit Go test |
+| 5 | Stale `@rk_desktop` after supervisor death → dead chip | Reconciler + read-time probe are in change 2's acceptance, not an afterthought |
+| 6 | Resolution restart kills X clients (change 4) | Prefer xrandr-on-virtual-display if viable; otherwise explicit destructive-action UI |
+| 7 | Scope creep back toward "desktop window type" | The spec's R1–R5 are binding; anything keying behavior off window names or hiding the tty is out |


### PR DESCRIPTION
## Summary

Introduces the **window-views lens model** (`docs/specs/window-views.md`): window rows are substrates (supervised processes), parallel renderings — iframe, desktop, chat — are derived **lenses** with per-viewer choice (`?view=`), unifying three features that each grew their own typing/view-state mechanism.

## Changes

- **`docs/specs/window-views.md`** (+ index entry) — the model: view registry (tty/web/chat/desktop), rules R1–R7 (derived availability, per-viewer URL-carried choice, tty always reachable, one shared switcher, default-hint precedence `desktop > chat > web > tty`), two-species taxonomy, migration map.
- **`fab/plans/sahil/desktop-view.md`** — how desktop (GUI) streaming should actually land: supersedes PR #71 (model conflicts + bitrot documented), keeps its validated Xvfb + x11vnc + noVNC stack, 3-change stack with decision log and pickup protocol.
- **`fab/changes/260714-t97o-web-view-lens/`** — drafted, ready-to-execute intake (confidence 4.7/5.0, not activated) retrofitting iframe viewing to the model: `?view=web`, generalized `[tty|web]` switcher, no more `@rk_type` mutation on view switch. Pick up via `/fab-switch 260714-t97o-web-view-lens` then `/fab-fff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)