### PR TITLE
docs: Socket-unification plan, spike findings, and state-socket intake

### DIFF
--- a/docs/findings/relay-mux-hol.md
+++ b/docs/findings/relay-mux-hol.md
@@ -1,0 +1,325 @@
+# Muxed terminal socket — head-of-line blocking measurements (spike)
+
+**Date**: 2026-07-16
+**Context**: Protocol-shaping evidence for the terminal relay mux (one WebSocket carrying
+all pane streams — see `docs/findings/socket-pool-accounting.md` for why the mux exists).
+Question: when N pane streams share one TCP connection, does one pane's flood destroy
+another pane's interactive latency — and does the v1 protocol therefore need per-stream
+flow control, or can it ship with a simple shared FIFO?
+
+## Method
+
+Go harness (gorilla/websocket v1.5.3, appendix): one WS connection, two streams framed
+as `[u32 streamId][payload]`. Stream 1 floods 4096-byte frames continuously (a pane
+running `yes`). Stream 2 echoes 12-byte client probes sent every 100ms (an interactive
+pane's keystroke→echo). The server's single writer is paced to a simulated link
+bandwidth (sleep proportional to bytes written). Two server architectures compared:
+
+- **naive** — one shared FIFO queue (depth 64 ≈ 262KB), single writer drains in order.
+- **fair** — per-stream bounded queues (depth 8) + interactive-priority scheduler
+  (echo queue drained first; a full queue blocks only that stream's producer —
+  the backpressure seam that would stop reading that pane's PTY).
+
+80 probes per 8s scenario, loopback, Go 1.26.
+
+## Results
+
+| Scenario | echo p50 | p95 | max | flood goodput |
+|----------|---------|-----|-----|---------------|
+| baseline, no flood, 1 Mbps | ~0ms | ~0ms | ~0ms | — |
+| **naive**, flood, 1 Mbps | **1.66s** | 2.09s | 2.19s | 0.98 Mbps |
+| **fair**, flood, 1 Mbps | **32ms** | 33ms | 33ms | 0.98 Mbps |
+| **naive**, flood, 10 Mbps | **265ms** | 268ms | 273ms | 7.87 Mbps |
+| **fair**, flood, 10 Mbps | **2ms** | 4ms | 4ms | 7.86 Mbps |
+
+## Findings
+
+1. **A shared FIFO makes typing unusable under any co-stream flood on slow links.**
+   Echo RTT ≈ queue-depth × frame-size ÷ bandwidth (observed 1.66s at 1 Mbps with a
+   modest 262KB buffer — matches theory). It scales linearly with whatever buffering
+   exists, so "tune the buffer" is not a fix.
+2. **Per-stream queues + a non-FIFO scheduler bound interactive RTT to ~1–2 in-flight
+   frames** (32ms at 1 Mbps, 4ms at 10 Mbps) — a 50–65× improvement.
+3. **Fairness costs zero throughput.** Flood goodput is identical in both modes
+   (0.98/0.98 and 7.87/7.86 Mbps) — the scheduler only reorders, never idles the link.
+4. Backpressure semantics fall out naturally: a full per-stream queue blocks that
+   stream's PTY reader only, pushing the stall into tmux's per-client buffering —
+   exactly what N independent sockets give today via N TCP send buffers.
+
+## Protocol implications (v1 requirements, not optimizations)
+
+- The terminal mux server MUST use per-stream bounded send queues with a scheduler
+  that does not FIFO across streams. Two-stream priority generalizes to N panes as
+  round-robin (or deficit round-robin) across ready streams; small
+  control/interactive frames should never queue behind bulk output.
+- A stream whose queue is full has its PTY read paused (backpressure), never dropped —
+  dropping bytes mid-stream corrupts VT state.
+- The kernel TCP send buffer is a shared tail *after* the scheduler that cannot be
+  reordered; keep it from growing unbounded (default autotuning is acceptable — the
+  scheduler bounds everything above it, and today's per-pane sockets have the same
+  kernel tail per pane).
+
+**Caveats**: loopback + simulated pacing (real links add jitter but not ordering
+differences); continuous flood is the worst case (real tmux output is bursty);
+scheduling below the WS frame boundary is not possible, so one already-accepted 4KB
+frame is always ahead of an echo (~33ms at 1 Mbps — the observed fair-mode floor).
+
+## Reproduction
+
+<details>
+<summary>main.go (go mod init && go mod tidy && go run . — gorilla/websocket v1.5.3)</summary>
+
+```go
+// Spike: head-of-line blocking on a muxed terminal WebSocket.
+// One WS, two streams: stream 1 floods 4096B frames (a pane running `yes`),
+// stream 2 echoes client probes (an interactive pane's keystroke->echo).
+// The server's write path is paced to simulate a slow link.
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	frameSize   = 4096
+	naiveQCap   = 64 // shared queue depth (262KB backlog potential)
+	fairQCap    = 8  // per-stream queue depth
+	probeEvery  = 100 * time.Millisecond
+	runDuration = 8 * time.Second
+	drainWindow = 3 * time.Second
+	port        = "39872"
+)
+
+var upgrader = websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+
+type frame struct {
+	stream uint32
+	data   []byte
+}
+
+func pack(f frame) []byte {
+	b := make([]byte, 4+len(f.data))
+	binary.BigEndian.PutUint32(b, f.stream)
+	copy(b[4:], f.data)
+	return b
+}
+
+func handleWS(w http.ResponseWriter, r *http.Request) {
+	mode := r.URL.Query().Get("mode")
+	bps, _ := strconv.ParseFloat(r.URL.Query().Get("bps"), 64)
+	flood := r.URL.Query().Get("flood") == "on"
+
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+
+	done := make(chan struct{})
+	var closeOnce sync.Once
+	stop := func() { closeOnce.Do(func() { close(done) }) }
+	defer stop()
+
+	var floodQ, echoQ chan frame
+	if mode == "naive" {
+		shared := make(chan frame, naiveQCap)
+		floodQ, echoQ = shared, shared
+	} else {
+		floodQ = make(chan frame, fairQCap)
+		echoQ = make(chan frame, fairQCap)
+	}
+
+	if flood {
+		go func() { // flood producer: blocks when its queue is full (backpressure seam)
+			payload := make([]byte, frameSize)
+			for {
+				select {
+				case <-done:
+					return
+				case floodQ <- frame{1, payload}:
+				}
+			}
+		}()
+	}
+
+	go func() { // reader: echo client probes back on stream 2
+		defer stop()
+		for {
+			_, msg, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			if len(msg) < 4 {
+				continue
+			}
+			data := make([]byte, len(msg)-4)
+			copy(data, msg[4:])
+			select {
+			case <-done:
+				return
+			case echoQ <- frame{2, data}:
+			}
+		}
+	}()
+
+	// single paced writer — the simulated slow link
+	write := func(f frame) bool {
+		b := pack(f)
+		if err := conn.WriteMessage(websocket.BinaryMessage, b); err != nil {
+			return false
+		}
+		time.Sleep(time.Duration(float64(len(b)) / bps * float64(time.Second)))
+		return true
+	}
+	if mode == "naive" {
+		for {
+			select {
+			case <-done:
+				return
+			case f := <-floodQ: // floodQ == echoQ (shared FIFO)
+				if !write(f) {
+					return
+				}
+			}
+		}
+	}
+	for { // fair: interactive-priority — drain echo queue first if ready
+		select {
+		case <-done:
+			return
+		case f := <-echoQ:
+			if !write(f) {
+				return
+			}
+			continue
+		default:
+		}
+		select {
+		case <-done:
+			return
+		case f := <-echoQ:
+			if !write(f) {
+				return
+			}
+		case f := <-floodQ:
+			if !write(f) {
+				return
+			}
+		}
+	}
+}
+
+type result struct {
+	name           string
+	probesSent     int
+	probesReturned int
+	p50, p95, max  time.Duration
+	floodMbps      float64
+}
+
+func runScenario(name, mode string, bps float64, flood bool) result {
+	floodStr := "off"
+	if flood {
+		floodStr = "on"
+	}
+	url := fmt.Sprintf("ws://127.0.0.1:%s/ws?mode=%s&bps=%d&flood=%s", port, mode, int64(bps), floodStr)
+	c, _, err := websocket.DefaultDialer.Dial(url, nil)
+	if err != nil {
+		panic(err)
+	}
+	var floodBytes int64
+	var mu sync.Mutex
+	rtts := []time.Duration{}
+	go func() {
+		for {
+			_, msg, err := c.ReadMessage()
+			if err != nil {
+				return
+			}
+			if len(msg) < 4 {
+				continue
+			}
+			switch binary.BigEndian.Uint32(msg) {
+			case 1:
+				atomic.AddInt64(&floodBytes, int64(len(msg)))
+			case 2:
+				if len(msg) >= 12 {
+					sent := int64(binary.BigEndian.Uint64(msg[4:12]))
+					rtt := time.Duration(time.Now().UnixNano() - sent)
+					mu.Lock()
+					rtts = append(rtts, rtt)
+					mu.Unlock()
+				}
+			}
+		}
+	}()
+
+	t0 := time.Now()
+	sent := 0
+	for time.Now().Before(t0.Add(runDuration)) {
+		buf := make([]byte, 12)
+		binary.BigEndian.PutUint32(buf, 2)
+		binary.BigEndian.PutUint64(buf[4:], uint64(time.Now().UnixNano()))
+		if err := c.WriteMessage(websocket.BinaryMessage, buf); err != nil {
+			break
+		}
+		sent++
+		time.Sleep(probeEvery)
+	}
+	time.Sleep(drainWindow) // let late echoes arrive
+	elapsed := time.Since(t0)
+	c.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	r := result{name: name, probesSent: sent, probesReturned: len(rtts)}
+	r.floodMbps = float64(atomic.LoadInt64(&floodBytes)) * 8 / elapsed.Seconds() / 1e6
+	if len(rtts) > 0 {
+		sort.Slice(rtts, func(i, j int) bool { return rtts[i] < rtts[j] })
+		r.p50 = rtts[len(rtts)/2]
+		r.p95 = rtts[len(rtts)*95/100]
+		r.max = rtts[len(rtts)-1]
+	}
+	return r
+}
+
+func main() {
+	http.HandleFunc("/ws", handleWS)
+	go http.ListenAndServe("127.0.0.1:"+port, nil)
+	time.Sleep(300 * time.Millisecond)
+
+	const mbps1, mbps10 = 125_000, 1_250_000
+	scenarios := []struct {
+		name  string
+		mode  string
+		bps   float64
+		flood bool
+	}{
+		{"baseline  fair  1Mbps  no-flood", "fair", mbps1, false},
+		{"naive  1Mbps  flood", "naive", mbps1, true},
+		{"fair   1Mbps  flood", "fair", mbps1, true},
+		{"naive 10Mbps  flood", "naive", mbps10, true},
+		{"fair  10Mbps  flood", "fair", mbps10, true},
+	}
+	fmt.Printf("%-34s %8s %8s %10s %10s %10s %10s\n",
+		"scenario", "sent", "returned", "p50", "p95", "max", "floodMbps")
+	for _, s := range scenarios {
+		r := runScenario(s.name, s.mode, s.bps, s.flood)
+		fmt.Printf("%-34s %8d %8d %10s %10s %10s %10.2f\n",
+			r.name, r.probesSent, r.probesReturned,
+			r.p50.Round(time.Millisecond), r.p95.Round(time.Millisecond),
+			r.max.Round(time.Millisecond), r.floodMbps)
+	}
+}
+```
+
+</details>

--- a/docs/findings/socket-pool-accounting.md
+++ b/docs/findings/socket-pool-accounting.md
@@ -1,0 +1,261 @@
+# Browser h1 connection-pool accounting — SSE vs WebSocket (spike)
+
+**Date**: 2026-07-16
+**Context**: Design evidence for the socket-unification effort (muxing terminal relays and
+SSE streams into a fixed number of sockets). The load-bearing unknown: which stream types
+actually occupy the browser's 6-per-origin HTTP/1.1 connection pool on plaintext origins,
+and whether that pool is shared across tabs.
+
+## Method
+
+Throwaway harness (`spike-pool.mjs`, appendix below): a zero-dependency Node HTTP/1.1
+server on `127.0.0.1:39871` (plaintext, keep-alive) with three endpoints — `/sse`
+(text/event-stream, held open), `/ws` (minimal 101 handshake, held open), `/ping`
+(instant 200, no-store) — driven by Playwright 1.59.1 headless engines:
+
+| Engine | Version |
+|--------|---------|
+| Chromium | 147.0.7727.15 |
+| Firefox | 148.0.2 |
+| WebKit | 26.4 |
+
+Each case runs on a fresh page (fresh pages, one shared browser context). "BLOCKED" =
+the operation did not complete within its timeout (fetch 3s, SSE/WS open 4s); "ok" =
+completed, with elapsed ms. Every SSE/WS open was individually confirmed via
+`onopen` before proceeding.
+
+## Results
+
+| Case | Chromium | Firefox | WebKit |
+|------|----------|---------|--------|
+| **A** — 6 SSE established, then `fetch` | fetch **BLOCKED** | fetch ok (2ms) | fetch **BLOCKED** |
+| **A2** — open 7 SSE | 6 open, **7th stalls** | 6 open, **7th stalls** | 6 open, **7th stalls** |
+| **B** — 5 SSE + 1 established WS, then `fetch` | ok (1ms) | ok (1ms) | ok (1ms) |
+| **C** — 6 SSE established, then open a WS | WS opens | WS **BLOCKED** | WS **BLOCKED** |
+| **E** — 6 established WS, then `fetch` + 1 SSE | both ok | both ok | both ok |
+| **D** — 3+3 SSE across two pages, `fetch` on each | both **BLOCKED** | both ok | both **BLOCKED** |
+
+## Findings
+
+1. **EventSource (SSE) holds a pool slot in every engine.** The cap is 6 per origin
+   everywhere; a 7th SSE never connects (A2, unanimous).
+2. **An *established* WebSocket holds NO h1 pool slot in any engine.** 5 SSE + 1 live WS
+   leaves a slot free (B); 6 live WS block nothing (E). Once past the handshake, WS
+   connections live outside the pool on all three engines.
+3. **The WS *handshake* diverges — this is the sharpest finding.** On Firefox and WebKit,
+   a saturated pool blocks new WebSocket handshakes entirely (C): **6 open SSE streams
+   mean no new terminal relay can ever connect** on those engines (plaintext). Chromium
+   lets handshakes through a full pool.
+4. **The pool is shared across tabs** in Chromium and WebKit (D) — per-tab stream budgets
+   aggregate. Firefox exempts plain fetches from its 6-persistent-connection cap (A, D:
+   fetches succeed even at saturation), so on Firefox only *streams* starve each other,
+   not request/response traffic.
+
+## Implications for socket unification
+
+- **SSE fan-out is the actual pool problem — not the terminal WebSockets.** The
+  per-server session SSE + metrics SSE + chat SSE are what consume the 6 slots. The
+  per-pane relay WSs, once connected, are invisible to the pool on every engine. This
+  partially inverts the intuitive priority: the **state-socket change (SSE → one muxed
+  WS) delivers the user-facing starvation fix**; the terminal relay mux is connection
+  hygiene (TCP count, one reconnect path, fewer handshakes) rather than pool relief.
+- **Firefox/WebKit make SSE consolidation urgent, not optional.** A 5-server host holds
+  6 SSE slots (5 session + 1 metrics) → on Firefox and Safari-family engines, *no
+  terminal can connect at all* (finding 3). This failure mode exists today.
+- **Converting streams to WebSockets clears the pool almost entirely.** With state +
+  chat + terminals all on WS, steady-state pool usage drops to ~zero; only transient
+  fetches and proxied-iframe (`/proxy/{port}/`) traffic remain pool tenants.
+- **Multi-tab scaling concern mostly evaporates.** Since established WSs are
+  pool-exempt everywhere, N tabs × 2 WS aggregate to zero pool pressure. A SharedWorker
+  socket owner is unnecessary for pool reasons (may still be worth it someday for
+  server-side attach dedup).
+- Prior debugging attributed part of the board-route starvation to "per-pane relay WSs"
+  occupying slots — per finding 2 that attribution was wrong for established WSs
+  (Chromium); the SSE fan-out + serial chunk fetches (+ possibly in-flight handshakes)
+  carried that failure.
+
+**Caveats**: headless Playwright builds on Linux loopback; Safari-proper may differ from
+WebKit-GTK in pool details; HTTPS/h2 origins multiplex fetches+SSE onto one connection
+and have none of these limits (WS still gets one TCP conn each — RFC 8441 ws-over-h2 is
+not available with Go's stock server stack).
+
+## Reproduction
+
+Harness preserved below. Run: `cd app/frontend && node spike-pool.mjs` (needs
+`@playwright/test` installed + browsers via `pnpm exec playwright install`).
+
+<details>
+<summary>spike-pool.mjs</summary>
+
+```js
+// Spike: h1 connection-pool accounting per browser engine.
+import { chromium, firefox, webkit } from '@playwright/test';
+import http from 'node:http';
+import crypto from 'node:crypto';
+
+const PORT = 39871;
+const BASE = `http://127.0.0.1:${PORT}`;
+
+const PAGE_HTML = `<!doctype html><meta charset="utf-8"><title>pool spike</title>
+<script>
+window.streams = [];
+window.openSSE = (n, timeoutMs) => {
+  const opens = [];
+  for (let i = 0; i < n; i++) {
+    opens.push(new Promise((resolve) => {
+      const es = new EventSource('/sse?i=' + i + '&r=' + Math.random());
+      window.streams.push(es);
+      const t = setTimeout(() => resolve('timeout'), timeoutMs);
+      es.onopen = () => { clearTimeout(t); resolve('open'); };
+    }));
+  }
+  return Promise.all(opens);
+};
+window.openWS = (timeoutMs) => new Promise((resolve) => {
+  const ws = new WebSocket('ws://' + location.host + '/ws?r=' + Math.random());
+  window.streams.push(ws);
+  const t = setTimeout(() => resolve('timeout'), timeoutMs);
+  ws.onopen = () => { clearTimeout(t); resolve('open'); };
+  ws.onerror = () => { clearTimeout(t); resolve('error'); };
+});
+window.openWSMany = async (n, timeoutMs) => {
+  const rs = [];
+  for (let i = 0; i < n; i++) rs.push(await window.openWS(timeoutMs));
+  return rs;
+};
+window.timedFetch = async (timeoutMs) => {
+  const ctl = new AbortController();
+  const t = setTimeout(() => ctl.abort(), timeoutMs);
+  const t0 = performance.now();
+  try {
+    const res = await fetch('/ping?r=' + Math.random(), { signal: ctl.signal, cache: 'no-store' });
+    await res.text();
+    return { result: 'ok', ms: Math.round(performance.now() - t0) };
+  } catch {
+    return { result: 'BLOCKED', ms: Math.round(performance.now() - t0) };
+  } finally { clearTimeout(t); }
+};
+</script>ready`;
+
+function startServer() {
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, 'http://x');
+    if (url.pathname === '/') {
+      res.writeHead(200, { 'content-type': 'text/html', 'cache-control': 'no-store' });
+      res.end(PAGE_HTML);
+    } else if (url.pathname === '/sse') {
+      res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-store' });
+      res.write('retry: 60000\n\ndata: hello\n\n');
+    } else if (url.pathname === '/ping') {
+      res.writeHead(200, { 'content-type': 'text/plain', 'cache-control': 'no-store' });
+      res.end('pong');
+    } else {
+      res.writeHead(404);
+      res.end();
+    }
+  });
+  server.on('upgrade', (req, socket) => {
+    const key = req.headers['sec-websocket-key'] || '';
+    const accept = crypto
+      .createHash('sha1')
+      .update(key + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11')
+      .digest('base64');
+    socket.write(
+      'HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n' +
+        `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
+    );
+    socket.on('data', () => {});
+    socket.on('error', () => {});
+  });
+  return new Promise((res) => server.listen(PORT, '127.0.0.1', () => res(server)));
+}
+
+const SSE_T = 4000, WS_T = 4000, FETCH_T = 3000;
+
+async function runEngine(browserType, label) {
+  const browser = await browserType.launch();
+  const context = await browser.newContext();
+  const fresh = async () => {
+    const p = await context.newPage();
+    await p.goto(BASE);
+    return p;
+  };
+  const results = {};
+
+  { // A: 6 SSE -> fetch
+    const p = await fresh();
+    const sse = await p.evaluate(({ n, t }) => window.openSSE(n, t), { n: 6, t: SSE_T });
+    const fetch = await p.evaluate((t) => window.timedFetch(t), FETCH_T);
+    results['A  6 SSE -> fetch'] = { sseOpen: sse.filter((r) => r === 'open').length, fetch };
+    await p.close();
+  }
+  { // A2: 7 SSE
+    const p = await fresh();
+    const sse = await p.evaluate(({ n, t }) => window.openSSE(n, t), { n: 7, t: SSE_T });
+    results['A2 7 SSE'] = { sseOpen: sse.filter((r) => r === 'open').length, detail: sse };
+    await p.close();
+  }
+  { // B: 5 SSE + 1 established WS -> fetch
+    const p = await fresh();
+    const sse = await p.evaluate(({ n, t }) => window.openSSE(n, t), { n: 5, t: SSE_T });
+    const ws = await p.evaluate((t) => window.openWS(t), WS_T);
+    const fetch = await p.evaluate((t) => window.timedFetch(t), FETCH_T);
+    results['B  5 SSE + 1 WS -> fetch'] = { sseOpen: sse.filter((r) => r === 'open').length, ws, fetch };
+    await p.close();
+  }
+  { // C: 6 SSE -> WS handshake
+    const p = await fresh();
+    const sse = await p.evaluate(({ n, t }) => window.openSSE(n, t), { n: 6, t: SSE_T });
+    const ws = await p.evaluate((t) => window.openWS(t), WS_T);
+    results['C  6 SSE -> WS'] = { sseOpen: sse.filter((r) => r === 'open').length, ws };
+    await p.close();
+  }
+  { // E: 6 WS -> fetch + SSE
+    const p = await fresh();
+    const ws = await p.evaluate(({ n, t }) => window.openWSMany(n, t), { n: 6, t: WS_T });
+    const fetch = await p.evaluate((t) => window.timedFetch(t), FETCH_T);
+    const sse = await p.evaluate(({ n, t }) => window.openSSE(n, t), { n: 1, t: SSE_T });
+    results['E  6 WS -> fetch, SSE'] = { wsOpen: ws.filter((r) => r === 'open').length, fetch, sse: sse[0] };
+    await p.close();
+  }
+  { // D: 3+3 SSE across two pages -> fetch on both
+    const p1 = await fresh();
+    const p2 = await fresh();
+    const s1 = await p1.evaluate(({ n, t }) => window.openSSE(n, t), { n: 3, t: SSE_T });
+    const s2 = await p2.evaluate(({ n, t }) => window.openSSE(n, t), { n: 3, t: SSE_T });
+    const f2 = await p2.evaluate((t) => window.timedFetch(t), FETCH_T);
+    const f1 = await p1.evaluate((t) => window.timedFetch(t), FETCH_T);
+    results['D  3+3 SSE across 2 pages -> fetch'] = {
+      sseOpen: s1.filter((r) => r === 'open').length + s2.filter((r) => r === 'open').length,
+      fetchP1: f1,
+      fetchP2: f2,
+    };
+    await p1.close();
+    await p2.close();
+  }
+
+  await browser.close();
+  return { label, results };
+}
+
+const server = await startServer();
+const out = [];
+for (const [type, label] of [
+  [chromium, 'chromium'],
+  [firefox, 'firefox'],
+  [webkit, 'webkit'],
+]) {
+  try {
+    out.push(await runEngine(type, label));
+    console.error(`${label} done`);
+  } catch (e) {
+    out.push({ label, error: String(e).slice(0, 300) });
+    console.error(`${label} FAILED: ${e}`);
+  }
+}
+server.close();
+console.log(JSON.stringify(out, null, 2));
+process.exit(0);
+```
+
+</details>

--- a/fab/changes/260716-qf3j-state-socket/.history.jsonl
+++ b/fab/changes/260716-qf3j-state-socket/.history.jsonl
@@ -1,0 +1,3 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-07-16T10:47:04Z"}
+{"args":"state-socket — replace the per-server session SSE pool + host-metrics SSE with a single multiplexed /ws/state WebSocket (subscribe/ack+snapshot protocol). Change 1 of fab/plans/sahil/socket-unification.md","cmd":"fab-new","event":"command","ts":"2026-07-16T10:47:04Z"}
+{"delta":"+4.8","event":"confidence","score":4.8,"trigger":"calc-score","ts":"2026-07-16T10:48:17Z"}

--- a/fab/changes/260716-qf3j-state-socket/.status.yaml
+++ b/fab/changes/260716-qf3j-state-socket/.status.yaml
@@ -1,0 +1,36 @@
+id: qf3j
+name: 260716-qf3j-state-socket
+created: 2026-07-16T10:47:04Z
+created_by: sahil-noon
+change_type: refactor
+issues: []
+progress:
+    intake: ready
+    apply: pending
+    review: pending
+    hydrate: pending
+    ship: pending
+    review-pr: pending
+plan:
+    generated: false
+    task_count: 0
+    acceptance_count: 0
+    acceptance_completed: 0
+confidence:
+    certain: 6
+    confident: 4
+    tentative: 0
+    unresolved: 0
+    score: 4.8
+    fuzzy: true
+    dimensions:
+        signal: 73.5
+        reversibility: 87.0
+        competence: 83.5
+        disambiguation: 80.5
+stage_metrics:
+    intake: {started_at: "2026-07-16T10:47:04Z", driver: fab-new, iterations: 1}
+prs: []
+change_type_source: explicit
+# true_impact: lazily created on first stage-finish that computes it (no placeholder here).
+last_updated: 2026-07-16T10:48:17Z

--- a/fab/changes/260716-qf3j-state-socket/intake.md
+++ b/fab/changes/260716-qf3j-state-socket/intake.md
@@ -1,0 +1,172 @@
+# Intake: State Socket — mux session-state + host-metrics SSE into one WebSocket
+
+**Change**: 260716-qf3j-state-socket
+**Created**: 2026-07-16
+
+## Origin
+
+Conversational (`/fab-discuss` session, 2026-07-16). The user's driving concern:
+
+> Right now, the number of socket connections a non https client connection can make to
+> the run-kit server (a max of 6) is a serious limit. I want to discuss unification of
+> all streams in a "multiplexed" stream.
+
+The discussion produced a three-change master plan — **read
+`fab/plans/sahil/socket-unification.md` first**; this change is its Change 1. Two spikes
+were run and verified during the session:
+
+- `docs/findings/socket-pool-accounting.md` — per-engine h1 pool accounting (the evidence
+  for this change).
+- `docs/findings/relay-mux-hol.md` — HOL blocking on a muxed terminal socket (evidence
+  for Change 2, `relay-mux`; not this change).
+
+Key user decisions from the discussion: fixed socket budget with terminals kept on their
+own socket ("I just want to keep Terminals separate — as that's the max load"); state +
+metrics muxed together; chat may join the state socket later (Change 3). The plan's
+Decisions table (D1–D6) records the settled choices — **do not relitigate them**.
+
+## Why
+
+1. **The pain**: every attached tmux server costs one EventSource
+   (`session-context.tsx:573`) plus one host-metrics EventSource (`:879`). SSE holds an
+   h1 pool slot in **every** browser engine and the pool caps at 6 per origin (spike 1,
+   unanimous across Chromium 147 / Firefox 148 / WebKit 26.4). A 5-server host holds all
+   6 slots from SSE alone on plaintext origins.
+2. **The consequence if unfixed**: on Firefox and WebKit, a saturated pool **blocks new
+   WebSocket handshakes entirely** — 6 open SSEs mean no terminal relay can ever connect
+   (spike 1, case C). On Chromium, fetches starve instead (case A). The pool is shared
+   across tabs (case D), so a second tab makes it worse. This failure mode exists in
+   production today for any non-HTTPS access path.
+3. **Why this approach**: an established WebSocket holds NO pool slot in any engine
+   (spike 1, cases B/E) — moving state streams onto one WS drops steady-state pool usage
+   to ~zero and is immune to multi-tab aggregation. A muxed *SSE* would still hold one
+   slot and would need out-of-band POSTs for subscription changes — reintroducing the
+   POST-races-the-stream class this codebase has hit twice (memory:
+   `relay-connect-select-alignment`; the preview-scope `conn=` coupling). In-band
+   subscribe messages are totally ordered with the events they gate, which also
+   structurally fixes the long-standing `attachServer`→SSE race (memory:
+   `multi-server-group-expand-async-race`).
+
+## What Changes
+
+### Backend — new `/ws/state` endpoint (gorilla/websocket, already a dependency)
+
+New handler in `app/backend/api/` implementing the state-socket protocol. JSON text
+frames both directions.
+
+Client → server ops:
+
+```jsonc
+{"op": "hello", "conn": "<client-generated id>"}          // once, first message
+{"op": "subscribe", "kind": "server",  "key": "<tmux server name>", "req": 1}
+{"op": "subscribe", "kind": "metrics", "req": 2}          // host metrics + services
+{"op": "unsubscribe", "kind": "...", "key": "..."}
+```
+
+Server → client:
+
+```jsonc
+{"op": "ack", "req": 1, "snapshot": { /* the same payload today's SSE snapshot carries */ }}
+{"op": "event", "kind": "server", "key": "<server>", "type": "<today's SSE event name>", "data": { ... }}
+{"op": "event", "kind": "global", "type": "version" | "update-available" | "server-order" | "board-order" | "status-refresh" | "metrics" | "services", "data": { ... }}
+{"op": "gone", "kind": "server", "key": "<server>", "reason": "server-exited"}
+{"op": "error", "req": N, "message": "..."}
+```
+
+**Contract-preservation rule (load-bearing)**: today's SSE event names and payloads move
+**verbatim** into `type`/`data` — the envelope changes, payloads do not. Frontend
+consumers above the `subscribe*` seams must not need changes.
+
+### Backend — `sseHub` refactor (`app/backend/api/sse.go`, 1474 lines)
+
+- `sseClient` (single-server, channel of pre-rendered SSE byte frames) becomes a
+  per-connection **subscription set** with per-subscription event routing.
+- Producers are unchanged: pollers, metrics collector, ports collector, PR-status join,
+  preview capture, and all `broadcast*` helpers keep their signatures — only the
+  client-facing edge changes.
+- Cached-slot replay maps 1:1: the global cached slots (`cachedVersionJSON`,
+  `cachedUpdateAvailableJSON`, `cachedServerOrderJSON`, `cachedBoardOrderJSON`,
+  `cachedMetricsJSON`, `cachedServicesJSON` — see `addClient` in `sse.go`) are sent once
+  after `hello` as `kind:"global"` events; per-server snapshots ride the subscribe `ack`.
+  `status-refresh` stays broadcast-only (no cached slot, no replay).
+- Dead-server handling: today a dead server is reaped from the poll set on fetch error
+  (memory: `tmux-sessions` § SSE poll-set reap); that reap now also emits the in-band
+  `gone` event to subscribed connections.
+- **Retire `GET /api/sessions/stream` + `handleSSE` + the SSE route in `router.go:539`
+  in this same change** (decision D2 — the frontend is the sole consumer; constitution
+  IV minimal surface). `POST /api/preview-scope` **stays**; its `conn=` id maps to the
+  WS `hello` conn id via the same `normalizeConnID` semantics (decision D4).
+
+### Frontend — `session-context.tsx` transport swap
+
+- Replace the per-server EventSource pool (`session-context.tsx:538-812`) and the
+  host-metrics EventSource effect (`:852+`) with one `StateSocket` client module
+  owning: hello, subscribe/ack, resubscribe-on-reconnect, exponential backoff (1s → 15s
+  cap).
+- **The `attachServer` lazy-attach API and every `subscribe*` helper keep their exact
+  signatures** — consumers (`use-boards.ts`, `use-window-pins.ts`, board/host pages,
+  update-notification, etc.) already route through these seams and must not change.
+- Version/boot auto-reload guard (`shouldReloadOnVersion`) consumes the replayed
+  `version` global event exactly as it consumes the SSE replay today; first-connect
+  semantics unchanged (never reload on first connect; boot-reload suppressed on dev).
+- Connection-dot semantics: page dots = (socket connected) AND (relevant subscription
+  acked). `hostMetricsConnected` (3s disconnect debounce, per-server fan-out fallback)
+  keys on the metrics subscription state instead of a dedicated EventSource.
+
+### Tests
+
+- Hub unit tests asserting payload byte-equality between the old SSE rendering and the
+  new envelope's `data` for each event type.
+- New e2e connection-budget guard: board / terminal / server / host routes hold **zero
+  EventSources and exactly one `/ws/state` WS** (relay WSs unchanged in this change).
+  Count via Playwright `page.on('websocket')` + assert zero `text/event-stream`
+  responses. Guard counts only rk endpoints (Vite HMR WS excluded).
+- `multi-server-sidebar:70` must pass deterministically under `just test-e2e` isolation —
+  the subscribe/ack protocol structurally fixes the attachServer→SSE race. **This
+  long-standing flake is an explicit acceptance test for this change.**
+- Playwright specs asserting EventSource internals are updated with their `.spec.md`
+  companions in the same commit (constitution: Test Companion Docs).
+
+## Affected Memory
+
+- `run-kit/architecture`: (modify) SSE hub → state-socket protocol; endpoint inventory
+  (retire `/api/sessions/stream`, add `/ws/state`); cached-slot replay → hello/global +
+  ack/snapshot semantics
+- `run-kit/ui-patterns`: (modify) connection-dot semantics (socket + subscription state);
+  SSE-reconnect reload guard now fed by the state socket
+- `run-kit/tmux-sessions`: (modify) SSE poll-set reap on dead-server fetch error now also
+  emits the in-band `gone` event
+
+## Impact
+
+- `app/backend/api/sse.go` (major refactor), `app/backend/api/router.go` (route swap),
+  new `app/backend/api/state_ws.go` (or similar), `sse_test.go` reworked.
+- `app/frontend/src/contexts/session-context.tsx` (1258 lines — the EventSource pool and
+  metrics effect are the change's frontend core), new `src/lib/state-socket.ts` (or
+  similar).
+- Consumers above `subscribe*` seams: no changes expected (acceptance criterion).
+- Chat SSE (`use-chat-stream.ts`, `GET /api/windows/{id}/chat/stream`) and terminal
+  relays (`/relay/{windowId}`): **untouched** (Changes 3 and 2 respectively).
+- e2e: new connection-guard spec + updates to any spec touching stream internals.
+
+## Open Questions
+
+None — the design was settled in the discussion session and the master plan (D1–D6);
+spike evidence closed the empirical unknowns.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Two-socket architecture with terminals on their own socket; this change touches only state+metrics streams | User stated explicitly in discussion ("keep Terminals separate — that's the max load"); phasing is the user's own | S:95 R:90 A:90 D:95 |
+| 2 | Certain | State socket transport is WebSocket, not a muxed SSE (plan D1) | Spike 1: established WS exits the h1 pool in every engine; in-band subscribe kills the POST-vs-stream race class; discussed and ratified | S:90 R:60 A:90 D:90 |
+| 3 | Certain | SSE event names/payloads move verbatim into the envelope; `subscribe*`/`attachServer` seams keep exact signatures | Codebase gives a clear answer (consumers already isolated behind seams); minimizes regression surface | S:80 R:85 A:90 D:90 |
+| 4 | Certain | `multi-server-sidebar:70` deterministic pass is an acceptance criterion | Known UNFIXED race (memory), root cause is exactly the implicit-subscription gap this protocol closes | S:85 R:90 A:85 D:85 |
+| 5 | Certain | Reconnect: client backoff 1s→15s cap, hello + resubscribe-all, fresh snapshot per ack | Obvious default, trivially tunable later; snapshot-on-ack is the protocol's own idiom | S:60 R:95 A:85 D:80 |
+| 6 | Certain | Route path `/ws/state`; global-slot replay once after `hello` | Naming/mechanics with one obvious shape, trivially changed pre-merge | S:60 R:95 A:90 D:85 |
+| 7 | Confident | Retire `GET /api/sessions/stream` + `handleSSE` in this same change, no deprecation shim (plan D2) | Constitution IV (minimal surface); frontend is sole consumer; handler is one `git revert` away if an external consumer surfaces | S:70 R:85 A:80 D:75 |
+| 8 | Confident | `POST /api/preview-scope` stays; `conn=` maps to WS hello conn id (plan D4) | Keeps change focused; preview-scope race is not an observed pain; in-band migration remains open as follow-up | S:70 R:90 A:75 D:70 |
+| 9 | Confident | Connection dots = socket-connected AND subscription-acked; `hostMetricsConnected` keys on metrics subscription with existing 3s debounce | Follows the dot-everywhere vocabulary (memory: ui-patterns); exact mapping is implementation detail, easily adjusted | S:75 R:85 A:80 D:75 |
+| 10 | Confident | Change type = refactor (transport swap preserving event contracts) | Primary motivation fixes a failure mode, but contract-wise this restructures plumbing; pinned explicitly to survive refresh re-inference (memory: `fab-change-type-refresh-flip`) | S:50 R:95 A:70 D:60 |
+
+10 assumptions (6 certain, 4 confident, 0 tentative, 0 unresolved).

--- a/fab/plans/sahil/socket-unification.md
+++ b/fab/plans/sahil/socket-unification.md
@@ -1,0 +1,302 @@
+# Plan: Socket Unification — a fixed 2-WebSocket budget per tab
+
+**Authored**: 2026-07-16
+**Author**: discussion session with Claude (spikes run and verified same day)
+**Executor**: change 1 interactively or via operator; changes 2–3 intended for fab-operator execution **from this plan**
+**Status**: Plan only — change 1 intake drafted (`state-socket`), changes 2–3 intakes to be drafted from §Change 2 / §Change 3 below
+
+## Goal
+
+Collapse run-kit's per-tab connection usage from `panes + servers + 1 (+ chat)` long-lived
+streams down to **two WebSockets per tab**, eliminating:
+
+1. **h1 pool starvation on plaintext origins** — the browser's 6-per-origin HTTP/1.1
+   connection pool, which SSE streams saturate today (a 5-server host holds all 6 slots
+   from SSE alone: 5 session streams + 1 metrics stream).
+2. **The Firefox/WebKit terminal-blocking failure** — on those engines a saturated pool
+   blocks new WebSocket *handshakes* entirely, so 6 open SSEs mean no terminal can ever
+   connect. This failure mode exists in production today for non-HTTPS access.
+
+## Evidence (read these first)
+
+| Source | What it establishes |
+|--------|---------------------|
+| `docs/findings/socket-pool-accounting.md` | SSE holds a pool slot in every engine (cap 6, 7th stalls); **established WS holds NO slot in any engine**; WS handshakes BLOCK behind a full pool on Firefox/WebKit; pool is shared across tabs (Chromium/WebKit). Consequence: converting streams to WS clears the pool; multi-tab WS usage is free. |
+| `docs/findings/relay-mux-hol.md` | On a muxed terminal socket, a shared FIFO gives 1.66s interactive echo p50 under a co-stream flood at 1 Mbps; per-stream bounded queues + non-FIFO scheduler give 32ms at identical throughput. **Per-stream queues + scheduler are a v1 protocol requirement.** |
+
+### Current stream inventory (verified 2026-07-16)
+
+| Stream | Site | Count |
+|--------|------|-------|
+| Terminal relay WS `/relay/{windowId}` | `app/frontend/src/components/terminal-client.tsx:813` → `app/backend/api/relay.go` (`handleRelay`) | 1 per live pane |
+| Session-state SSE `/api/sessions/stream?server=` | `app/frontend/src/contexts/session-context.tsx:573` → `app/backend/api/sse.go` (`handleSSE`, `sseHub`) | 1 per attached tmux server |
+| Host-metrics SSE `/api/sessions/stream?metrics=1` | `session-context.tsx:879` | 1 per tab |
+| Chat SSE `/api/windows/{id}/chat/stream` | `app/frontend/src/hooks/use-chat-stream.ts:59` → `app/backend/api/chat.go` | 1 per open chat lens |
+
+## Target architecture
+
+```
+Browser tab
+ ├── STATE socket    /ws/state      (change 1; chat joins in change 3)
+ │     JSON text frames. Session-state per subscribed server, host metrics,
+ │     global slots (version, update-available, server-order, board-order,
+ │     status-refresh, services), previews, chat incrementals.
+ │     In-band subscribe/ack+snapshot protocol.
+ └── TERMINAL socket /ws/terminals  (change 2)
+       Binary frames [u32 streamId][bytes] + JSON text control frames.
+       All pane relays. Per-stream bounded queues + fair scheduler server-side.
+```
+
+Everything else stays request/response. Steady-state h1 pool usage ≈ 0 (transient
+fetches and proxied-iframe traffic only). Old endpoints are **retired in the same
+change that replaces them** — the frontend is the only consumer (personal tool, no API
+compatibility contract).
+
+## Protocol specifications
+
+### State socket — `/ws/state`
+
+Transport: WebSocket, JSON text frames both directions.
+**Why WS and not one muxed SSE**: established WS exits the h1 pool entirely (spike 1),
+and in-band subscribe messages are totally ordered with the event stream — eliminating
+the POST-races-the-stream class this codebase has been burned by twice (preview-scope
+`conn=` coupling; relay connect-select, see memory `relay-connect-select-alignment`).
+
+Client → server ops:
+
+```jsonc
+{"op": "hello", "conn": "<client-generated id>"}          // once, first message
+{"op": "subscribe", "kind": "server",  "key": "<tmux server name>", "req": 1}
+{"op": "subscribe", "kind": "metrics", "req": 2}          // host metrics + services
+{"op": "subscribe", "kind": "chat", "key": "<windowId>", "from": <byteOffset>, "req": 3}  // change 3
+{"op": "unsubscribe", "kind": "...", "key": "..."}
+{"op": "preview-scope", "server": "...", "expanded": ["<session>", ...]}   // decision D4
+```
+
+Server → client:
+
+```jsonc
+{"op": "ack", "req": 1, "snapshot": { /* same payload the SSE snapshot carries today */ }}
+{"op": "event", "kind": "server", "key": "<server>", "type": "<today's SSE event name>", "data": { ... }}
+{"op": "event", "kind": "global", "type": "version" | "update-available" | "server-order" | "board-order" | "status-refresh", "data": { ... }}
+{"op": "gone", "kind": "server", "key": "<server>", "reason": "server-exited"}   // replaces stream-death-as-signal
+{"op": "error", "req": N, "message": "..."}
+```
+
+Contract-preservation rule: **today's SSE event names and payloads move verbatim into
+`type`/`data`** — the envelope changes, the payloads do not. The `sseHub` cached-slot
+replay semantics map 1:1: cached global slots (`cachedVersionJSON`,
+`cachedUpdateAvailableJSON`, `cachedServerOrderJSON`, `cachedBoardOrderJSON`,
+`cachedMetricsJSON`, `cachedServicesJSON` — see `sse.go` `addClient`) are sent once
+after `hello` as `kind: "global"` events; per-server snapshots ride the subscribe `ack`.
+`status-refresh` stays broadcast-only (no replay).
+
+Reconnect: client-side exponential backoff (1s → 15s cap), then `hello` + resubscribe
+all active subscriptions; every subscription re-acks with a fresh snapshot. The
+version/boot auto-reload guard (`shouldReloadOnVersion`) consumes the replayed
+`version` global exactly as it consumes the SSE replay today — first-connect semantics
+unchanged.
+
+Connection-dot semantics: page dots derive from (socket connected) AND (relevant
+subscription acked). `hostMetricsConnected` (3s disconnect debounce) keys on the
+metrics subscription state instead of a dedicated EventSource.
+
+### Terminal socket — `/ws/terminals`
+
+Transport: one WebSocket per tab. Binary data frames `[u32 BE streamId][payload]` both
+directions (output server→client, keystrokes client→server). JSON text frames for
+control:
+
+```jsonc
+// client → server
+{"op": "open", "id": 7, "server": "<tmux server>", "windowId": "@42", "cols": 120, "rows": 32}
+{"op": "resize", "id": 7, "cols": 100, "rows": 40}
+{"op": "close", "id": 7}
+// server → client
+{"op": "opened", "id": 7}
+{"op": "closed", "id": 7, "code": 4004 | 4001 | 1000, "reason": "Window not found" | "Failed to attach to tmux session" | "closed"}
+```
+
+Per-stream server behavior preserves `handleRelay` exactly (`relay.go:49-208`): window-ID
+validation via the shared decode helper, `ResolveWindowSession`, **session-scoped**
+`SelectWindowInSession` (the group-ambiguity comment at `relay.go:88-99` still applies),
+`forceTERM`, best-effort config reload, PTY attach at the open frame's initial size,
+cleanup (cancel + ptmx close + process kill) on stream close. Today's WS close codes
+4004/4001 become `closed` control events — the socket itself never closes for
+stream-level failures.
+
+**Write path (v1 requirement, per spike 2)**: per-stream bounded send queue (8 × 4096B)
++ single writer goroutine scheduling round-robin across ready streams, control frames
+and short frames never queuing behind another stream's bulk output. A full queue pauses
+that stream's PTY reader (backpressure into tmux's per-client buffering) — never drops
+bytes (VT-state corruption). The existing relay's read loop (`buf 4096` at
+`relay.go:173`) becomes the per-stream producer.
+
+Frontend: a singleton `RelayMux` (one per tab) owning the socket, exposing
+`openStream({server, windowId, cols, rows}) → handle {send, resize, close, onData, onClosed}`.
+`TerminalClient` keeps its exact external behavior but consumes a stream handle:
+
+- The **confirmation-gated window-switch** (change 260715-38kg) keys "first write" at
+  socket `onmessage` today → becomes **first data frame for this stream id**. The gate
+  state machine is pure; only the receipt source changes.
+- The **connect-select alignment** race fix (epoch-tagged in-flight receipt, memory
+  `relay-connect-select-alignment`) now anchors on the `open`→`opened` exchange, which
+  is ordered in-band — verify the epoch logic simplifies rather than breaks.
+- IntersectionObserver pane suspension = `close`/`open` stream ops (no socket churn) —
+  this also fixes the board pane-resize suspension drop's cost (memory
+  `board-pane-resize-suspension-drop`).
+- Socket-level reconnect: `RelayMux` reconnects with backoff; each live
+  `TerminalClient` re-issues `open` through its existing per-pane reconnect path
+  (deferred per-connection reset already handles re-init).
+
+## Change breakdown
+
+### Change 1 — `state-socket` (intake drafted)
+
+**Delivers the user-facing fix**: session SSEs are what starve the pool and block
+Firefox/WebKit terminals.
+
+Scope — backend:
+- New `/ws/state` handler in `app/backend/api/` implementing the state-socket protocol
+  above (gorilla/websocket, already a dependency).
+- `sseHub` (`api/sse.go`) refactor: `sseClient` (single-server, channel of pre-rendered
+  SSE bytes) → per-connection **subscription set** with per-subscription event routing.
+  Producers (pollers, metrics collector, ports collector, PR-status join, preview
+  capture, broadcast helpers) are unchanged — only the client-facing edge changes.
+- Retire `GET /api/sessions/stream` + `handleSSE` in the same change (frontend is sole
+  consumer). `POST /api/preview-scope` stays (D4).
+- Dead-server reap becomes an in-band `gone` event (today: poll-set reap on fetch error,
+  memory: SSE poll-set reap in `tmux-sessions`).
+
+Scope — frontend:
+- `session-context.tsx` (1258 lines): the per-server EventSource pool (`:538-812`) and
+  the metrics EventSource effect (`:852+`) are replaced by one `StateSocket` client
+  module (hello/subscribe/ack/resubscribe/backoff). The `attachServer` lazy-attach API
+  and every `subscribe*` helper signature stay identical — consumers (`use-boards`,
+  `use-window-pins`, etc.) already go through these seams and must not change.
+- Connection-dot wiring per §Protocol.
+
+Acceptance:
+1. Board / terminal / server / host routes hold **zero EventSources and exactly one
+   `/ws/state` WS** (plus relay WSs unchanged) — new e2e guard counting connections
+   via Playwright's `page.on('websocket')` + a request-count assertion for
+   `text/event-stream` (must be 0).
+2. All existing SSE-event consumers work unmodified above the `subscribe*` seams;
+   event payloads byte-identical inside the new envelope (hub unit tests assert this).
+3. `multi-server-sidebar:70` passes deterministically under `just test-e2e` isolation —
+   the attachServer→SSE race (memory `multi-server-group-expand-async-race`) is
+   structurally fixed by subscribe/ack. **This long-standing flake is an explicit
+   acceptance test.**
+4. Version-bump auto-reload, update chip, server/board order live re-sort, previews,
+   status-refresh spinner: covered by existing e2e; must stay green.
+5. Full-page RefreshButton recovery affordance still recovers after `rk daemon restart`
+   (socket reconnect + resubscribe path).
+
+Non-goals: terminal relays (untouched), chat SSE (untouched until change 3),
+SharedWorker, `/api/sessions/stream` deprecation shims.
+
+### Change 2 — `relay-mux`
+
+Scope — backend:
+- New `/ws/terminals` handler: connection registry + per-stream `startStream` extracted
+  from `handleRelay`'s guts (resolve → select → attach → pump), per-stream queues +
+  scheduler per §Protocol (spike 2 requirement).
+- Port the HOL harness assertion into a Go test: with stream A flooding through a paced
+  writer, a stream B echo frame is written within a bounded number of frames (unit test
+  on the scheduler, no real network needed).
+- Retire `/relay/{windowId}` + `handleRelay` in the same change.
+
+Scope — frontend:
+- `RelayMux` singleton module + `TerminalClient` port per §Protocol (the four delicate
+  seams: confirmation gate receipt source, select-alignment epoch, suspension
+  open/close, per-stream reset). `terminal-client.tsx:813` is the only socket-creation
+  site to replace.
+
+Acceptance:
+1. A board with N panes holds exactly **2 WebSockets total** (state + terminals) — e2e
+   connection guard updated.
+2. Full window-switch-transition e2e suite green (confirmation gate, bounce-back,
+   grace mask). Note: `window-heading` history-arrows flake is pre-existing on main
+   (memory `window-heading-history-arrows-flaky-main`) — do not attribute.
+3. Scheduler Go test (above) green; relay behaviors (4004 on bad window, initial-size
+   attach, TERM forcing) re-asserted in `relay_test.go` equivalents.
+4. Manual/e2e: two panes on one board, one running `yes`, typing latency in the other
+   stays interactive (the spike's scenario, in vivo).
+
+Dependency: none hard on change 1 (different seams, can run in a parallel worktree),
+but sequence it after — change 1 carries the urgent fix and merging order keeps the
+e2e connection-guard evolution linear (guard tightens 1→2).
+
+### Change 3 — `chat-on-state-socket`
+
+Scope:
+- Chat incremental events become `kind: "chat"` subscriptions on the state socket
+  (subscribe on chat-lens enter, unsubscribe on leave). The per-view SSE
+  (`GET /api/windows/{id}/chat/stream`, `use-chat-stream.ts`) is retired.
+- **Backfill demoted to the existing `GET /api/windows/{id}/chat`** (fetch on lens
+  enter), so big transcripts never head-of-line-block state events. The subscribe op
+  carries `from: <byteOffset>` (the JSONL adapter is already byte-offset-tailed — see
+  memory `chat` § read side); the ack returns the current offset so fetch+subscribe
+  compose without gaps or duplicates.
+- The stream's provider-rotation re-resolve (~2s) and lazy-transcript not-yet tolerance
+  move into the chat subscription's server-side producer unchanged.
+- Chat-mode connection dot = chat subscription state (socket + acked).
+
+Acceptance:
+1. Chat lens holds zero EventSources; **any route holds ≤ 2 WS + 0 SSE** (final
+   connection-guard form).
+2. Chat e2e specs green: backfill renders, incremental events append, pending bubble,
+   send path (POST, untouched), provider rotation tolerance.
+3. No gap/duplicate at the fetch→subscribe seam (unit test the offset composition).
+
+Dependency: **requires change 1** (protocol + hub subscription machinery). Small
+enough for one review pass.
+
+## Execution model (operator handoff for changes 2–3)
+
+1. Change 1 (`state-socket`): intake exists (drafted via `/fab-draft` alongside this
+   plan). Execute via `/fab-switch state-socket && /fab-proceed`, interactively or
+   operator-dispatched.
+2. After change 1 reaches review-pr DONE: draft intakes for `relay-mux` and
+   `chat-on-state-socket` **from this plan** — each intake's Requirements/Decisions
+   sections should be lifted from §Change 2 / §Change 3 plus §Protocol specifications
+   (they are written to be liftable). Evidence links: both findings docs + this plan.
+3. Operator queue: `fab operator autopilot start relay-mux chat-on-state-socket` —
+   implicit chaining gives `chat-on-state-socket.depends_on = [relay-mux]`, which is
+   stricter than required (chat needs only change 1) but keeps the e2e
+   connection-guard evolution conflict-free, since both changes edit the same guard
+   spec.
+4. Auto-answer policy: standard (Confident → default; Tentative/Unresolved → halt).
+   Decisions D1–D6 below are **made** — agents should not re-open them.
+
+## Decisions (made in this plan; do not relitigate in intakes)
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | State socket is a **WebSocket**, not a muxed SSE | Exits the h1 pool (spike 1); in-band subscribe kills the POST-vs-stream race class |
+| D2 | Old endpoints retired in the same change that replaces them | Sole consumer is our frontend; constitution IV (minimal surface) |
+| D3 | Terminal mux ships with per-stream queues + fair scheduler in v1 | Spike 2: shared FIFO = 1.66s typing latency under flood; fairness costs zero throughput |
+| D4 | `POST /api/preview-scope` stays in change 1 (conn-id maps to the WS `hello` conn); optional in-band migration later | Keeps change 1 focused; preview-scope race is not an observed pain today |
+| D5 | Chat backfill via GET + offset-composed subscribe (not snapshot-in-ack) | Bounded event sizes on the shared socket; adapter is already byte-offset-tailed |
+| D6 | 2 sockets (terminals separate from state), not 1 | Bulk binary output must not share a send buffer/scheduler with state events (user requirement + spike 2) |
+
+## Risk register
+
+| # | Risk | Mitigation |
+|---|------|------------|
+| 1 | Hub refactor regresses an SSE contract consumed by one of the many frontend surfaces | Envelope-only rule (payloads byte-identical) + hub unit tests asserting payload equality + existing e2e breadth |
+| 2 | Confirmation-gate port breaks window-switch UX subtly | Gate module is pure — swap only the receipt source; window-switch-transition e2e suite is the guard |
+| 3 | tmux behavior when a stream's PTY reader pauses (backpressure) differs from a stalled TCP socket | It is the same mechanism (unread PTY), tmux buffers per client; verify manually with a flooding pane (change 2 acceptance 4) |
+| 4 | Reconnect storms: one socket drop now drops everything | Backoff + resubscribe-all is simpler than today's N independent reconnect paths; RefreshButton remains the manual recovery affordance |
+| 5 | e2e specs asserting transport internals (EventSource counts, relay URLs) churn | Each change updates specs + `.spec.md` companions in the same commit (constitution: Test Companion Docs) |
+| 6 | Vite dev origin quirks (HMR WS shares origin) confuse the connection guard | Guard counts only rk endpoints (`/ws/state`, `/ws/terminals`, `text/event-stream` responses) |
+| 7 | Playwright's bundled engines mask a real-Safari difference in pool behavior | Findings doc carries the caveat; the design doesn't depend on engine specifics (fewer connections is strictly better everywhere) |
+
+## Out of scope (explicit)
+
+- SharedWorker socket ownership (unnecessary for pool reasons — established WS are
+  pool-exempt in every engine; revisit only if server-side per-tab attach cost hurts).
+- ws-over-h2 (RFC 8441), TLS termination, HTTPS setup changes.
+- Proxied-iframe (`/proxy/{port}/`) pool consumption — inherent, documented residual.
+- Merging the two WebSockets into one (D6).
+- Any change to the chat send path (`POST .../chat/send`) or Web Push.


### PR DESCRIPTION
## Summary

Design groundwork for collapsing run-kit's per-tab connection usage (one relay WS per pane + one SSE per tmux server + metrics/chat SSE) down to a fixed budget of two multiplexed WebSockets — eliminating h1 6-per-origin pool starvation on plaintext origins, where 6 open SSEs today block all fetches (Chromium/WebKit) and even block new WebSocket handshakes entirely (Firefox/WebKit).

Two spikes were run and their findings committed: per-engine connection-pool accounting (SSE holds pool slots everywhere; established WS never does), and head-of-line-blocking measurements on a muxed terminal socket (shared FIFO = 1.66s interactive latency under flood at 1 Mbps; per-stream queues + fair scheduler = 32ms at identical throughput).

## Changes

- `docs/findings/socket-pool-accounting.md` — spike 1: h1 pool accounting matrix across Chromium/Firefox/WebKit, with reproduction harness
- `docs/findings/relay-mux-hol.md` — spike 2: HOL measurements fixing the terminal-mux protocol shape (per-stream bounded queues + non-FIFO scheduler as v1 requirements)
- `fab/plans/sahil/socket-unification.md` — master plan: target architecture, both socket protocols, three-change breakdown (state-socket → relay-mux → chat-on-state-socket), settled decisions D1–D6, operator handoff for changes 2–3
- `fab/changes/260716-qf3j-state-socket/` — drafted intake for change 1 (confidence 4.8/5.0, not activated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)