### PR TITLE
docs: add shll install one-liner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@
 
 What makes it sing in 2026 is what you tend to run in those panes: **AI coding agents, many at once.** `rk riff` spawns each one in its own [git worktree](https://github.com/sahil87/wt), and the dashboard lets you watch the whole fleet. But run-kit never wraps the agent — a pane is just a pane. It's equally a build, a REPL, an ssh session, `htop`. **The agent is one of the things you run, not the thing run-kit is.** That's the point: when the agent tooling churns underneath you (and it does, monthly), the terminal layer stays put.
 
+## Install
+
+```sh
+curl -fsSL https://shll.ai/install | sh -s -- run-kit
+```
+
+Installs run-kit (plus the shll meta-CLI) via Homebrew, handling tap trust automatically. To install the entire sahil87 toolkit instead:
+
+```sh
+curl -fsSL https://shll.ai/install | sh
+```
+
 ## What run-kit is (and isn't)
 
 |  | run-kit |


### PR DESCRIPTION
Adds a `## Install` section right after the title/badges/description pointing at the `shll.ai/install` one-liner, which installs the tool (plus the shll meta-CLI) via Homebrew with automatic tap-trust handling. No prior Install section existed; the inline brew example in Quick Start is left as-is (illustrative flow, not competing install docs).