### PR TITLE
fix: Top-bar heading hover retrigger and prefix-name spacing

### DIFF
--- a/app/frontend/src/components/top-bar.test.tsx
+++ b/app/frontend/src/components/top-bar.test.tsx
@@ -237,6 +237,96 @@ describe("TopBar", () => {
     });
   });
 
+  describe("boot sweep hover — single owner for the whole heading", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      // The sweep must actually RUN here: re-stub matchMedia query-sensitively
+      // (the suite default stubs `matches: true` for EVERY query, which makes
+      // `prefersReducedMotion()` true and skips the sweep entirely). Dark theme
+      // still matches; reduced-motion does not.
+      vi.stubGlobal(
+        "matchMedia",
+        vi.fn().mockImplementation((query: string) => ({
+          matches: query.includes("prefers-color-scheme"),
+          media: query,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        })),
+      );
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    // `Window: main` = 7 prefix + 1 space + 4 name cells at 28ms/cell; the
+    // mount replay (name-effect null seed) must be flushed before hovering.
+    const SWEEP_MS = (7 + 1 + 4 + 2) * 28;
+    const INTENT_MS = 140;
+
+    function renderAndSettle() {
+      renderTopBar();
+      act(() => {
+        vi.advanceTimersByTime(SWEEP_MS + 100);
+      });
+      const button = screen.getByRole("button", { name: "Rename window main" });
+      const wrapper = button.parentElement!;
+      const prefixWord = screen.getByText("Window", { exact: true });
+      // Structure: ONE wrapper span owns both the prefix and the name button —
+      // it is the single hover owner for the sweep.
+      expect(wrapper).toContainElement(prefixWord);
+      return { button, wrapper, prefixWord };
+    }
+
+    const cursorIn = (wrapper: HTMLElement) => wrapper.querySelector(".rk-typed-cursor");
+
+    it("does NOT restart the sweep when the pointer crosses the prefix → name boundary", () => {
+      const { button, wrapper, prefixWord } = renderAndSettle();
+
+      // Enter the heading over the prefix: hover-intent delay, then sweep starts.
+      fireEvent.mouseOver(prefixWord, { relatedTarget: document.body });
+      act(() => {
+        vi.advanceTimersByTime(INTENT_MS + 28 * 2);
+      });
+      expect(cursorIn(wrapper)).not.toBeNull();
+
+      // Cross from the prefix onto the name button. With per-sibling hover
+      // handlers this fired resolve() (cursor snapped away) plus a deferred
+      // replay; with the wrapper as the single owner it is a non-event — the
+      // in-flight sweep continues uninterrupted.
+      fireEvent.mouseOut(prefixWord, { relatedTarget: button });
+      fireEvent.mouseOver(button, { relatedTarget: prefixWord });
+      expect(cursorIn(wrapper)).not.toBeNull();
+
+      // The same pass runs to completion and settles to rest.
+      act(() => {
+        vi.advanceTimersByTime(SWEEP_MS + 100);
+      });
+      expect(cursorIn(wrapper)).toBeNull();
+      expect(wrapper.textContent).toContain("Window");
+      expect(wrapper.textContent).toContain("main");
+    });
+
+    it("resolves the sweep when the pointer leaves the whole heading", () => {
+      const { button, wrapper } = renderAndSettle();
+
+      fireEvent.mouseOver(button, { relatedTarget: document.body });
+      act(() => {
+        vi.advanceTimersByTime(INTENT_MS + 28);
+      });
+      expect(cursorIn(wrapper)).not.toBeNull();
+
+      // Leaving the wrapper entirely resolves immediately to rest.
+      fireEvent.mouseOut(button, { relatedTarget: document.body });
+      expect(cursorIn(wrapper)).toBeNull();
+      expect(wrapper.textContent).toContain("main");
+    });
+  });
+
   describe("history nav arrows + hierarchy dropdown (260714-uco1)", () => {
     beforeEach(() => {
       mockNavigate.mockReset();

--- a/app/frontend/src/components/top-bar.tsx
+++ b/app/frontend/src/components/top-bar.tsx
@@ -183,7 +183,14 @@ function HistoryNav() {
   const arrowClass =
     "rk-glint min-w-[24px] min-h-[24px] coarse:min-w-[30px] coarse:min-h-[30px] rounded border border-border text-text-secondary hover:border-text-secondary transition-colors flex items-center justify-center shrink-0";
   return (
-    <span className="flex items-center gap-1 mr-1.5 shrink-0">
+    // mr-2.5 (10px) separates the arrows from the page heading — the arrows are
+    // global chrome, not part of the heading, so their gap must read WIDER than
+    // the heading's own internal prefix↔name spacing (~4px, see HeadingPrefix's
+    // -mr-1). Exactly +4px so the pair is width-neutral with -mr-1's −4px: the
+    // heading's fixed furniture inside the `sm:min-w-[28ch]` anchor box must
+    // not grow, or names near the band edge start drifting the anchor (see the
+    // stable-anchor e2e in window-heading.spec.ts).
+    <span className="flex items-center gap-1 mr-2.5 shrink-0">
       <button
         type="button"
         onClick={() => router.history.back()}
@@ -995,18 +1002,10 @@ function splitSweepCells(cells: SweepCell[]): {
 function HeadingPrefix({
   cells,
   scrambling,
-  onMouseEnter,
-  onMouseLeave,
   caret,
 }: {
   cells: SweepCell[];
   scrambling: boolean;
-  // Optional hover handlers so the terminal prefix replays the sweep too
-  // (260704-pr0p rework N5 — unifies with board/root/cockpit, which hover the
-  // whole heading; the demo replayed from the whole bar). Display-only headings
-  // pass none: their outer wrapper already owns the hover.
-  onMouseEnter?: () => void;
-  onMouseLeave?: () => void;
   // Optional element rendered BEFORE the trailing `:` of the prefix word
   // (260714-uco1 — the hierarchy ▾ binds to the prefix "before the colon" per
   // intake §3, rendering `Window ▾: name`). When present, the prefix cells are
@@ -1015,15 +1014,18 @@ function HeadingPrefix({
   // array (and its ordering) is untouched; only the DOM is split at render time.
   caret?: React.ReactNode;
 }) {
+  // -mr-1 on both return branches: the sweep's `sp` separator cell is a full
+  // monospace space (1ch ≈ 8px at text-sm) — noticeably wider than a natural
+  // `label: value` gap next to the semibold name. Pulling the following name
+  // element back 4px tightens the separator to ~half a space while the cursor
+  // still visibly crosses the real space cell (N4: the cell, not a flex gap,
+  // owns the separation — do not swap it for a margin/gap on the name).
+
   // No caret: emit the prefix as one swept run (the original single-span path;
   // keeps `Window:` contiguous for headings with no hierarchy ▾).
   if (!caret) {
     return (
-      <span
-        className="hidden sm:inline text-sm text-text-secondary whitespace-pre shrink-0"
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-      >
+      <span className="hidden sm:inline text-sm text-text-secondary whitespace-pre shrink-0 -mr-1">
         <SweepCells cells={cells} scrambling={scrambling} />
       </span>
     );
@@ -1037,11 +1039,7 @@ function HeadingPrefix({
   const wordCells = colonIdx >= 0 ? cells.slice(0, colonIdx) : cells;
   const tailCells = colonIdx >= 0 ? cells.slice(colonIdx) : [];
   return (
-    <span
-      className="hidden sm:inline-flex items-center text-sm text-text-secondary whitespace-pre shrink-0"
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
-    >
+    <span className="hidden sm:inline-flex items-center text-sm text-text-secondary whitespace-pre shrink-0 -mr-1">
       <span className="whitespace-pre">
         <SweepCells cells={wordCells} scrambling={scrambling} />
       </span>
@@ -1292,25 +1290,25 @@ function WindowHeading({
   }
 
   return (
-    <>
-      {/* Static `Terminal:` prefix — a sibling OUTSIDE the button so clicking
+    // ONE hover owner for the whole heading: enter/leave live on this wrapper
+    // (mirroring PageHeadingDisplay's outer span), NEVER on the prefix and the
+    // button individually — per-sibling handlers fire resolve() + playDeferred()
+    // when the pointer crosses the prefix↔name boundary, restarting the sweep
+    // mid-flight. Enter/leave don't refire while the pointer moves between
+    // children, so the sweep plays once per whole-heading hover.
+    <span
+      className="inline-flex items-center min-w-0"
+      onMouseEnter={sweep.playDeferred}
+      onMouseLeave={sweep.resolve}
+    >
+      {/* Static `Window:` prefix — a sibling OUTSIDE the button so clicking
           it never starts an edit; hidden below `sm` (mobile keeps just the
-          name). Its content rides the same sweep so the one cursor crosses it.
-          Hovering the prefix replays the sweep too (matches the whole-heading
-          hover on board/root/cockpit), but it is NOT a click target — clicking
-          it never enters edit (only the button below does). */}
-      <HeadingPrefix
-        cells={prefixCells}
-        scrambling={sweep.scrambling}
-        onMouseEnter={sweep.playDeferred}
-        onMouseLeave={sweep.resolve}
-        caret={caret}
-      />
+          name). Its content rides the same sweep so the one cursor crosses it,
+          but it is NOT a click target — only the button below enters edit. */}
+      <HeadingPrefix cells={prefixCells} scrambling={sweep.scrambling} caret={caret} />
       <button
         type="button"
         onClick={startEdit}
-        onMouseEnter={sweep.playDeferred}
-        onMouseLeave={sweep.resolve}
         aria-label={`Rename window ${name}`}
         title="Click to rename"
         // The heading is the mobile leaf and the primary rename affordance
@@ -1333,7 +1331,7 @@ function WindowHeading({
           <SweepCells cells={nameCells} scrambling={sweep.scrambling} />
         </span>
       </button>
-    </>
+    </span>
   );
 }
 


### PR DESCRIPTION
## Summary

Two user-reported polish issues on the top-bar center heading (`Window ▾: <name>`), both in `app/frontend/src/components/top-bar.tsx`:

1. The boot-sweep hover animation restarted when the pointer crossed from the `Window:` prefix onto the window name — the animation *travels* across both, but the *trigger* lived on each sibling separately. It now lives on one parent wrapper.
2. The gap between `Window:` and the name read unnaturally wide, while the history ◀ ▶ arrows sat *closer* to the heading than the heading's own internal parts sat to each other. The internal gap is now tighter and the arrows gap wider — as an exactly width-neutral pair (see below).

Rebased onto `main` after #363 (Top-Bar Overlap Fixes) landed; no conflicts — this change touches the heading internals (`WindowHeading` / `HeadingPrefix` / `HistoryNav`), #363 touched the nav/center grid containers.

## Why

**Hover retrigger.** `WindowHeading` attached `onMouseEnter`/`onMouseLeave` to the prefix span and to the rename button individually. Moving the pointer across the prefix→name boundary therefore fired `resolve()` (snap the sweep to rest) followed by `playDeferred()` (a fresh 140ms hover-intent delay, then a full replay) — the sweep visibly restarted mid-word. Mouse enter/leave events do not re-fire when the pointer moves between children of the element that owns the handler, so hoisting the pair onto a single wrapper `<span>` makes the whole heading one hover surface: the sweep plays once per hover and continues uninterrupted across its internal boundary. This also brings `WindowHeading` in line with `PageHeadingDisplay` (the board/root/cockpit headings), which already owned hover on its outer wrapper — the terminal heading was the only one with per-sibling triggers.

**Prefix↔name gap.** The heading deliberately uses no flex `gap`: the separator between `Window:` and the name is the boot sweep's own space cell, so the cursor visibly crosses it (260704-pr0p rework N4). But that cell is a full monospace space — ~1ch ≈ 8px at `text-sm` — which reads much wider than a natural `label: value` gap, especially against the semibold name. A `-mr-1` (−4px) on the prefix container pulls the name back to ~half a space. The sweep cells are untouched, so the cursor still crosses the real space cell; only the rendered gap tightens. Applied on both `HeadingPrefix` return branches, it covers all consumers uniformly (window display heading, window inline-edit input, board and Server Cabin headings). Below `sm` the prefix is hidden, so mobile is unaffected.

**Arrows↔heading gap.** The ◀ ▶ history arrows carried `mr-1.5` (6px) — *less* than the heading's internal spacing, which made the arrows read as part of the heading rather than as adjacent global chrome. Bumped to `mr-2.5` (10px), so the chrome/heading boundary is wider than any gap inside the heading.

**Why exactly +4px / −4px (the e2e lesson).** The first push used `mr-3` (+6px) and CI's stable-anchor e2e failed (`window-heading.spec.ts` — prefix left edge must not drift >2px between a 7-char and an 11-char window name). Root cause: the anchor band is the inner box's `sm:min-w-[28ch]`, but that box also contains the arrows, hierarchy caret, and window switcher — its fixed furniture. The test's 11-char name sits essentially at the band's edge, so any *net* growth in fixed furniture pushes it past the band, the box grows beyond its min-width, and the centered box's left edge drifts. The fix: make the two spacing changes an exactly offsetting pair (arrows +4px, prefix −4px, net 0), keeping the anchor-band arithmetic byte-identical to `main`. A code comment on `HistoryNav` now records this constraint so the next spacing tweak doesn't rediscover it in CI.

## Changes

- `WindowHeading` display branch: new wrapper `<span className="inline-flex items-center min-w-0">` owns `onMouseEnter={sweep.playDeferred}` / `onMouseLeave={sweep.resolve}`; the prefix span and rename button no longer carry hover handlers.
- `HeadingPrefix`: the now-unused optional `onMouseEnter`/`onMouseLeave` props removed (no caller passes them anymore); both return branches gain `-mr-1`.
- `HistoryNav`: `mr-1.5` → `mr-2.5`, with the width-neutrality constraint documented.
- Tests (`top-bar.test.tsx`): new `boot sweep hover — single owner` describe block with two regression tests:
  - crossing the prefix→name boundary mid-sweep does **not** restart the sweep (the cursor cell survives the crossing; this fails against the old per-sibling handlers, which resolved the sweep instantly at the boundary);
  - leaving the whole heading still resolves the sweep to rest immediately.

  These needed a query-sensitive `matchMedia` stub: the suite's default stub returns `matches: true` for *every* query, which made `prefersReducedMotion()` true and silently skipped the sweep in all existing tests — the reason this file had no sweep coverage before.

## Verification

- `tsc --noEmit` clean.
- Full frontend Vitest suite: 1265 tests / 74 files pass on the rebase (includes #363's new tests plus the two new regression tests here).
- E2E: `just test-e2e window-heading top-bar-overlap` — 23/23 pass locally, including the stable-anchor test that failed on the first CI run and #363's new overlap sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
