### PR TITLE
fix: Chat-Send Long-Single-Line Paste-Collapse Probe Fix

### DIFF
--- a/app/backend/api/chat.go
+++ b/app/backend/api/chat.go
@@ -480,7 +480,8 @@ var ansiEscapeRe = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07\x1
 // baseline (a stale chip from a prior send is in the baseline count).
 //
 // The pattern matches the WHITESPACE-STRIPPED capture (stripForProbe removes all
-// spaces), i.e. "[Pastedtext#1+12lines]" or "[Pastedtext#5]"; the "+M lines" part
+// whitespace — spaces, tabs, newlines, etc.), i.e. "[Pastedtext#1+12lines]" or
+// "[Pastedtext#5]"; the "+M lines" part
 // is optional and tolerant of singular/plural "line"/"lines" and any digit counts.
 var pasteCollapseRe = regexp.MustCompile(`\[Pastedtext#\d+(?:\+\d+lines?)?\]`)
 

--- a/app/backend/api/chat.go
+++ b/app/backend/api/chat.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
 	"rk/internal/chat"
 	"rk/internal/sessions"
@@ -313,22 +314,32 @@ func (chatProbeFailure) Error() string {
 		"The text remains in the agent's input — check the terminal view before retrying, as a resend would duplicate it."
 }
 
+// chatSendCollapseMinRunes is the single-line rune length at or above which the
+// paste-collapse placeholder is counted as a valid echo signal. Claude Code
+// collapses a single-line paste over 800 chars into a suffix-less
+// "[Pasted text #N]" chip (empirical, CC 2.1.215, INDEPENDENT of TUI width — the
+// observed threshold is 801). 200 is a deliberately conservative lower bound so an
+// upstream threshold reduction cannot silently rebreak long-single-line sends,
+// while short interactive sends (which never collapse) keep exact-needle-only
+// matching and so keep the narrowest false-positive window.
+const chatSendCollapseMinRunes = 200
+
 // injectChatMessage runs the pane-targeted injection sequence (Constitution I —
 // all argv slices, no shell strings, text as a discrete argv element via the
 // named buffer): baseline capture → set-buffer → paste-buffer (-d -p, bracketed)
 // → NOVELTY echo probe → send-keys Enter (only on probe success). Every step
 // targets paneID, never the window, and shares the caller's ctx deadline.
 //
-// The probe verifies NOVELTY, not mere presence: it counts the needle (and, for
-// multiline text, the paste-collapse placeholder) in a PRE-PASTE baseline
+// The probe verifies NOVELTY, not mere presence: it counts the needle (and, for a
+// COLLAPSIBLE paste, the paste-collapse placeholder) in a PRE-PASTE baseline
 // capture and requires the count to strictly INCREASE after the paste. This is
-// what makes the guard sound: a stale "[Pasted text #N +M lines]" chip already
-// in-frame (this very handler's 409 path leaves the pasted text in the composer)
-// or a short/common needle like "y"/"ok" already on screen no longer
-// false-positives the probe — only the CURRENT paste, which adds a fresh
-// occurrence, satisfies it. If the pane scrolls between baseline and probe the
-// count cannot rise, so it fails CLOSED (409, no blind Enter) — the exact hazard
-// (blind Enter into e.g. a permission dialog) R5 exists to prevent.
+// what makes the guard sound: a stale "[Pasted text #N …]" chip already in-frame
+// (this very handler's 409 path leaves the pasted text in the composer) or a
+// short/common needle like "y"/"ok" already on screen no longer false-positives
+// the probe — only the CURRENT paste, which adds a fresh occurrence, satisfies it.
+// If the pane scrolls between baseline and probe the count cannot rise, so it
+// fails CLOSED (409, no blind Enter) — the exact hazard (blind Enter into e.g. a
+// permission dialog) R5 exists to prevent.
 //
 // A tmux failure is returned verbatim (→ 500); a probe failure is returned as
 // chatProbeFailure (→ 409, Enter withheld).
@@ -340,10 +351,13 @@ func (s *Server) injectChatMessage(ctx context.Context, server, paneID, text str
 		// verify", so fail closed BEFORE touching the buffer — never a blind Enter.
 		return chatProbeFailure{}
 	}
-	// Multiline text can be collapsed by the TUI into a "[Pasted text #N +M lines]"
-	// chip; single-line pastes never collapse, so the placeholder is only a valid
-	// echo signal (and only counted) for multiline text.
-	multiline := strings.Contains(text, "\n")
+	// The TUI can collapse a paste into a "[Pasted text #N …]" chip instead of
+	// echoing the raw text — for MULTILINE text (a "+M lines" chip) OR for a long
+	// single line (a suffix-less chip, empirically >800 chars). A paste is
+	// "collapsible" when either is possible, and only then is the chip a valid
+	// echo signal (see chatSendCollapseMinRunes). Short single-line pastes keep
+	// exact-needle-only matching.
+	collapsible := strings.Contains(text, "\n") || utf8.RuneCountInString(text) >= chatSendCollapseMinRunes
 
 	// Serialize the WHOLE sequence per (server, paneID): a second send to the SAME
 	// pane only begins after this one has fully finished (baseline → set → paste →
@@ -361,7 +375,7 @@ func (s *Server) injectChatMessage(ctx context.Context, server, paneID, text str
 	if err != nil {
 		return fmt.Errorf("capture-pane (baseline): %w", err)
 	}
-	baseCount := countProbeOccurrences(baseline, needle, multiline)
+	baseCount := countProbeOccurrences(baseline, needle, collapsible)
 
 	// The set → paste critical section is additionally serialized across ALL panes
 	// (chatSetPasteMu) because the named buffer is shared server-wide; held only
@@ -371,7 +385,7 @@ func (s *Server) injectChatMessage(ctx context.Context, server, paneID, text str
 		return err
 	}
 
-	if err := s.probeChatEcho(ctx, server, paneID, needle, multiline, baseCount); err != nil {
+	if err := s.probeChatEcho(ctx, server, paneID, needle, collapsible, baseCount); err != nil {
 		return err
 	}
 	if err := s.tmux.SendEnterToPane(ctx, paneID, server); err != nil {
@@ -405,7 +419,7 @@ func (s *Server) setAndPaste(ctx context.Context, server, paneID, text string) e
 // is returned verbatim (→ 500, distinct from a clean probe miss); an exhausted
 // retry returns chatProbeFailure (→ 409). All captures and sleeps share the
 // caller's ctx deadline, so the loop stays well under the route budget.
-func (s *Server) probeChatEcho(ctx context.Context, server, paneID, needle string, multiline bool, baseCount int) error {
+func (s *Server) probeChatEcho(ctx context.Context, server, paneID, needle string, collapsible bool, baseCount int) error {
 	for attempt := 0; attempt < chatSendProbeAttempts; attempt++ {
 		d := chatSendProbeGap
 		if attempt == 0 {
@@ -421,7 +435,7 @@ func (s *Server) probeChatEcho(ctx context.Context, server, paneID, needle strin
 		if err != nil {
 			return fmt.Errorf("capture-pane: %w", err)
 		}
-		if countProbeOccurrences(capture, needle, multiline) > baseCount {
+		if countProbeOccurrences(capture, needle, collapsible) > baseCount {
 			return nil
 		}
 	}
@@ -450,18 +464,25 @@ func sleepCtx(ctx context.Context, d time.Duration) error {
 var ansiEscapeRe = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)`)
 
 // pasteCollapseRe matches Claude Code's paste-collapse placeholder — the TUI
-// replaces a larger multiline bracketed paste with a "[Pasted text #N +M lines]"
-// chip rather than echoing the raw text, so the raw needle would never be found
-// and the probe would 409 exactly the multiline case. The placeholder counts as
-// a SUCCESSFUL echo (the paste demonstrably reached the input buffer — the TUI
-// only renders this chip for content it accepted) — but ONLY for multiline text
-// (single-line pastes never collapse), and ONLY as a fresh occurrence vs the
-// pre-paste baseline (a stale chip from a prior send is in the baseline count).
+// replaces a larger bracketed paste with a chip rather than echoing the raw text,
+// so the raw needle would never be found and the probe would 409 exactly the
+// collapsed case. There are TWO chip forms:
+//   - multiline collapse:            "[Pasted text #N +M lines]"
+//   - long single-line collapse:     "[Pasted text #N]" (NO "+M lines" suffix)
+//
+// The single-line collapse is a pure character-count threshold (empirically
+// >800 chars on Claude Code 2.1.215, INDEPENDENT of TUI width — verified at
+// 60/80/200 cols), NOT a wrap effect, so the suffix-less chip carries no line
+// count. The placeholder counts as a SUCCESSFUL echo (the paste demonstrably
+// reached the input buffer — the TUI only renders this chip for content it
+// accepted) — but ONLY when the paste is COLLAPSIBLE (see countProbeOccurrences /
+// chatSendCollapseMinRunes), and ONLY as a fresh occurrence vs the pre-paste
+// baseline (a stale chip from a prior send is in the baseline count).
 //
 // The pattern matches the WHITESPACE-STRIPPED capture (stripForProbe removes all
-// spaces), i.e. "[Pastedtext#1+12lines]", and is tolerant of singular/plural
-// "line"/"lines" and any digit counts.
-var pasteCollapseRe = regexp.MustCompile(`\[Pastedtext#\d+\+\d+lines?\]`)
+// spaces), i.e. "[Pastedtext#1+12lines]" or "[Pastedtext#5]"; the "+M lines" part
+// is optional and tolerant of singular/plural "line"/"lines" and any digit counts.
+var pasteCollapseRe = regexp.MustCompile(`\[Pastedtext#\d+(?:\+\d+lines?)?\]`)
 
 // sanitizeChatText strips terminal control bytes from a chat-send message before
 // it is pasted into the agent pane. Bracketed paste makes ordinary text inert, but
@@ -509,24 +530,27 @@ func chatProbeNeedle(text string) string {
 }
 
 // countProbeOccurrences counts how many times this paste's echo signal appears
-// in the pane capture: the raw needle occurrences PLUS, for multiline text only,
-// the paste-collapse placeholder occurrences. Both the capture and the needle
-// have ALL whitespace removed (stripForProbe) so a TUI wrap that inserts
-// spaces/newlines mid-fragment (or a leading prompt glyph on the wrapped row)
-// cannot defeat the match.
+// in the pane capture: the raw needle occurrences PLUS, when the paste is
+// COLLAPSIBLE, the paste-collapse placeholder occurrences. Both the capture and
+// the needle have ALL whitespace removed (stripForProbe) so a TUI wrap that
+// inserts spaces/newlines mid-fragment (or a leading prompt glyph on the wrapped
+// row) cannot defeat the match.
 //
 // The handler compares this count against a pre-paste BASELINE and requires a
 // strict increase, so a stale needle/placeholder already in-frame is a floor to
-// beat rather than a false positive. The multiline gate matters: a short/common
-// single-line needle ("y", "ok") could substring-match unrelated stale content,
-// but that content is in the baseline too — the caller's increase requirement,
-// not this counter, is what makes short needles fail closed against stale
-// content. The placeholder is only counted for multiline text because
-// single-line pastes never collapse into the chip.
-func countProbeOccurrences(capture, needle string, multiline bool) int {
+// beat rather than a false positive. The collapsible gate matters: `collapsible`
+// means the TUI may have collapsed THIS paste into a chip (multiline text, or a
+// single line long enough to collapse — chatSendCollapseMinRunes), so the chip is
+// a valid fresh-echo signal; a short single-line paste never collapses, so
+// counting the chip for it would only widen the concurrent-fresh-chip
+// false-positive window. A short/common single-line needle ("y", "ok") could
+// substring-match unrelated stale content, but that content is in the baseline
+// too — the caller's strict-increase requirement, not this counter, is what makes
+// short needles fail closed against stale content.
+func countProbeOccurrences(capture, needle string, collapsible bool) int {
 	stripped := stripForProbe(capture)
 	n := strings.Count(stripped, needle)
-	if multiline {
+	if collapsible {
 		n += len(pasteCollapseRe.FindAllString(stripped, -1))
 	}
 	return n

--- a/app/backend/api/chat_send_test.go
+++ b/app/backend/api/chat_send_test.go
@@ -381,6 +381,86 @@ func TestChatSendMultilinePlaceholderNovelty(t *testing.T) {
 	}
 }
 
+// TestChatSendLongSingleLineCollapseNovelty: a LONG SINGLE-LINE paste (>800 chars,
+// no newline) that Claude Code collapses into a SUFFIX-LESS "[Pasted text #N]" chip
+// (empirical, CC 2.1.215, width-independent) is a legitimate echo → 200, Enter
+// sent. The raw needle never appears (the TUI shows the chip, not the text), so
+// before the collapsible-gate widening this send would have deterministically 409'd
+// — this is the regression the fix closes.
+func TestChatSendLongSingleLineCollapseNovelty(t *testing.T) {
+	fastChatSendProbe(t)
+	// A single line over the observed 801-char collapse threshold, no newline.
+	longLine := strings.Repeat("x", 900)
+	sf := &mockSessionFetcher{result: chatSessions("@1", "claude", testChatRef)}
+	// [0] baseline (no chip) → [1] the suffix-less collapse chip appears (fresh).
+	ops := &mockTmuxOps{capturePaneResults: []string{"❯ ", "❯ [Pasted text #1]"}}
+	router := NewTestRouter(slog.Default(), sf, ops, "host")
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, sendReq(`{"text":"`+longLine+`"}`))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if ops.setChatBufferText != longLine {
+		t.Errorf("buffer text len = %d, want the verbatim %d-char line", len(ops.setChatBufferText), len(longLine))
+	}
+	if !ops.sendEnterCalled {
+		t.Error("Enter not sent on a fresh suffix-less collapse chip (valid long-single-line echo)")
+	}
+}
+
+// TestChatSendStaleSuffixlessChipNoBlindEnter: a stale suffix-less "[Pasted text
+// #N]" chip already in the baseline (e.g. this handler's prior 409 left the long
+// paste in the composer) must NOT satisfy the probe for a new long-single-line
+// send whose raw needle does not echo. Every capture returns the same stale chip,
+// so the count never strictly increases → 409, Enter withheld. Mirrors the
+// multiline stale-chip guard for the single-line collapse form.
+func TestChatSendStaleSuffixlessChipNoBlindEnter(t *testing.T) {
+	fastChatSendProbe(t)
+	longLine := strings.Repeat("y", 900)
+	sf := &mockSessionFetcher{result: chatSessions("@1", "claude", testChatRef)}
+	// Baseline == probe: the stale suffix-less chip is present throughout, so no
+	// FRESH occurrence is added by this paste.
+	ops := &mockTmuxOps{capturePaneResult: "❯ [Pasted text #1]"}
+	router := NewTestRouter(slog.Default(), sf, ops, "host")
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, sendReq(`{"text":"`+longLine+`"}`))
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 (stale suffix-less chip must not pass); body=%s", rec.Code, rec.Body.String())
+	}
+	if ops.sendEnterCalled {
+		t.Error("Enter sent on a stale (non-novel) suffix-less chip — blind-Enter hazard")
+	}
+}
+
+// TestChatSendShortLineFreshChipNotCounted: a SHORT single-line send is not
+// collapsible, so even a FRESH chip appearing post-paste (e.g. a concurrent
+// human paste into the same pane) must not satisfy the probe — short sends keep
+// exact-needle-only matching. Pins the false branch of the collapsible gate at
+// the handler seam: if the gate ever regressed to unconditionally counting
+// chips, this send would 200 instead of 409.
+func TestChatSendShortLineFreshChipNotCounted(t *testing.T) {
+	fastChatSendProbe(t)
+	sf := &mockSessionFetcher{result: chatSessions("@1", "claude", testChatRef)}
+	// Baseline chip-free; every probe capture shows a fresh chip but never the
+	// pasted text "ok" — a non-collapsible send must ignore the chip and 409.
+	ops := &mockTmuxOps{capturePaneResults: []string{"❯ ", "❯ [Pasted text #1]", "❯ [Pasted text #1]", "❯ [Pasted text #1]"}}
+	router := NewTestRouter(slog.Default(), sf, ops, "host")
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, sendReq(`{"text":"ok"}`))
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 (short send must not ride a chip); body=%s", rec.Code, rec.Body.String())
+	}
+	if ops.sendEnterCalled {
+		t.Error("Enter sent for a short send on a chip occurrence — the collapsible gate is not being applied")
+	}
+}
+
 // TestChatSendSharedDeadlineAborts: the whole injection sequence shares ONE
 // context deadline (chatSendTotalBudget). When it is tiny and a tmux subprocess
 // (the baseline capture here) respects ctx cancellation, the sequence aborts as
@@ -591,15 +671,15 @@ func TestChatProbeNeedle(t *testing.T) {
 // TestCountProbeOccurrences exercises the occurrence-COUNTING matcher directly.
 // The handler compares a pre-paste baseline count against a post-paste count and
 // requires a strict increase; these cases pin the counting rules (raw needle,
-// multiline-gated placeholder, ANSI/whitespace normalization) the comparison
-// rests on.
+// collapsible-gated placeholder — BOTH chip forms, ANSI/whitespace normalization)
+// the comparison rests on.
 func TestCountProbeOccurrences(t *testing.T) {
 	needle := chatProbeNeedle("please run the tests")
 	tests := []struct {
-		name      string
-		capture   string
-		multiline bool
-		want      int
+		name        string
+		capture     string
+		collapsible bool
+		want        int
 	}{
 		{"echo present once", "❯ please run the tests", false, 1},
 		{"echo absent", "unrelated scrollback\n❯ ", false, 0},
@@ -609,24 +689,29 @@ func TestCountProbeOccurrences(t *testing.T) {
 		{"wrapped across rows", "❯ please run the\n  tests", false, 1},
 		// ANSI-styled input (CapturePane keeps escapes with -e) is stripped first.
 		{"ansi-styled echo", "\x1b[1m❯\x1b[0m please run \x1b[32mthe tests\x1b[0m", false, 1},
-		// Placeholder counts ONLY for multiline text (single-line pastes never
-		// collapse). Same capture, opposite gate:
-		{"placeholder counted when multiline", "❯ [Pasted text #1 +12 lines]", true, 1},
-		{"placeholder ignored when single-line", "❯ [Pasted text #1 +12 lines]", false, 0},
-		// Singular "line" + a leading prompt glyph still counts (multiline).
+		// The multiline "+M lines" chip counts ONLY when collapsible. Same capture,
+		// opposite gate:
+		{"multiline chip counted when collapsible", "❯ [Pasted text #1 +12 lines]", true, 1},
+		{"multiline chip ignored when not collapsible", "❯ [Pasted text #1 +12 lines]", false, 0},
+		// The suffix-less single-line collapse chip (a long single line >800 chars
+		// collapses with NO "+M lines" suffix) counts ONLY when collapsible. Same
+		// capture, opposite gate:
+		{"suffix-less chip counted when collapsible", "❯ [Pasted text #7]", true, 1},
+		{"suffix-less chip ignored when not collapsible", "❯ [Pasted text #7]", false, 0},
+		// Singular "line" + a leading prompt glyph still counts (collapsible).
 		{"placeholder singular line", "❯ [Pasted text #3 +1 line]", true, 1},
-		// ANSI-styled placeholder is stripped before matching (multiline).
+		// ANSI-styled placeholder is stripped before matching (collapsible).
 		{"ansi-styled placeholder", "\x1b[2m[Pasted text #2 +40 lines]\x1b[0m", true, 1},
-		// Two chips → two placeholder occurrences (multiline).
-		{"two placeholders", "[Pasted text #1 +2 lines]\n[Pasted text #2 +3 lines]", true, 2},
-		// A partial / malformed chip (no "+M lines" tail) is NOT counted — only a
-		// genuine paste-collapse placeholder, never arbitrary bracketed text.
+		// Two chips (one of each form) → two placeholder occurrences (collapsible).
+		{"two chips both forms", "[Pasted text #1 +2 lines]\n[Pasted text #2]", true, 2},
+		// Arbitrary bracketed text is NOT counted — only a genuine paste-collapse
+		// placeholder chip.
 		{"non-placeholder bracketed text", "❯ [some other note]", true, 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := countProbeOccurrences(tt.capture, needle, tt.multiline); got != tt.want {
-				t.Errorf("countProbeOccurrences(%q, %q, multiline=%v) = %d, want %d", tt.capture, needle, tt.multiline, got, tt.want)
+			if got := countProbeOccurrences(tt.capture, needle, tt.collapsible); got != tt.want {
+				t.Errorf("countProbeOccurrences(%q, %q, collapsible=%v) = %d, want %d", tt.capture, needle, tt.collapsible, got, tt.want)
 			}
 		})
 	}

--- a/docs/memory/run-kit/chat.md
+++ b/docs/memory/run-kit/chat.md
@@ -472,15 +472,20 @@ delivered literally — never interpreted as keys/flags nor submitted per-line.
 ### Requirement: NOVELTY echo probe (fail-closed), settle + bounded retry
 Before Enter the handler SHALL verify the pasted text ECHOED into the pane's live
 input buffer, using **novelty**, not mere presence: it counts a probe **needle**
-(and, for multiline text only, the paste-collapse placeholder) in the pre-paste
-**baseline** capture, then requires that count to strictly INCREASE in a post-paste
-capture. The needle is derived from the LAST non-empty line of the text,
+(and, when the paste is *collapsible*, the paste-collapse placeholder) in the
+pre-paste **baseline** capture, then requires that count to strictly INCREASE in a
+post-paste capture. The needle is derived from the LAST non-empty line of the text,
 whitespace-stripped (both needle and capture stripped of ANSI + all whitespace so
 an ~80-col TUI wrap cannot split the fragment) and capped to the last
-`chatSendNeedleMaxLen = 40` runes. The multiline paste-collapse placeholder
-(`[Pasted text #N +M lines]`, matched whitespace-stripped) counts as a successful
-echo — but ONLY for multiline text (single-line pastes never collapse) and ONLY as
-a *fresh* occurrence vs baseline. A short settle (`chatSendProbeSettle = 80ms`)
+`chatSendNeedleMaxLen = 40` runes. A paste is **collapsible** when it is multiline
+OR a single line of at least `chatSendCollapseMinRunes = 200` runes — the Claude
+Code TUI collapses such a paste into a chip, so the chip is a valid fresh-echo
+signal. `pasteCollapseRe` matches BOTH chip forms whitespace-stripped:
+`[Pasted text #N +M lines]` (multiline collapse) and the suffix-less
+`[Pasted text #N]` (long-single-line collapse), with the `+M lines` suffix optional.
+The chip counts as a successful echo ONLY when the paste is collapsible and ONLY as
+a *fresh* occurrence vs baseline; a short single-line send keeps exact-needle-only
+matching. A short settle (`chatSendProbeSettle = 80ms`)
 precedes the first capture, then up to `chatSendProbeAttempts = 3` captures with a
 `chatSendProbeGap = 80ms` gap (settle/gap are package **vars** solely so tests can
 shrink them). The probe **fails closed**: an empty needle, a pane that scrolls
@@ -495,8 +500,9 @@ dialog. A `CapturePane` subprocess error is distinct (→ `500`, not a clean mis
 - **WHEN** the paste does not add a fresh occurrence (or the pane scrolls)
 - **THEN** the count does not strictly increase, so no Enter is sent and the
   response is `409` — the stale occurrence is a floor to beat, not a false positive.
-- **AND GIVEN** the text (or its multiline paste-collapse chip) newly appears within
-  the retry budget, **THEN** Enter is sent and the response is `200 {"ok":true}`.
+- **AND GIVEN** the text (or, for a collapsible paste, its paste-collapse chip in
+  either form) newly appears within the retry budget, **THEN** Enter is sent and the
+  response is `200 {"ok":true}`.
 
 ### Requirement: 409 on probe failure — Enter withheld, text left recoverable
 On probe failure the handler SHALL send no Enter and return `409` with a structured
@@ -952,9 +958,9 @@ rejecting control-byte requests with a `400` (hostile to legitimate paste conten
 
 ### NOVELTY echo probe before Enter, fail-closed
 **Decision**: Never send Enter blindly. Capture the pane tail BEFORE the paste, then
-require a probe needle's (or the multiline paste-collapse chip's) occurrence count
-to strictly INCREASE after the paste; on failure withhold Enter and return `409`
-with the text left recoverable in the composer.
+require a probe needle's (or, for a collapsible paste, the paste-collapse chip's in
+either form) occurrence count to strictly INCREASE after the paste; on failure
+withhold Enter and return `409` with the text left recoverable in the composer.
 **Why**: A visible `❯ <text>` line in a capture can be STALE printed output, not the
 live input buffer (a recorded operator lesson) — a mere-presence check would false
 pass on a stale chip (this very handler's 409 path leaves pasted text in-frame) or a
@@ -973,6 +979,30 @@ reachable but low-consequence false-positive.
 reject-while-busy (superseded — Claude Code queues typed input natively, and the
 probe already guards the unsafe cases).
 *Introduced by*: `260714-jdyg-chat-send`
+
+### Collapse-chip gate at 200 runes, a conservative lower bound
+**Decision**: Count the paste-collapse chip whenever the paste is *collapsible* —
+multiline OR a single line of at least `chatSendCollapseMinRunes = 200` runes — and
+make the `+M lines` suffix optional in `pasteCollapseRe` so both the multiline chip
+(`[Pasted text #N +M lines]`) and the suffix-less long-single-line chip
+(`[Pasted text #N]`) match.
+**Why**: Claude Code collapses a single-line paste over 800 chars into a suffix-less
+chip (empirical, CC 2.1.215, width-independent, observed threshold 801), so its raw
+needle never echoes and the probe would 409 for a paste that demonstrably reached
+the buffer. Gating chip-counting on `collapsible` (not merely on the presence of a
+newline) is what makes the long-single-line chip a valid echo signal. The NOVELTY
+strict-increase-over-baseline design is
+unchanged and is what keeps chip-counting sound: a stale chip is in the pre-paste
+floor, so only THIS paste's fresh occurrence can satisfy the probe — soundness is
+independent of whether the text is multiline. 200 is a deliberate conservative lower
+bound (vs the observed 801) so an upstream threshold reduction cannot silently
+rebreak long-single-line sends, while short interactive sends keep exact-needle-only
+matching.
+**Rejected**: keying the gate to the exact observed 801 (brittle — an upstream
+Claude Code release can lower it silently); counting the chip unconditionally for
+ALL sends (needlessly widens the concurrent-fresh-chip false-positive window to
+short interactive sends that never collapse).
+*Introduced by*: `260719-yxi0-chat-send-single-line-collapse-probe`
 
 ### Allow + probe busy policy — no server-side gate, no queue
 **Decision**: There is NO `agentState` gate on send and NO server-side queue. A busy

--- a/fab/changes/260719-yxi0-chat-send-single-line-collapse-probe/.history.jsonl
+++ b/fab/changes/260719-yxi0-chat-send-single-line-collapse-probe/.history.jsonl
@@ -1,0 +1,10 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-07-19T20:31:27Z"}
+{"args":"Chat-send long-single-line paste-collapse (backlog yxi0): empirically disproved the never-collapses assumption — CC 2.1.215 collapses single lines \u003e800 chars into a [Pasted text #N] chip (no lines suffix, width-independent); probe must count the chip for long single-line sends and the regex must accept the suffix-less form","cmd":"fab-new","event":"command","ts":"2026-07-19T20:31:27Z"}
+{"delta":"+5.0","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-07-19T20:32:22Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-07-19T20:32:31Z"}
+{"cmd":"fab-continue","event":"command","ts":"2026-07-19T20:33:20Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-07-19T20:37:52Z"}
+{"cmd":"fab-continue","event":"command","ts":"2026-07-19T20:38:30Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-07-19T20:43:29Z"}
+{"event":"review","result":"passed","ts":"2026-07-19T20:43:29Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-07-19T20:45:40Z"}

--- a/fab/changes/260719-yxi0-chat-send-single-line-collapse-probe/.history.jsonl
+++ b/fab/changes/260719-yxi0-chat-send-single-line-collapse-probe/.history.jsonl
@@ -9,3 +9,4 @@
 {"event":"review","result":"passed","ts":"2026-07-19T20:43:29Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-07-19T20:45:40Z"}
 {"action":"enter","event":"stage-transition","stage":"review-pr","ts":"2026-07-19T20:48:31Z"}
+{"event":"review","result":"passed","ts":"2026-07-19T20:56:37Z"}

--- a/fab/changes/260719-yxi0-chat-send-single-line-collapse-probe/.history.jsonl
+++ b/fab/changes/260719-yxi0-chat-send-single-line-collapse-probe/.history.jsonl
@@ -8,3 +8,4 @@
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-07-19T20:43:29Z"}
 {"event":"review","result":"passed","ts":"2026-07-19T20:43:29Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-07-19T20:45:40Z"}
+{"action":"enter","event":"stage-transition","stage":"review-pr","ts":"2026-07-19T20:48:31Z"}

--- a/fab/changes/260719-yxi0-chat-send-single-line-collapse-probe/.status.yaml
+++ b/fab/changes/260719-yxi0-chat-send-single-line-collapse-probe/.status.yaml
@@ -9,8 +9,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 plan:
     generated: true
     task_count: 6
@@ -33,22 +33,24 @@ stage_metrics:
     apply: {started_at: "2026-07-19T20:32:31Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:37:52Z"}
     review: {started_at: "2026-07-19T20:37:52Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:43:29Z"}
     hydrate: {started_at: "2026-07-19T20:43:29Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:45:40Z"}
-    ship: {started_at: "2026-07-19T20:45:40Z", driver: fab-fff, iterations: 1}
-prs: []
+    ship: {started_at: "2026-07-19T20:45:40Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:48:31Z"}
+    review-pr: {started_at: "2026-07-19T20:48:31Z", iterations: 1}
+prs:
+    - https://github.com/sahil87/run-kit/pull/406
 change_type_source: explicit
 true_impact:
-    added: 0
-    deleted: 0
-    net: 0
+    added: 532
+    deleted: 70
+    net: 462
     excluding:
-        added: 0
-        deleted: 0
-        net: 0
+        added: 167
+        deleted: 58
+        net: 109
     tests:
-        added: 0
-        deleted: 0
-        net: 0
-    computed_at: "2026-07-19T20:45:40Z"
-    computed_at_stage: hydrate
+        added: 103
+        deleted: 18
+        net: 85
+    computed_at: "2026-07-19T20:48:31Z"
+    computed_at_stage: ship
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-07-19T20:45:40Z
+last_updated: 2026-07-19T20:48:31Z

--- a/fab/changes/260719-yxi0-chat-send-single-line-collapse-probe/.status.yaml
+++ b/fab/changes/260719-yxi0-chat-send-single-line-collapse-probe/.status.yaml
@@ -10,7 +10,7 @@ progress:
     review: done
     hydrate: done
     ship: done
-    review-pr: active
+    review-pr: done
 plan:
     generated: true
     task_count: 6
@@ -34,7 +34,7 @@ stage_metrics:
     review: {started_at: "2026-07-19T20:37:52Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:43:29Z"}
     hydrate: {started_at: "2026-07-19T20:43:29Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:45:40Z"}
     ship: {started_at: "2026-07-19T20:45:40Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:48:31Z"}
-    review-pr: {started_at: "2026-07-19T20:48:31Z", iterations: 1}
+    review-pr: {started_at: "2026-07-19T20:48:31Z", iterations: 1, completed_at: "2026-07-19T20:56:37Z"}
 prs:
     - https://github.com/sahil87/run-kit/pull/406
 change_type_source: explicit
@@ -53,4 +53,4 @@ true_impact:
     computed_at: "2026-07-19T20:48:31Z"
     computed_at_stage: ship
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-07-19T20:48:31Z
+last_updated: 2026-07-19T20:56:37Z

--- a/fab/changes/260719-yxi0-chat-send-single-line-collapse-probe/.status.yaml
+++ b/fab/changes/260719-yxi0-chat-send-single-line-collapse-probe/.status.yaml
@@ -1,0 +1,54 @@
+id: yxi0
+name: 260719-yxi0-chat-send-single-line-collapse-probe
+created: 2026-07-19T20:31:27Z
+created_by: sahil-noon
+change_type: fix
+issues: []
+progress:
+    intake: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+plan:
+    generated: true
+    task_count: 6
+    acceptance_count: 12
+    acceptance_completed: 12
+confidence:
+    certain: 4
+    confident: 1
+    tentative: 0
+    unresolved: 0
+    score: 5.0
+    fuzzy: true
+    dimensions:
+        signal: 81.0
+        reversibility: 91.0
+        competence: 89.0
+        disambiguation: 80.0
+stage_metrics:
+    intake: {started_at: "2026-07-19T20:31:27Z", driver: fab-new, iterations: 1, completed_at: "2026-07-19T20:32:31Z"}
+    apply: {started_at: "2026-07-19T20:32:31Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:37:52Z"}
+    review: {started_at: "2026-07-19T20:37:52Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:43:29Z"}
+    hydrate: {started_at: "2026-07-19T20:43:29Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-19T20:45:40Z"}
+    ship: {started_at: "2026-07-19T20:45:40Z", driver: fab-fff, iterations: 1}
+prs: []
+change_type_source: explicit
+true_impact:
+    added: 0
+    deleted: 0
+    net: 0
+    excluding:
+        added: 0
+        deleted: 0
+        net: 0
+    tests:
+        added: 0
+        deleted: 0
+        net: 0
+    computed_at: "2026-07-19T20:45:40Z"
+    computed_at_stage: hydrate
+# true_impact: lazily created on first stage-finish that computes it (no placeholder here).
+last_updated: 2026-07-19T20:45:40Z

--- a/fab/changes/260719-yxi0-chat-send-single-line-collapse-probe/intake.md
+++ b/fab/changes/260719-yxi0-chat-send-single-line-collapse-probe/intake.md
@@ -1,0 +1,97 @@
+# Intake: Chat-Send Long-Single-Line Paste-Collapse Probe Fix
+
+**Change**: 260719-yxi0-chat-send-single-line-collapse-probe
+**Created**: 2026-07-20
+
+## Origin
+
+<!-- Backlog item [yxi0], picked up by the backlog-bugs sweep (BUG scope). The item asked for empirical verification of an unverified assumption; the verification was performed live before this intake and DISPROVED the assumption, converting the item from "unverified note" to "confirmed bug". -->
+
+> [yxi0] Chat-send long-single-line paste-collapse assumption (unverified): the NOVELTY echo probe counts the [Pasted text ...] collapse placeholder only for MULTILINE text, assuming a long single line never collapses into the chip; not empirically re-verified across TUI widths. (relocated from docs/memory/run-kit/chat.md by /docs-distill-memory)
+
+**Empirical verification (2026-07-20, Claude Code 2.1.215, tmux 3.6a)** — performed with the exact production mechanism (`set-buffer -b <named> -- <text>` then `paste-buffer -d -p`) into a live Claude Code composer on an isolated tmux server, across 60/80/200-column widths:
+
+| Input | Observed composer echo |
+|-------|------------------------|
+| Single line, 203 chars (80 cols) | Raw text, wrapped — no collapse |
+| Single line, 500 chars (60 cols, ~9 wrapped rows) | Raw text, wrapped — no collapse |
+| Single line, 700 chars (80 cols) | Raw text — no collapse |
+| Single line, 800 chars (80 cols) | Raw text — no collapse |
+| Single line, 801 chars (80 cols) | **Collapsed: `[Pasted text #N]`** — NO `+M lines` suffix |
+| Single line, 850 / 900 / 1001 chars (80 cols) | **Collapsed: `[Pasted text #N]`** |
+| Single line, 900 chars (200 cols) | **Collapsed: `[Pasted text #N]`** — width-independent |
+| 12-line multiline | Collapsed: `[Pasted text #N +11 lines]` |
+
+Conclusions: the collapse is a **pure character-count threshold (>800 chars)**, independent of TUI width; the single-line collapse chip carries **no `+M lines` suffix**; the multiline chip format matches the existing regex.
+
+## Why
+
+1. **The pain point** (two-layer bug in `app/backend/api/chat.go`):
+   - `injectChatMessage` computes `multiline := strings.Contains(text, "\n")` and `countProbeOccurrences` counts the paste-collapse placeholder **only when `multiline` is true**. A single-line message over 800 chars collapses into a chip, so its raw needle never appears in the capture, the placeholder is not counted, the count never exceeds the baseline, and the probe **always returns 409** — Enter withheld, the (successfully pasted) text stranded in the agent's composer. Long single-line sends are deterministically broken.
+   - Even if the multiline gate were dropped, `pasteCollapseRe` (`\[Pastedtext#\d+\+\d+lines?\]` against the whitespace-stripped capture) **requires** the `+\d+lines` part — the suffix-less single-line chip `[Pastedtext#5]` would not match.
+
+2. **The consequence if unfixed**: any chat-send of a long single line (a long prompt, a pasted URL list, a minified snippet — all common) fails with 409 even though the paste demonstrably reached the input buffer (the TUI only renders the chip for content it accepted). Worse, the 409 error message tells the user the text remains in the composer and warns against blind retry — every retry pastes a second chip. The feature is unusable for exactly the messages long enough to be worth sending from the web UI.
+
+3. **Why this approach**: extend the existing placeholder-counting mechanism rather than redesign the probe. The NOVELTY baseline design (pre-paste count must strictly increase) is what makes chip-counting sound — a stale chip from a prior 409 is in the baseline floor; only THIS paste adds a fresh occurrence. That soundness argument is grade-independent of whether the text is multiline, so widening when the chip is counted is safe. Alternatives rejected: counting the chip **unconditionally** for all sends (needlessly widens the concurrent-fresh-chip false-positive window to short interactive sends that never collapse); keying the gate to the exact observed threshold 801 (brittle — an upstream Claude Code release can lower it silently; a conservative lower bound keeps working).
+
+## What Changes
+
+### `app/backend/api/chat.go` — regex + gate
+
+1. **Make the `+M lines` suffix optional** in `pasteCollapseRe` so both chip forms match:
+
+```go
+var pasteCollapseRe = regexp.MustCompile(`\[Pastedtext#\d+(?:\+\d+lines?)?\]`)
+```
+
+Update the comment above it: the TUI renders `[Pasted text #N +M lines]` for collapsed multiline pastes and the suffix-less `[Pasted text #N]` for collapsed long single-line pastes (empirically: >800 chars on Claude Code 2.1.215, width-independent).
+
+2. **Widen the placeholder gate from `multiline` to `collapsible`**. Add a named constant and derive a `collapsible` flag where `multiline` is derived today (`injectChatMessage`):
+
+```go
+// chatSendCollapseMinRunes is the single-line length at or above which the
+// paste-collapse placeholder is counted as an echo signal. Claude Code
+// collapses a single-line paste over 800 chars into a suffix-less
+// "[Pasted text #N]" chip (empirical, CC 2.1.215, width-independent);
+// 200 is a deliberately conservative lower bound so an upstream threshold
+// reduction cannot silently break long-single-line sends again, while
+// short interactive sends keep exact-needle-only matching.
+const chatSendCollapseMinRunes = 200
+
+collapsible := strings.Contains(text, "\n") || len([]rune(text)) >= chatSendCollapseMinRunes
+```
+
+Thread `collapsible` through where `multiline` is threaded today: `injectChatMessage` → `countProbeOccurrences(capture, needle, collapsible)` and `probeChatEcho(..., collapsible, baseCount)`. Rename the parameter (`multiline` → `collapsible`) in both functions and update their doc comments — the parameter no longer means "text has newlines", it means "the TUI may have collapsed this paste into a chip, so the chip is a valid fresh-echo signal". The baseline capture count and the strict-increase comparison are unchanged.
+
+### `app/backend/api/chat_send_test.go` — tests
+
+- **Regex/unit coverage** (extend the existing probe-matching unit tests): `countProbeOccurrences` counts the suffix-less chip (`[Pasted text #7]` → stripped `[Pastedtext#7]`) when `collapsible` is true; still counts the multiline form; does NOT count either chip when `collapsible` is false; short single-line text (< 200 runes) is not collapsible.
+- **Handler-level test**: a >800-char single-line send whose post-paste capture shows only `[Pasted text #1]` (baseline without it) succeeds — 200, Enter sent. A companion assertion that a stale chip already in the baseline does not satisfy the probe (409) — mirroring the existing stale-placeholder test for multiline, if one exists; otherwise add it for the single-line form.
+- Follow the existing `mockTmuxOps`/`chatSessions`/`sendReq` seams and the file's comment style. Prefer inserting new tests adjacent to the existing paste-collapse/probe tests (mid-file) rather than appending at EOF.
+
+## Affected Memory
+
+- `run-kit/chat`: (modify) — the send-path probe description: placeholder counting is gated on *collapsible* (multiline OR ≥200-rune single line), both chip forms (`+M lines` and suffix-less) match, and the empirical collapse threshold (>800 chars, width-independent, CC 2.1.215) is recorded. The former "single-line pastes never collapse" claim is removed wherever stated.
+
+## Impact
+
+- `app/backend/api/chat.go` — one regex edit, one named constant, a `multiline` → `collapsible` rename threaded through `injectChatMessage` / `probeChatEcho` / `countProbeOccurrences` with comment updates.
+- `app/backend/api/chat_send_test.go` — new/extended unit + handler tests.
+- No API-shape change, no frontend change, no tmux-layer change.
+- **Merge-overlap note**: change `260719-t9uk-chat-send-control-byte-sanitize` (PR #402, unmerged) also touches both files (sanitize helper + tests appended at EOF). This branch is cut from the same base; whichever merges second resolves small textual conflicts (different regions in chat.go; EOF-adjacent in the test file — hence the insert-mid-file guidance above).
+
+## Open Questions
+
+_None._
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | The bug is real and the assumption in the code comment is false | Empirically reproduced with the production paste mechanism: single-line >800 chars collapses to a suffix-less chip on CC 2.1.215, at 60/80/200 cols | S:95 R:90 A:95 D:95 |
+| 2 | Certain | Fix = optional-suffix regex + widen the placeholder gate; the NOVELTY baseline keeps chip-counting sound | The strict-increase-over-baseline design already absorbs stale chips; soundness is independent of the multiline property | S:85 R:90 A:90 D:85 |
+| 3 | Confident | Gate constant `chatSendCollapseMinRunes = 200` (conservative lower bound, not the observed 801) | Robust to upstream threshold reductions; keeps short interactive sends on exact-needle matching; exact value is a judgment call within a safe range | S:70 R:90 A:80 D:60 |
+| 4 | Certain | Parameter renamed `multiline` → `collapsible` (semantics changed, name must follow) | Code-quality: the gate no longer tests for newlines; keeping the old name would lie | S:80 R:95 A:95 D:85 |
+| 5 | Confident | Scope excludes re-verifying other providers (codex/gemini) — claude is the only registered send adapter in v1 | Adapter registry has claude only; provider-agnostic seam noted in code for later | S:75 R:90 A:85 D:75 |
+
+5 assumptions (3 certain, 2 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260719-yxi0-chat-send-single-line-collapse-probe/plan.md
+++ b/fab/changes/260719-yxi0-chat-send-single-line-collapse-probe/plan.md
@@ -1,0 +1,162 @@
+# Plan: Chat-Send Long-Single-Line Paste-Collapse Probe Fix
+
+**Change**: 260719-yxi0-chat-send-single-line-collapse-probe
+**Intake**: `intake.md`
+
+## Requirements
+
+### run-kit/chat: Send-path novelty echo probe — collapse-chip counting
+
+#### R1: Both paste-collapse chip forms match the placeholder regex
+`pasteCollapseRe` MUST match BOTH the multiline chip form
+`[Pasted text #N +M lines]` AND the suffix-less single-line chip form
+`[Pasted text #N]` (against the whitespace-stripped capture), while still NOT
+matching arbitrary bracketed text (`[some other note]`). The `+M lines` suffix
+SHALL be optional; the singular/plural `line`/`lines` and any digit counts remain
+tolerated.
+
+- **GIVEN** a whitespace-stripped capture containing `[Pastedtext#7]`
+- **WHEN** `pasteCollapseRe` is applied
+- **THEN** it matches (one occurrence)
+- **AND GIVEN** a capture containing `[Pastedtext#1+12lines]`, **THEN** it still
+  matches
+- **AND GIVEN** a capture containing `[someothernote]`, **THEN** it does not match.
+
+#### R2: Placeholder counting is gated on `collapsible`, not `multiline`
+`countProbeOccurrences` SHALL count the paste-collapse placeholder when — and only
+when — the paste is `collapsible`: the text contains a newline OR its rune length
+is at least `chatSendCollapseMinRunes`. A single-line send at or above the rune
+threshold is collapsible; a short single-line send below it is not. The raw-needle
+count and the strict-increase-over-baseline comparison in the caller are unchanged.
+
+- **GIVEN** a suffix-less chip `[Pasted text #7]` in the capture and
+  `collapsible=true`
+- **WHEN** `countProbeOccurrences` runs
+- **THEN** the chip is counted
+- **AND GIVEN** the same capture with `collapsible=false`, **THEN** the chip is NOT
+  counted
+- **AND GIVEN** the multiline chip `[Pasted text #1 +12 lines]` with
+  `collapsible=true`, **THEN** it is still counted.
+
+#### R3: `injectChatMessage` derives `collapsible` from a named threshold constant
+`injectChatMessage` SHALL replace the `multiline := strings.Contains(text, "\n")`
+derivation with `collapsible := strings.Contains(text, "\n") || len([]rune(text))
+>= chatSendCollapseMinRunes`, where `chatSendCollapseMinRunes` is a named
+package-level constant set to `200` (a deliberate conservative lower bound; the
+empirically observed threshold on Claude Code 2.1.215 is 801, width-independent).
+The `collapsible` flag SHALL be threaded to `countProbeOccurrences` and
+`probeChatEcho` in place of `multiline`.
+
+- **GIVEN** a single-line message of 801 runes with no newline
+- **WHEN** `injectChatMessage` derives the flag
+- **THEN** `collapsible` is true (rune length ≥ 200), so a fresh `[Pasted text #N]`
+  chip in the post-paste capture satisfies the probe and Enter is sent
+- **AND GIVEN** a single-line message of 11 runes, **THEN** `collapsible` is false.
+
+#### R4: `probeChatEcho` / `countProbeOccurrences` parameter renamed to `collapsible`
+The threaded boolean parameter in `probeChatEcho` and `countProbeOccurrences` SHALL
+be named `collapsible` (not `multiline`), and their doc comments plus
+`pasteCollapseRe`'s and `injectChatMessage`'s doc comments SHALL be updated to state
+the two chip forms and the empirical collapse facts (>800 chars, CC 2.1.215,
+width-independent), and to describe the parameter's new meaning ("the TUI may have
+collapsed this paste into a chip, so the chip is a valid fresh-echo signal"). The
+NOVELTY baseline strict-increase soundness argument is unchanged.
+
+- **GIVEN** the renamed functions
+- **WHEN** the code is read/compiled
+- **THEN** no `multiline` identifier remains in these signatures and all call sites
+  pass `collapsible`; the code compiles and the doc comments reflect the new
+  semantics.
+
+### Non-Goals
+
+- Re-verifying collapse behavior for other providers (codex/gemini) — `claude` is
+  the only registered send adapter in v1; the provider-agnostic seam is unchanged.
+- Changing the API shape, the frontend, or the tmux layer — none are touched.
+- Keying the gate to the exact observed threshold 801 — a conservative lower bound
+  (200) is intentional so an upstream threshold reduction cannot silently rebreak
+  long single-line sends.
+
+### Design Decisions
+
+#### Widen the gate to `collapsible`, keep the NOVELTY baseline
+**Decision**: Count the paste-collapse chip whenever the paste is `collapsible`
+(newline OR ≥200 runes) and make the `+M lines` suffix optional in the regex.
+**Why**: A single-line paste over 800 chars collapses into a suffix-less chip, so
+its raw needle never echoes and the probe always 409s. The strict-increase-over-
+baseline design already absorbs a stale chip (it is in the pre-paste floor), so
+soundness is independent of the multiline property — widening WHEN the chip counts
+is safe.
+**Rejected**: Counting the chip unconditionally for all sends (needlessly widens the
+concurrent-fresh-chip false-positive window to short interactive sends that never
+collapse); keying the gate to the exact 801 threshold (brittle to upstream
+changes).
+*Introduced by*: `260719-yxi0-chat-send-single-line-collapse-probe`
+
+## Tasks
+
+### Phase 2: Core Implementation
+
+- [x] T001 Make the `+M lines` suffix optional in `pasteCollapseRe` (`\[Pastedtext#\d+(?:\+\d+lines?)?\]`) in `app/backend/api/chat.go`, and update its doc comment to describe both chip forms (`[Pasted text #N +M lines]` multiline, suffix-less `[Pasted text #N]` single-line) plus the empirical collapse facts (>800 chars, CC 2.1.215, width-independent) <!-- R1 -->
+- [x] T002 Add the named constant `const chatSendCollapseMinRunes = 200` with a doc comment (observed threshold 801 on CC 2.1.215, 200 a deliberate conservative lower bound) in `app/backend/api/chat.go` <!-- R3 -->
+- [x] T003 In `injectChatMessage` (`app/backend/api/chat.go`) replace the `multiline` derivation with `collapsible := strings.Contains(text, "\n") || len([]rune(text)) >= chatSendCollapseMinRunes`, update the surrounding doc comment, and pass `collapsible` to `countProbeOccurrences` and `probeChatEcho` <!-- R3 -->
+- [x] T004 Rename the threaded parameter `multiline` → `collapsible` in `probeChatEcho` and `countProbeOccurrences` (`app/backend/api/chat.go`) and update their doc comments to the new semantics ("the TUI may have collapsed this paste into a chip") <!-- R4 -->
+
+### Phase 3: Integration & Edge Cases
+
+- [x] T005 In `app/backend/api/chat_send_test.go`, extend `TestCountProbeOccurrences` (rename its `multiline` field to `collapsible`) with cases: suffix-less chip counted when collapsible, suffix-less chip NOT counted when not collapsible, multiline chip still counted; keep the existing non-placeholder-bracketed-text case <!-- R1 R2 -->
+- [x] T006 Add a handler-level test in `app/backend/api/chat_send_test.go` (mid-file, adjacent to `TestChatSendMultilinePlaceholderNovelty`): a >800-char single-line send whose baseline lacks `[Pasted text #1]` and whose post-paste capture contains it succeeds (200, Enter sent); a companion assertion that a stale suffix-less chip already in the baseline with no fresh occurrence → 409, Enter withheld <!-- R2 R3 -->
+
+## Execution Order
+
+- T001–T004 (chat.go) precede T005–T006 (tests reference the renamed field/constant and new behavior).
+
+## Acceptance
+
+### Functional Completeness
+
+- [x] A-001 R1: `pasteCollapseRe` matches both `[Pasted text #N +M lines]` and suffix-less `[Pasted text #N]` (whitespace-stripped) and rejects arbitrary bracketed text.
+- [x] A-002 R2: `countProbeOccurrences` counts the placeholder iff `collapsible` is true (both chip forms), and never when `collapsible` is false.
+- [x] A-003 R3: `chatSendCollapseMinRunes = 200` exists as a named constant and `injectChatMessage` derives `collapsible` from newline OR the rune-length threshold.
+- [x] A-004 R4: `probeChatEcho` and `countProbeOccurrences` take a `collapsible` parameter (no `multiline` identifier remains) with updated doc comments.
+
+### Behavioral Correctness
+
+- [x] A-005 R3: A >800-char single-line send whose post-paste capture shows only `[Pasted text #1]` (absent from baseline) returns 200 and sends Enter — the previously-deterministic 409 is fixed.
+- [x] A-006 R2: A short single-line send (< 200 runes) whose raw needle does not echo does NOT ride a chip — it remains a 409 when no fresh needle occurrence appears.
+
+### Scenario Coverage
+
+- [x] A-007 R2: `TestCountProbeOccurrences` covers suffix-less-counted-when-collapsible, suffix-less-not-counted-when-not, and multiline-still-counted.
+- [x] A-008 R3: A handler-level test exercises the long-single-line success path (200, Enter) and the stale-suffix-less-chip 409 (Enter withheld).
+
+### Edge Cases & Error Handling
+
+- [x] A-009 R2: The NOVELTY baseline strict-increase remains the sole soundness guard — a stale chip already in the pre-paste baseline does not false-pass the probe.
+
+### Code Quality
+
+- [x] A-010 Pattern consistency: New code follows the surrounding naming (named constant per the anti-magic-number rule), doc-comment style, and test-seam conventions (`mockTmuxOps`/`chatSessions`/`sendReq`/`fastChatSendProbe`).
+- [x] A-011 No unnecessary duplication: The fix extends the existing placeholder-counting mechanism rather than adding a parallel path; the new tests reuse existing fixtures/helpers.
+- [x] A-012 Magic numbers: The collapse threshold is a named constant (`chatSendCollapseMinRunes`), not an inline literal.
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All acceptance items must pass before `/fab-continue` (hydrate)
+- Merge-overlap: sibling branch `260719-t9uk` appends at EOF of both files; new tests here are inserted mid-file to reduce conflicts.
+
+## Deletion Candidates
+
+None — this change adds new functionality without making existing code redundant (it widens an existing gate and regex in place; the sole superseded artifact — the old "malformed chip not counted" unit case, whose input is now a genuine chip form — was already replaced within this change's own diff).
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Fix = optional-suffix regex + widen the gate from `multiline` to `collapsible`; NOVELTY baseline keeps chip-counting sound | Directly specified by the intake's What Changes and empirically grounded; strict-increase absorbs stale chips independent of the multiline property | S:95 R:90 A:95 D:95 |
+| 2 | Confident | `chatSendCollapseMinRunes = 200` (conservative lower bound, not the observed 801) | Intake-specified value; robust to upstream threshold reductions while keeping short interactive sends on exact-needle matching | S:75 R:90 A:85 D:70 |
+| 3 | Certain | Rename the threaded param `multiline` → `collapsible` in both functions and the test struct field | Semantics changed (no longer tests for newlines); keeping the old name would lie — code-quality naming rule | S:85 R:95 A:95 D:90 |
+| 4 | Confident | Handler test placed adjacent to `TestChatSendMultilinePlaceholderNovelty` (mid-file), not at EOF | Intake mandates mid-file insertion to reduce conflicts with sibling branch t9uk which appends at EOF | S:80 R:90 A:85 D:80 |
+
+4 assumptions (2 certain, 2 confident, 0 tentative).


### PR DESCRIPTION
## Meta

| Change ID | Type | Confidence | Plan | Review |
|-----------|------|------------|------|--------|
| `yxi0` | fix | 5.0/5.0 | 6/6 tasks, 12/12 acceptance ✓ | ✓ 1 cycle |

| Impact | +/− | Net |
|--------|----:|----:|
| raw | +532 / −70 | +462 |
| **true** | **+167 / −58** | **+109** |
| └ impl | +64 / −40 | +24 |
| └ tests | +103 / −18 | +85 |

<sub>excludes `fab/`, `docs/` · generated by fab-kit v2.16.3</sub>

**Pipeline:** intake ✓ → apply ✓ → review ✓ → hydrate ✓ → ship → review-pr

## Summary

Fixes a confirmed bug in the chat-send echo probe: Claude Code collapses a single-line paste over 800 chars into a suffix-less `[Pasted text #N]` chip (empirically verified, width-independent, CC 2.1.215), which the probe neither counted (its gate was multiline-only) nor matched (its regex required the `+M lines` suffix) — long single-line sends deterministically 409'd even though the paste reached the composer.

## Changes

- `app/backend/api/chat.go` — made the `+M lines` suffix optional in `pasteCollapseRe` so both chip forms match; widened the placeholder gate from `multiline` to `collapsible` (multiline OR ≥200 runes), threaded through `injectChatMessage` / `probeChatEcho` / `countProbeOccurrences` with updated comments
- `app/backend/api/chat_send_test.go` — new/extended unit and handler-level tests covering the suffix-less chip, the collapsible gate, and the stale-chip-in-baseline case for single-line sends
- `docs/memory/run-kit/chat.md` — updated send-path probe description; removed the stale "single-line pastes never collapse" claim
