### PR TITLE
fix: desktop win/linux release jobs — deb homepage + cmd-safe compile script

### DIFF
--- a/app/desktop/package.json
+++ b/app/desktop/package.json
@@ -3,15 +3,15 @@
   "version": "0.0.0",
   "private": true,
   "description": "run-kit desktop viewer shell — loads an existing rk serve URL (client only, never spawns or supervises the daemon)",
+  "homepage": "https://github.com/sahil87/run-kit",
   "main": "dist/main.js",
   "engines": {
     "node": ">=22.12.0"
   },
   "scripts": {
-    "compile": "tsc && mkdir -p dist/welcome && cp src/welcome/welcome.html dist/welcome/",
+    "compile": "tsc && node -e \"fs.mkdirSync('dist/welcome',{recursive:true});fs.copyFileSync('src/welcome/welcome.html','dist/welcome/welcome.html')\"",
     "test": "node --test \"dist/**/*.test.js\"",
-    "dev": "pnpm run compile && electron .",
-    "dist": "electron-builder --mac --publish never"
+    "dev": "pnpm run compile && electron ."
   },
   "pnpm": {
     "onlyBuiltDependencies": [


### PR DESCRIPTION
Fixes the two desktop job failures on the [v3.12.5 release run](https://github.com/sahil87/run-kit/actions/runs/30529283462) (both jobs new in #471):

## desktop-linux — `Please specify project homepage`

electron-builder's fpm (**deb**) target hard-requires a project `homepage` in `package.json`; the desktop package had none (the error fired twice — once per deb arch). Added `"homepage": "https://github.com/sahil87/run-kit"`.

**Verified** with a full local linux build (`scripts/build-desktop.sh linux`): all four artifacts now build — `run-kit-desktop-3.12.5-x86_64.AppImage`, `-amd64.deb`, `-arm64.AppImage`, `-arm64.deb`.

## desktop-windows — `The syntax of the command is incorrect`

pnpm executes package scripts through **cmd.exe** on Windows — the workflow step's `shell: bash` does not reach inside `pnpm run compile` — so the script's `mkdir -p … && cp …` is invalid syntax there. Rewrote the welcome-page copy as a cmd-safe, cross-platform `node -e` one-liner (double-quoted for cmd; verified locally: compile + node:test 30/30).

## Also

Removed the dead `dist` script (hard-coded `--mac`, zero call sites) — flagged as a deletion candidate in #471's review.

Follow-up worth considering (not in scope): electron-builder warns that `desktopName` is unset, so Linux desktop environments may not associate running windows with the `.desktop` entry (taskbar grouping/icon) — needs verification on a real distro.