### PR TITLE
feat: Spin Only the Logo Border Ring on Brand Hover

### DIFF
--- a/app/frontend/src/components/logo-spinner.tsx
+++ b/app/frontend/src/components/logo-spinner.tsx
@@ -30,20 +30,25 @@ export function LogoSpinner({
       aria-hidden="true"
       role="img"
     >
-      {BORDER_SEGMENTS.map((seg, i) => (
-        <polygon
-          key={i}
-          points={seg.points}
-          fill={loading ? ANIM_FILL : seg.staticFill}
-          style={{
-            animation: loading
-              ? `logo-chase 1.2s ease-in-out ${i * 0.2}s infinite`
-              : "none",
-            transition: loading ? "none" : "opacity 0.5s ease-out, fill 0.5s ease-out",
-            opacity: loading ? undefined : 1,
-          }}
-        />
-      ))}
+      {/* The ring group exists so CSS can move the border hexagon
+          independently of the cube faces (the brand crumb's hover spin
+          targets .rk-logo-ring). */}
+      <g className="rk-logo-ring">
+        {BORDER_SEGMENTS.map((seg, i) => (
+          <polygon
+            key={i}
+            points={seg.points}
+            fill={loading ? ANIM_FILL : seg.staticFill}
+            style={{
+              animation: loading
+                ? `logo-chase 1.2s ease-in-out ${i * 0.2}s infinite`
+                : "none",
+              transition: loading ? "none" : "opacity 0.5s ease-out, fill 0.5s ease-out",
+              opacity: loading ? undefined : 1,
+            }}
+          />
+        ))}
+      </g>
       {INNER_FACES.map((face, i) => (
         <polygon key={`face-${i}`} points={face.points} fill={face.fill} />
       ))}

--- a/app/frontend/src/components/top-bar.tsx
+++ b/app/frontend/src/components/top-bar.tsx
@@ -392,7 +392,10 @@ export function TopBar({
             title="Cockpit"
             className={`flex items-center gap-2 shrink-0 rk-brand-glitch ${LINK_CRUMB_CLASS}`}
           >
-            <img src="/icon.svg" alt="Run Kit" width={20} height={20} className="rk-brand-logo" />
+            {/* Inline SVG (LogoSpinner at rest), not the /icon.svg img — the
+                hover spin rotates the border ring (.rk-logo-ring) while the
+                cube faces stay pinned, which CSS can't reach inside an img. */}
+            <LogoSpinner size={20} loading={false} />
             {/* [text-decoration:inherit] — the anchor is a flex container and
                 text-decoration does not propagate into flex items, so an
                 underline-based LINK_CRUMB_CLASS would silently skip the

--- a/app/frontend/src/globals.css
+++ b/app/frontend/src/globals.css
@@ -104,8 +104,8 @@ summary {
 
 /* ── Hover-animation vocabulary (change 260703-5ilm; boot sweep 260704-pr0p) ──
    One motion treatment per element category, so motion carries meaning:
-     glitch      = brand (rk-brand-glitch; the logo inside additionally
-                   kickstart-spins — rk-brand-logo)
+     glitch      = brand (rk-brand-glitch; the logo's border ring additionally
+                   kickstart-spins — rk-logo-ring)
      boot sweep  = top-bar page heading (JS, in top-bar.tsx — one inverse-video
                    cursor sweeps the `PageType: name` string: TypedLabel-style
                    over the prefix, decode glyph churn over the name; reuses the
@@ -178,15 +178,22 @@ summary {
   color: var(--color-accent-green);
 }
 
-/* The logo rides the glitch with a kickstart spin: four full turns in 600ms,
-   launched at full speed and decelerating into the landing. 1440° is a 360°
-   multiple so the hexagon always lands aligned; at this speed the launch reads
-   as flicker (the glitch's texture) and the decelerating tail is where the
-   rotation becomes visible. Scoped to the logo — the wordmark only glitches. */
+/* The logo rides the glitch with a kickstart spin of its border ring only:
+   two full turns in 600ms, launched at full speed and decelerating into the
+   landing, while the inner cube faces stay pinned (.rk-logo-ring is the <g>
+   wrapping the border segments in logo-spinner.tsx). 720° is a 360° multiple
+   so the ring always lands aligned. transform-box must be fill-box, not
+   view-box: view-box resolves origin percentages against the viewBox
+   dimensions but ignores its min-x/min-y (7,10), pivoting off-center — the
+   ring's own bbox is centered on the hexagon center (32,32). */
 @keyframes rk-brand-spin {
-  to { transform: rotate(1440deg); }
+  to { transform: rotate(720deg); }
 }
-.rk-brand-glitch:hover .rk-brand-logo {
+.rk-logo-ring {
+  transform-box: fill-box;
+  transform-origin: 50% 50%;
+}
+.rk-brand-glitch:hover .rk-logo-ring {
   animation: rk-brand-spin 600ms cubic-bezier(0.16, 0.84, 0.32, 1) 1;
 }
 
@@ -288,7 +295,7 @@ summary {
   .rk-glint::after,
   .rk-glint:hover::after { animation: none; opacity: 0; }
   .rk-brand-glitch:hover { animation: none; }
-  .rk-brand-glitch:hover .rk-brand-logo { animation: none; }
+  .rk-brand-glitch:hover .rk-logo-ring { animation: none; }
   /* (typed-label sweep is skipped in JS — no CSS gate needed) */
   .rk-bracket-group .rk-bracket,
   .rk-bracket-group:hover .rk-bracket-open,


### PR DESCRIPTION
## Summary

Refines the brand hover spin shipped in #346: instead of rotating the whole logo, only the hexagon border ring rotates — two full turns (720°) in 600ms with the same ease-out kickstart — while the inner cube faces stay pinned. The two-tone border makes the ring's motion far more readable than the whole-logo spin, and 720° keeps the landing aligned.

## Changes

- `logo-spinner.tsx` — border segments wrapped in `<g class="rk-logo-ring">` so CSS can move the ring independently of the cube faces
- `top-bar.tsx` — brand icon swapped from the `/icon.svg` img to the inline `<LogoSpinner loading={false} />` (CSS can't reach inside an img)
- `globals.css` — `rk-brand-spin` retargeted to `.rk-logo-ring` at 720°, with `transform-box: fill-box` so the ring pivots on the true hexagon center (view-box ignores the viewBox min-x/min-y and pivots off-center); reduced-motion gate updated