### PR TITLE
chore: Delete Unused sendKeys Frontend Client Wrapper

### DIFF
--- a/app/frontend/src/api/client.test.ts
+++ b/app/frontend/src/api/client.test.ts
@@ -13,7 +13,6 @@ import {
   createWindow,
   killWindow,
   renameWindow,
-  sendKeys,
   sendChatMessage,
   getDirectories,
   uploadFile,
@@ -207,19 +206,6 @@ describe("API client", () => {
     expect(result.ok).toBe(true);
     expect(capturedUrl).toMatch(/\/api\/windows\/%400\/rename\?server=runkit$/);
     expect(capturedBody.name).toBe("renamed");
-  });
-
-  it("sendKeys sends POST /api/windows/:windowId/keys with server query", async () => {
-    let capturedUrl = "";
-    mswServer.use(
-      http.post("/api/windows/:windowId/keys", async ({ request }) => {
-        capturedUrl = request.url;
-        return HttpResponse.json({ ok: true });
-      }),
-    );
-    const result = await sendKeys("runkit", "@0", "echo hello");
-    expect(result.ok).toBe(true);
-    expect(capturedUrl).toContain("?server=runkit");
   });
 
   it("sendChatMessage POSTs /api/windows/:windowId/chat/send with {text} and server query", async () => {

--- a/app/frontend/src/api/client.ts
+++ b/app/frontend/src/api/client.ts
@@ -194,23 +194,6 @@ export async function renameWindow(
   return res.json();
 }
 
-export async function sendKeys(
-  server: string,
-  windowId: string,
-  keys: string,
-): Promise<{ ok: boolean }> {
-  const res = await fetch(
-    withServer(`/api/windows/${encodeURIComponent(windowId)}/keys`, server),
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ keys }),
-    },
-  );
-  if (!res.ok) await throwOnError(res);
-  return res.json();
-}
-
 /** An HTTP error carrying the response status, so callers can branch on it (the
  *  chat lens treats a 404 "transcript not yet" as a wait-and-retry, not a fatal
  *  error). */

--- a/docs/memory/run-kit/architecture.md
+++ b/docs/memory/run-kit/architecture.md
@@ -224,7 +224,6 @@ The `POST /api/riff` + `GET /api/riff/presets` handlers surface the extracted `i
 | `setWindowOptions(server, windowId, options)` | POST | `/api/windows/{windowId}/options` — partial-merge; `options` is `Record<string, string \| null>` (since `260529-jad6`) |
 | `updateWindowUrl(server, windowId, url)` | POST | delegates to `setWindowOptions` → `/api/windows/{windowId}/options` (`{"@rk_url": url}`) |
 | `updateWindowType(server, windowId, rkType)` | POST | delegates to `setWindowOptions` → `/api/windows/{windowId}/options` (`{"@rk_type": rkType === "" ? null : rkType}`). **Deletion candidate since `260714-t97o-web-view-lens`** — that change removed both view-switch call sites (the `IframeWindow` `>_` button and the `toggle-iframe-terminal` palette action / tty-branch hint bar), so zero non-test references remain (only its own `client.test.ts` case). Kept for now; the backend `POST /options` endpoint stays regardless (shared with `updateWindowUrl`, and `@rk_type` remains legitimate substrate state an external process may set) |
-| `sendKeys(server, windowId, keys)` | POST | `/api/windows/{windowId}/keys` |
 | `getDirectories(prefix)` | GET | `/api/directories?prefix=...` |
 | `selectWindow(server, windowId)` | POST | `/api/windows/{windowId}/select?server=...` |
 | `splitWindow(server, windowId, horizontal, cwd?)` | POST | `/api/windows/{windowId}/split` |

--- a/docs/memory/run-kit/tmux-sessions.md
+++ b/docs/memory/run-kit/tmux-sessions.md
@@ -292,7 +292,7 @@ Functions that take `server` (read + mutation):
 |----------|-----------|
 | Read | `getSessions`, `getKeybindings`, `getSessionOrder` |
 | Session mutation | `createSession`, `renameSession`, `killSession`, `setSessionOrder` |
-| Window mutation | `createWindow` (session-scoped), `renameWindow`, `killWindow`, `moveWindow`, `moveWindowToSession`, `selectWindow`, `splitWindow`, `closePane`, `sendKeys` (all but `createWindow` take `windowId: string` as the 2nd positional arg and hit `/api/windows/{windowId}/...` — `260529-chgz-window-id-routing`) |
+| Window mutation | `createWindow` (session-scoped), `renameWindow`, `killWindow`, `moveWindow`, `moveWindowToSession`, `selectWindow`, `splitWindow`, `closePane` (all but `createWindow` take `windowId: string` as the 2nd positional arg and hit `/api/windows/{windowId}/...` — `260529-chgz-window-id-routing`) |
 | Window options | `updateWindowUrl`, `updateWindowType` (both `(server, windowId, …)`) |
 | Color | `setWindowColor`, `setSessionColor` |
 | Server-scoped | `reloadTmuxConfig` |

--- a/fab/changes/260719-4ujs-delete-sendkeys-frontend-wrapper/.history.jsonl
+++ b/fab/changes/260719-4ujs-delete-sendkeys-frontend-wrapper/.history.jsonl
@@ -1,0 +1,11 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-07-19T19:49:50Z"}
+{"args":"Delete the unused sendKeys frontend client wrapper in app/frontend/src/api/client.ts plus its test block (backlog [4ujs])","cmd":"fab-new","event":"command","ts":"2026-07-19T19:49:50Z"}
+{"delta":"+5.0","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-07-19T19:50:57Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-07-19T19:51:45Z"}
+{"cmd":"fab-continue","event":"command","ts":"2026-07-19T19:52:26Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-07-19T19:54:52Z"}
+{"cmd":"fab-continue","event":"command","ts":"2026-07-19T19:55:39Z"}
+{"cmd":"fab-continue","event":"command","ts":"2026-07-19T20:01:21Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-07-19T20:03:12Z"}
+{"event":"review","result":"passed","ts":"2026-07-19T20:03:12Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-07-19T20:04:41Z"}

--- a/fab/changes/260719-4ujs-delete-sendkeys-frontend-wrapper/.history.jsonl
+++ b/fab/changes/260719-4ujs-delete-sendkeys-frontend-wrapper/.history.jsonl
@@ -10,3 +10,4 @@
 {"event":"review","result":"passed","ts":"2026-07-19T20:03:12Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-07-19T20:04:41Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-07-19T20:06:05Z"}
+{"event":"review","result":"passed","ts":"2026-07-19T20:10:29Z"}

--- a/fab/changes/260719-4ujs-delete-sendkeys-frontend-wrapper/.history.jsonl
+++ b/fab/changes/260719-4ujs-delete-sendkeys-frontend-wrapper/.history.jsonl
@@ -9,3 +9,4 @@
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-07-19T20:03:12Z"}
 {"event":"review","result":"passed","ts":"2026-07-19T20:03:12Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-07-19T20:04:41Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-07-19T20:06:05Z"}

--- a/fab/changes/260719-4ujs-delete-sendkeys-frontend-wrapper/.status.yaml
+++ b/fab/changes/260719-4ujs-delete-sendkeys-frontend-wrapper/.status.yaml
@@ -10,7 +10,7 @@ progress:
     review: done
     hydrate: done
     ship: done
-    review-pr: active
+    review-pr: done
 plan:
     generated: true
     task_count: 4
@@ -34,7 +34,7 @@ stage_metrics:
     review: {started_at: "2026-07-19T19:54:52Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:03:12Z"}
     hydrate: {started_at: "2026-07-19T20:03:12Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:04:41Z"}
     ship: {started_at: "2026-07-19T20:04:41Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:06:05Z"}
-    review-pr: {started_at: "2026-07-19T20:06:05Z", driver: git-pr, iterations: 1}
+    review-pr: {started_at: "2026-07-19T20:06:05Z", driver: git-pr, iterations: 1, completed_at: "2026-07-19T20:10:29Z"}
 prs:
     - https://github.com/sahil87/run-kit/pull/400
 change_type_source: explicit
@@ -54,4 +54,4 @@ true_impact:
     computed_at_stage: ship
 summary: Removed the dead sendKeys frontend client wrapper from client.ts and its test; backend /keys endpoint retained
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-07-19T20:06:05Z
+last_updated: 2026-07-19T20:10:29Z

--- a/fab/changes/260719-4ujs-delete-sendkeys-frontend-wrapper/.status.yaml
+++ b/fab/changes/260719-4ujs-delete-sendkeys-frontend-wrapper/.status.yaml
@@ -1,0 +1,55 @@
+id: 4ujs
+name: 260719-4ujs-delete-sendkeys-frontend-wrapper
+created: 2026-07-19T19:49:50Z
+created_by: sahil-noon
+change_type: chore
+issues: []
+progress:
+    intake: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+plan:
+    generated: true
+    task_count: 4
+    acceptance_count: 7
+    acceptance_completed: 7
+confidence:
+    certain: 4
+    confident: 0
+    tentative: 0
+    unresolved: 0
+    score: 5.0
+    fuzzy: true
+    dimensions:
+        signal: 87.5
+        reversibility: 90.0
+        competence: 92.5
+        disambiguation: 91.3
+stage_metrics:
+    intake: {started_at: "2026-07-19T19:49:50Z", driver: fab-new, iterations: 1, completed_at: "2026-07-19T19:51:45Z"}
+    apply: {started_at: "2026-07-19T19:51:45Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T19:54:52Z"}
+    review: {started_at: "2026-07-19T19:54:52Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:03:12Z"}
+    hydrate: {started_at: "2026-07-19T20:03:12Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:04:41Z"}
+    ship: {started_at: "2026-07-19T20:04:41Z", driver: fab-fff, iterations: 1}
+prs: []
+change_type_source: explicit
+true_impact:
+    added: 0
+    deleted: 0
+    net: 0
+    excluding:
+        added: 0
+        deleted: 0
+        net: 0
+    tests:
+        added: 0
+        deleted: 0
+        net: 0
+    computed_at: "2026-07-19T20:04:41Z"
+    computed_at_stage: hydrate
+summary: Removed the dead sendKeys frontend client wrapper from client.ts and its test; backend /keys endpoint retained
+# true_impact: lazily created on first stage-finish that computes it (no placeholder here).
+last_updated: 2026-07-19T20:04:41Z

--- a/fab/changes/260719-4ujs-delete-sendkeys-frontend-wrapper/.status.yaml
+++ b/fab/changes/260719-4ujs-delete-sendkeys-frontend-wrapper/.status.yaml
@@ -9,8 +9,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 plan:
     generated: true
     task_count: 4
@@ -33,23 +33,25 @@ stage_metrics:
     apply: {started_at: "2026-07-19T19:51:45Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T19:54:52Z"}
     review: {started_at: "2026-07-19T19:54:52Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:03:12Z"}
     hydrate: {started_at: "2026-07-19T20:03:12Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:04:41Z"}
-    ship: {started_at: "2026-07-19T20:04:41Z", driver: fab-fff, iterations: 1}
-prs: []
+    ship: {started_at: "2026-07-19T20:04:41Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:06:05Z"}
+    review-pr: {started_at: "2026-07-19T20:06:05Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/sahil87/run-kit/pull/400
 change_type_source: explicit
 true_impact:
-    added: 0
-    deleted: 0
-    net: 0
+    added: 243
+    deleted: 33
+    net: 210
     excluding:
         added: 0
-        deleted: 0
-        net: 0
+        deleted: 31
+        net: -31
     tests:
         added: 0
-        deleted: 0
-        net: 0
-    computed_at: "2026-07-19T20:04:41Z"
-    computed_at_stage: hydrate
+        deleted: 14
+        net: -14
+    computed_at: "2026-07-19T20:06:05Z"
+    computed_at_stage: ship
 summary: Removed the dead sendKeys frontend client wrapper from client.ts and its test; backend /keys endpoint retained
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-07-19T20:04:41Z
+last_updated: 2026-07-19T20:06:05Z

--- a/fab/changes/260719-4ujs-delete-sendkeys-frontend-wrapper/intake.md
+++ b/fab/changes/260719-4ujs-delete-sendkeys-frontend-wrapper/intake.md
@@ -1,0 +1,83 @@
+# Intake: Delete Unused sendKeys Frontend Client Wrapper
+
+**Change**: 260719-4ujs-delete-sendkeys-frontend-wrapper
+**Created**: 2026-07-20
+
+## Origin
+
+Backlog item `[4ujs]` (fab/backlog.md:24), worked by a backlog-cleanup agent in one-shot mode:
+
+> [4ujs] 2026-07-19: Delete the sendKeys frontend client wrapper (app/frontend/src/api/client.ts + its test block) — zero production callers; the backend /keys endpoint stays (possible external callers); chat-send provides the pane-targeted alternative for the only contemplated UI use. (relocated from docs/memory/run-kit/chat.md by /docs-distill-memory)
+
+Validity was verified in-session before intake creation: a `grep -rn sendKeys` across `app/frontend/src/` and `app/frontend/tests/`, plus a NUL-safe `perl` sweep (which catches `session-tiles.tsx`, a file grep silently skips due to a deliberate NUL join), found references only at the definition (`client.ts:197`) and its own test (`client.test.ts:16` import, `:212-223` test body). Zero production callers — the claim holds exactly as written.
+
+## Why
+
+1. **Problem**: `sendKeys` in `app/frontend/src/api/client.ts` is dead code — an exported wrapper for `POST /api/windows/{windowId}/keys` that no production code calls. Its only "coverage" is a test that exercises the wrapper itself, which is test weight spent proving nothing about the product.
+2. **Consequence of not fixing**: dead exports invite accidental reuse (the chat-send path is the sanctioned pane-targeted alternative for UI use), inflate the client surface that future refactors (like the `server`-threading change `yadg`) must mechanically drag along, and mislead readers into thinking the UI has a keystroke-injection path.
+3. **Why this approach**: straight deletion is the cheapest correct move. The backend endpoint is deliberately NOT touched — it may have external (non-SPA) callers, and the backlog item explicitly scopes it to stay.
+
+## What Changes
+
+### Remove the wrapper — `app/frontend/src/api/client.ts`
+
+Delete the `sendKeys` function (lines 197-212 at time of writing):
+
+```ts
+export async function sendKeys(
+  server: string,
+  windowId: string,
+  keys: string,
+): Promise<{ ok: boolean }> {
+  const res = await fetch(
+    withServer(`/api/windows/${encodeURIComponent(windowId)}/keys`, server),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ keys }),
+    },
+  );
+  if (!res.ok) await throwOnError(res);
+  return res.json();
+}
+```
+
+Nothing else in `client.ts` changes — `renameWindow` (above it) and `HttpError` (below it) are untouched.
+
+### Remove the test block — `app/frontend/src/api/client.test.ts`
+
+1. Remove `sendKeys` from the import list at line 16.
+2. Delete the test `it("sendKeys sends POST /api/windows/:windowId/keys with server query", ...)` (lines 212-223 at time of writing). Neighboring tests (`renameWindow` above, `sendChatMessage` below) are untouched.
+
+### Explicitly out of scope
+
+- **Backend `/keys` endpoint** (`POST /api/windows/{windowId}/keys`, handled in `app/backend/api/`): stays as-is — possible external callers.
+- **`docs/specs/api.md`**: specs document the API surface (which is unchanged — the endpoint remains); no spec edit needed.
+- **Backend tests for the endpoint**: untouched.
+
+## Affected Memory
+
+- `run-kit/architecture`: (modify) remove the `sendKeys(server, windowId, keys)` row from the frontend API-client table (~line 227); the backend endpoint documentation stays
+- `run-kit/tmux-sessions`: (modify) remove `sendKeys` from the window-mutation client-function list (~line 295)
+
+## Impact
+
+- `app/frontend/src/api/client.ts` — one function removed (~16 lines)
+- `app/frontend/src/api/client.test.ts` — one import identifier + one test removed (~13 lines)
+- No route, component, or backend change. No behavior change for any user-facing feature.
+- Verification: frontend type check (`npx tsc --noEmit`) proves zero remaining references at compile time; frontend unit tests (`just test-frontend`) prove the remaining client tests still pass.
+
+## Open Questions
+
+None — the backlog item is fully specified and the dead-code claim was re-verified against current code before intake.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | `sendKeys` has zero production callers today | Verified in-session with grep AND a NUL-safe perl sweep over `app/frontend/src` + `tests` (covers the NUL-joined `session-tiles.tsx` grep blind spot); only the definition and its own test reference it | S:95 R:90 A:95 D:95 |
+| 2 | Certain | Backend `POST /api/windows/{windowId}/keys` endpoint stays untouched | Explicit in the backlog item ("the backend /keys endpoint stays — possible external callers") | S:95 R:85 A:95 D:95 |
+| 3 | Certain | The test block and its import are removed alongside the wrapper | Explicit in the backlog item ("+ its test block"); leaving the test would break the build after the export is removed | S:90 R:95 A:95 D:95 |
+| 4 | Confident | No spec (`docs/specs/api.md`) edit needed | Specs document the HTTP surface, which is unchanged — only the unused SPA-side wrapper is deleted; memory files (architecture, tmux-sessions) that enumerate client functions are updated at hydrate instead | S:70 R:90 A:85 D:80 |
+
+4 assumptions (3 certain, 1 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260719-4ujs-delete-sendkeys-frontend-wrapper/plan.md
+++ b/fab/changes/260719-4ujs-delete-sendkeys-frontend-wrapper/plan.md
@@ -1,0 +1,93 @@
+# Plan: Delete Unused sendKeys Frontend Client Wrapper
+
+**Change**: 260719-4ujs-delete-sendkeys-frontend-wrapper
+**Intake**: `intake.md`
+
+## Requirements
+
+### Frontend API Client: Dead-Code Removal
+
+#### R1: The `sendKeys` wrapper is removed from the frontend client
+The `sendKeys` function exported from `app/frontend/src/api/client.ts` (the wrapper around `POST /api/windows/{windowId}/keys`) MUST be deleted. It has zero production callers, so its removal SHALL NOT affect any user-facing behavior. Adjacent exports (`renameWindow` above it, `HttpError` below it) MUST remain untouched.
+
+- **GIVEN** `client.ts` currently exports `sendKeys(server, windowId, keys)`
+- **WHEN** the change is applied
+- **THEN** the `sendKeys` function no longer exists anywhere in `client.ts`
+- **AND** `renameWindow` and `HttpError` are byte-for-byte unchanged
+
+#### R2: The `sendKeys` unit test and its import are removed
+The `sendKeys` identifier in the import list of `app/frontend/src/api/client.test.ts` and the test case `it("sendKeys sends POST /api/windows/:windowId/keys with server query", ...)` MUST both be deleted. Neighboring tests (`renameWindow` above, `sendChatMessage` below) MUST remain untouched. Removing the export without removing the test would break the type check, so both edits SHALL land together.
+
+- **GIVEN** `client.test.ts` imports `sendKeys` and contains a test that calls it
+- **WHEN** the change is applied
+- **THEN** neither the import identifier nor the test case references `sendKeys`
+- **AND** the `renameWindow` and `sendChatMessage` tests are unchanged
+
+#### R3: The frontend compiles and its unit tests pass after removal
+After R1 and R2, the frontend MUST type-check clean (`npx tsc --noEmit`) and the frontend unit suite MUST pass (`just test-frontend`), proving zero dangling references to `sendKeys` and no regression in the remaining client tests.
+
+- **GIVEN** the wrapper and its test have been deleted
+- **WHEN** `cd app/frontend && npx tsc --noEmit` runs
+- **THEN** it exits 0 with no errors
+- **AND WHEN** `just test-frontend` runs, the suite passes
+
+### Non-Goals
+
+- Backend `POST /api/windows/{windowId}/keys` endpoint (`app/backend/api/`) — stays as-is; possible external (non-SPA) callers.
+- `docs/specs/api.md` — the HTTP surface is unchanged (endpoint remains), so no spec edit.
+- Backend tests for the endpoint — untouched.
+- `docs/memory/run-kit/architecture.md` and `docs/memory/run-kit/tmux-sessions.md` — client-function lists there are updated at hydrate, not apply.
+
+## Tasks
+
+### Phase 1: Removal
+
+- [x] T001 Delete the `sendKeys` function (the full `export async function sendKeys(...) { ... }` block) from `app/frontend/src/api/client.ts`, leaving `renameWindow` and `HttpError` intact. <!-- R1 -->
+- [x] T002 Remove the `sendKeys,` identifier from the import list and delete the `it("sendKeys sends POST /api/windows/:windowId/keys with server query", ...)` test case in `app/frontend/src/api/client.test.ts`, leaving the `renameWindow` and `sendChatMessage` tests intact. <!-- R2 -->
+
+### Phase 2: Verification
+
+- [x] T003 Run `cd app/frontend && npx tsc --noEmit` and confirm a clean type check (proves no dangling `sendKeys` references). <!-- R3 -->
+- [x] T004 Run `just test-frontend` and confirm the frontend unit suite passes. <!-- R3 -->
+
+## Execution Order
+
+- T001 and T002 must both land before T003 (the type check fails if only one side is removed).
+- T003 before T004.
+
+## Acceptance
+
+### Functional Completeness
+
+- [x] A-001 R1: The `sendKeys` function is absent from `app/frontend/src/api/client.ts`; `renameWindow` and `HttpError` remain.
+- [x] A-002 R2: The `sendKeys` import identifier and its test case are absent from `app/frontend/src/api/client.test.ts`; `renameWindow` and `sendChatMessage` tests remain.
+
+### Removal Verification
+
+- [x] A-003 R1: A repo-wide search (`grep -rna sendKeys app/frontend/src app/frontend/tests`) returns zero matches — no dead export, no dangling reference.
+
+### Scenario Coverage
+
+- [x] A-004 R3: `cd app/frontend && npx tsc --noEmit` exits 0 with no errors.
+- [x] A-005 R3: `just test-frontend` passes.
+
+### Code Quality
+
+- [x] A-006 Pattern consistency: The edits are pure deletions that preserve the surrounding client and test file structure.
+- [x] A-007 No unnecessary duplication: No new code introduced; the sanctioned pane-targeted alternative (`sendChatMessage`) is unaffected.
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All acceptance items must pass before `/fab-continue` (hydrate)
+- Backend `/keys` endpoint intentionally retained (out of scope).
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Delete both the wrapper and its test in one apply pass | Intake and backlog item are explicit ("+ its test block"); removing the export alone would break the type check | S:95 R:95 A:95 D:95 |
+| 2 | Certain | Backend `/keys` endpoint and its tests stay untouched | Intake Non-Goals + backlog item scope the endpoint to remain (possible external callers) | S:95 R:85 A:95 D:95 |
+| 3 | Certain | Memory-file client-function lists are updated at hydrate, not apply | Apply does not edit `docs/memory/`; the intake's Affected Memory feeds hydrate | S:95 R:90 A:95 D:95 |
+
+3 assumptions (3 certain, 0 confident, 0 tentative).


### PR DESCRIPTION
## Meta

| Change ID | Type | Confidence | Plan | Review |
|-----------|------|------------|------|--------|
| `4ujs` | chore | 5.0/5.0 | 4/4 tasks, 7/7 acceptance ✓ | ✓ 1 cycle |

| Impact | +/− | Net |
|--------|----:|----:|
| raw | +243 / −33 | +210 |
| **true** | **+0 / −31** | **-31** |
| └ impl  (clamped from net -17) | +0 / −17 | +0 |
| └ tests | +0 / −14 | -14 |

<sub>excludes `fab/`, `docs/` · generated by fab-kit v2.16.3</sub>

**Pipeline:** [intake](https://github.com/sahil87/run-kit/blob/260719-4ujs-delete-sendkeys-frontend-wrapper/fab/changes/260719-4ujs-delete-sendkeys-frontend-wrapper/intake.md) ✓ → [apply](https://github.com/sahil87/run-kit/blob/260719-4ujs-delete-sendkeys-frontend-wrapper/fab/changes/260719-4ujs-delete-sendkeys-frontend-wrapper/plan.md) ✓ → review ✓ → hydrate ✓ → ship → review-pr

## Summary

`sendKeys` in the frontend API client was dead code — an exported wrapper around `POST /api/windows/{windowId}/keys` with zero production callers, only exercised by its own test. This removes the wrapper and its test; the backend endpoint stays untouched since it may have external callers.

## Changes

- Remove the wrapper — `app/frontend/src/api/client.ts`
- Remove the test block — `app/frontend/src/api/client.test.ts`
- Explicitly out of scope: backend `/keys` endpoint, `docs/specs/api.md`, backend tests
