### PR TITLE
chore: Label Picker Marker Previews — Unmasked Hazard Weave + Dashed Data Rain

### DIFF
--- a/app/frontend/src/components/swatch-popover.test.tsx
+++ b/app/frontend/src/components/swatch-popover.test.tsx
@@ -434,8 +434,9 @@ describe("SwatchPopover", () => {
   // ── Combined Label picker: side-by-side marker column | hairline | paired
   //    color grid. Marker section gated on onSelectMarker alone; the non-∅
   //    cells are LIVE ROW PREVIEWS of the currently selected color (tint.base
-  //    background, guarded stripe with a 2px inset, paired texture) and never
-  //    animate. ──
+  //    background, guarded stripe with a 2px inset, paired texture) mirroring
+  //    the row's RESTING look — always-on rain animates, the selection crawl
+  //    never appears. ──
   describe("combined Label picker (side-by-side marker column)", () => {
     const tints = computeRowTints(DEFAULT_DARK_THEME.palette);
     const borders = computeRowBorders(DEFAULT_DARK_THEME.palette, DEFAULT_DARK_THEME.category);
@@ -590,25 +591,34 @@ describe("SwatchPopover", () => {
       expect(dotted.style.backgroundColor).toBe(rgb(tints.get(UNCOLORED_SELECTED_KEY)!.base));
     });
 
-    it("preview cells carry the paired STATIC row textures and never animate", () => {
+    it("preview cells carry the paired row textures (resting look) — never the selection crawl", () => {
       renderLabelPicker({ selectedColor: "green", selectedMarker: "double" });
       const listbox = screen.getByRole("listbox");
-      // Thick pairs with the hazard wedge; double with the scanline wash.
-      expect(
-        screen.getByRole("option", { name: "Marker thick" }).querySelector(".rk-hazard"),
-      ).not.toBeNull();
+      // Thick pairs with the hazard weave — with the preview modifier that
+      // drops the left-wedge mask (masked at 18px the weave fades out under
+      // the 6px stripe and is invisible); double with the scanline wash;
+      // dashed with the data rain (always-on on real rows — the resting look —
+      // so the preview carries it, animation included).
+      const hazard = screen
+        .getByRole("option", { name: "Marker thick" })
+        .querySelector(".rk-hazard");
+      expect(hazard).not.toBeNull();
+      expect((hazard as HTMLElement).classList.contains("rk-hazard-preview")).toBe(true);
       expect(
         screen.getByRole("option", { name: "Marker double" }).querySelector(".rk-scanlines"),
       ).not.toBeNull();
+      expect(
+        screen.getByRole("option", { name: "Marker dashed" }).querySelector(".rk-dash-rain"),
+      ).not.toBeNull();
       // Other cells carry no texture.
       expect(
-        screen.getByRole("option", { name: "Marker solid" }).querySelector(".rk-hazard, .rk-scanlines"),
+        screen
+          .getByRole("option", { name: "Marker solid" })
+          .querySelector(".rk-hazard, .rk-scanlines, .rk-dash-rain"),
       ).toBeNull();
-      // NEVER animated — even with double SELECTED, the crawl class is absent
-      // everywhere in the picker, and the dashed preview never carries the
-      // data-rain overlay (motion belongs to real rows only).
+      // The scanline crawl is SELECTED-STATE motion, not the resting look —
+      // absent everywhere in the picker even with double selected.
       expect(listbox.querySelector(".rk-scanlines-crawl")).toBeNull();
-      expect(listbox.querySelector(".rk-dash-rain")).toBeNull();
     });
 
     it("ArrowLeft crosses the hairline into the marker column; ArrowUp/Down move within it", () => {

--- a/app/frontend/src/components/swatch-popover.tsx
+++ b/app/frontend/src/components/swatch-popover.tsx
@@ -45,10 +45,13 @@ type SwatchPopoverProps = {
    *  background = that value's `tint.base` (gray sentinel when uncolored),
    *  stripe in the guarded border color with a 2px left inset (so the marker
    *  does not kiss the cell edge and the cell reads as a mini row), plus the
-   *  paired row texture (static hazard wedge on thick, static scanline wash on
-   *  double). Picking a different swatch repaints the marker column
-   *  immediately. PREVIEW CELLS NEVER ANIMATE — motion belongs to real rows
-   *  only; the double cell never gets the scanline crawl, even when selected.
+   *  paired row texture: hazard weave on thick (mask dropped via
+   *  rk-hazard-preview — the 18px cell reads as the row's full-strength left
+   *  corner), scanline wash on double, data rain on dashed. Picking a
+   *  different swatch repaints the marker column immediately. PREVIEWS MIRROR
+   *  THE ROW'S RESTING LOOK: the dashed rain animates (it is always-on on real
+   *  rows), but the double cell never gets the scanline crawl — that is
+   *  selected-state motion, absent even when double is selected.
    *  Selection calls `onSelectMarker` DIRECTLY (no cycling — any state is one
    *  click) with `""` clearing the marker. Keyboard nav crosses the hairline
    *  (ArrowLeft/Right). When `onSelectMarker` is ABSENT the component renders
@@ -309,8 +312,10 @@ export function SwatchPopover({
             thick beside the five color rows. Non-∅ cells are LIVE ROW PREVIEWS
             of the currently selected color: tint.base background (gray sentinel
             when uncolored), guarded-color stripe with a 2px left inset, and the
-            paired row texture (static scanline wash on double, static hazard
-            wedge on thick). NEVER animated — no rk-scanlines-crawl here. */}
+            paired row texture (scanline wash on double, hazard weave on thick,
+            data rain on dashed). Previews mirror the row's RESTING look — the
+            always-on rain animates, but never rk-scanlines-crawl (selected-
+            state motion) here. */}
         {showMarkers && (
           <>
             <div className="flex flex-col gap-[3px]">
@@ -341,13 +346,20 @@ export function SwatchPopover({
                         : undefined
                     }
                   >
-                    {/* Paired row texture — static only (preview cells never
-                        animate: no crawl class, even when double is selected). */}
+                    {/* Paired row texture — the row's RESTING look: the dashed
+                        rain animates (always-on on real rows), but no crawl
+                        class ever, even when double is selected. The thick
+                        cell drops the hazard's left-wedge mask (preview
+                        modifier) — masked at 18px the weave fades out under
+                        the 6px stripe and is invisible. */}
                     {state === "double" && (
                       <span aria-hidden="true" className="rk-scanlines absolute inset-0 pointer-events-none" />
                     )}
+                    {state === "dashed" && (
+                      <span aria-hidden="true" className="rk-dash-rain absolute inset-0 pointer-events-none" />
+                    )}
                     {state === "thick" && (
-                      <span aria-hidden="true" className="rk-hazard absolute inset-0 pointer-events-none" />
+                      <span aria-hidden="true" className="rk-hazard rk-hazard-preview absolute inset-0 pointer-events-none" />
                     )}
                     {/* Mini-row stripe: guarded color, 2px inset off the cell's
                         left edge so the marker doesn't kiss the boundary. */}

--- a/app/frontend/src/globals.css
+++ b/app/frontend/src/globals.css
@@ -445,6 +445,16 @@ summary {
   mask-image: linear-gradient(to right, #000 22%, transparent 55%);
 }
 
+/* Picker preview modifier (swatch-popover marker cells): the 18px cell stands
+   for the row's LEFT CORNER — entirely inside the wedge's full-strength zone —
+   so the preview drops the mask. Applied to the tiny cell itself, the wedge
+   mask would fade the weave out by ~10px, mostly under the 6px thick stripe,
+   leaving it invisible. Still static — the no-animation rule above holds. */
+.rk-hazard-preview::before {
+  -webkit-mask-image: none;
+  mask-image: none;
+}
+
 /* ── Dashed-marker data rain (260723, ALWAYS-ON) ─────────────────────────────
    A window row whose left-gutter marker is `dashed` carries a "data rain":
    two sparse 1px dash tracks streaming LEFT→RIGHT across the row's full
@@ -463,7 +473,9 @@ summary {
    the keyframes displace each layer by an integer multiple of its own period
    (72 = 2×36, 56 = 2×28), so the cycle point is invisible.
    background-position only — never transform (the drag-ghost rule). The
-   picker's marker preview cells never carry it.
+   picker's dashed marker preview cell carries it too — the rain IS the dashed
+   row's resting look, so the mini-row preview animates with it (unlike the
+   selection-gated scanline crawl, which never enters the picker).
 
    ORDER MATTERS: precedes the reduced-motion block so its override wins by
    source order (the rain is motion-only and hides entirely there — the static

--- a/app/frontend/src/themes.ts
+++ b/app/frontend/src/themes.ts
@@ -454,9 +454,9 @@ export const UNCOLORED_SELECTED_KEY = `${UNCOLORED_SELECTED_ANSI}`;
  *  set (validate.MarkerValues) minus the empty string, with `""` at the front
  *  followed by the display order dotted → dashed → solid → double → thick.
  *  `dashed` ("working") and `thick` ("completed") are LABEL CONVENTIONS only —
- *  no wiring to @rk_agent_state or the status pyramid, and no marker state is
- *  ever animated (the shipped double-marker selection crawl stays the label
- *  system's only motion). */
+ *  no wiring to @rk_agent_state or the status pyramid. The stripe itself never
+ *  animates; the label system's only motion is the row-overlay pair — the
+ *  always-on dashed data rain and the double selection crawl. */
 export const MARKER_STATES = ["", "dotted", "dashed", "solid", "double", "thick"] as const;
 
 /** Inline style rendering a marker state as a left-edge stripe in the given


### PR DESCRIPTION
## Summary

The Label picker's marker preview cells now show all three paired row textures: the thick cell's hazard weave was already mounted but invisible at 18px (its left-wedge mask faded out under the 6px stripe — a preview modifier now drops the mask), and the dashed cell gains the always-on data rain that real dashed rows carry (#455). This refines the preview contract from "never animate" to "mirror the row's resting look" — the rain animates, the selection-gated scanline crawl still never enters the picker.