### PR TITLE
docs: intakes for shell keyboard-tier symmetry + desktop win/linux packaging

### DIFF
--- a/fab/changes/260730-9lez-shell-keyboard-tier-symmetry/.history.jsonl
+++ b/fab/changes/260730-9lez-shell-keyboard-tier-symmetry/.history.jsonl
@@ -1,0 +1,3 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-07-30T07:32:59Z"}
+{"args":"Shell keyboard-tier symmetry: Shift+CmdOrCtrl+1-9 server switcher, two-tier accelerator rule, command-palette server switching via bridge","cmd":"fab-new","event":"command","ts":"2026-07-30T07:32:59Z"}
+{"delta":"+4.5","event":"confidence","score":4.5,"trigger":"calc-score","ts":"2026-07-30T07:36:32Z"}

--- a/fab/changes/260730-9lez-shell-keyboard-tier-symmetry/.status.yaml
+++ b/fab/changes/260730-9lez-shell-keyboard-tier-symmetry/.status.yaml
@@ -1,0 +1,36 @@
+id: 9lez
+name: 260730-9lez-shell-keyboard-tier-symmetry
+created: 2026-07-30T07:32:59Z
+created_by: sahil-noon
+change_type: feat
+issues: []
+progress:
+    intake: ready
+    apply: pending
+    review: pending
+    hydrate: pending
+    ship: pending
+    review-pr: pending
+plan:
+    generated: false
+    task_count: 0
+    acceptance_count: 0
+    acceptance_completed: 0
+confidence:
+    certain: 4
+    confident: 4
+    tentative: 0
+    unresolved: 0
+    score: 4.5
+    fuzzy: true
+    dimensions:
+        signal: 73.1
+        reversibility: 81.9
+        competence: 80.6
+        disambiguation: 78.1
+stage_metrics:
+    intake: {started_at: "2026-07-30T07:32:59Z", driver: fab-new, iterations: 1}
+prs: []
+change_type_source: explicit
+# true_impact: lazily created on first stage-finish that computes it (no placeholder here).
+last_updated: 2026-07-30T07:36:42Z

--- a/fab/changes/260730-9lez-shell-keyboard-tier-symmetry/intake.md
+++ b/fab/changes/260730-9lez-shell-keyboard-tier-symmetry/intake.md
@@ -1,0 +1,96 @@
+# Intake: Shell Keyboard-Tier Symmetry
+
+**Change**: 260730-9lez-shell-keyboard-tier-symmetry
+**Created**: 2026-07-30
+
+## Origin
+
+Conversational — emerged from a `/fab-discuss` session about porting the desktop shell (`app/desktop`, shipped in 260728-04pg) to Windows/Linux. The user set the governing principle and picked the switcher direction:
+
+> The best case is to have symmetry between Windows - MacOS. Whatever is Cmd+\<ANY\> for Mac can be Ctrl+\<ANY\> for Windows. So keeping this in mind, Ctrl+1 / 2 aren't available to switch between servers. The switch can be done directly by the menu entry "Servers" - OR - can be Cmd/Ctrl + SHIFT + \<NUM\>. Thoughts?
+
+The agent recommended `Shift+CmdOrCtrl+1–9` (keeping the menu radios as the mouse path) and proposed a two-tier accelerator rule; it also suggested exposing server switching through the SPA command palette via the existing `runkitShell` bridge. The user confirmed:
+
+> yes, it can be exposed via the command palette, we should definitely do that.
+
+Scope note: this change covers **everything except cross-platform packaging** — the accelerator migration, the tier rule, and the palette integration, all landing on the current (macOS-only) shell. The actual Windows/Linux build targets and CI are a separate change: `260730-ler1-desktop-windows-linux-packaging`, which depends on this one.
+
+## Why
+
+1. **The current switcher binding blocks the cross-platform premise.** The Servers switcher binds literal `Ctrl+1–9` — deliberately chosen on macOS *because* it leaves ⌘1–9 free for the page. On Windows/Linux the browser-reserved tier the shell exists to liberate is the **Ctrl** tier, so `Ctrl+1–9` would steal exactly the keys the shell's premise promises to the SPA. The binding must move before (or together with) any Windows/Linux build.
+2. **The ⌘-tier seam is stated in macOS-specific terms.** The shell's key contract ("do not bind accelerators on keys the page should own"; guaranteed fall-through set includes "all unlisted ⇧⌘ combos") is written against macOS keys. Restating it platform-neutrally — as a two-tier rule expressed with `CmdOrCtrl` — makes the same accelerator table and the same documented contract valid on every platform, instead of per-platform hand-tuning.
+3. **Keyboard-first demands a keyboard path everywhere (Constitution V).** Server switching should be reachable from the SPA's primary discovery mechanism, the command palette (`Cmd+K`), not only via a shell accelerator chord and a native menu. The `window.runkitShell` bridge already exists as the SPA↔shell seam; extending it is the designed-for path.
+
+If we don't do this: the cross-platform change either ships a shell that undermines its own keyboard-first premise on Windows/Linux, or blocks on this design work anyway — and macOS users keep a switcher chord that has no discoverable palette equivalent.
+
+## What Changes
+
+### 1. Two-tier accelerator rule (the contract)
+
+Replace the macOS-specific fall-through contract with a platform-neutral two-tier rule, documented in the `menu.ts` header comment (the existing home of the seam rationale):
+
+- **Page tier — unshifted `CmdOrCtrl+<any>`**: the shell NEVER binds it, on any platform. This is the shell's premise, stated platform-neutrally. (macOS: ⌘-tier; Windows/Linux: Ctrl-tier.)
+- **Shell tier — `Shift+CmdOrCtrl+<any>`**: shell chrome MAY claim keys here, sparingly. Today the only claim is the Servers switcher (1–9).
+
+The guaranteed fall-through promise narrows accordingly: from "all unlisted ⇧⌘ combos" to "the unshifted Cmd/Ctrl tier is inviolable; the shifted tier is shell-claimable". The existing rule that a menu-bound key the SPA later needs is fixed by *un-binding the accelerator, never by intercepting input events* is unchanged.
+
+Platform carve-outs the rule tolerates (documented alongside it, not silently violated):
+
+- macOS Edit roles (⌘Z/⇧⌘Z/⌘X/⌘C/⌘V/⌘A) stay — clipboard in web content is dead on macOS without them. This is a macOS quirk, not part of the cross-platform rule; on Windows/Linux Chromium handles these natively and the equivalent accelerators are NOT bound (that application lands in the cross-platform change).
+- View/App-menu accelerators (⌘R, ⌥⌘I, zoom roles, etc.) keep their current bindings; they are conventional shell chrome and predate the rule.
+
+### 2. Servers switcher migration: `Ctrl+1–9` → `Shift+CmdOrCtrl+1–9` (`src/menu.ts`)
+
+- The Servers radio items move from literal `Ctrl+1…Ctrl+9` to `Shift+CmdOrCtrl+1…9` (⇧⌘1–9 on macOS today).
+- The old `Ctrl+1–9` bindings are **dropped entirely** — one accelerator table, one documented rule, no legacy alias. The feature shipped 2026-07-28; there is no meaningful muscle-memory install base to migrate.
+- Menu radios remain as the mouse path — the accelerator and the menu entry are the same item, not alternatives.
+- Accelerators throughout `menu.ts` are expressed with `CmdOrCtrl` (except the deliberate macOS-only carve-outs above), so the identical table is correct when the Windows/Linux build lands. Zero behavior change on macOS from this re-expression alone.
+
+### 3. Command-palette server switching via the bridge (`src/preload.ts`, `src/main.ts`, `app/frontend/src/lib/shell.ts`, palette registration)
+
+Extend the `window.runkitShell` bridge so the SPA palette can list and switch servers:
+
+- **Preload**: expose a `servers` group — `list()` returning `{ id, name, url, active }[]` and `switch(id)` — as thin `ipcRenderer.invoke` wrappers (new `servers:*` channels), following the existing `__welcome` wrapper pattern.
+- **Main**: `servers:list` / `servers:switch` handlers. Sender-frame gating follows the established trust-boundary pattern, with a different allowlist than `welcome:*`: these channels are privileged for **registered server origins** (the pages that host the palette) and the welcome page — any other sender gets `{ ok: false, error: "Not allowed" }`. `switch` resolves via the existing store functions (set active, rebuild menu, `loadURL`), reusing the same code path as the menu radio callback. IPC payloads structurally validated in main before use, per the existing pattern.
+- **SPA** (`app/frontend/src/lib/shell.ts`): extend the structural narrowing to the new bridge surface (typed as `unknown`, narrowed by guards — no `as` casts, per the existing pattern), still never leaking `__welcome`. Update `shell.test.ts` for present/absent/malformed shapes of the new surface.
+- **Palette**: register `Server: Switch to "<name>"` commands (one per registered server, active one indicated), gated on `isShell()` — outside the shell the commands are absent. This is the first real consumer of `isShell()`. Per the project review rules, the new commands are documented in the palette registration.
+- Palette scope v1 is **switch only** — Add/Remove Server stay in the native menu + welcome flow.
+
+### 4. Verify-on-hardware additions
+
+Shifted-digit accelerators are the flakiest accelerator class (AZERTY digits already require Shift; Electron resolves accelerators by character, not scancode). Add ⇧⌘1–9 switching on a non-US layout to the existing manual verification list (alongside xterm ⌘C/⌘V interplay and ⌘-fall-through feel). No scancode workaround is attempted in v1.
+
+## Affected Memory
+
+- `run-kit/desktop-shell`: (modify) ⌘-tier seam section becomes the two-tier `CmdOrCtrl` rule; switcher accelerator ⌃1–9 → ⇧⌘1–9; bridge section gains the `servers` group + its origin-gating; fall-through contract narrowed; verify-on-hardware list extended
+- `run-kit/ui-patterns`: (modify) command palette gains the shell-gated `Server: Switch` commands — the first `isShell()` consumer (§ Keyboard Shortcuts cross-reference)
+
+## Impact
+
+- `app/desktop/src/menu.ts` — accelerator table, header-comment contract
+- `app/desktop/src/preload.ts` — `servers` bridge group
+- `app/desktop/src/main.ts` — `servers:*` IPC handlers, sender-frame gating, switch path reuse
+- `app/desktop/src/servers.ts` — possibly a small read helper; store logic otherwise unchanged
+- `app/frontend/src/lib/shell.ts` + `shell.test.ts` — bridge narrowing + tests
+- Frontend command-palette registration — new shell-gated commands
+- Tests: node:test for any store-level additions; vitest for `shell.ts`; palette unit test if the registration file has one. Accelerator behavior and non-US layouts are hardware-verify items, not CI-testable.
+- Sequencing: `260730-ler1-desktop-windows-linux-packaging` depends on this change landing first (or in the same release) — without it, Ctrl+1–9 collides with the page tier on Windows/Linux.
+
+## Open Questions
+
+- None blocking. (Palette Add/Remove Server, and whether the switcher should also get palette-visible ⇧⌘N hint text, are deferred as v1 scope decisions recorded in Assumptions.)
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Two-tier rule: page tier = unshifted `CmdOrCtrl` (never bound), shell tier = `Shift+CmdOrCtrl` (claimable sparingly) | Discussed — user set the Cmd↔Ctrl symmetry principle; the tier rule is its direct restatement | S:90 R:70 A:90 D:90 |
+| 2 | Certain | Switcher chord is `Shift+CmdOrCtrl+1–9`; menu radios stay as the mouse path | Discussed — user proposed this exact option ("Cmd/Ctrl + SHIFT + \<NUM\>"); agent recommended it over menu-only (Constitution V) | S:90 R:85 A:85 D:85 |
+| 3 | Confident | Old ⌃1–9 bindings dropped entirely — no legacy alias on macOS | Recommended in discussion, unchallenged; feature is days old, trivially reversible, one accelerator table is the cleaner contract | S:60 R:90 A:75 D:70 |
+| 4 | Certain | Server switching exposed via the SPA command palette through the `runkitShell` bridge | Discussed — user: "we should definitely do that" | S:95 R:80 A:85 D:90 |
+| 5 | Confident | Bridge shape: `servers.list()`/`servers.switch(id)` invokers, main-side sender-frame gating allowlisting registered server origins + welcome | Not discussed in detail; follows the established `__welcome` pattern and the one-authoritative-check-in-main decision | S:55 R:75 A:85 D:75 |
+| 6 | Confident | Palette scope v1 is switch-only; Add/Remove Server remain menu + welcome flow | Not discussed; minimal-surface default (Constitution IV), easily extended later | S:50 R:85 A:70 D:65 |
+| 7 | Confident | Non-US-layout risk handled by hardware-verify listing, no scancode workaround in v1 | Raised in discussion as a caveat to carry, not a blocker; workaround complexity unjustified before a repro | S:70 R:80 A:70 D:70 |
+| 8 | Confident | All portable accelerators re-expressed as `CmdOrCtrl` now (macOS-only carve-outs stay explicit), zero mac behavior change | Direct prep for the dependent cross-platform change; inert on today's mac-only build | S:75 R:90 A:85 D:80 |
+
+8 assumptions (3 certain, 5 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260730-ler1-desktop-windows-linux-packaging/.history.jsonl
+++ b/fab/changes/260730-ler1-desktop-windows-linux-packaging/.history.jsonl
@@ -1,0 +1,3 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-07-30T07:33:29Z"}
+{"args":"Cross-platform desktop shell: Windows and Linux packaging plus release CI for the Electron viewer shell","cmd":"fab-new","event":"command","ts":"2026-07-30T07:33:29Z"}
+{"delta":"+4.2","event":"confidence","score":4.2,"trigger":"calc-score","ts":"2026-07-30T07:36:32Z"}

--- a/fab/changes/260730-ler1-desktop-windows-linux-packaging/.status.yaml
+++ b/fab/changes/260730-ler1-desktop-windows-linux-packaging/.status.yaml
@@ -1,0 +1,36 @@
+id: ler1
+name: 260730-ler1-desktop-windows-linux-packaging
+created: 2026-07-30T07:33:29Z
+created_by: Sahil Ahuja
+change_type: feat
+issues: []
+progress:
+    intake: ready
+    apply: pending
+    review: pending
+    hydrate: pending
+    ship: pending
+    review-pr: pending
+plan:
+    generated: false
+    task_count: 0
+    acceptance_count: 0
+    acceptance_completed: 0
+confidence:
+    certain: 2
+    confident: 6
+    tentative: 0
+    unresolved: 0
+    score: 4.2
+    fuzzy: true
+    dimensions:
+        signal: 56.9
+        reversibility: 82.5
+        competence: 79.4
+        disambiguation: 75.6
+stage_metrics:
+    intake: {started_at: "2026-07-30T07:33:29Z", driver: fab-new, iterations: 1}
+prs: []
+change_type_source: explicit
+# true_impact: lazily created on first stage-finish that computes it (no placeholder here).
+last_updated: 2026-07-30T07:36:42Z

--- a/fab/changes/260730-ler1-desktop-windows-linux-packaging/intake.md
+++ b/fab/changes/260730-ler1-desktop-windows-linux-packaging/intake.md
@@ -1,0 +1,87 @@
+# Intake: Desktop Shell Windows & Linux Packaging
+
+**Change**: 260730-ler1-desktop-windows-linux-packaging
+**Created**: 2026-07-30
+
+## Origin
+
+Conversational — from a `/fab-discuss` session. The user asked:
+
+> How difficult is it to generate the electron app for Windows and Linux also?
+
+Assessment during discussion: mechanically easy — the shell (`app/desktop`, shipped 260728-04pg) is a pure viewer with zero native dependencies (three devDeps, `npmRebuild: false`, no `child_process`), which is the best-case Electron portability profile — but the keyboard seam doesn't translate as-is. The user then set the governing principle ("Whatever is Cmd+\<ANY\> for Mac can be Ctrl+\<ANY\> for Windows") and the seam redesign was split into its own change: **`260730-9lez-shell-keyboard-tier-symmetry`, which this change depends on**. This intake covers ONLY the cross-platform build: packaging targets, per-platform menu application, build scripts, and release CI.
+
+## Why
+
+1. **The shell is macOS-only by packaging, not by architecture.** Nothing in the viewer-shell design is Mac-specific — it loads an `rk serve` URL over HTTP; `runkitShell.platform` already exposes `process.platform`. Users on Windows or Linux desktops get the same browser keyboard ceiling the shell exists to remove (browser-reserved Ctrl-tier there), and currently have no shell at all.
+2. **User-set symmetry principle**: the product intent is Cmd-on-Mac ↔ Ctrl-on-Windows parity — one keyboard contract across platforms, which requires actual Windows/Linux builds to be real.
+3. **Cheap to do now**: `electron-builder` already drives the mac DMG pipeline; Windows/Linux are additional targets on the same tool, additive CI jobs on the same release workflow, and the artifact/version conventions are already established (`run-kit-desktop-{version}-{arch}.{ext}`, version from the release job's output).
+
+If we don't: the keyboard-tier symmetry work (9lez) has no consumer beyond macOS, and non-Mac users are stuck with the browser tab and its reserved-key ceiling.
+
+## What Changes
+
+### 1. electron-builder targets (`app/desktop/electron-builder.yml`)
+
+- **Windows**: NSIS installer, x64. Artifact `run-kit-desktop-${version}-${arch}.${ext}` (naming convention unchanged).
+- **Linux**: AppImage + deb, x64 and arm64. Same artifact naming.
+- macOS config untouched.
+- **Signing posture mirrors the mac decision**: Windows ships unsigned — the accepted cost is a SmartScreen "unrecognized app" first-launch dialog, the same personal-infra posture as the mac ad-hoc signing (no Developer ID, no notarization there; no Authenticode here). Linux requires no signing. The `after-pack.js` ad-hoc codesign hook stays mac-only (guard on `electronPlatformName`).
+
+### 2. Per-platform menu application (`app/desktop/src/menu.ts`)
+
+Builds on the two-tier `CmdOrCtrl` table from 9lez (hard dependency — without it, the switcher's old Ctrl+1–9 binding steals the page tier on Windows/Linux):
+
+- **Edit roles omitted on Windows/Linux**: the ⌘Z/X/C/V/A menu roles exist because clipboard in web content is dead on macOS without them — a macOS quirk. Chromium handles Ctrl+C/V/X/A/Z natively on Windows/Linux, so those accelerators are NOT bound there and the page tier stays completely clean. Symmetry of rule, not symmetry of accelerator table.
+- **App-menu / window-menu variants**: the macOS App menu (⌘Q/⌘H/⌥⌘H) and custom Window template are mac-only shapes; Windows/Linux get the conventional minimal equivalents (File → Quit, no hide roles) without binding anything in the page tier.
+- `window-all-closed` already quits on non-mac — no change.
+
+### 3. Build scripts (`scripts/build-desktop.sh`, `justfile`)
+
+- `build-desktop.sh` is currently Mac-only (hard `--mac` + icon check). Extend to platform-branching (`--mac`/`--win`/`--linux` per host platform, or an explicit target argument) while keeping the justfile recipe a one-liner (Constitution VIII). Version injection via `--config.extraMetadata.version` is platform-neutral and unchanged.
+- Icons: the committed 1024px `build/icon.png` is sufficient source material — electron-builder derives the Windows `.ico` and uses the png directly for Linux. No new committed assets expected; `scripts/generate-icons.sh` untouched unless the ico derivation proves lossy.
+
+### 4. Release CI (`.github/workflows/release.yml`)
+
+Two additive jobs mirroring `desktop-macos` (needs: release, version from the release job's output, frozen deps under Node 22, `--publish never`, `gh release upload --clobber`):
+
+- **`desktop-linux`** on `ubuntu-latest` — AppImage + deb, x64 + arm64.
+- **`desktop-windows`** on `windows-latest` — NSIS x64. Native runner rather than wine cross-compilation: cleaner, and runner minutes are not a constraint here.
+- The codesign verification hard-gate stays mac-only (the ad-hoc signature is a macOS launch requirement; there is no equivalent invariant to assert on the other platforms).
+
+### 5. Verification split
+
+Compile/tsc/node:test/vitest remain Linux-CI-runnable. New hardware-verify items: Windows first-launch SmartScreen walkthrough, Linux AppImage launch on a real distro, and the Ctrl+C/Ctrl+V ↔ xterm.js interplay on Windows/Linux (the equivalent of the existing mac ⌘C/⌘V item — load-bearing in a terminal product, and untestable in CI).
+
+## Affected Memory
+
+- `run-kit/desktop-shell`: (modify) packaging section gains win/linux targets + signing posture; menu seam gains the per-platform application (Edit-role omission); verification split extended
+- `run-kit/architecture`: (modify) release flow / CI section gains the `desktop-linux` and `desktop-windows` jobs
+
+## Impact
+
+- `app/desktop/electron-builder.yml`, `app/desktop/after-pack.js` (platform guard)
+- `app/desktop/src/menu.ts` (per-platform table application; the contract itself comes from 9lez)
+- `scripts/build-desktop.sh`, `justfile`
+- `.github/workflows/release.yml`
+- Release surface: each tagged release grows from 2 desktop assets to ~6 (mac arm64/x64 DMG, linux x64/arm64 AppImage + deb, win x64 exe)
+- **Dependency**: `260730-9lez-shell-keyboard-tier-symmetry` must land first (or in the same release). Sequencing is a hard ordering constraint, not a soft preference.
+
+## Open Questions
+
+- Is Windows arm64 worth a target now, or wait for demand? (Deferred — x64-only assumed below; adding it later is a config-line change.)
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Both Windows AND Linux are in scope | Discussed — the user's question named both; the symmetry principle names Windows explicitly | S:90 R:80 A:90 D:90 |
+| 2 | Certain | Hard dependency on 9lez (keyboard-tier symmetry) landing first | Discussed — shipping win/linux with the old Ctrl+1–9 switcher contradicts the shell's premise on those platforms | S:85 R:70 A:90 D:90 |
+| 3 | Confident | Windows ships unsigned; SmartScreen friction accepted | Discussed — mirrors the established mac ad-hoc posture (no notarization) for a personal-infra tool | S:70 R:80 A:80 D:75 |
+| 4 | Confident | Edit-role accelerators omitted on Windows/Linux (Chromium native clipboard); page tier fully clean there | Discussed — "symmetry of rule, not symmetry of accelerator table" | S:70 R:85 A:80 D:80 |
+| 5 | Confident | Linux formats: AppImage + deb | Not discussed; AppImage is the zero-install default, deb covers the Debian/Ubuntu majority — clear front-runner pair, config-level reversible | S:30 R:85 A:70 D:60 |
+| 6 | Confident | Windows format: NSIS installer, x64 only | Not discussed; electron-builder's default Windows target, matches user expectations; win-arm64 deferred as an open question | S:30 R:85 A:75 D:70 |
+| 7 | Confident | Linux arch coverage: x64 + arm64 | Not discussed; mirrors the per-arch convention of the rk binaries and mac DMGs; cheap on ubuntu runners | S:25 R:85 A:65 D:60 |
+| 8 | Confident | Native runners (windows-latest / ubuntu-latest), no wine cross-compilation | Not discussed; simplest correct CI shape, mirrors desktop-macos job structure | S:55 R:90 A:85 D:80 |
+
+8 assumptions (2 certain, 6 confident, 0 tentative, 0 unresolved).


### PR DESCRIPTION
Two drafted fab intakes (created via `/fab-draft`, neither activated) from a `/fab-discuss` session on bringing the Electron desktop shell to Windows and Linux. Intakes only — no implementation.

## 260730-9lez-shell-keyboard-tier-symmetry (confidence 4.5/5.0)

Everything except the cross-platform build itself, landing on the current macOS-only shell:

- **Two-tier accelerator rule**: page tier = unshifted `CmdOrCtrl+<any>` (shell never binds it, any platform); shell tier = `Shift+CmdOrCtrl+<any>` (claimable sparingly)
- **Servers switcher migration**: `Ctrl+1–9` → `Shift+CmdOrCtrl+1–9`, old bindings dropped; menu radios stay as the mouse path
- **Command-palette server switching** via a new `runkitShell.servers` bridge group (`list`/`switch`, sender-frame-gated in main) — the first real `isShell()` consumer

## 260730-ler1-desktop-windows-linux-packaging (confidence 4.2/5.0)

Only the cross-platform build; **hard dependency on 9lez** (the old `Ctrl+1–9` switcher would steal the page tier on Windows/Linux):

- electron-builder targets: Windows NSIS x64 (unsigned, SmartScreen friction accepted — mirrors the mac ad-hoc posture); Linux AppImage + deb, x64 + arm64
- Per-platform menu application: Edit-role accelerators omitted on win/linux (Chromium handles clipboard natively — page tier fully clean)
- `build-desktop.sh` platform-branching; additive `desktop-linux` / `desktop-windows` release-CI jobs mirroring `desktop-macos`

🤖 Generated with [Claude Code](https://claude.com/claude-code)