### PR TITLE
docs: README leads with the full-toolkit install

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,10 @@ What makes it sing in 2026 is what you tend to run in those panes: **AI coding a
 ## Install
 
 ```sh
-curl -fsSL https://shll.ai/install | sh -s -- run-kit
-```
-
-Installs run-kit (plus the shll meta-CLI) via Homebrew, handling tap trust automatically. To install the entire shll toolkit instead:
-
-```sh
 curl -fsSL https://shll.ai/install | sh
 ```
+
+Installs the entire shll toolkit via Homebrew, handling tap trust automatically. run-kit relies on its sibling tools (`wt` for the riff worktree flow), so the full-toolkit install is the supported path.
 
 ## Quick start
 


### PR DESCRIPTION
run-kit does not work properly without the rest of the toolkit, so the per-tool subset install (`sh -s -- run-kit`) is the wrong default to advertise. The README now shows only the full-toolkit curl install and names the sibling-tool reliance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)