### PR TITLE
fix: lighten instance-accent titlebar wash to 35%

### DIFF
--- a/app/frontend/src/instance-accent.ts
+++ b/app/frontend/src/instance-accent.ts
@@ -31,9 +31,9 @@ export const INSTANCE_COLOR_STORAGE_KEY = "runkit-instance-color";
 export const INSTANCE_WASH_RATIO = 0.065;
 
 /** Ratio of the accent blended into the theme background for the PWA titlebar
- *  (theme-color meta) tint — mock parity ≈ 12% within the granted ~0.12–0.15
- *  band; a taste constant, trivially tunable. */
-export const INSTANCE_TITLEBAR_RATIO = 0.12;
+ *  (theme-color meta) tint — user-tuned to 35% (the mock-parity 12% read
+ *  nearly black); a taste constant, trivially tunable. */
+export const INSTANCE_TITLEBAR_RATIO = 0.35;
 
 export type InstanceColorEcho = { value: string; hex: string };
 


### PR DESCRIPTION
Follow-on to #436. The shipped 12% titlebar blend (mock parity) read nearly black in practice — the tint was barely distinguishable from the plain background. Raised `INSTANCE_TITLEBAR_RATIO` to 0.35, picked visually from a ratio-ladder mockup (12/18/22/28/35/100%) rendered with the production `blendHex` math across the three reference hues and both themes.

One constant + doc comment; stripe (full hue) and top-bar wash (6.5%) untouched. `tsc --noEmit` clean, both accent test files 16/16 (no test hardcodes the ratio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)