### PR TITLE
fix: Uniform Bottom-Bar Chip Sizes — ArrowPad Trigger + E2E Guard

### DIFF
--- a/app/frontend/src/components/arrow-pad.tsx
+++ b/app/frontend/src/components/arrow-pad.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from "react";
+import { KBD_CLASS } from "@/components/kbd-chip";
 import { Tip } from "@/components/tip";
 
 /** Minimum drag distance (px) to register a swipe vs a tap. */
@@ -106,7 +107,7 @@ export function ArrowPad({ onArrow, className }: ArrowPadProps) {
           aria-label="Arrow keys"
           aria-haspopup="true"
           aria-expanded={open}
-          className="rk-glint h-8 w-8 flex items-center justify-center text-sm text-text-secondary border border-border rounded select-none transition-colors hover:border-text-secondary active:bg-bg-card focus-visible:outline-2 focus-visible:outline-accent touch-none"
+          className={`${KBD_CLASS} text-text-secondary touch-none`}
           onTouchStart={handleTouchStart}
           onTouchEnd={handleTouchEnd}
           onMouseDown={handleMouseDown}

--- a/app/frontend/src/components/bottom-bar.tsx
+++ b/app/frontend/src/components/bottom-bar.tsx
@@ -3,6 +3,7 @@ import { useModifierState, type ModifierSnapshot } from "@/hooks/use-modifier-st
 import { useFocusedTerminal } from "@/contexts/focused-terminal-context";
 import { useChromeState } from "@/contexts/chrome-context";
 import { ArrowPad } from "@/components/arrow-pad";
+import { KBD_CLASS } from "@/components/kbd-chip";
 import { Tip, TipGroup } from "@/components/tip";
 import { focusComposeStrip } from "@/lib/compose-strip-events";
 
@@ -47,12 +48,6 @@ const EXT_KEYS = [
   { label: "Ins", plain: "\x1b[2~", mod: (p: number) => `\x1b[2;${p}~` },
   { label: "Del", plain: "\x1b[3~", mod: (p: number) => `\x1b[3;${p}~` },
 ] as const;
-
-// Chip size splits by pointer: 33×35 on fine pointers (lighter bar, more air
-// between chips) while coarse pointers keep the full 36×36 touch target and
-// the tighter 4px gap so the 375px single-row budget is unchanged.
-const KBD_CLASS =
-  "rk-glint min-h-[33px] min-w-[35px] coarse:min-h-[36px] coarse:min-w-[36px] flex items-center justify-center px-1 py-0 text-xs border border-border rounded select-none transition-colors hover:border-text-secondary active:bg-bg-card focus-visible:outline-2 focus-visible:outline-accent";
 
 /** Long-press duration (ms) to toggle scroll-lock. */
 const LONG_PRESS_MS = 500;

--- a/app/frontend/src/components/kbd-chip.ts
+++ b/app/frontend/src/components/kbd-chip.ts
@@ -1,0 +1,9 @@
+// Shared class for every chip in the bottom bar — the BottomBar key chips and
+// the ArrowPad trigger. One constant so all chips render the same box
+// (uniformity is asserted by tests/e2e/bottom-bar-chip-size.spec.ts).
+//
+// Chip size splits by pointer: 33×35 on fine pointers (lighter bar, more air
+// between chips) while coarse pointers keep the full 36×36 touch target and
+// the tighter 4px gap so the 375px single-row budget is unchanged.
+export const KBD_CLASS =
+  "rk-glint min-h-[33px] min-w-[35px] coarse:min-h-[36px] coarse:min-w-[36px] flex items-center justify-center px-1 py-0 text-xs border border-border rounded select-none transition-colors hover:border-text-secondary active:bg-bg-card focus-visible:outline-2 focus-visible:outline-accent";

--- a/app/frontend/tests/e2e/bottom-bar-chip-size.spec.md
+++ b/app/frontend/tests/e2e/bottom-bar-chip-size.spec.md
@@ -1,0 +1,45 @@
+# bottom-bar-chip-size.spec.ts
+
+Uniform chip sizing in the bottom bar at mobile width: every visible button in
+the `Terminal keys` toolbar (Tab, `^`, `⌥`, `F▴`, the ArrowPad trigger, `>_`,
+`⌘K`, and the coarse-only `⌨` toggle) must render the exact same box. All chips
+share one class (`KBD_CLASS` in `src/components/kbd-chip.ts`); a chip that
+hardcodes its own size drifts — the ArrowPad trigger once shipped at 32×32
+(`h-8 w-8`) next to 36×36 neighbors and never grew to the touch target.
+
+## Shared setup
+
+- Viewport is iPhone 14-sized (375×812) in both describes via `test.use`.
+- The touch describe adds `hasTouch: true`, which flips Chromium's
+  `(pointer: coarse)` media query — activating the Tailwind `coarse:` variant
+  (the real 36×36 touch-target path) and revealing the coarse-only `⌨` chip.
+- Chips are measured by `collectChipSizes`: every button inside
+  `toolbar[name='Terminal keys']` via `getByRole` (accessibility-tree match, so
+  pointer-hidden chips are excluded automatically), bounding boxes rounded to
+  whole px. Popup contents (F▴ menu, arrow popup) stay closed and unmeasured.
+
+## Tests
+
+### `all chips share one size and meet the 36px touch target`
+
+**What it proves:** On a touch device at mobile width the chip row is visually
+uniform (one distinct width×height across all chips) and every chip meets the
+36px minimum touch target from `coarse:min-h/w-[36px]`.
+
+**Steps:**
+1. Navigate to `/${TMUX_SERVER}` with `hasTouch: true` at 375×812.
+2. Collect the size of every button in the `Terminal keys` toolbar.
+3. Assert the set of distinct `width×height` values has exactly one entry
+   (failure message lists every chip's label and size).
+4. Assert each chip's width and height is `≥ 36`.
+
+### `all chips share one size at mobile width`
+
+**What it proves:** The fine-pointer branch of the pointer split (33×35 chips)
+is just as uniform — a chip that hardcodes its own size diverges here even if
+the coarse branch happens to match.
+
+**Steps:**
+1. Navigate to `/${TMUX_SERVER}` at 375×812 (no touch emulation).
+2. Collect the size of every button in the `Terminal keys` toolbar.
+3. Assert the set of distinct `width×height` values has exactly one entry.

--- a/app/frontend/tests/e2e/bottom-bar-chip-size.spec.ts
+++ b/app/frontend/tests/e2e/bottom-bar-chip-size.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const TMUX_SERVER = process.env.E2E_TMUX_SERVER ?? "rk-test-e2e";
+// iPhone 14 viewport
+const MOBILE_VIEWPORT = { width: 375, height: 812 };
+
+/** Coarse-pointer touch target minimum (px) — KBD_CLASS `coarse:min-h/w-[36px]`. */
+const TOUCH_TARGET_MIN = 36;
+
+type ChipSize = { label: string; width: number; height: number };
+
+/**
+ * Measure every visible button in the bottom-bar toolbar. `getByRole` matches
+ * the accessibility tree, so chips hidden by the pointer split (the
+ * coarse-only ⌨ keyboard toggle on fine pointers) are excluded automatically.
+ * Sizes are rounded to whole px — the chips are integer-sized by design, and
+ * any real divergence (the pre-fix arrow trigger was 32px vs 36px) is ≥1px.
+ */
+async function collectChipSizes(page: Page): Promise<ChipSize[]> {
+  const toolbar = page.getByRole("toolbar", { name: "Terminal keys" });
+  await expect(toolbar).toBeVisible({ timeout: 10_000 });
+
+  const buttons = toolbar.getByRole("button");
+  const count = await buttons.count();
+  expect(count).toBeGreaterThan(0);
+
+  const sizes: ChipSize[] = [];
+  for (let i = 0; i < count; i++) {
+    const btn = buttons.nth(i);
+    const box = await btn.boundingBox();
+    expect(box, `button ${i} has no bounding box`).not.toBeNull();
+    sizes.push({
+      label: (await btn.getAttribute("aria-label")) ?? `button ${i}`,
+      width: Math.round(box!.width),
+      height: Math.round(box!.height),
+    });
+  }
+  return sizes;
+}
+
+function distinctSizes(sizes: ChipSize[]): string[] {
+  return [...new Set(sizes.map((s) => `${s.width}x${s.height}`))];
+}
+
+test.describe("Bottom bar chip size — touch device", () => {
+  // hasTouch flips Chromium's `(pointer: coarse)` media query, activating the
+  // Tailwind `coarse:` variant — the real mobile touch-target path.
+  test.use({ hasTouch: true, viewport: MOBILE_VIEWPORT });
+
+  test("all chips share one size and meet the 36px touch target", async ({
+    page,
+  }) => {
+    await page.goto(`/${TMUX_SERVER}`);
+    const sizes = await collectChipSizes(page);
+
+    expect(
+      distinctSizes(sizes),
+      `chips diverge: ${JSON.stringify(sizes)}`,
+    ).toHaveLength(1);
+
+    for (const s of sizes) {
+      expect(s.width, `${s.label} width below touch target`).toBeGreaterThanOrEqual(TOUCH_TARGET_MIN);
+      expect(s.height, `${s.label} height below touch target`).toBeGreaterThanOrEqual(TOUCH_TARGET_MIN);
+    }
+  });
+});
+
+test.describe("Bottom bar chip size — fine pointer", () => {
+  test.use({ viewport: MOBILE_VIEWPORT });
+
+  test("all chips share one size at mobile width", async ({ page }) => {
+    await page.goto(`/${TMUX_SERVER}`);
+    const sizes = await collectChipSizes(page);
+
+    expect(
+      distinctSizes(sizes),
+      `chips diverge: ${JSON.stringify(sizes)}`,
+    ).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

The ArrowPad trigger in the bottom bar hardcoded `h-8 w-8` (32×32), rendering smaller than every other chip (35×33 on fine pointers) and never growing to the 36×36 touch target under `pointer: coarse`. The shared `KBD_CLASS` chip class is extracted to `src/components/kbd-chip.ts` and the ArrowPad trigger now uses it, so all chips render one uniform box on both pointer branches.

A new e2e spec (`bottom-bar-chip-size.spec.ts` + companion `.spec.md`) guards this at 375×812: a touch-device test (`hasTouch: true` flips Chromium's `(pointer: coarse)`, activating the real `coarse:` variant) asserts all toolbar buttons share one size and meet the 36px touch target, and a fine-pointer test asserts uniformity on the 33×35 branch. Verified red on the old sizing, green on the fix; typecheck and all 1875 unit tests pass.