### PR TITLE
chore: Delete Inert WindowHeading Prefix-Flip Replay Machinery

### DIFF
--- a/app/frontend/src/components/top-bar.tsx
+++ b/app/frontend/src/components/top-bar.tsx
@@ -1355,9 +1355,9 @@ function WindowHeading({
   windowId: string;
   sessionName: string;
   name: string;
-  /** Page-type prefix (`Terminal:` / `Web:`) — follows the active lens (spec
-   *  R4). The boot sweep runs over `prefix + " " + name`, so a prefix change
-   *  (a tty↔web view switch) replays the sweep just like a name change. */
+  /** Page-type prefix — the static `Window:` constant (`WINDOW_PREFIX`) in every
+   *  lens; the lens-following `Terminal:`/`Web:`/`Chat:` prefix was retired by
+   *  260714-uco1. The boot sweep renders over `prefix + " " + name`. */
   prefix: string;
   /** Optional element rendered inside the prefix, BEFORE its trailing `:`
    *  (260714-uco1 — the hierarchy ▾ binds to the prefix "before the colon",
@@ -1391,13 +1391,6 @@ function WindowHeading({
   // play path (rather than a separate mount effect) is what keeps mount from
   // double-playing over a name change.
   const prevNameRef = useRef<string | null>(null);
-  // Track the displayed prefix so a lens switch (tty↔web changes `Terminal:`↔
-  // `Web:` with the SAME window name) replays the boot sweep and re-seeds the
-  // sweep cells — otherwise `useBootSweep`'s `cells` state (seeded once from
-  // `rest()`) would stay stale and the heading would show the old prefix. Seeded
-  // with the initial prefix so the mount replay is owned by the name effect
-  // alone (no double-play on mount).
-  const prevPrefixRef = useRef<string>(prefix);
   const editingRef = useRef(editing);
   editingRef.current = editing;
   // Set true by a key-driven commit/cancel (Enter/Escape) so the onBlur that
@@ -1447,18 +1440,6 @@ function WindowHeading({
       else sweep.resolve();
     }
   }, [name, sweep]);
-
-  // Lens switch: the page-type prefix flipped (`Terminal:`↔`Web:`) with the
-  // same window name. Replay the sweep (or, while editing, resolve to rest) so
-  // the heading re-seeds `sweep.cells` to the new prefix — the same one-effect
-  // mechanism as the name change, keyed on the prefix instead.
-  useEffect(() => {
-    if (prefix !== prevPrefixRef.current) {
-      prevPrefixRef.current = prefix;
-      if (!editingRef.current) sweep.play();
-      else sweep.resolve();
-    }
-  }, [prefix, sweep]);
 
   const startEdit = useCallback(() => {
     sweep.resolve();

--- a/fab/changes/260719-a2ss-delete-inert-prefix-flip-replay/.history.jsonl
+++ b/fab/changes/260719-a2ss-delete-inert-prefix-flip-replay/.history.jsonl
@@ -7,3 +7,4 @@
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-07-19T20:25:19Z"}
 {"event":"review","result":"passed","ts":"2026-07-19T20:25:19Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-07-19T20:26:39Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-07-19T20:28:50Z"}

--- a/fab/changes/260719-a2ss-delete-inert-prefix-flip-replay/.history.jsonl
+++ b/fab/changes/260719-a2ss-delete-inert-prefix-flip-replay/.history.jsonl
@@ -8,3 +8,4 @@
 {"event":"review","result":"passed","ts":"2026-07-19T20:25:19Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-07-19T20:26:39Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-07-19T20:28:50Z"}
+{"event":"review","result":"passed","ts":"2026-07-19T20:34:35Z"}

--- a/fab/changes/260719-a2ss-delete-inert-prefix-flip-replay/.history.jsonl
+++ b/fab/changes/260719-a2ss-delete-inert-prefix-flip-replay/.history.jsonl
@@ -1,0 +1,9 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-07-19T20:18:30Z"}
+{"args":"Delete the inert WindowHeading prefix-flip replay machinery (prevPrefixRef + prefix-keyed effect, top-bar.tsx) — inert since the sole call site passes the constant WINDOW_PREFIX (backlog [a2ss])","cmd":"fab-new","event":"command","ts":"2026-07-19T20:18:30Z"}
+{"delta":"+5.0","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-07-19T20:19:12Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-07-19T20:19:54Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-07-19T20:21:59Z"}
+{"cmd":"fab-continue","event":"command","ts":"2026-07-19T20:22:44Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-07-19T20:25:19Z"}
+{"event":"review","result":"passed","ts":"2026-07-19T20:25:19Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-07-19T20:26:39Z"}

--- a/fab/changes/260719-a2ss-delete-inert-prefix-flip-replay/.status.yaml
+++ b/fab/changes/260719-a2ss-delete-inert-prefix-flip-replay/.status.yaml
@@ -10,7 +10,7 @@ progress:
     review: done
     hydrate: done
     ship: done
-    review-pr: active
+    review-pr: done
 plan:
     generated: true
     task_count: 6
@@ -34,7 +34,7 @@ stage_metrics:
     review: {started_at: "2026-07-19T20:21:59Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:25:19Z"}
     hydrate: {started_at: "2026-07-19T20:25:19Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:26:39Z"}
     ship: {started_at: "2026-07-19T20:26:39Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:28:50Z"}
-    review-pr: {started_at: "2026-07-19T20:28:50Z", driver: git-pr, iterations: 1}
+    review-pr: {started_at: "2026-07-19T20:28:50Z", driver: git-pr, iterations: 1, completed_at: "2026-07-19T20:34:35Z"}
 prs:
     - https://github.com/sahil87/run-kit/pull/403
 change_type_source: explicit
@@ -54,4 +54,4 @@ true_impact:
     computed_at_stage: ship
 summary: Deleted inert WindowHeading prefix-flip replay machinery (prevPrefixRef + prefix-keyed effect) and corrected the stale prefix-prop docstring in top-bar.tsx
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-07-19T20:28:50Z
+last_updated: 2026-07-19T20:34:35Z

--- a/fab/changes/260719-a2ss-delete-inert-prefix-flip-replay/.status.yaml
+++ b/fab/changes/260719-a2ss-delete-inert-prefix-flip-replay/.status.yaml
@@ -1,0 +1,55 @@
+id: a2ss
+name: 260719-a2ss-delete-inert-prefix-flip-replay
+created: 2026-07-19T20:18:30Z
+created_by: Sahil Ahuja
+change_type: chore
+issues: []
+progress:
+    intake: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+plan:
+    generated: true
+    task_count: 6
+    acceptance_count: 8
+    acceptance_completed: 8
+confidence:
+    certain: 4
+    confident: 0
+    tentative: 0
+    unresolved: 0
+    score: 5.0
+    fuzzy: true
+    dimensions:
+        signal: 82.5
+        reversibility: 92.5
+        competence: 92.5
+        disambiguation: 90.0
+stage_metrics:
+    intake: {started_at: "2026-07-19T20:18:30Z", driver: fab-new, iterations: 1, completed_at: "2026-07-19T20:19:54Z"}
+    apply: {started_at: "2026-07-19T20:19:54Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:21:59Z"}
+    review: {started_at: "2026-07-19T20:21:59Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:25:19Z"}
+    hydrate: {started_at: "2026-07-19T20:25:19Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:26:39Z"}
+    ship: {started_at: "2026-07-19T20:26:39Z", driver: fab-fff, iterations: 1}
+prs: []
+change_type_source: explicit
+true_impact:
+    added: 0
+    deleted: 0
+    net: 0
+    excluding:
+        added: 0
+        deleted: 0
+        net: 0
+    tests:
+        added: 0
+        deleted: 0
+        net: 0
+    computed_at: "2026-07-19T20:26:39Z"
+    computed_at_stage: hydrate
+summary: Deleted inert WindowHeading prefix-flip replay machinery (prevPrefixRef + prefix-keyed effect) and corrected the stale prefix-prop docstring in top-bar.tsx
+# true_impact: lazily created on first stage-finish that computes it (no placeholder here).
+last_updated: 2026-07-19T20:26:39Z

--- a/fab/changes/260719-a2ss-delete-inert-prefix-flip-replay/.status.yaml
+++ b/fab/changes/260719-a2ss-delete-inert-prefix-flip-replay/.status.yaml
@@ -9,8 +9,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 plan:
     generated: true
     task_count: 6
@@ -33,23 +33,25 @@ stage_metrics:
     apply: {started_at: "2026-07-19T20:19:54Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:21:59Z"}
     review: {started_at: "2026-07-19T20:21:59Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:25:19Z"}
     hydrate: {started_at: "2026-07-19T20:25:19Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:26:39Z"}
-    ship: {started_at: "2026-07-19T20:26:39Z", driver: fab-fff, iterations: 1}
-prs: []
+    ship: {started_at: "2026-07-19T20:26:39Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:28:50Z"}
+    review-pr: {started_at: "2026-07-19T20:28:50Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/sahil87/run-kit/pull/403
 change_type_source: explicit
 true_impact:
-    added: 0
-    deleted: 0
-    net: 0
+    added: 255
+    deleted: 22
+    net: 233
     excluding:
-        added: 0
-        deleted: 0
-        net: 0
+        added: 3
+        deleted: 22
+        net: -19
     tests:
         added: 0
         deleted: 0
         net: 0
-    computed_at: "2026-07-19T20:26:39Z"
-    computed_at_stage: hydrate
+    computed_at: "2026-07-19T20:28:50Z"
+    computed_at_stage: ship
 summary: Deleted inert WindowHeading prefix-flip replay machinery (prevPrefixRef + prefix-keyed effect) and corrected the stale prefix-prop docstring in top-bar.tsx
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-07-19T20:26:39Z
+last_updated: 2026-07-19T20:28:50Z

--- a/fab/changes/260719-a2ss-delete-inert-prefix-flip-replay/intake.md
+++ b/fab/changes/260719-a2ss-delete-inert-prefix-flip-replay/intake.md
@@ -1,0 +1,97 @@
+# Intake: Delete Inert WindowHeading Prefix-Flip Replay Machinery
+
+**Change**: 260719-a2ss-delete-inert-prefix-flip-replay
+**Created**: 2026-07-20
+
+## Origin
+
+Backlog item `[a2ss]` (fab/backlog.md:30), worked by a backlog-cleanup agent in one-shot mode:
+
+> [a2ss] 2026-07-19: Delete the inert WindowHeading prefix-flip replay machinery (prevPrefixRef + prefix-keyed effect, top-bar.tsx ~:1053/:1108) — inert since the sole call site passes the constant WINDOW_PREFIX. (relocated from docs/memory/run-kit/ui-patterns.md by /docs-distill-memory)
+
+Validity was verified in-session before intake creation (line numbers have drifted since the note was written — current locations below):
+
+- `prevPrefixRef` is declared at `top-bar.tsx:1400` (with its explanatory comment at :1394-1399), and the prefix-keyed effect lives at `top-bar.tsx:1451-1461`.
+- The **sole** JSX call site is `top-bar.tsx:871-876`, which passes `prefix={WINDOW_PREFIX}` — a module constant `const WINDOW_PREFIX = "Window:"` (`top-bar.tsx:1233`). A repo-wide search (grep plus a NUL-safe perl sweep covering the NUL-joined `session-tiles.tsx`) found no other `<WindowHeading` usage — remaining hits are comments and a test `describe` label.
+- The lens-following prefix (`Terminal:`/`Web:`/`Chat:`) was retired by change `260714-uco1` — the test suite documents this (`top-bar.test.tsx:182-183`: "the lens-following `Terminal:`/`Web:`/`Chat:` prefix was retired") and asserts a static `Window:` prefix in every lens. No test passes a `prefix=` prop directly or exercises a prefix flip.
+
+Since the `prefix` prop is a compile-time constant, `prefix !== prevPrefixRef.current` can never be true after mount — the effect body is unreachable. The claim holds exactly as written.
+
+## Why
+
+1. **Problem**: `WindowHeading` carries a ref (`prevPrefixRef`) and a `useEffect` whose entire purpose is to replay the boot sweep when the page-type prefix flips on a lens switch (`Terminal:` ↔ `Web:`). Change `260714-uco1` made the prefix a static constant (`Window:` in every lens), so the effect's condition can never fire — it is dead machinery kept alive only syntactically.
+2. **Consequence of not fixing**: the component's comments actively mislead — the `prefix` prop's docstring still says it "follows the active lens (spec R4)" and that "a prefix change (a tty↔web view switch) replays the sweep", describing retired behavior. Future readers reason about a replay path that cannot execute, and the ref/effect add noise to an already-subtle animation choreography (mount/name/identity effects with carefully documented double-play guards).
+3. **Why this approach**: delete the ref and the effect; correct the stale docstring. Keep the `prefix` prop itself — it is genuinely used for rendering (the boot sweep runs over `prefix + " " + name` via `useBootSweep(prefix, name, ...)`), only the flip-*replay* machinery is inert.
+
+## What Changes
+
+### Remove the inert machinery — `app/frontend/src/components/top-bar.tsx`
+
+1. **Delete the `prevPrefixRef` declaration and its comment block** (currently :1394-1400):
+
+```tsx
+// Track the displayed prefix so a lens switch (tty↔web changes `Terminal:`↔
+// `Web:` with the SAME window name) replays the boot sweep and re-seeds the
+// sweep cells — otherwise `useBootSweep`'s `cells` state (seeded once from
+// `rest()`) would stay stale and the heading would show the old prefix. Seeded
+// with the initial prefix so the mount replay is owned by the name effect
+// alone (no double-play on mount).
+const prevPrefixRef = useRef<string>(prefix);
+```
+
+2. **Delete the prefix-keyed effect and its comment** (currently :1451-1461):
+
+```tsx
+// Lens switch: the page-type prefix flipped (`Terminal:`↔`Web:`) with the
+// same window name. Replay the sweep (or, while editing, resolve to rest) so
+// the heading re-seeds `sweep.cells` to the new prefix — the same one-effect
+// mechanism as the name change, keyed on the prefix instead.
+useEffect(() => {
+  if (prefix !== prevPrefixRef.current) {
+    prevPrefixRef.current = prefix;
+    if (!editingRef.current) sweep.play();
+    else sweep.resolve();
+  }
+}, [prefix, sweep]);
+```
+
+3. **Correct the stale `prefix` prop docstring** (currently :1358-1360). It reads:
+
+```tsx
+/** Page-type prefix (`Terminal:` / `Web:`) — follows the active lens (spec
+ *  R4). The boot sweep runs over `prefix + " " + name`, so a prefix change
+ *  (a tty↔web view switch) replays the sweep just like a name change. */
+```
+
+Replace with a docstring reflecting present truth: the prefix is the static `Window:` constant in every lens (260714-uco1 retired the lens-following prefix); the boot sweep renders over `prefix + " " + name`. No replay-on-change claim.
+
+### Explicitly out of scope
+
+- The `prefix` prop and `WINDOW_PREFIX` constant stay — they feed `useBootSweep(prefix, name, ...)` rendering and the `HeadingPrefix`/caret composition (260714-uco1).
+- The name-keyed effect (:1442-1449), identity-change guard (:1421-1431), and all other sweep choreography are untouched.
+- No test changes expected: no test passes `prefix=` or exercises a flip. Existing sweep/rename tests must keep passing unchanged.
+
+## Affected Memory
+
+None — `docs/memory/run-kit/ui-patterns.md` no longer describes the prefix-flip replay (the claim was relocated to the backlog by /docs-distill-memory, which is where this item came from), and grep confirms no memory file references `prevPrefixRef` or a prefix-flip replay. Implementation-only cleanup.
+
+## Impact
+
+- `app/frontend/src/components/top-bar.tsx` — one ref, one effect, ~18 lines removed; one docstring corrected.
+- No behavior change: the deleted code path was unreachable.
+- Verification: `cd app/frontend && pnpm exec tsc --noEmit` (compile-proves `prevPrefixRef` had no other readers) and `just test-frontend` (the WindowHeading sweep/rename suite in `top-bar.test.tsx` must pass unchanged).
+
+## Open Questions
+
+None — the backlog item is fully specified and the inertness claim was re-verified against current code before intake.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | The prefix-keyed effect is unreachable (inert) | Sole call site passes the module constant `WINDOW_PREFIX`; verified via grep + NUL-safe perl sweep that no other call site exists; 260714-uco1 retired the lens-following prefix (documented in the test suite) | S:90 R:90 A:95 D:95 |
+| 2 | Certain | Keep the `prefix` prop and `WINDOW_PREFIX` constant | They actively feed `useBootSweep` rendering and the caret composition — only the flip-replay machinery is dead | S:85 R:90 A:95 D:90 |
+| 3 | Confident | Also correct the stale prop docstring (lens-following claim) in the same change | The docstring describes the exact behavior being deleted; leaving it would recreate the misleading-comment problem the deletion solves; trivially reversible | S:70 R:95 A:90 D:85 |
+| 4 | Certain | No test edits needed | No test passes `prefix=` or covers a flip; verified by grepping `top-bar.test.tsx` for `prefix=` (zero hits) and replay-related test names | S:85 R:95 A:90 D:90 |
+
+4 assumptions (3 certain, 1 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260719-a2ss-delete-inert-prefix-flip-replay/intake.md
+++ b/fab/changes/260719-a2ss-delete-inert-prefix-flip-replay/intake.md
@@ -9,9 +9,9 @@ Backlog item `[a2ss]` (fab/backlog.md:30), worked by a backlog-cleanup agent in 
 
 > [a2ss] 2026-07-19: Delete the inert WindowHeading prefix-flip replay machinery (prevPrefixRef + prefix-keyed effect, top-bar.tsx ~:1053/:1108) — inert since the sole call site passes the constant WINDOW_PREFIX. (relocated from docs/memory/run-kit/ui-patterns.md by /docs-distill-memory)
 
-Validity was verified in-session before intake creation (line numbers have drifted since the note was written — current locations below):
+Validity was verified in-session before intake creation (line numbers below refer to the **pre-change** state — they have drifted since the backlog note was written, and the referenced items are deleted by this change):
 
-- `prevPrefixRef` is declared at `top-bar.tsx:1400` (with its explanatory comment at :1394-1399), and the prefix-keyed effect lives at `top-bar.tsx:1451-1461`.
+- `prevPrefixRef` was declared at `top-bar.tsx:1400` (with its explanatory comment at :1394-1399), and the prefix-keyed effect lived at `top-bar.tsx:1451-1461`.
 - The **sole** JSX call site is `top-bar.tsx:871-876`, which passes `prefix={WINDOW_PREFIX}` — a module constant `const WINDOW_PREFIX = "Window:"` (`top-bar.tsx:1233`). A repo-wide search (grep plus a NUL-safe perl sweep covering the NUL-joined `session-tiles.tsx`) found no other `<WindowHeading` usage — remaining hits are comments and a test `describe` label.
 - The lens-following prefix (`Terminal:`/`Web:`/`Chat:`) was retired by change `260714-uco1` — the test suite documents this (`top-bar.test.tsx:182-183`: "the lens-following `Terminal:`/`Web:`/`Chat:` prefix was retired") and asserts a static `Window:` prefix in every lens. No test passes a `prefix=` prop directly or exercises a prefix flip.
 

--- a/fab/changes/260719-a2ss-delete-inert-prefix-flip-replay/plan.md
+++ b/fab/changes/260719-a2ss-delete-inert-prefix-flip-replay/plan.md
@@ -1,0 +1,91 @@
+# Plan: Delete Inert WindowHeading Prefix-Flip Replay Machinery
+
+**Change**: 260719-a2ss-delete-inert-prefix-flip-replay
+**Intake**: `intake.md`
+
+## Requirements
+
+### Frontend: WindowHeading sweep choreography
+
+#### R1: The inert prefix-flip replay machinery MUST be removed
+The `prevPrefixRef` declaration (with its explanatory comment block) and the prefix-keyed `useEffect` (with its comment) in `WindowHeading` (`app/frontend/src/components/top-bar.tsx`) SHALL be deleted. They implement a lens-switch replay path that can never fire — the sole call site passes the module constant `WINDOW_PREFIX` (`const WINDOW_PREFIX = "Window:"`), so `prefix !== prevPrefixRef.current` is unsatisfiable after mount.
+
+- **GIVEN** `WindowHeading` is only ever rendered with `prefix={WINDOW_PREFIX}` (a compile-time constant)
+- **WHEN** the component mounts and re-renders
+- **THEN** `prevPrefixRef` and the prefix-keyed effect are absent from the source
+- **AND** no other reader of `prevPrefixRef` remains (compile-proven by `tsc --noEmit`)
+
+#### R2: The `prefix` prop and `WINDOW_PREFIX` constant MUST be retained
+The `prefix` prop on `WindowHeading` and the module-level `WINDOW_PREFIX` constant SHALL remain — they feed `useBootSweep(prefix, name, ...)` rendering and the `HeadingPrefix`/caret composition. Only the flip-*replay* machinery is inert.
+
+- **GIVEN** the boot sweep runs over `prefix + " " + name`
+- **WHEN** the component renders
+- **THEN** `prefix` is still a declared prop consumed by `useBootSweep`, and `WINDOW_PREFIX` is still passed at the call site
+- **AND** the rendered heading is byte-identical to before (no behavior change)
+
+#### R3: The stale `prefix` prop docstring MUST be corrected to present truth
+The `prefix` prop's docstring (currently claiming it "follows the active lens (spec R4)" and that a prefix change "replays the sweep just like a name change") SHALL be replaced with a docstring reflecting present truth: the prefix is the static `Window:` constant in every lens (the lens-following prefix was retired by 260714-uco1), and the boot sweep renders over `prefix + " " + name`. No replay-on-change claim.
+
+- **GIVEN** the lens-following `Terminal:`/`Web:`/`Chat:` prefix was retired by 260714-uco1
+- **WHEN** a future reader reads the `prefix` prop docstring
+- **THEN** the docstring describes a static `Window:` prefix and the `prefix + " " + name` render, with no replay-on-flip claim
+
+### Non-Goals
+
+- The name-keyed effect, identity-change guard, mount-replay seeding, and all other sweep choreography — untouched.
+- Any test edits — no test passes `prefix=` or exercises a prefix flip; existing sweep/rename tests must keep passing unchanged.
+- Removing the `prefix` prop or `WINDOW_PREFIX` constant — explicitly retained (R2).
+
+## Tasks
+
+### Phase 1: Core Implementation
+
+- [x] T001 Delete the `prevPrefixRef` declaration and its comment block (~:1394-1400) in `app/frontend/src/components/top-bar.tsx` <!-- R1 -->
+- [x] T002 Delete the prefix-keyed `useEffect` and its comment (~:1451-1461) in `app/frontend/src/components/top-bar.tsx` <!-- R1 -->
+- [x] T003 Correct the stale `prefix` prop docstring (~:1358-1360) in `app/frontend/src/components/top-bar.tsx` to present truth (static `Window:` constant; boot sweep over `prefix + " " + name`; no replay-on-change claim) <!-- R3 -->
+
+### Phase 2: Verification
+
+- [x] T004 Confirm the `prefix` prop and `WINDOW_PREFIX` constant remain (retained per R2) <!-- R2 -->
+- [x] T005 Run `cd app/frontend && pnpm exec tsc --noEmit` (compile-proves `prevPrefixRef` had no other readers) <!-- R1 -->
+- [x] T006 Run `just test-frontend` (WindowHeading sweep/rename suite in `top-bar.test.tsx` must pass unchanged) <!-- R1 -->
+
+## Acceptance
+
+### Functional Completeness
+
+- [x] A-001 R1: `prevPrefixRef` and the prefix-keyed effect (plus their comments) are absent from `top-bar.tsx`; no `prevPrefixRef` references remain
+- [x] A-002 R2: The `prefix` prop is still declared and consumed by `useBootSweep`; `WINDOW_PREFIX` is still defined and passed at the sole call site
+- [x] A-003 R3: The `prefix` prop docstring reflects present truth (static `Window:`, `prefix + " " + name` render, no replay-on-flip claim)
+
+### Behavioral Correctness
+
+- [x] A-004 R2: No behavior change — the deleted path was unreachable; the rendered heading is unchanged
+
+### Removal Verification
+
+- [x] A-005 R1: `tsc --noEmit` passes, compile-proving `prevPrefixRef` had no other readers (no dead references)
+
+### Scenario Coverage
+
+- [x] A-006 R1: `just test-frontend` passes — the WindowHeading sweep/rename suite in `top-bar.test.tsx` is green unchanged (no test edits)
+
+### Code Quality
+
+- [x] A-007 Pattern consistency: The remaining sweep effects and comments read coherently after the deletion (no orphaned references, no misleading comments left behind)
+- [x] A-008 **N/A**: deletion-only change, no new code introduced
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All acceptance items must pass before `/fab-continue` (hydrate)
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | The prefix-keyed effect is unreachable; delete ref + effect + comments | Sole call site passes the module constant `WINDOW_PREFIX`; grep confirms `prevPrefixRef` is only read by the effect being deleted; 260714-uco1 retired the lens-following prefix | S:90 R:90 A:95 D:95 |
+| 2 | Certain | Keep the `prefix` prop and `WINDOW_PREFIX` constant | They feed `useBootSweep` rendering and the caret composition — only the flip-replay machinery is dead | S:85 R:90 A:95 D:90 |
+| 3 | Confident | Correct the stale prop docstring in the same change | The docstring describes the exact behavior being deleted; leaving it recreates the misleading-comment problem the deletion solves; trivially reversible | S:70 R:95 A:90 D:85 |
+
+3 assumptions (2 certain, 1 confident, 0 tentative).


### PR DESCRIPTION
## Meta

| Change ID | Type | Confidence | Plan | Review |
|-----------|------|------------|------|--------|
| `a2ss` | chore | 5.0/5.0 | 6/6 tasks, 8/8 acceptance ✓ | ✓ 1 cycle |

| Impact | +/− | Net |
|--------|----:|----:|
| raw | +255 / −22 | +233 |
| **true** | **+3 / −22** | **-19** |
| └ impl  (clamped from net -19) | +3 / −22 | +0 |
| └ tests | +0 / −0 | +0 |

<sub>excludes `fab/`, `docs/` · generated by fab-kit v2.16.3</sub>

**Pipeline:** intake ✓ → apply ✓ → review ✓ → hydrate ✓ → ship → review-pr

## Summary

`WindowHeading` carried a ref (`prevPrefixRef`) and a `useEffect` whose sole purpose was to replay the boot sweep when the page-type prefix flipped on a lens switch (`Terminal:` ↔ `Web:`). Change 260714-uco1 made the prefix a static constant (`Window:` in every lens), so the effect's condition can never fire — it was dead machinery kept alive only syntactically, and the docstring on the `prefix` prop still described the retired lens-following behavior.

## Changes

- Remove the inert machinery — `app/frontend/src/components/top-bar.tsx`
  - Deleted the `prevPrefixRef` declaration and its comment block
  - Deleted the prefix-keyed replay effect and its comment
  - Corrected the stale `prefix` prop docstring to reflect present truth (static `Window:` constant, no replay-on-change)
