### PR TITLE
docs: Bind Constitution to sahil87 Toolkit Standards

### DIFF
--- a/fab/changes/260717-zn03-constitution-toolkit-standards/.history.jsonl
+++ b/fab/changes/260717-zn03-constitution-toolkit-standards/.history.jsonl
@@ -9,3 +9,4 @@
 {"event":"review","result":"passed","ts":"2026-07-17T19:46:45Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-07-17T19:47:48Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-07-17T19:49:37Z"}
+{"event":"review","result":"passed","ts":"2026-07-17T19:57:10Z"}

--- a/fab/changes/260717-zn03-constitution-toolkit-standards/.history.jsonl
+++ b/fab/changes/260717-zn03-constitution-toolkit-standards/.history.jsonl
@@ -8,3 +8,4 @@
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-07-17T19:46:45Z"}
 {"event":"review","result":"passed","ts":"2026-07-17T19:46:45Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-07-17T19:47:48Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-07-17T19:49:37Z"}

--- a/fab/changes/260717-zn03-constitution-toolkit-standards/.history.jsonl
+++ b/fab/changes/260717-zn03-constitution-toolkit-standards/.history.jsonl
@@ -1,0 +1,10 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-07-17T19:34:46Z"}
+{"args":"Task: Amend this repo's fab constitution to bind it to the sahil87 toolkit standards. Add a Toolkit Standards article under Additional Constraints in fab/project/constitution.md (standards enumerated by `shll standards`, canonical source sahil87/shll docs/site/standards/, rendered on https://shll.ai), bump Last Amended date and version. Do NOT copy standard names/counts/URLs into the constitution. Docs-type fab change -\u003e PR. No conformance fixes in scope.","cmd":"fab-new","event":"command","ts":"2026-07-17T19:34:46Z"}
+{"delta":"+5.0","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-07-17T19:36:11Z"}
+{"cmd":"fab-fff","event":"command","ts":"2026-07-17T19:39:21Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-07-17T19:39:32Z"}
+{"cmd":"fab-continue","event":"command","ts":"2026-07-17T19:40:23Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-07-17T19:41:38Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-07-17T19:46:45Z"}
+{"event":"review","result":"passed","ts":"2026-07-17T19:46:45Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-07-17T19:47:48Z"}

--- a/fab/changes/260717-zn03-constitution-toolkit-standards/.status.yaml
+++ b/fab/changes/260717-zn03-constitution-toolkit-standards/.status.yaml
@@ -9,8 +9,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 plan:
     generated: true
     task_count: 2
@@ -33,13 +33,15 @@ stage_metrics:
     apply: {started_at: "2026-07-17T19:39:32Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-17T19:41:38Z"}
     review: {started_at: "2026-07-17T19:41:38Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-17T19:46:45Z"}
     hydrate: {started_at: "2026-07-17T19:46:45Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-17T19:47:48Z"}
-    ship: {started_at: "2026-07-17T19:47:48Z", driver: fab-fff, iterations: 1}
-prs: []
+    ship: {started_at: "2026-07-17T19:47:48Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-17T19:49:37Z"}
+    review-pr: {started_at: "2026-07-17T19:49:37Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/sahil87/run-kit/pull/379
 change_type_source: explicit
 true_impact:
-    added: 0
-    deleted: 0
-    net: 0
+    added: 241
+    deleted: 1
+    net: 240
     excluding:
         added: 0
         deleted: 0
@@ -48,7 +50,7 @@ true_impact:
         added: 0
         deleted: 0
         net: 0
-    computed_at: "2026-07-17T19:47:48Z"
-    computed_at_stage: hydrate
+    computed_at: "2026-07-17T19:49:37Z"
+    computed_at_stage: ship
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-07-17T19:47:48Z
+last_updated: 2026-07-17T19:49:37Z

--- a/fab/changes/260717-zn03-constitution-toolkit-standards/.status.yaml
+++ b/fab/changes/260717-zn03-constitution-toolkit-standards/.status.yaml
@@ -1,0 +1,54 @@
+id: zn03
+name: 260717-zn03-constitution-toolkit-standards
+created: 2026-07-17T19:34:46Z
+created_by: sahil-noon
+change_type: docs
+issues: []
+progress:
+    intake: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+plan:
+    generated: true
+    task_count: 2
+    acceptance_count: 5
+    acceptance_completed: 5
+confidence:
+    certain: 6
+    confident: 1
+    tentative: 0
+    unresolved: 0
+    score: 5.0
+    fuzzy: true
+    dimensions:
+        signal: 83.6
+        reversibility: 89.3
+        competence: 90.7
+        disambiguation: 85.7
+stage_metrics:
+    intake: {started_at: "2026-07-17T19:34:46Z", driver: fab-new, iterations: 1, completed_at: "2026-07-17T19:39:32Z"}
+    apply: {started_at: "2026-07-17T19:39:32Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-17T19:41:38Z"}
+    review: {started_at: "2026-07-17T19:41:38Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-17T19:46:45Z"}
+    hydrate: {started_at: "2026-07-17T19:46:45Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-17T19:47:48Z"}
+    ship: {started_at: "2026-07-17T19:47:48Z", driver: fab-fff, iterations: 1}
+prs: []
+change_type_source: explicit
+true_impact:
+    added: 0
+    deleted: 0
+    net: 0
+    excluding:
+        added: 0
+        deleted: 0
+        net: 0
+    tests:
+        added: 0
+        deleted: 0
+        net: 0
+    computed_at: "2026-07-17T19:47:48Z"
+    computed_at_stage: hydrate
+# true_impact: lazily created on first stage-finish that computes it (no placeholder here).
+last_updated: 2026-07-17T19:47:48Z

--- a/fab/changes/260717-zn03-constitution-toolkit-standards/.status.yaml
+++ b/fab/changes/260717-zn03-constitution-toolkit-standards/.status.yaml
@@ -10,7 +10,7 @@ progress:
     review: done
     hydrate: done
     ship: done
-    review-pr: active
+    review-pr: done
 plan:
     generated: true
     task_count: 2
@@ -34,7 +34,7 @@ stage_metrics:
     review: {started_at: "2026-07-17T19:41:38Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-17T19:46:45Z"}
     hydrate: {started_at: "2026-07-17T19:46:45Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-17T19:47:48Z"}
     ship: {started_at: "2026-07-17T19:47:48Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-17T19:49:37Z"}
-    review-pr: {started_at: "2026-07-17T19:49:37Z", driver: git-pr, iterations: 1}
+    review-pr: {started_at: "2026-07-17T19:49:37Z", driver: git-pr, iterations: 1, completed_at: "2026-07-17T19:57:10Z"}
 prs:
     - https://github.com/sahil87/run-kit/pull/379
 change_type_source: explicit
@@ -53,4 +53,4 @@ true_impact:
     computed_at: "2026-07-17T19:49:37Z"
     computed_at_stage: ship
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-07-17T19:49:37Z
+last_updated: 2026-07-17T19:57:10Z

--- a/fab/changes/260717-zn03-constitution-toolkit-standards/intake.md
+++ b/fab/changes/260717-zn03-constitution-toolkit-standards/intake.md
@@ -63,7 +63,7 @@ Version bumps MINOR (1.5.0 → 1.6.0) because a new article is added and no exis
 
 - **No enumeration in the constitution**: do NOT copy standard names, counts, or per-standard URLs into the article — `shll standards` is the enumeration; the article must stay correct as standards evolve. Reviewers should treat any hardcoded standard list in the diff as a defect.
 - **No conformance fixes**: this change does not audit or fix the CLI surface, help output, README.md, or docs against the standards. Binding only.
-- No other file changes — constitution.md is the entire diff.
+- No other file changes — constitution.md is the only substantive file in the diff. The PR also carries the standard fab change artifacts (`intake.md`, `plan.md`, `.status.yaml`, `.history.jsonl`), which are co-committed pipeline bookkeeping present in every fab change and excluded from impact per config `true_impact_exclude`.
 
 ## Affected Memory
 

--- a/fab/changes/260717-zn03-constitution-toolkit-standards/intake.md
+++ b/fab/changes/260717-zn03-constitution-toolkit-standards/intake.md
@@ -1,0 +1,94 @@
+# Intake: Bind Constitution to sahil87 Toolkit Standards
+
+**Change**: 260717-zn03-constitution-toolkit-standards
+**Created**: 2026-07-18
+
+## Origin
+
+One-shot `/fab-new` invocation with a fully-specified task (no prior conversation). Raw input:
+
+> Task: Amend this repo's fab constitution to bind it to the sahil87 toolkit standards.
+>
+> This repo is part of the sahil87 toolkit. The toolkit publishes binding, producer-facing standards — CLI design principles plus mechanical contracts (machine-readable help output, README/docs-site structure, and others over time). They are canonically authored in the sahil87/shll repository's docs/site/standards/ tree, rendered on https://shll.ai, and readable offline via the `shll standards` command. This change adds a constitution article so every future pipeline run in this repo loads and enforces the obligation.
+>
+> Make this change:
+>
+> 1. In fab/project/constitution.md, add a new article under Additional Constraints (create the section if this constitution lacks it, matching the file's existing structure):
+>
+>    ### Toolkit Standards
+>
+>    This tool is part of the sahil87 toolkit and MUST conform to the toolkit's published standards. The standards are enumerated by running `shll standards` — each entry names what it governs; read one with `shll standards <name>`. Before changing the CLI surface, help output, README.md, or docs/site/, the change MUST be checked against the standards governing that surface. If shll is unavailable, the canonical sources are the sahil87/shll repository's docs/site/standards/ tree (rendered on https://shll.ai). Standards added or revised there bind this repo without further amendment to this constitution.
+>
+> 2. Bump the constitution's Last Amended date (and version, per this file's own governance line).
+> 3. Deliberate constraint: do NOT copy standard names, counts, or per-standard URLs into the constitution — `shll standards` is the enumeration, and the article must stay correct as standards evolve.
+>
+> Ship per this repo's normal flow (docs-type fab change → PR). Nothing else is in scope — no conformance fixes in this change.
+
+## Why
+
+1. **Problem**: run-kit is part of the sahil87 toolkit (the README already links https://shll.ai and installs via the shll meta-CLI), and the toolkit publishes binding, producer-facing standards — CLI design principles plus mechanical contracts (machine-readable help output, README/docs-site structure, more over time). Nothing in this repo's fab governance layer obligates pipeline runs to check those standards. An agent changing the CLI surface, help output, README.md, or docs site has no loaded instruction to consult them.
+2. **Consequence if unfixed**: silent drift — each CLI/docs change is made against local conventions only, and the repo diverges from the toolkit's published contracts until someone notices by hand.
+3. **Why this approach**: `fab/project/constitution.md` is the always-load layer for every pipeline stage (every skill and every dispatched subagent reads it before acting), so a constitution article is the one place where the obligation is guaranteed to be in context for every future run. Weaker alternatives were implicitly rejected by the task framing: a README note or `context.md` paragraph is descriptive, not binding — the constitution is the MUST/SHALL governance surface. The article deliberately references `shll standards` as the enumeration rather than listing standards, so it stays correct as the toolkit adds or revises standards without re-amending this file.
+
+## What Changes
+
+### `fab/project/constitution.md`: new "Toolkit Standards" article
+
+The `## Additional Constraints` section **already exists** in this constitution (articles: Test Integrity, Test Companion Docs, Process Execution, Self-Improvement Safety) — no section creation is needed. Append the new article as the **last article** of that section, immediately after `### Self-Improvement Safety` and before `## Governance`, matching the file's existing structure (`###` heading, prose body with RFC-2119 keywords, em-dash typography):
+
+```markdown
+### Toolkit Standards
+This tool is part of the sahil87 toolkit and MUST conform to the toolkit's published standards. The standards are enumerated by running `shll standards` — each entry names what it governs; read one with `shll standards <name>`. Before changing the CLI surface, help output, README.md, or docs/site/, the change MUST be checked against the standards governing that surface. If shll is unavailable, the canonical sources are the sahil87/shll repository's docs/site/standards/ tree (rendered on https://shll.ai). Standards added or revised there bind this repo without further amendment to this constitution.
+```
+
+The text is the user's provided article verbatim, with the input's shell-flattened `--` rendered as em-dashes (`—`) to match the file's existing typography. Note the body starts directly under the heading with no blank-line-separated lead-in, matching sibling articles.
+
+### `fab/project/constitution.md`: governance line bump
+
+Current governance line:
+
+```markdown
+**Version**: 1.5.0 | **Ratified**: 2026-03-02 | **Last Amended**: 2026-07-15
+```
+
+New governance line:
+
+```markdown
+**Version**: 1.6.0 | **Ratified**: 2026-03-02 | **Last Amended**: 2026-07-18
+```
+
+Version bumps MINOR (1.5.0 → 1.6.0) because a new article is added and no existing principle is changed or removed. Ratified date is untouched.
+
+### Deliberate non-goals
+
+- **No enumeration in the constitution**: do NOT copy standard names, counts, or per-standard URLs into the article — `shll standards` is the enumeration; the article must stay correct as standards evolve. Reviewers should treat any hardcoded standard list in the diff as a defect.
+- **No conformance fixes**: this change does not audit or fix the CLI surface, help output, README.md, or docs against the standards. Binding only.
+- No other file changes — constitution.md is the entire diff.
+
+## Affected Memory
+
+None — this is a governance amendment to `fab/project/constitution.md`, not a spec-level system-behavior change. The constitution is itself part of the always-load layer, so its content needs no memory duplication.
+
+## Impact
+
+- **Files**: `fab/project/constitution.md` only (one new article + governance-line bump). No source code, no tests, no README/docs changes.
+- **Process**: every future pipeline run in this repo loads the obligation; changes touching the CLI surface, help output, README.md, or docs/site/ must be checked against the standards enumerated by `shll standards` (canonical fallback: the sahil87/shll repo's docs/site/standards/ tree, rendered on https://shll.ai).
+- **Change type**: docs (explicitly pinned — governance/documentation change, no runtime behavior).
+
+## Open Questions
+
+None.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Insert the article text verbatim as provided in the task | Exact wording supplied by the user; no rephrasing | S:95 R:90 A:100 D:95 |
+| 2 | Certain | Render the input's shell-flattened `--` as em-dashes (`—`) | Constitution uses em-dashes throughout; the `--` is a command-line artifact, not intended typography | S:70 R:95 A:90 D:85 |
+| 3 | Certain | Append as the last article under the existing `## Additional Constraints` (after Self-Improvement Safety) | Section already exists; articles accrete at the end; no semantic ordering rule in the file | S:80 R:90 A:90 D:80 |
+| 4 | Confident | Version bump 1.5.0 → 1.6.0 (MINOR) | Governance line records semver but states no bump policy; constitution-semver convention (new article/section = MINOR, wording fix = PATCH) is the clear front-runner and the user delegated to "per this file's own governance line" | S:75 R:90 A:70 D:70 |
+| 5 | Certain | Pin `change_type: docs` explicitly via `fab status set-change-type` | User stated "docs-type fab change"; explicit source survives `fab status refresh` re-inference (inference had defaulted to feat) | S:90 R:85 A:95 D:90 |
+| 6 | Certain | Affected memory: none | Governance amendment, not spec-level system behavior; constitution is already always-loaded | S:80 R:85 A:90 D:85 |
+| 7 | Certain | Scope excludes conformance fixes and any standard names/counts/per-standard URLs in the article | Explicit deliberate constraints in the task | S:95 R:90 A:100 D:95 |
+
+7 assumptions (6 certain, 1 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260717-zn03-constitution-toolkit-standards/plan.md
+++ b/fab/changes/260717-zn03-constitution-toolkit-standards/plan.md
@@ -32,7 +32,7 @@ The governance line MUST read `**Version**: 1.6.0 | **Ratified**: 2026-03-02 | *
 
 - No enumeration in the constitution — no standard names, counts, or per-standard URLs in the article (`shll standards` is the enumeration; the article must stay correct as standards evolve). A hardcoded standard list in the diff is a defect.
 - No conformance fixes — this change does not audit or fix the CLI surface, help output, README.md, or docs against the standards. Binding only.
-- No other file changes — `fab/project/constitution.md` is the entire diff (no code, no tests, no README/docs, no memory).
+- No other file changes — `fab/project/constitution.md` is the only substantive file in the diff (no code, no tests, no README/docs, no memory). The PR also carries the standard fab change artifacts (`intake.md`, `plan.md`, `.status.yaml`, `.history.jsonl`), which are co-committed pipeline bookkeeping present in every fab change and excluded from impact per config `true_impact_exclude`.
 
 ## Tasks
 

--- a/fab/changes/260717-zn03-constitution-toolkit-standards/plan.md
+++ b/fab/changes/260717-zn03-constitution-toolkit-standards/plan.md
@@ -1,0 +1,79 @@
+# Plan: Bind Constitution to sahil87 Toolkit Standards
+
+**Change**: 260717-zn03-constitution-toolkit-standards
+**Intake**: `intake.md`
+
+## Requirements
+
+<!-- Docs-type change: the sole edited file is fab/project/constitution.md — a
+     governance document, not source code. Requirements below describe the exact
+     documentary state the amendment must produce. No runtime behavior, no code,
+     no tests. -->
+
+### Constitution: Toolkit Standards Binding
+
+#### R1: Toolkit Standards article present under Additional Constraints
+The constitution MUST carry a `### Toolkit Standards` article as the **last** article of the `## Additional Constraints` section — placed immediately after `### Self-Improvement Safety` and immediately before `## Governance`. The article body MUST be the intake's verbatim text with the shell-flattened `--` rendered as em-dashes (`—`) to match the file's typography, and MUST start directly under the heading with no blank-line-separated lead-in (matching sibling articles). It MUST enumerate standards via `shll standards` (not a hardcoded list), name `shll standards <name>` for reading one, require checking the CLI surface / help output / README.md / docs/site/ against the governing standards before changing them, and name the canonical fallback source (the sahil87/shll repo's `docs/site/standards/` tree, rendered on https://shll.ai) with the "bind without further amendment" clause.
+
+- **GIVEN** the current constitution whose `## Additional Constraints` section ends with `### Self-Improvement Safety`
+- **WHEN** the amendment is applied
+- **THEN** a `### Toolkit Standards` article appears as the final article of `## Additional Constraints`, before `## Governance`
+- **AND** its body matches the intake's What-Changes text verbatim with `—` typography and no blank-line lead-in
+
+#### R2: Governance line bumped to 1.6.0 / Last Amended 2026-07-18
+The governance line MUST read `**Version**: 1.6.0 | **Ratified**: 2026-03-02 | **Last Amended**: 2026-07-18`. The version bumps MINOR (1.5.0 → 1.6.0) because a new article is added and no existing principle changes or is removed; the Ratified date is untouched.
+
+- **GIVEN** the current governance line `**Version**: 1.5.0 | **Ratified**: 2026-03-02 | **Last Amended**: 2026-07-15`
+- **WHEN** the amendment is applied
+- **THEN** the line reads `**Version**: 1.6.0 | **Ratified**: 2026-03-02 | **Last Amended**: 2026-07-18`
+- **AND** the Ratified date is unchanged
+
+### Non-Goals
+
+- No enumeration in the constitution — no standard names, counts, or per-standard URLs in the article (`shll standards` is the enumeration; the article must stay correct as standards evolve). A hardcoded standard list in the diff is a defect.
+- No conformance fixes — this change does not audit or fix the CLI surface, help output, README.md, or docs against the standards. Binding only.
+- No other file changes — `fab/project/constitution.md` is the entire diff (no code, no tests, no README/docs, no memory).
+
+## Tasks
+
+<!-- Docs-only amendment: two discrete edits to one file. No code/test phases. -->
+
+### Phase 1: Constitution Amendment
+
+- [x] T001 Append the `### Toolkit Standards` article as the last article of `## Additional Constraints` in `fab/project/constitution.md` — immediately after the `### Self-Improvement Safety` article body and before `## Governance` — using the intake's verbatim text with `—` em-dash typography and no blank-line lead-in under the heading <!-- R1 -->
+- [x] T002 Bump the governance line in `fab/project/constitution.md` to `**Version**: 1.6.0 | **Ratified**: 2026-03-02 | **Last Amended**: 2026-07-18` (Ratified untouched) <!-- R2 -->
+
+## Acceptance
+
+### Functional Completeness
+
+- [x] A-001 R1: The `### Toolkit Standards` article exists as the final article of `## Additional Constraints`, positioned after `### Self-Improvement Safety` and before `## Governance`, with the verbatim intake body, `—` typography, and no blank-line lead-in under the heading
+- [x] A-002 R2: The governance line reads `**Version**: 1.6.0 | **Ratified**: 2026-03-02 | **Last Amended**: 2026-07-18` with the Ratified date unchanged
+
+### Behavioral Correctness
+
+- [x] A-003 R1: The article enumerates standards via `shll standards` / `shll standards <name>` and names the sahil87/shll `docs/site/standards/` (https://shll.ai) fallback with the "bind without further amendment" clause — no standard names, counts, or per-standard URLs are hardcoded
+
+### Code Quality
+
+- [x] A-004 Pattern consistency: The new article matches the file's existing article structure (`###` heading, prose body with RFC-2119 keywords, em-dash typography, body starting directly under the heading)
+- [x] A-005 Scope containment: `fab/project/constitution.md` is the only file changed — no code, tests, README/docs, or memory touched
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All acceptance items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] A-NNN **N/A**: {reason}`
+
+## Assumptions
+
+<!-- Apply-agent record of graded decisions made while co-generating ## Requirements
+     from the docs-type intake. The intake resolved all substantive decisions
+     (verbatim text, em-dash typography, placement, MINOR bump) as Certain/Confident;
+     no new under-specified points arose during plan generation. -->
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Plan carries no code/test tasks — docs-only amendment to constitution.md | constitution.md is not in config `source_paths`/`test_paths`; the intake pins change_type docs and scopes the diff to one governance file; the amendment IS the change | S:95 R:90 A:100 D:95 |
+
+1 assumptions (1 certain, 0 confident, 0 tentative).

--- a/fab/project/constitution.md
+++ b/fab/project/constitution.md
@@ -46,6 +46,9 @@ All `exec.CommandContext` calls MUST use a context with timeout (default 5-10 se
 ### Self-Improvement Safety
 The restart mechanism uses tmux-based kill-and-restart: `run-kit serve --restart` sends `C-c` to the daemon tmux pane, waits for graceful shutdown, then sends a fresh `run-kit serve` command. There is no supervisor loop, no `.restart-requested` signal file, and no automatic file-change watching. Rollback MUST be atomic (`git revert HEAD`).
 
+### Toolkit Standards
+This tool is part of the sahil87 toolkit and MUST conform to the toolkit's published standards. The standards are enumerated by running `shll standards` — each entry names what it governs; read one with `shll standards <name>`. Before changing the CLI surface, help output, README.md, or docs/site/, the change MUST be checked against the standards governing that surface. If shll is unavailable, the canonical sources are the sahil87/shll repository's docs/site/standards/ tree (rendered on https://shll.ai). Standards added or revised there bind this repo without further amendment to this constitution.
+
 ## Governance
 
-**Version**: 1.5.0 | **Ratified**: 2026-03-02 | **Last Amended**: 2026-07-15
+**Version**: 1.6.0 | **Ratified**: 2026-03-02 | **Last Amended**: 2026-07-18


### PR DESCRIPTION
## Meta

| Change ID | Type | Confidence | Plan | Review |
|-----------|------|------------|------|--------|
| `zn03` | docs | 5.0/5.0 | 2/2 tasks, 5/5 acceptance ✓ | ✓ 1 cycle |


**Pipeline:** [intake](https://github.com/sahil87/run-kit/blob/260717-zn03-constitution-toolkit-standards/fab/changes/260717-zn03-constitution-toolkit-standards/intake.md) ✓ → [apply](https://github.com/sahil87/run-kit/blob/260717-zn03-constitution-toolkit-standards/fab/changes/260717-zn03-constitution-toolkit-standards/plan.md) ✓ → review ✓ → hydrate ✓ → ship → review-pr

## Summary

run-kit is part of the sahil87 toolkit, which publishes binding, producer-facing standards (CLI design principles plus mechanical contracts) enumerated via `shll standards`. Nothing in this repo's fab governance layer previously obligated pipeline runs to check those standards, risking silent drift on CLI surface, help output, README, or docs-site changes. This change adds a constitution article binding the repo to those standards, since the constitution is the always-load layer every pipeline stage and subagent reads before acting.

## Changes

- `fab/project/constitution.md`: new "Toolkit Standards" article under Additional Constraints (last article, after Self-Improvement Safety)
- `fab/project/constitution.md`: governance line bump (Version 1.5.0 → 1.6.0, Last Amended → 2026-07-18)
