### PR TITLE
docs: Draft top-bar overlap-fixes and overflow-chevron intakes

### DIFF
--- a/fab/changes/260715-h1ck-top-bar-overflow-chevron-menu/.history.jsonl
+++ b/fab/changes/260715-h1ck-top-bar-overflow-chevron-menu/.history.jsonl
@@ -1,0 +1,3 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-07-15T08:29:45Z"}
+{"args":"Top-bar right-cluster overflow mechanism: priority+ chevron menu absorbing buttons under width pressure, fixed Run Kit version row, registry-driven bar/menu rendering","cmd":"fab-new","event":"command","ts":"2026-07-15T08:29:45Z"}
+{"delta":"+4.4","event":"confidence","score":4.4,"trigger":"calc-score","ts":"2026-07-15T08:31:35Z"}

--- a/fab/changes/260715-h1ck-top-bar-overflow-chevron-menu/.status.yaml
+++ b/fab/changes/260715-h1ck-top-bar-overflow-chevron-menu/.status.yaml
@@ -1,0 +1,35 @@
+id: h1ck
+name: 260715-h1ck-top-bar-overflow-chevron-menu
+created: 2026-07-15T08:29:45Z
+created_by: sahil-noon
+change_type: refactor
+issues: []
+progress:
+    intake: ready
+    apply: pending
+    review: pending
+    hydrate: pending
+    ship: pending
+    review-pr: pending
+plan:
+    generated: false
+    task_count: 0
+    acceptance_count: 0
+    acceptance_completed: 0
+confidence:
+    certain: 4
+    confident: 6
+    tentative: 0
+    unresolved: 0
+    score: 4.4
+    fuzzy: true
+    dimensions:
+        signal: 69.0
+        reversibility: 84.0
+        competence: 85.0
+        disambiguation: 74.0
+stage_metrics:
+    intake: {started_at: "2026-07-15T08:29:45Z", driver: fab-new, iterations: 1}
+prs: []
+# true_impact: lazily created on first stage-finish that computes it (no placeholder here).
+last_updated: 2026-07-15T08:31:35Z

--- a/fab/changes/260715-h1ck-top-bar-overflow-chevron-menu/intake.md
+++ b/fab/changes/260715-h1ck-top-bar-overflow-chevron-menu/intake.md
@@ -1,0 +1,128 @@
+# Intake: Top-Bar Overflow Chevron Menu
+
+**Change**: 260715-h1ck-top-bar-overflow-chevron-menu
+**Created**: 2026-07-15
+
+## Origin
+
+Conversational (`/fab-discuss` session, 2026-07-15), following the diagnosis of top-bar overlap at mid widths (companion change `260715-q8ey-top-bar-overlap-fixes`). The user designed the right-cluster degradation mechanism:
+
+> "On the top right corner, we need a mechanism to start hiding buttons, in a dropdown. [...] The right section pays the price for lesser available width, as buttons keep dropping down into the down arrow. We could have a down chevron as a fixed button at the end — a fixed item inside it can be an entry about the version of Run Kit (e.g. `Run Kit v3.3.3`). The rest of the items make it there as we get squeezed for space."
+
+The assistant's design recommendations (drop order from the existing L1/L2/L3 pyramid, ViewSwitcher/dot exemptions, chevron left of the dot, version-row-as-update-surface, registry architecture, ResizeObserver + pure fit function) were accepted by the user proceeding to intake creation.
+
+## Why
+
+**Problem.** The top-bar right cluster is rigid: buttons are `shrink-0` and degrade only via a blunt `hidden sm:flex` cliff at 640px. Between "everything fits" and "mobile leaf layout" there is no graceful middle — width pressure currently produces overlap/clipping (the companion change `q8ey` converts that to clean clipping, but clipping controls is still losing them). Below `sm`, most controls simply vanish; on touch devices (no Cmd+K keyboard) they become unreachable entirely.
+
+**Consequence if unfixed.** Mid-width layouts (VS Code side panes, half-screen windows — a primary run-kit context) lose working controls arbitrarily off the right edge, and mobile users permanently lose theme/refresh/help/update affordances.
+
+**Why this approach.** This is the standard "priority+" overflow pattern (browser toolbars, macOS `»`), and the right cluster already encodes drop priority: the documented L1/L2/L3 cumulative pyramid (260704-9o7k) grows leftward from a stable always-block pinned right. Overflow consuming from the left = L1 drops first, L3 last — and surviving buttons never change screen position, preserving the pyramid's core invariant ("no shared button ever changes screen position between pages"). The always-present chevron with a fixed version row also gives the version a passive chrome surface consistent with 260715-ifco's philosophy, and gives future rarely-used actions a home without new top-bar real estate (Constitution IV).
+
+**Dependency.** Builds on `260715-q8ey-top-bar-overlap-fixes` (left/center min-width floors + clip backstops). Sequence q8ey first. This change adds the right cluster's `min-w-0` so its grid track becomes squeezable — the overflow menu is what makes that squeeze safe.
+
+## What Changes
+
+### 1. Overflow chevron button (fixed, always visible)
+
+A new down-chevron icon button in the right cluster, matching the top-bar icon-button convention (`rk-glint`, bordered chip, `min-w-[24px] min-h-[24px] coarse:min-w-[30px] coarse:min-h-[30px]`), visible at ALL breakpoints and in all four page modes. Placement: **immediately left of the connection dot** — the dot keeps its documented "right-most status terminator in every mode" role.
+<!-- assumed: chevron sits left of the dot rather than after it — preserves the dot-terminator invariant; recommended in discussion and accepted -->
+
+The chevron renders even when nothing is overflowed, because the menu always contains the fixed version row (user-specified). `aria-label` e.g. "More controls"; `aria-expanded`/`aria-haspopup` per menu-button pattern.
+
+### 2. Overflow menu
+
+Dropdown panel anchored to the chevron, following the existing dropdown a11y conventions (reuse/mirror `BreadcrumbDropdown`'s `role="menu"`/`menuitem`, Escape, ArrowUp/ArrowDown, outside-click close — `app/frontend/src/components/breadcrumb-dropdown.tsx`).
+
+Contents, top to bottom:
+
+1. **Overflowed controls** as labeled menu rows (see change area 4), in pyramid order.
+2. **Fixed version row** (always last, always present): `Run Kit v{version}` using `daemonVersion` from `useUpdateNotification()` (session-context) formatted via `displayVersion()` (`src/lib/palette-version.ts`). Click = copy the displayed form to clipboard with success/error toast — same behavior as the existing `run-kit: Version` palette action (`buildVersionAction`). When a qualifying update is pending AND the UpdateChip is currently overflowed, the row becomes the update surface: `Run Kit v{current} → v{latest} ⬆` and click triggers the update (same POST `/api/update` path as the chip). Version unknown (no `event: version` yet) → row shows plain `Run Kit` (never `vundefined`).
+
+### 3. Drop order and exemptions
+
+- **Drop priority = the existing pyramid, consumed from the left**: L1 first (SplitButton ×2, FixedWidthToggle), then L2 (TerminalFontControl Aa, BoardAutofitToggle, ClosePaneButton ✕), then L3 last (UpdateChip, NotificationControl, ThemeToggle, RefreshButton, HelpLink). Within a tier, leftmost drops first. Surviving buttons keep their exact positions.
+- **Exempt (never overflow)**: the ViewSwitcher (deliberately visible at all breakpoints — chat on mobile is a primary use case, 260714-r7rq), the connection dot, and the chevron itself.
+- **Attention propagation**: when the menu contains attention-bearing overflowed items (today: the UpdateChip with a qualifying, undismissed update), the chevron carries a small accent dot/badge so the signal isn't lost.
+
+### 4. Menu-row representations
+
+Icon buttons become labeled rows. Per-control mapping:
+
+- SplitButton ×2 → two rows: "Split vertical" / "Split horizontal"
+- FixedWidthToggle → "Fixed width" row with pressed/checked state (`role="menuitemcheckbox"` or equivalent)
+- TerminalFontControl (Aa) → a single row with inline `−` / `+` steppers operating on `ChromeContext.terminalFontSize` (same bounds `TERMINAL_FONT_BOUNDS`); does NOT open the existing popover from inside the menu
+  <!-- assumed: inline stepper row over reopening the Aa popover — avoids nested-popover interaction; implementer may adjust if the row proves awkward -->
+- BoardAutofitToggle → "Autofit panes" checkbox row (board mode only, only when `onToggleAutofit` present)
+- ClosePaneButton → "Close pane" (terminal) / "Unpin pane" (board) row, honoring the same disabled conditions
+- UpdateChip → when overflowed, its function merges into the fixed version row (change area 2); no separate row
+- NotificationControl → flatten its own dropdown into direct rows ("Enable notifications" / "Send test notification", per current subscription state); hidden entirely when push is unsupported (unchanged)
+- ThemeToggle → "Theme: {current}" row cycling system/light/dark on click
+- RefreshButton → row labeled **"Refresh page"** (NOT "Refresh" — disambiguate from the new `Status: Refresh` palette action shipped in 260715-jykd; Shift+click force-reload behavior preserved or noted)
+- HelpLink → "Help / Documentation" row (external link to `HELP_URL`)
+
+### 5. Registry architecture
+
+Replace the hardcoded right-cluster JSX sequence in `top-bar.tsx` with an ordered registry: each entry declares `{ id, tier, modes, exempt?, barRender, menuRender, hidden? }`. The registry:
+
+- drives both the bar (first N items render as buttons) and the menu (the rest render as rows) from one ordered source;
+- absorbs the per-item responsive gating hacks — UpdateChip's and NotificationControl's self-carried `hidden sm:flex` (needed to avoid empty-flex-item double gaps) become registry data;
+- **removes the `hidden sm:flex` breakpoint cliff**: below `sm`, buttons no longer vanish — they overflow into the menu like at any other width. This is a deliberate behavior change: mobile gains access to theme/refresh/help/split/etc. through the chevron. Per-item opt-out (e.g. if splits prove undesirable on touch) remains possible via a registry `hidden` predicate.
+  <!-- assumed: all current controls become menu-reachable on mobile rather than hidden; flagged in discussion as a win, user did not object — revisit per-item during apply if any control is clearly touch-hostile -->
+
+### 6. Measurement mechanism
+
+- Give the right-cluster grid item `min-w-0` (its track becomes squeezable; with q8ey's left/center floors in place, the right `1fr` track's width is then fully determined by the grid — independent of how many buttons the cluster shows, so there is **no feedback loop and no oscillation**, and no hysteresis buffer is needed).
+- One `ResizeObserver` on the right cell; measured actual child widths (buttons vary: ViewSwitcher, UpdateChip, `coarse:` sizing — do not hardcode 24px).
+- Pure fit computation in `src/lib/top-bar-overflow.ts`: `computeVisibleCount(availableWidth, itemWidths, reservedWidth)` → how many non-exempt items fit after reserving space for exempt items + chevron + dot + gaps. Unit-tested (Vitest) like the other `lib/palette-*.ts` pure helpers.
+- Initial render: collapse-first (render with everything overflowed or measure in `useLayoutEffect` before paint) to avoid a visible flash of overflowing buttons.
+
+### 7. Keyboard path unchanged
+
+Constitution V is satisfied by the command palette, which already exposes every affected action (`View:`/`Pane:` splits, fixed width, terminal font, theme, update, maintenance, version, help on AppShell routes). The menu is a pointer affordance; no palette changes required. The menu itself is keyboard-operable per change area 2's a11y contract.
+
+### 8. Tests
+
+- Vitest: `computeVisibleCount` edge cases (zero width, all fit, partial fit, exempt reservation); registry mode-filtering; version-row states (plain / update-pending / unknown version).
+- Playwright e2e + companion `.spec.md` (constitution; `just pw` / `just test-e2e` only): width sweep (e.g. 1280 → 1024 → 800 → 700 → 640 → 500 → 375) asserting (a) no bounding-box overlap anywhere, (b) L1 drops before L2 before L3, (c) chevron menu contains exactly the dropped controls + version row, (d) version row copies to clipboard, (e) exempt items (ViewSwitcher when multi-view, dot, chevron) always visible, (f) a menu action (e.g. theme cycle) works from the menu.
+
+### Non-Goals
+
+- No changes to the bottom bar (mobile terminal toolbar) or sidebar.
+- No new palette actions; no removal of existing ones.
+- No change to the left breadcrumb / center heading beyond what `q8ey` ships.
+- No settings/config surface for customizing the order (convention over configuration).
+
+## Affected Memory
+
+- `run-kit/ui-patterns`: (modify) chrome section — the right-cluster L1/L2/L3 pyramid gains the overflow-chevron mechanism (drop order, exemptions, attention propagation, registry, always-present version row); the "update notification" entry gains the version-row-as-update-surface behavior; the 260715-ifco steady-state version surfaces list gains the menu's fixed version row.
+
+## Impact
+
+- `app/frontend/src/components/top-bar.tsx` — right cluster refactored to registry-driven rendering (largest single-file impact).
+- New: `src/components/top-bar-overflow-menu.tsx` (or similar), `src/lib/top-bar-overflow.ts` + `.test.ts`, possibly `src/hooks/use-top-bar-overflow.ts`.
+- Touched: `update-chip.tsx` (overflow-aware suppression when merged into version row), `view-switcher.tsx` (exempt flag only, if anything), `top-bar.test.tsx`.
+- New Playwright spec + `.spec.md` companion.
+- Frontend only — no Go/backend changes, no new dependencies (no floating-ui addition needed if the menu follows `BreadcrumbDropdown`'s positioning approach; `status-dot-tip.tsx` already brings floating-ui if absolute positioning proves insufficient).
+- Constitution: IV (dropdown, not a new page/route), V (palette remains the keyboard path; menu keyboard-operable).
+
+## Open Questions
+
+- Should any controls be excluded from the mobile menu on touch-hostility grounds (e.g. splits at 375px)? Default: include everything; revisit during apply.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Always-visible chevron with a fixed `Run Kit v{version}` menu row | User-specified verbatim | S:95 R:90 A:95 D:95 |
+| 2 | Certain | Drop order = L1→L2→L3 pyramid consumed from the left; surviving buttons never shift | Follows the documented pyramid invariant (260704-9o7k); recommended and accepted | S:85 R:85 A:95 D:90 |
+| 3 | Confident | Chevron placed left of the connection dot (dot stays right-most terminator) | Preserves documented dot invariant; user said "at the end" but accepted the recommendation without objection | S:65 R:90 A:80 D:70 |
+| 4 | Confident | ViewSwitcher + dot + chevron exempt from overflow | ViewSwitcher's all-breakpoints visibility is a documented deliberate decision (chat on mobile) | S:75 R:85 A:90 D:80 |
+| 5 | Confident | Version row doubles as update surface when UpdateChip is overflowed; chevron carries an attention dot | Solves the lost-attention problem the pattern creates; extends 260715-ifco surfaces consistently; recommended and accepted | S:70 R:80 A:85 D:75 |
+| 6 | Confident | Measurement via ResizeObserver on the right cell + pure `computeVisibleCount`, measured child widths, no hysteresis | Grid-determined track width removes the feedback loop; matches pure-lib project pattern | S:70 R:85 A:90 D:80 |
+| 7 | Confident | Registry `{id, tier, modes, exempt, barRender, menuRender}` replaces hardcoded JSX + per-item `hidden sm:flex` gating | Single ordered source for bar+menu; kills the documented empty-flex-item gap hack | S:70 R:70 A:85 D:75 |
+| 8 | Confident | Below-`sm` cliff removed: controls overflow into the menu on mobile instead of vanishing | Flagged in discussion as a deliberate behavior change and a win; per-item opt-out retained | S:65 R:75 A:80 D:70 |
+| 9 | Tentative | Aa terminal-font control becomes an inline `−/+` stepper row in the menu | Avoids nested popover; one of two viable options discussed (stepper row vs reopening popover) | S:45 R:85 A:70 D:45 |
+| 10 | Tentative | RefreshButton menu row labeled "Refresh page" | Disambiguates from 260715-jykd's `Status: Refresh`; exact label is implementer's call | S:50 R:95 A:80 D:60 |
+
+10 assumptions (2 certain, 6 confident, 2 tentative, 0 unresolved).

--- a/fab/changes/260715-q8ey-top-bar-overlap-fixes/.history.jsonl
+++ b/fab/changes/260715-q8ey-top-bar-overlap-fixes/.history.jsonl
@@ -1,0 +1,3 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-07-15T08:28:01Z"}
+{"args":"Fix top-bar center-section overlap at mid widths: crumb truncation min-w-0, nav clip backstop + min-width, center heading min-width protection, server crumb md: demotion","cmd":"fab-new","event":"command","ts":"2026-07-15T08:28:01Z"}
+{"delta":"+4.7","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-07-15T08:29:32Z"}

--- a/fab/changes/260715-q8ey-top-bar-overlap-fixes/.status.yaml
+++ b/fab/changes/260715-q8ey-top-bar-overlap-fixes/.status.yaml
@@ -1,0 +1,36 @@
+id: q8ey
+name: 260715-q8ey-top-bar-overlap-fixes
+created: 2026-07-15T08:28:01Z
+created_by: sahil-noon
+change_type: fix
+issues: []
+progress:
+    intake: ready
+    apply: pending
+    review: pending
+    hydrate: pending
+    ship: pending
+    review-pr: pending
+plan:
+    generated: false
+    task_count: 0
+    acceptance_count: 0
+    acceptance_completed: 0
+confidence:
+    certain: 5
+    confident: 2
+    tentative: 0
+    unresolved: 0
+    score: 4.7
+    fuzzy: true
+    dimensions:
+        signal: 75.0
+        reversibility: 90.0
+        competence: 83.6
+        disambiguation: 73.6
+stage_metrics:
+    intake: {started_at: "2026-07-15T08:28:01Z", driver: fab-new, iterations: 1}
+prs: []
+change_type_source: explicit
+# true_impact: lazily created on first stage-finish that computes it (no placeholder here).
+last_updated: 2026-07-15T08:29:44Z

--- a/fab/changes/260715-q8ey-top-bar-overlap-fixes/intake.md
+++ b/fab/changes/260715-q8ey-top-bar-overlap-fixes/intake.md
@@ -1,0 +1,100 @@
+# Intake: Top-Bar Overlap Fixes
+
+**Change**: 260715-q8ey-top-bar-overlap-fixes
+**Created**: 2026-07-15
+
+## Origin
+
+Conversational (`/fab-discuss` session, 2026-07-15). The user shared a screenshot of the top bar at a mid width (~760 CSS px, terminal route `/testServer/2`) where the left breadcrumb text ("testServer", session crumb) painted directly over the centered `Window: GA1` heading — garbled, unreadable overlap.
+
+> "I want you to make a series of fixes on the new topbar nav area (the center section of the top bar). 1) How do we fix the problem we see in the screenshot? At this width, the layout breaks down."
+
+Follow-up direction from the same conversation: "Have a min width for breadcrumbs (+ the clip backstop you proposed). Have a min width for the heading sections (The center section)." The user approved the diagnosed fix set (items 1, 2, 4 below). A companion change (top-bar right-cluster overflow chevron menu, drafted separately) handles the right cluster; this change is the standalone correctness fix and deliberately does NOT touch the right cluster.
+
+## Why
+
+**Problem.** The top bar is a 3-column grid `grid-cols-[1fr_auto_1fr]` (`app/frontend/src/components/top-bar.tsx`, header grid ~line 383). In the band between the `sm` breakpoint (640px) and roughly 900px, the bar's content cannot fit, and the failure mode is *unclipped overlap*, not graceful degradation:
+
+1. The left `<nav>` grid item carries `min-w-0` (~line 384), so its **grid track** can compress toward zero. But the two crumb wrapper spans inside it — the server link crumb (`hidden sm:flex items-center gap-1.5`, ~line 436) and the session crumb (~line 452) — have **no `min-w-0`**. A nested flex item defaults to `min-width: auto`, which blocks the `truncate max-w-[16ch]` already present on the server anchor and the session `BreadcrumbDropdown` trigger from ever engaging. The crumbs refuse to shrink, overflow the nav's box (overflow is visible), and paint straight over the centered heading.
+2. The center `auto` column's content floor grew in 260714-uco1 (history ◀ ▶ arrows + hierarchy ▾ + the stable-anchor `sm:min-w-[28ch]` inner box, ~line 488) — roughly 260px+ of non-negotiable width exactly where space runs out. Additionally, the center cell's *outer* wrapper (~line 487) carries `min-w-0`, meaning the center track itself can also be squeezed below its content, producing center-side overlap in the other direction.
+3. The right cluster is rigid (`shrink-0`, items hide only below `sm`), so all squeeze lands on the left column.
+
+**Consequence if unfixed.** Any window with sidebars open / mid-width browser panes (a primary run-kit use case — VS Code side panels, half-screen windows) renders a garbled, unreadable, unusable top bar: rename affordance, window switcher, and breadcrumb all visually collide.
+
+**Why this approach.** Root cause is the blocked flex shrink chain; fixing it (adding `min-w-0` at the blocked links) makes the existing `truncate` classes do their job. Clip backstops and explicit min-widths convert any *residual* pressure into clean clipping instead of overlap. Demoting the server crumb to `md:` is safe because the 260714-uco1 hierarchy ▾ in the center heading already provides "go to Server Cabin" navigation. Alternatives rejected: demoting the `sm:min-w-[28ch]` stable anchor to `md:` was considered and **superseded** — the companion overflow-chevron change makes the right cluster absorb squeeze, so the center keeps its anchor at `sm:`.
+
+## What Changes
+
+All in `app/frontend/src/components/top-bar.tsx` (line refs as of commit 29a2c73; locate by element if drifted).
+
+### 1. Unblock crumb truncation (root cause)
+
+Add `min-w-0` to the two crumb wrapper spans in the left nav:
+
+- Server link crumb wrapper (~line 436): `hidden sm:flex items-center gap-1.5` → `hidden md:flex items-center gap-1.5 min-w-0` (the `md:` demotion is change area 4, folded into the same class edit)
+- Session crumb wrapper (~line 452): `hidden sm:flex items-center gap-1.5` → `hidden sm:flex items-center gap-1.5 min-w-0`
+
+Under pressure the crumbs then compress to ellipsis (the anchors/triggers already carry `truncate max-w-[16ch]`) instead of overflowing the nav box. The `BreadcrumbSeparator`, brand chip, and hamburger stay `shrink-0` — they are the protected identity floor.
+
+### 2. Nav min-width + clip backstop
+
+On the `<nav aria-label="Breadcrumb">` element (~line 384):
+
+- Add `overflow-hidden` so content past the shrunk floor **clips** instead of painting over the center heading. Overlap becomes impossible rather than unlikely.
+- Replace the bare `min-w-0` with an explicit breakpoint-aware floor, e.g. `min-w-[76px] sm:min-w-[180px]`. Intent: below `sm` the floor guarantees brand icon + hamburger (~76px); at `sm+` it additionally guarantees a usable sliver of the session crumb. Exact values are implementer-tunable via Playwright at 375 / 640 / 700 / 768 / 1024px — the *mechanism* (explicit floor + clip) is the requirement, the pixel values are not.
+  <!-- assumed: min-width values 76px / 180px are starting points to be tuned visually, not hard requirements -->
+
+### 3. Center section min-width protection
+
+On the center cell's outer wrapper (~line 487, `flex items-center justify-center min-w-0`): **remove `min-w-0`** so the `auto` grid column never shrinks below the heading's content floor. That floor is already bounded (it cannot grow unbounded) because:
+
+- the heading name spans carry `max-w-[16ch] sm:max-w-[28ch]` + `truncate` (WindowHeading button ~line 1300 and PageHeadingDisplay ~line 1407),
+- the history arrows, hierarchy ▾, and window/board ▾ switchers are fixed-width `shrink-0`,
+- the `sm:min-w-[28ch]` stable anchor on the inner box (~line 488) **stays at `sm:` unchanged** (decision: NOT demoted to `md:` — superseded by the companion overflow change).
+
+Net effect: left and right columns absorb squeeze; the center heading is never compressed into overlap.
+
+### 4. Server crumb demoted to `md:`
+
+The server link crumb (wrapper ~line 436) renders only at `md+` instead of `sm+`. Rationale: since 260714-uco1 the hierarchy ▾ inside the heading prefix (`Window ▾:`) lists `Server Cabin: {server}` → `Cockpit`, so the left server crumb is redundant navigation at cramped widths and is the natural first element to give way. The session crumb (with its switcher + `+ New Session` action) stays at `sm+`.
+
+### 5. Accepted interim behavior (right cluster untouched)
+
+This change does NOT add `min-w-0`/clip to the right cluster. With left/center floors in place, extreme narrowness can push the grid wider than the viewport so the right cluster's rightmost items (connection dot first) clip at the app-shell edge. This is accepted and *transitional*: the companion overflow-chevron change gives the right cluster its proper degradation (buttons collapse into a menu). Do not attempt a partial right-cluster fix here — a plain `overflow-hidden` on the right cluster would clip the always-block L3/dot end first (flex overflow spills toward inline-end), which is the wrong end to lose.
+
+### 6. Tests
+
+Playwright e2e (constitution: run via `just pw` / `just test-e2e`, never raw playwright; companion `.spec.md` updated in the same commit — likely extending `app/frontend/tests/e2e/window-heading.spec.ts` or a new `top-bar-overlap.spec.ts`):
+
+- At ~700×800 viewport on a terminal route with a long window name and long session name: assert the breadcrumb nav's bounding box and the center heading's bounding box do **not** intersect.
+- Assert crumbs show ellipsis (not overflow) under pressure; assert the server crumb is hidden below `md` and visible at `md+`.
+- Re-verify 375px (mobile leaf layout unchanged) and 1024px+ (no visual regression, anchor intact).
+
+## Affected Memory
+
+- `run-kit/ui-patterns`: (modify) TopBar universal-page-heading section — record the degradation ladder (crumbs truncate → server crumb hides below `md` → nav clips at its floor; center protected by content floor + 28ch anchor; right cluster degradation deferred to the overflow-chevron change) and the min-w-0-chain/clip-backstop rules.
+
+## Impact
+
+- `app/frontend/src/components/top-bar.tsx` — class-level changes only (~4 elements); no component API, prop, routing, or backend changes.
+- `app/frontend/tests/e2e/` — new/extended Playwright spec + companion `.spec.md`.
+- `app/frontend/src/components/top-bar.test.tsx` — may need class-assertion updates if it asserts the touched class strings.
+- No Go/backend impact. No new dependencies.
+
+## Open Questions
+
+- (none — the tunable min-width pixel values are recorded as a Tentative assumption rather than a blocking question)
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Add `min-w-0` to both crumb wrapper spans to unblock the existing `truncate` | Discussed and user-approved (fix 1); standard nested-flex min-width fix; trivially reversible | S:90 R:95 A:95 D:90 |
+| 2 | Certain | Clip backstop: `overflow-hidden` on the breadcrumb `<nav>` | Discussed and user-approved (fix 2, re-confirmed "+ the clip backstop you proposed") | S:90 R:95 A:90 D:90 |
+| 3 | Confident | Server crumb demoted `sm:`→`md:` | User-approved (fix 4); hierarchy ▾ covers the navigation; easily reverted | S:85 R:90 A:85 D:75 |
+| 4 | Confident | Keep `sm:min-w-[28ch]` center anchor at `sm:` (do NOT demote to `md:`) | Earlier fix-3 idea explicitly superseded once the companion overflow change absorbs right-side squeeze; user approved the two-change split | S:75 R:90 A:80 D:70 |
+| 5 | Confident | Center protection implemented by removing the outer wrapper's `min-w-0` (content-floor protection) rather than a new explicit pixel min | User asked for "a min width for the center section"; the heading's floor is already bounded by existing `max-w` caps + fixed-width controls, so protecting the content floor satisfies the intent without a magic number | S:60 R:85 A:85 D:65 |
+| 6 | Tentative | Nav min-width floor values `min-w-[76px] sm:min-w-[180px]` | Mechanism (explicit floor) is agreed; exact pixels are visual-tuning territory — implementer adjusts via Playwright sweep | S:45 R:90 A:70 D:50 |
+| 7 | Confident | Right cluster untouched; possible right-edge clipping at extreme narrowness accepted as interim until the overflow-chevron change | User's design assigns right-cluster degradation to the companion change ("the right section pays the price" via the chevron menu) | S:80 R:85 A:80 D:75 |
+
+7 assumptions (2 certain, 4 confident, 1 tentative, 0 unresolved).


### PR DESCRIPTION
## Summary

Adds two intake-stage change drafts (created via /fab-draft, not activated) for another agent to pick up: `260715-q8ey-top-bar-overlap-fixes` — the correctness fix for the top-bar breadcrumb/center-heading overlap at mid widths (crumb truncation unblock, nav min-width + clip backstop, center content-floor protection, server crumb demoted to md:) — and `260715-h1ck-top-bar-overflow-chevron-menu` — the priority+ overflow mechanism collapsing right-cluster buttons into a fixed down-chevron menu with an always-present `Run Kit v{version}` row. Sequence q8ey before h1ck; both scored above the intake gate (4.7 and 4.4) with zero unresolved decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)