### PR TITLE
docs: Record the Default-Branch Carve-Out in the Status-Pyramid Spec

### DIFF
--- a/docs/specs/status-pyramid.md
+++ b/docs/specs/status-pyramid.md
@@ -24,7 +24,7 @@ display-precedence ladder built on them.
 | L0 — tmux output | `activity` (active/idle), `activityTimestamp` | always, every window | `#{window_activity}` within 10s (`ActivityThresholdSeconds`) |
 | L1 — agent lifecycle | `agentState` (active / waiting / idle) + epoch | an instrumented agent runs in a pane of the window | `@rk_agent_state` pane option, window rollup `waiting > active > idle`; absent = unknown; PID-liveness reconciler clears dead-agent values, shell-name fallback for legacy two-segment values (see agent-state.md) |
 | L2 — fab pipeline | `fabChange`, `fabStage`, `fabDisplayState` | the pane's worktree has an active change | cwd → `.fab-status.yaml` → `.status.yaml`, via the pane-map join |
-| L3 — PR | `prNumber`/`prUrl` + `prState`/`prChecks`/`prReview`/`prIsDraft` | the pane's branch resolves to a PR | branch → `gh` lookup in the prstatus collector (post-#314; previously fab's `.status.yaml` `prs:` list) |
+| L3 — PR | `prNumber`/`prUrl` + `prState`/`prChecks`/`prReview`/`prIsDraft` | the pane's branch resolves to a PR — never for the repo's default branch (#389, see invariant 6) | branch → `gh` lookup in the prstatus collector (post-#314; previously fab's `.status.yaml` `prs:` list) |
 
 Two orthogonal *axes* run across these layers:
 
@@ -163,6 +163,15 @@ waiting   →  additive yellow halo, over anything (core hue + shape kept)
    as the pane sits on that branch — no grace clock, no negative-stamp
    machinery (`wentNegativeAt` retires). Branch-reuse edge: an open PR always
    outranks an older merged one on the same branch.
+   **Default-branch carve-out (#389)**: a pane on the repo's *default* branch
+   never derives a branch-PR at all. `gh pr list --head` matches by head-ref
+   *name* only, so every default-branch match is degenerate (a fork PR whose
+   head is named `main`, or a historical same-repo PR whose head was the
+   default branch) — and the durability rule above would pin that wrong PR
+   forever. The refresher detects the default branch locally
+   (`git symbolic-ref refs/remotes/origin/HEAD`, per-repo cached, fail-open
+   on lookup failure) and resolves excluded pairs to an authoritative
+   negative, clearing any stale positive within one pass.
 7. **Unknown beats wrong**: absent `@rk_agent_state`, or a value on a pane whose
    command is a plain shell (reconciler), means *no agent tier* — the ladder
    falls through to tmux. Nothing renders a guessed agent state.
@@ -306,5 +315,5 @@ One overlay at a time: `waiting` outranks `stuck`.
 | ID | Question | Resolution |
 |----|----------|-----------|
 | ~~D1~~ | ~~PR tier gate: `prNumber` alone?~~ | **Resolved (palette v3)**: PR dot-ownership is per-family — purple requires `fabChange && prNumber`, orange requires `fresh agentState && prNumber`. A plain pane's PR never owns the dot (derivation stays universal in register/tip/PR-status-line) |
-| D2 | Merged/closed PR retention under branch-derivation | **Revised after production observation** (first resolution — `--state open` + 10-min in-memory grace — decayed merged purple into green on grace expiry or rk restart): derivation queries **all PR states**; precedence open (most recent) > merged (most recent); merged owns the dot statelessly (durable done-square); closed-unmerged never owns (green fab fallback / floor — shipped). Grace-window machinery retired. **[current]** |
+| D2 | Merged/closed PR retention under branch-derivation | **Revised after production observation** (first resolution — `--state open` + 10-min in-memory grace — decayed merged purple into green on grace expiry or rk restart): derivation queries **all PR states**; precedence open (most recent) > merged (most recent); merged owns the dot statelessly (durable done-square); closed-unmerged never owns (green fab fallback / floor — shipped). Grace-window machinery retired. **Default-branch carve-out (#389)**: the derivation never runs for a pane on the repo's default branch — head-name-only matching makes every such candidate degenerate, so excluded pairs resolve to an authoritative negative (invariant 6). **[current]** |
 | ~~D3~~ | ~~Is a 7px halo pulse salient enough for `waiting`?~~ | **Resolved (additive halo, palette v3)**: `waiting` = constant-**yellow** pulsing halo around the dot, core hue and shape untouched. Rejected: hue-flip (destroys family identity precisely when attention is highest — e.g. fab intake asking); self-colored halo (reduced-motion form nearly invisible + collides with the `ring` shape); fuchsia (its motivating amber collision no longer exists). Reduced-motion: static yellow outer ring. Final glow tuning at implementation with a visual check against all six core hues |


### PR DESCRIPTION
Follow-up to #389, which excluded a repo's default branch from branch→PR derivation. The status-pyramid spec still described the pre-#389 behavior in three places; this updates them:

- **L3 gate row** (Signal Layers table): "the pane's branch resolves to a PR" now notes the default-branch carve-out.
- **Invariant 6** (merged-PR durability): adds the carve-out paragraph — why every default-branch head-name match is degenerate, and how the refresher detects/excludes it (local `git symbolic-ref`, per-repo cache, fail-open, authoritative negative).
- **Open Decisions D2**: the durable-merged resolution now records that the derivation never runs on the default branch.

Spec-only change; the implementation and memory docs landed with #389.