### PR TITLE
fix: Shorten Modifier-Chip Tips to Plain Key Names

### DIFF
--- a/app/frontend/src/components/bottom-bar.test.tsx
+++ b/app/frontend/src/components/bottom-bar.test.tsx
@@ -259,14 +259,16 @@ describe("BottomBar chip tips (260723-fm08)", () => {
     expect(kbd).toHaveTextContent("⌘K");
   });
 
-  it("modifier chips carry latch-describing tips and still toggle aria-pressed", () => {
+  it("modifier chips carry plain key-name tips and still toggle aria-pressed", () => {
     renderBottomBar({ onOpenCompose: vi.fn() });
     const ctrl = screen.getByLabelText("Control");
     act(() => {
       fireEvent.mouseEnter(ctrl);
       vi.advanceTimersByTime(TIP_OPEN_DELAY_MS);
     });
-    expect(screen.getByRole("tooltip")).toHaveTextContent("Ctrl for next key");
+    // Terminal vocabulary ("Ctrl"), not the mac aria-name ("Control") — and no
+    // latch prose: the pressed state teaches the one-shot behavior.
+    expect(screen.getByRole("tooltip")).toHaveTextContent(/^Ctrl$/);
 
     // The one-shot latch behavior survives the Tip wrap: clicking arms it.
     expect(ctrl).toHaveAttribute("aria-pressed", "false");

--- a/app/frontend/src/components/bottom-bar.tsx
+++ b/app/frontend/src/components/bottom-bar.tsx
@@ -65,12 +65,14 @@ const MODIFIER_LABELS: Record<string, string> = {
   alt: "Option",
 };
 
-/** Tier-1 tip copy for the modifier latch chips (260723-fm08): describes the
- *  verified one-shot latch — the armed modifier applies to the NEXT key sent
- *  (chip or physical keystroke) and is consumed. */
+/** Tier-1 tip copy for the modifier latch chips: plain key names in terminal
+ *  vocabulary ("Ctrl"/"Alt" — what the chip SENDS), while the aria-labels
+ *  above keep the mac key names matching the glyphs. The one-shot latch
+ *  behavior isn't spelled out — the pressed/accent state teaches it on first
+ *  tap, and every other chip tip likewise just names its key. */
 const MODIFIER_TIP_LABELS: Record<string, string> = {
-  ctrl: "Ctrl for next key",
-  alt: "Alt for next key",
+  ctrl: "Ctrl",
+  alt: "Alt",
 };
 
 /** Prevent mousedown from stealing focus away from the terminal. */


### PR DESCRIPTION
"Ctrl for next key" / "Alt for next key" → **"Ctrl"** / **"Alt"** (follow-up to #448, requested in review).

The latch prose was redundant: the pressed/accent state teaches the one-shot behavior on first tap, and every other chip tip just names its key ("Tab", "Function keys"). Tips keep terminal vocabulary — what the chip *sends* — while the aria-labels keep the mac key names ("Control"/"Option") matching the ^/⌥ glyphs for screen readers.

Gates: `tsc --noEmit` clean, bottom-bar Vitest 14/14.