### PR TITLE
docs: intakes for keyboard shortcut registry + macro riff bindings

### DIFF
--- a/fab/changes/260730-g40a-keyboard-shortcut-registry-overlay/.history.jsonl
+++ b/fab/changes/260730-g40a-keyboard-shortcut-registry-overlay/.history.jsonl
@@ -1,0 +1,3 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-07-30T11:20:41Z"}
+{"args":"keyboard shortcut registry + Shift+CmdOrCtrl tier (B) + cheatsheet overlay + per-device overrides (from /fab-discuss session)","cmd":"fab-new","event":"command","ts":"2026-07-30T11:20:41Z"}
+{"delta":"+4.6","event":"confidence","score":4.6,"trigger":"calc-score","ts":"2026-07-30T11:23:56Z"}

--- a/fab/changes/260730-g40a-keyboard-shortcut-registry-overlay/.status.yaml
+++ b/fab/changes/260730-g40a-keyboard-shortcut-registry-overlay/.status.yaml
@@ -1,0 +1,35 @@
+id: g40a
+name: 260730-g40a-keyboard-shortcut-registry-overlay
+created: 2026-07-30T11:20:41Z
+created_by: sahil-noon
+change_type: refactor
+issues: []
+progress:
+    intake: ready
+    apply: pending
+    review: pending
+    hydrate: pending
+    ship: pending
+    review-pr: pending
+plan:
+    generated: false
+    task_count: 0
+    acceptance_count: 0
+    acceptance_completed: 0
+confidence:
+    certain: 6
+    confident: 4
+    tentative: 0
+    unresolved: 0
+    score: 4.6
+    fuzzy: true
+    dimensions:
+        signal: 72.5
+        reversibility: 84.5
+        competence: 85.5
+        disambiguation: 81.0
+stage_metrics:
+    intake: {started_at: "2026-07-30T11:20:41Z", driver: fab-new, iterations: 1}
+prs: []
+# true_impact: lazily created on first stage-finish that computes it (no placeholder here).
+last_updated: 2026-07-30T11:24:00Z

--- a/fab/changes/260730-g40a-keyboard-shortcut-registry-overlay/design-mock.html
+++ b/fab/changes/260730-g40a-keyboard-shortcut-registry-overlay/design-mock.html
@@ -1,0 +1,365 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Shortcuts: keyboard — run-kit</title>
+<style>
+  :root, html[data-theme="dark"] {
+    color-scheme: dark;
+    --bg-primary: #0f1117; --bg-card: #171b24; --bg-inset: #0a0c12;
+    --text-primary: #e8eaf0; --text-secondary: #7a8394;
+    --border: #454d66; --accent: #5b8af0; --accent-bright: #82a8f7; --green: #22c55e;
+    --amber: #d97706; --red: #ef4444;
+  }
+  html[data-theme="light"] {
+    color-scheme: light;
+    --bg-primary: #f8f9fb; --bg-card: #ffffff; --bg-inset: #e8eaef;
+    --text-primary: #1a1d24; --text-secondary: #6b7280;
+    --border: #d1d5db; --accent: #4a7ae8; --accent-bright: #3b66d6; --green: #16a34a;
+    --amber: #b45309; --red: #dc2626;
+  }
+  * { box-sizing: border-box; margin: 0; }
+  body {
+    font-family: "MonaspiceNe Nerd Font Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    background: var(--bg-primary); color: var(--text-primary);
+    font-size: 13px; line-height: 1.5; min-height: 100vh;
+    display: flex; align-items: flex-start; justify-content: center;
+    padding: 28px 16px 60px;
+    background-image: radial-gradient(ellipse 80% 50% at 50% -10%, color-mix(in srgb, var(--accent) 7%, transparent), transparent);
+  }
+  .sheet {
+    width: 100%; max-width: 860px; background: var(--bg-card);
+    border: 1px solid var(--border); border-radius: 8px;
+    box-shadow: 0 24px 80px rgba(0,0,0,.5), 0 0 0 1px rgba(0,0,0,.3);
+    overflow: hidden;
+  }
+
+  /* ── header ─────────────────────────────────────── */
+  .hdr {
+    display: flex; align-items: center; gap: 14px;
+    padding: 14px 18px; border-bottom: 1px solid var(--border);
+    background: linear-gradient(180deg, color-mix(in srgb, var(--bg-inset) 60%, transparent), transparent);
+  }
+  .title { font-weight: 700; letter-spacing: .02em; white-space: nowrap; }
+  .title .ptype { color: var(--text-secondary); font-weight: 400; }
+  .title .brk { color: var(--text-secondary); }
+  .title .caret { display:inline-block; width: 7px; height: 14px; background: var(--green); vertical-align: -2px; margin: 0 2px 0 4px; animation: blink 1.1s steps(1) infinite; }
+  @keyframes blink { 50% { opacity: 0; } }
+
+  .seg { display: flex; border: 1px solid var(--border); border-radius: 5px; overflow: hidden; flex: none; }
+  .seg button {
+    font: inherit; font-size: 11px; padding: 4px 10px; border: 0; cursor: pointer;
+    background: transparent; color: var(--text-secondary); letter-spacing: .02em;
+  }
+  .seg button.on { background: color-mix(in srgb, var(--accent) 18%, transparent); color: var(--text-primary); }
+  .seg button:not(.on):hover { color: var(--green); }
+
+  .search { flex: 1; min-width: 120px; position: relative; }
+  .search input {
+    width: 100%; font: inherit; font-size: 12px; color: var(--text-primary);
+    background: var(--bg-inset); border: 1px solid var(--border); border-radius: 5px;
+    padding: 5px 10px 5px 26px; outline: none;
+  }
+  .search input:focus { border-color: var(--accent); }
+  .search::before { content: "/"; position: absolute; left: 10px; top: 4px; color: var(--text-secondary); }
+
+  .hint { color: var(--text-secondary); font-size: 11px; white-space: nowrap; }
+  .x { background: none; border: 0; color: var(--text-secondary); font: inherit; font-size: 15px; cursor: pointer; padding: 2px 6px; }
+  .x:hover { color: var(--red); }
+
+  /* ── tier map ───────────────────────────────────── */
+  .tiermap { padding: 18px 18px 8px; }
+  .tierlabel { font-size: 11px; color: var(--text-secondary); margin-bottom: 10px; display: flex; justify-content: space-between; flex-wrap: wrap; gap: 6px;}
+  .tierlabel b { color: var(--text-primary); font-weight: 700; }
+  .kb { display: flex; flex-direction: column; gap: 5px; align-items: center; }
+  .krow { display: flex; gap: 5px; }
+  .key {
+    width: 44px; height: 40px; border-radius: 5px; border: 1px solid var(--border);
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    font-size: 12px; color: var(--text-secondary); position: relative; cursor: default;
+    background: var(--bg-inset); transition: transform .08s, border-color .12s;
+  }
+  .key small { font-size: 7.5px; letter-spacing: .01em; line-height: 1.1; text-align: center; padding: 0 2px; }
+  .key.bound { border-color: color-mix(in srgb, var(--green) 60%, var(--border)); background: color-mix(in srgb, var(--green) 12%, var(--bg-inset)); color: var(--text-primary); }
+  .key.bound small { color: var(--green); }
+  .key.custom { border-color: color-mix(in srgb, var(--accent) 70%, var(--border)); background: color-mix(in srgb, var(--accent) 13%, var(--bg-inset)); color: var(--text-primary); }
+  .key.custom small { color: var(--accent-bright); }
+  .key.claimed { opacity: .55; background: repeating-linear-gradient(45deg, var(--bg-inset) 0 4px, color-mix(in srgb, var(--amber) 10%, var(--bg-inset)) 4px 8px); }
+  .key.claimed small { color: var(--amber); }
+  .key.free:hover { border-color: var(--green); color: var(--green); transform: translateY(-1px); }
+  .legend { display: flex; gap: 16px; margin: 12px 2px 4px; font-size: 10.5px; color: var(--text-secondary); flex-wrap: wrap; }
+  .legend i { display:inline-block; width: 9px; height: 9px; border-radius: 2px; margin-right: 5px; border: 1px solid var(--border); vertical-align: -1px; font-style: normal; }
+  .legend .b i { background: color-mix(in srgb, var(--green) 25%, transparent); border-color: var(--green); }
+  .legend .c i { background: color-mix(in srgb, var(--accent) 25%, transparent); border-color: var(--accent); }
+  .legend .cl i { background: repeating-linear-gradient(45deg, transparent 0 3px, color-mix(in srgb, var(--amber) 45%, transparent) 3px 5px); }
+
+  /* ── sections ───────────────────────────────────── */
+  .body { padding: 6px 18px 18px; }
+  .sec { margin-top: 18px; }
+  .sechead { font-size: 11.5px; font-weight: 700; letter-spacing: .04em; color: var(--text-secondary); user-select: none; }
+  .sechead .ob, .sechead .cb { color: var(--text-secondary); transition: transform .12s, color .12s; display: inline-block; }
+  .sechead:hover .ob { transform: translateX(-3px); color: var(--green); }
+  .sechead:hover .cb { transform: translateX(3px); color: var(--green); }
+  .sechead .lbl { color: var(--text-primary); margin: 0 6px; }
+  .sechead .scaret { display: inline-block; width: 6px; height: 11px; background: var(--green); margin-right: 6px; vertical-align: -1px; animation: blink 1.3s steps(1) infinite; }
+
+  .row {
+    display: flex; align-items: center; gap: 10px; padding: 7px 8px; border-radius: 5px;
+    border: 1px solid transparent;
+  }
+  .row:hover { background: color-mix(in srgb, var(--bg-inset) 70%, transparent); }
+  .row .act { flex: 1; }
+  .row .desc { color: var(--text-secondary); font-size: 11px; }
+  .scope {
+    font-size: 9.5px; padding: 1px 7px; border-radius: 999px; border: 1px solid var(--border);
+    color: var(--text-secondary); letter-spacing: .05em; flex: none;
+  }
+  .scope.term { border-color: color-mix(in srgb, var(--green) 50%, var(--border)); color: var(--green); }
+  .scope.board { border-color: color-mix(in srgb, var(--accent) 60%, var(--border)); color: var(--accent-bright); }
+
+  .combo { display: flex; gap: 4px; align-items: center; cursor: pointer; padding: 2px 4px; border-radius: 5px; }
+  .combo:hover { outline: 1px dashed color-mix(in srgb, var(--green) 60%, transparent); }
+  kbd {
+    font: inherit; font-size: 11.5px; padding: 2px 7px; min-width: 24px; text-align: center;
+    background: var(--bg-inset); border: 1px solid var(--border); border-bottom-width: 2px;
+    border-radius: 4px; color: var(--text-primary); display: inline-block;
+  }
+  .combo.capturing { outline: 1px solid var(--green); animation: pulse 1s ease-in-out infinite; }
+  .combo.capturing kbd { border-color: var(--green); color: var(--green); background: color-mix(in srgb, var(--green) 8%, var(--bg-inset)); }
+  @keyframes pulse { 50% { box-shadow: 0 0 0 4px color-mix(in srgb, var(--green) 15%, transparent); } }
+
+  .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--accent); flex: none; opacity: 0; }
+  .row.modified .dot { opacity: 1; }
+  .reset { visibility: hidden; background: none; border: 0; color: var(--text-secondary); font: inherit; font-size: 11px; cursor: pointer; padding: 0 2px; }
+  .row.modified:hover .reset { visibility: visible; }
+  .reset:hover { color: var(--amber); }
+  .lock { color: var(--text-secondary); font-size: 11px; flex:none; }
+
+  .conflict {
+    margin: 2px 8px 4px; padding: 5px 10px; font-size: 11px; border-radius: 5px; display: none;
+    color: var(--amber); border: 1px solid color-mix(in srgb, var(--amber) 45%, transparent);
+    background: color-mix(in srgb, var(--amber) 8%, transparent);
+  }
+  .conflict.show { display: block; }
+
+  /* macro rows */
+  .macro-cmd { color: var(--text-secondary); font-size: 11px; background: var(--bg-inset); border: 1px solid var(--border); border-radius: 4px; padding: 2px 8px; overflow-x: auto; white-space: nowrap; max-width: 46ch; }
+  .macro-cmd b { color: var(--green); font-weight: 400; }
+  .addrow { display: flex; align-items:center; gap: 8px; padding: 7px 8px; color: var(--text-secondary); cursor: pointer; border-radius: 5px; border: 1px dashed color-mix(in srgb, var(--border) 80%, transparent); margin-top: 4px; font-size: 12px;}
+  .addrow:hover { color: var(--green); border-color: var(--green); }
+
+  /* ── footer ─────────────────────────────────────── */
+  .ftr {
+    display: flex; align-items: center; gap: 10px; padding: 12px 18px;
+    border-top: 1px solid var(--border); color: var(--text-secondary); font-size: 11px;
+    flex-wrap: wrap;
+  }
+  .ftr .grow { flex: 1; }
+  .btn {
+    font: inherit; font-size: 11px; padding: 4px 12px; cursor: pointer; border-radius: 5px;
+    background: transparent; border: 1px solid var(--border); color: var(--text-primary);
+    position: relative; overflow: hidden;
+  }
+  .btn:hover { border-color: var(--green); color: var(--green); }
+  .btn:hover::after {
+    content: ""; position: absolute; inset: -4px; pointer-events: none;
+    background: linear-gradient(105deg, transparent 40%, color-mix(in srgb, var(--green) 40%, transparent) 50%, transparent 60%);
+    animation: glint .45s ease-out 1;
+  }
+  @keyframes glint { from { transform: translateX(-110%);} to { transform: translateX(110%);} }
+  .btn.danger:hover { border-color: var(--red); color: var(--red); }
+  .row.hidden, .sec.hidden { display: none; }
+
+  @media (max-width: 700px) {
+    .hint { display: none; }
+    .key { width: 30px; height: 34px; }
+    .key small { display: none; }
+    .macro-cmd { max-width: 24ch; }
+  }
+</style>
+</head>
+<body>
+<div class="sheet" role="dialog" aria-label="Keyboard shortcuts">
+
+  <div class="hdr">
+    <div class="title"><span class="brk">[</span><span class="caret"></span><span class="ptype">Shortcuts:&nbsp;</span>keyboard <span class="brk">]</span></div>
+    <div class="seg" id="plat">
+      <button class="on" data-p="mac">macOS</button><button data-p="win">Win · Linux</button>
+    </div>
+    <div class="search"><input id="q" placeholder="filter actions…" aria-label="Filter shortcuts"></div>
+    <span class="hint" id="sheetHint">⇧⌘/ toggles this sheet</span>
+    <button class="x" aria-label="Close">✕</button>
+  </div>
+
+  <div class="tiermap">
+    <div class="tierlabel">
+      <span>run-kit tier — <b id="tierName">⇧ ⌘</b> + key · one tier, every platform</span>
+      <span id="tierNote">plain Ctrl always reaches the pane</span>
+    </div>
+    <div class="kb" id="kb"></div>
+    <div class="legend">
+      <span class="b"><i></i>bound</span>
+      <span class="c"><i></i>custom / macro</span>
+      <span class="cl"><i></i>claimed (shell · system)</span>
+      <span><i></i>free</span>
+    </div>
+  </div>
+
+  <div class="body" id="list"></div>
+
+  <div class="ftr">
+    <span>overrides stored on this device <span style="opacity:.6">(localStorage · runkit-keybindings)</span></span>
+    <span class="grow"></span>
+    <button class="btn">export</button>
+    <button class="btn">import</button>
+    <button class="btn danger">reset all</button>
+  </div>
+</div>
+
+<script>
+  // ── data ──────────────────────────────────────────
+  const T = "tier";           // run-kit tier: Shift+CmdOrCtrl
+  const state = { plat: "mac", capturing: null };
+  const M = { tier: p => p==="mac" ? ["⇧","⌘"] : ["Shift","Ctrl"],
+              cmd:  p => p==="mac" ? ["⌘"] : ["Ctrl"] };
+
+  const sections = [
+    { name: "GLOBAL", rows: [
+      { act:"New session",            key:"N", mod:T, desc:"create a tmux session" },
+      { act:"New window",             key:"T", mod:T, desc:"tab-analog in current session" },
+      { act:"Close window",           key:"W", mod:T, desc:"confirm unless ⌘-click" },
+      { act:"Previous window",        key:"H", mod:T },
+      { act:"Next window",            key:"L", mod:T },
+      { act:"Back",                   key:"[", mod:T, desc:"history" },
+      { act:"Forward",                key:"]", mod:T, desc:"history" },
+      { act:"Next waiting agent",     key:"A", mod:T, desc:"jump to agent blocked on input", modified:true },
+      { act:"Command palette",        key:"K", mod:"cmd", legacy:true },
+      { act:"Toggle sidebar",         key:"\\", mod:"cmd", legacy:true },
+      { act:"This cheatsheet",        key:"/", mod:T },
+    ]},
+    { name: "TERMINAL", scope:"term", rows: [
+      { act:"Cycle view lens",        key:".", mod:"cmd", desc:"tty → web → chat", legacy:true },
+      { act:"Chat lens toggle",       key:"`", mod:"ctrl", desc:"tty ↔ chat", legacy:true },
+      { act:"Copy selection",         key:"C", mod:"cmd", desc:"falls through to SIGINT when empty", fixed:true },
+    ]},
+    { name: "BOARD", scope:"board", rows: [
+      { act:"Cycle pane focus →",     key:"]", mod:"cmd", legacy:true },
+      { act:"Cycle pane focus ←",     key:"[", mod:"cmd", legacy:true },
+    ]},
+    { name: "SHELL — desktop app", rows: [
+      { act:"Switch to server 1–9",   key:"1…9", mod:T, locked:true, desc:"owned by the shell menu" },
+      { act:"Force reload",           key:"R", mod:T, locked:true },
+      { act:"DevTools",               key:"I", mod:T, locked:true, winOnly:true },
+    ]},
+    { name: "CUSTOM", rows: [
+      { act:"riff: worktree + fab-discuss", key:"D", mod:T, custom:true,
+        cmd:'rk riff <b>--preset discuss</b>  · wt create --command "/fab-discuss"' },
+      { act:"riff: codex loop @a",    key:"G", mod:T, custom:true,
+        cmd:'rk riff <b>--preset codex-loop</b> "@a"' },
+    ]},
+  ];
+
+  // tier-map key states, per platform
+  const rows_keys = [["Q","W","E","R","T","Y","U","I","O","P","[","]"],
+                     ["A","S","D","F","G","H","J","K","L",";","/"],
+                     ["Z","X","C","V","B","N","M","1","2","…","9","0"]];
+  const bound  = { N:"new session", T:"new window", W:"close win", H:"prev win", L:"next win",
+                   "[":"back", "]":"fwd", A:"agent ⏳", "/":"cheatsheet" };
+  const custom = { D:"riff:discuss", G:"riff:codex" };
+  const claimedMac = { Q:"logout ⇧⌘Q", R:"reload", "1":"server", "2":"server", "…":"server", "9":"server" };
+  const claimedWin = { R:"reload", I:"devtools", C:"copy", V:"paste", "1":"server", "2":"server", "…":"server", "9":"server" };
+
+  function renderKb() {
+    const claimed = state.plat==="mac" ? claimedMac : claimedWin;
+    document.getElementById("kb").innerHTML = rows_keys.map(r =>
+      `<div class="krow">` + r.map(k => {
+        let cls="free", label="";
+        if (bound[k])  { cls="bound";  label=bound[k]; }
+        if (custom[k]) { cls="custom"; label=custom[k]; }
+        if (claimed[k]){ cls="claimed";label=claimed[k]; }
+        return `<div class="key ${cls}" title="${label||'free'}">${k}${label?`<small>${label}</small>`:""}</div>`;
+      }).join("") + `</div>`).join("");
+    document.getElementById("tierName").textContent = state.plat==="mac" ? "⇧ ⌘" : "Shift Ctrl";
+    document.getElementById("sheetHint").textContent = (state.plat==="mac" ? "⇧⌘/" : "Shift+Ctrl+/") + " toggles this sheet";
+  }
+
+  // ── rows ──────────────────────────────────────────
+  function comboHtml(row) {
+    const p = state.plat;
+    let parts;
+    if (row.mod===T) parts = [...M.tier(p), row.key];
+    else if (row.mod==="cmd") parts = [...M.cmd(p), row.key];
+    else parts = ["Ctrl", row.key];
+    return parts.map(x=>`<kbd>${x}</kbd>`).join("");
+  }
+  function renderList() {
+    document.getElementById("list").innerHTML = sections.map((s,si) => `
+      <div class="sec" data-sec="${si}">
+        <div class="sechead"><span class="ob">[</span><span class="lbl">${s.name}</span><span class="scaret"></span><span class="cb">]</span></div>
+        ${s.rows.filter(r=>!(r.winOnly&&state.plat==="mac")).map((r,ri)=>`
+          <div class="row ${r.modified?'modified':''}" data-act="${r.act.toLowerCase()}">
+            <span class="dot" title="modified from default"></span>
+            <span class="act">${r.act} ${r.desc?`<span class="desc">— ${r.desc}</span>`:""}</span>
+            ${r.cmd?`<span class="macro-cmd">${r.cmd}</span>`:""}
+            ${s.scope?`<span class="scope ${s.scope}">${s.scope==="term"?"TERMINAL":"BOARD"}</span>`:""}
+            ${r.locked?`<span class="lock" title="bound by the desktop shell menu — edit there">🔒</span>`
+                      :`<span class="combo" data-si="${si}" data-ri="${ri}" title="click to rebind">${comboHtml(r)}</span>`}
+            <button class="reset" title="reset to default">↺</button>
+          </div>`).join("")}
+        ${s.name==="CUSTOM"?`<div class="addrow">+ bind a key to a palette action or riff preset…</div>`:""}
+      </div>`).join("");
+    document.getElementById("conflictNote")?.remove();
+  }
+
+  // ── interactions (mock-level) ─────────────────────
+  document.getElementById("plat").addEventListener("click", e => {
+    const b = e.target.closest("button"); if (!b) return;
+    state.plat = b.dataset.p;
+    document.querySelectorAll("#plat button").forEach(x=>x.classList.toggle("on", x===b));
+    renderKb(); renderList();
+  });
+  document.getElementById("q").addEventListener("input", e => {
+    const q = e.target.value.toLowerCase();
+    document.querySelectorAll(".row").forEach(r =>
+      r.classList.toggle("hidden", q && !r.dataset.act?.includes(q)));
+    document.querySelectorAll(".sec").forEach(s =>
+      s.classList.toggle("hidden", q && ![...s.querySelectorAll(".row")].some(r=>!r.classList.contains("hidden"))));
+  });
+  // click-to-capture demo: click a combo, press keys (matches on e.code)
+  document.addEventListener("click", e => {
+    const c = e.target.closest(".combo");
+    document.querySelectorAll(".combo.capturing").forEach(x=>{ x.classList.remove("capturing"); });
+    if (!c) { state.capturing = null; return; }
+    state.capturing = c;
+    c.classList.add("capturing");
+    c.innerHTML = "<kbd>press keys…</kbd>";
+  });
+  document.addEventListener("keydown", e => {
+    if (!state.capturing) return;
+    e.preventDefault();
+    if (e.key === "Escape") { state.capturing.classList.remove("capturing"); renderList(); state.capturing=null; return; }
+    if (["Shift","Meta","Control","Alt"].includes(e.key)) return;
+    const p = state.plat, parts = [];
+    if (e.shiftKey) parts.push(p==="mac"?"⇧":"Shift");
+    if (e.metaKey||e.ctrlKey) parts.push(p==="mac"?"⌘":"Ctrl");
+    if (e.altKey) parts.push(p==="mac"?"⌥":"Alt");
+    const keyName = e.code.replace(/^(Key|Digit)/,"");
+    parts.push(keyName);
+    state.capturing.innerHTML = parts.map(x=>`<kbd>${x}</kbd>`).join("");
+    state.capturing.classList.remove("capturing");
+    const row = state.capturing.closest(".row"); row.classList.add("modified");
+    // conflict demo
+    if (e.shiftKey && (e.metaKey||e.ctrlKey) && keyName==="N") {
+      const warn = document.createElement("div");
+      warn.className = "conflict show"; warn.id = "conflictNote";
+      warn.textContent = "⚠ conflicts with “New session” — press again to steal, or Esc";
+      row.after(warn);
+    }
+    state.capturing = null;
+  });
+
+  renderKb(); renderList();
+</script>
+</body>
+</html>

--- a/fab/changes/260730-g40a-keyboard-shortcut-registry-overlay/intake.md
+++ b/fab/changes/260730-g40a-keyboard-shortcut-registry-overlay/intake.md
@@ -1,0 +1,130 @@
+# Intake: Keyboard Shortcut Registry, Uniform Shifted Tier & Cheatsheet Overlay
+
+**Change**: 260730-g40a-keyboard-shortcut-registry-overlay
+**Created**: 2026-07-30
+
+## Origin
+
+Conversational — a `/fab-discuss` session that researched Conductor's shortcut scheme, audited run-kit's existing bindings, and converged on a tier decision over several rounds.
+
+> User's raw asks, in sequence: "Check the keyboard shortcuts for conductor. Then suggest a model to think of keyboard shortcuts for run-kit." → "Is alt available?" → "What if run-kit owns the whole Shift+Cmd / Ctrl namespace?" → "Three finger, 4 finger — doesn't matter as much as making sure that N becomes the letter associated with new, H and L for up tab, down tab. Then we need one for back and forward also. I want to know the cleanest namespace available" → (post-Electron) "We should keep Cmd and Ctrl symmetry" → disambiguation: "(B) — Shift is always part of the chord" → "Ok, lets start somewhere (B). Whatever we do, we should be able to override easily. Can you design a great looking keyboard shortcuts page?"
+
+Key decisions from the discussion:
+
+1. **Tier (B) chosen explicitly** over (A): the run-kit action tier is `Shift+CmdOrCtrl+<key>` — ⇧⌘ on macOS, ⇧Ctrl on Windows/Linux — *uniform on every platform*. The user's stated priority: letter consistency matters more than chord weight ("three finger, 4 finger — doesn't matter"). (A) plain-⌘-on-mac was rejected because ⌘H (Hide), ⌘M, ⌘Q are macOS/HIG-bound, so the H/L pair couldn't live in the same tier as N/T/W — the exact fragmentation Conductor exhibits (their attention-nav pair is exiled to ⌥H/⌥L because ⌘H is Hide, despite being macOS-only).
+2. **Plain Ctrl must always reach the pane** on Windows/Linux (Ctrl+W delete-word, Ctrl+L clear-screen, Ctrl+T fzf, Ctrl+N/P history). This is why plain Cmd↔Ctrl symmetry was rejected and why every cross-platform terminal (Windows Terminal, GNOME Terminal, Konsole, kitty) uses Ctrl+Shift as its app tier. Legacy TTY encoding cannot distinguish Ctrl+Shift+letter from Ctrl+letter, so claiming the shifted tier costs terminal apps nothing.
+3. **Overrides are a day-one requirement** ("Whatever we do, we should be able to override easily").
+4. **The shortcuts "page" is an overlay, not a route** (Constitution IV bans settings pages; route set is fixed).
+5. An interactive HTML design mock was built and reviewed by the user in an iframe window — preserved at `design-mock.html` in this change folder. It demonstrates the tier map, grouped rows with scope badges, click-to-capture rebinding, conflict warning, platform toggle, and locked shell-owned rows.
+6. A follow-up change (`260730-hbyh-shortcut-macro-riff-bindings`) covers macro bindings; this change only reserves the schema slot for it.
+
+## Why
+
+run-kit's Constitution V mandates keyboard-first operation, but the current shortcut surface is five hand-rolled chords (⌘K palette, ⌘\ sidebar, ⌘. lens cycle, Ctrl+` chat toggle, board-only ⌘[/⌘]) each with its own `keydown` listener and its own ad-hoc suppression logic (`shouldSuppressViewChord`, a `.xterm` carve-out in the sidebar toggle, capture-phase handlers in dropdowns). There is no navigation or creation via keyboard at all — no new-session, no window switching, no back/forward — and discoverability is near-zero: only the view-lens palette actions render a `shortcut` hint; nothing else does, and there is no cheatsheet.
+
+The desktop shell (PRs #465–#472) made this urgent and solvable: the shell's keyboard contract (`app/desktop/src/menu.ts`) deliberately leaves the entire unshifted Cmd/Ctrl tier unbound for the SPA and establishes `Shift+CmdOrCtrl` as the app-action tier (server switcher ⇧⌘1–9 / ⇧Ctrl+1–9). The SPA now needs to claim its half of that tier coherently, or ad-hoc chords will keep accreting listener-by-listener with inconsistent suppression, no override path, and no discoverability.
+
+If we don't do this: every new action adds another scattered listener; users on Windows/Linux get chords that collide with the shell or the terminal; nothing is rebindable; and the keyboard-first principle stays aspirational for navigation.
+
+Why this approach: a single declarative registry gives one place to define, suppress, override, display, and test every binding — and the uniform shifted tier is the only namespace where the user's required letters (N, T, W, H, L) coexist on every platform and in both shell and browser hosts.
+
+## What Changes
+
+### 1. Canonical tier & starter bindings
+
+The run-kit action tier is `Shift+CmdOrCtrl+<key>` on all platforms. Starter set (letters are canonical, agreed in discussion and shown in the mock):
+
+| Key | Action | Notes |
+|-----|--------|-------|
+| N | New session | opens the create-session dialog |
+| T | New window | tab-analog in the current session |
+| W | Close window | confirm flow, same as sidebar close |
+| H | Previous window | within current session, sidebar order |
+| L | Next window | within current session, sidebar order |
+| [ | Back | router history |
+| ] | Forward | router history |
+| A | Next waiting agent | jump to the next window whose agent-state is `waiting` — the attention-nav loop |
+| / | Toggle shortcuts overlay | the cheatsheet |
+
+Claimed keys the registry must treat as unavailable (shown locked in the overlay): ⇧CmdOrCtrl+1–9 (shell server switcher), ⇧CmdOrCtrl+R (shell force reload), ⇧Ctrl+I (shell DevTools, win/linux), ⇧⌘Q (macOS logout), and — in *browser* hosts only — N/T/W (browser-reserved: incognito/reopen-tab/close-window; the actions remain palette-reachable there).
+
+### 2. Declarative registry (new `lib/keybindings.ts` or similar)
+
+One module owning all bindings:
+
+```ts
+type KeyBinding = {
+  actionId: string;          // stable id, doubles as palette action id where one exists
+  code: string;              // KeyboardEvent.code — layout-independent ("KeyN", "BracketLeft")
+  tier: "shifted" | "cmd" | "ctrl";  // shifted = Shift+CmdOrCtrl (the run-kit tier)
+  scope: "global" | "terminal" | "board" | "sidebar";
+  kind: "builtin";           // "macro" reserved for change hbyh — schema slot only, no executor here
+  label: string;             // human label for overlay + palette hint
+};
+```
+
+- **Match on `e.code`, never `e.key`** — layout-safe, and sidesteps the Electron character-resolution flakiness the shell docs flag for shifted accelerators (`menu.ts:47-50`).
+- Defaults are data; a resolver merges the per-device override layer (below) and produces the effective map.
+- Conflict detection is a pure function over the effective map (used by capture UI and by tests).
+
+### 3. Dispatch seams
+
+- One `window`-level keydown listener for the app at large, consulting the registry + scope + a single shared suppression predicate (real text inputs suppress; `.xterm` and `.rk-chat-input` carve-outs preserved).
+- `attachCustomKeyEventHandler` in `terminal-client.tsx` (currently only the ⌘C-copy special case at ~line 328) consults the registry and returns `false` for app-owned chords so they fire even with the terminal focused, while everything else — including all plain-Ctrl — flows to the pane untouched.
+- Existing scattered chords (⌘K, ⌘\, ⌘., Ctrl+`, board ⌘[/⌘]) migrate INTO the registry with their **combos unchanged** (they are established, browser-safe punctuation; only their definition/suppression centralizes). The board pane-cycle stays scoped to `board`; the new ⇧-tier [/] back/forward is `global`.
+- NOT Electron menu accelerators: the shell's documented seam is accelerator *avoidance* (`desktop-shell.md` design decisions); SPA keys live in the renderer and therefore work identically in shell and browser hosts.
+
+### 4. Per-device overrides
+
+- `localStorage["runkit-keybindings"]` stores **diffs only**: `{ [actionId]: { code, tier } | null }` (null = disabled). Same persistence pattern as `runkit-terminal-font-size`.
+- Capture UI records `e.code` + modifiers; conflicts resolve as steal-with-warning (the previous owner becomes unbound and is flagged in the overlay until rebound or reset).
+- Per-row reset + reset-all. Export/import deferred (it's a JSON blob; trivial later).
+- No backend, no new config file — Constitution II.
+
+### 5. Shortcuts overlay (the "page")
+
+- Opened by ⇧CmdOrCtrl+/ and via a palette action; rendered as a dialog/sheet (focus-trapped like existing dialogs), NOT a new route.
+- Contents per the reviewed mock (`design-mock.html`): tier-map keyboard visualization (bound / custom / claimed / free per key, per platform), platform display toggle (macOS ↔ Win·Linux keycap rendering), filter input, grouped rows with scope badges, click-to-rebind capture with Esc-cancel and conflict warning, modified-dot + per-row reset, shell-owned rows shown locked (🔒, edit lives in the shell menu), footer with storage note + reset all.
+- Styling uses the existing hover-animation vocabulary (bracket section headings, CRT-glint buttons, accent-green states) and the three-mode theme tokens.
+
+### 6. Palette hints
+
+Every registered action that has a palette entry renders its effective combo as the palette `shortcut` hint (today only view-lens actions do). Hints reflect overrides, formatted per platform (⇧⌘N vs Shift+Ctrl+N).
+
+### 7. Shell coordination
+
+Document the tier-ownership split in `docs/memory/run-kit/desktop-shell.md` during hydrate: shifted digits + R/I = shell (menu accelerators), shifted letters = SPA registry; future shell menu additions must check the registry before claiming a shifted key.
+
+## Affected Memory
+
+- `run-kit/ui-patterns`: (modify) new keyboard-shortcut registry section — tier rule, starter bindings, override layer, overlay, palette hints
+- `run-kit/desktop-shell`: (modify) tier-ownership split note (shell digits/R/I vs SPA letters)
+
+## Impact
+
+- `app/frontend/src/lib/` — new registry module + conflict/format helpers (pure, unit-testable)
+- `app/frontend/src/components/` — new shortcuts-overlay component; edits to `terminal-client.tsx` (custom key handler consults registry), `command-palette.tsx` (hint rendering), `app.tsx` / `shell.tsx` / `board-page.tsx` (existing listeners migrate to registry dispatch)
+- `app/frontend/tests/` — e2e for the new chords + overlay (with `.spec.md` companions per constitution); unit tests for resolver/conflict logic
+- No backend changes. No shell (`app/desktop/`) changes — coordination is documentation-only.
+- Board ⌘[/⌘] and all legacy chords keep working byte-identically during migration.
+
+## Open Questions
+
+- Should ⇧CmdOrCtrl+T create the new window in the current session always, or offer the session picker when invoked outside a session context (e.g., on the board route)? Default assumption: current session when on a terminal route; palette fallback elsewhere.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Tier (B): uniform `Shift+CmdOrCtrl+<key>` on every platform | User explicitly chose (B) after an (A)/(B) disambiguation question; rationale documented in Origin | S:95 R:70 A:95 D:95 |
+| 2 | Confident | Letter map: N=new session, T=new window (window = tab-analog) | User once said "Cmd+N should be the Open window shortcut"; N=session/T=window presented twice (incl. the mock) without objection; trivially swappable in the registry data | S:60 R:90 A:70 D:60 |
+| 3 | Certain | Cheatsheet is an overlay, not a route | Constitution IV fixes the route set and bans settings pages | S:80 R:80 A:100 D:95 |
+| 4 | Certain | Overrides in `localStorage` diffs, no backend | Constitution II (no database); mirrors `runkit-terminal-font-size` pattern; user asked only for "easily overridable" | S:85 R:85 A:95 D:90 |
+| 5 | Certain | Match bindings on `e.code`, not `e.key` | Layout-independent; avoids the shifted-accelerator flakiness the shell docs flag; standard practice | S:70 R:85 A:90 D:85 |
+| 6 | Confident | Legacy chords (⌘K, ⌘\, ⌘., Ctrl+`, board ⌘[/]) migrate into the registry with combos unchanged | Discussed ("keep the existing punctuation chords"); centralizing their definition is the registry's purpose | S:55 R:85 A:80 D:75 |
+| 7 | Confident | v1 binding set = the 9 starter actions above | The set shown in the reviewed mock; registry makes additions cheap | S:65 R:90 A:75 D:70 |
+| 8 | Certain | Dispatch in the SPA renderer, not Electron menu accelerators | Shell's documented accelerator-avoidance seam; must work in browser hosts too | S:70 R:75 A:90 D:85 |
+| 9 | Certain | `kind` field reserves the macro slot; no macro executor in this change | User explicitly approved the two-change split | S:90 R:95 A:90 D:90 |
+| 10 | Confident | Conflict policy = steal-with-warning; browser-dead letters (N/T/W) fall back to palette | Shown in the mock; consistent with "override easily" | S:55 R:90 A:70 D:65 |
+
+10 assumptions (6 certain, 4 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260730-hbyh-shortcut-macro-riff-bindings/.history.jsonl
+++ b/fab/changes/260730-hbyh-shortcut-macro-riff-bindings/.history.jsonl
@@ -1,0 +1,3 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-07-30T11:20:41Z"}
+{"args":"macro shortcut bindings targeting riff presets / palette actions (follow-up to shortcut registry change)","cmd":"fab-new","event":"command","ts":"2026-07-30T11:20:41Z"}
+{"delta":"+4.1","event":"confidence","score":4.1,"trigger":"calc-score","ts":"2026-07-30T11:23:56Z"}

--- a/fab/changes/260730-hbyh-shortcut-macro-riff-bindings/.status.yaml
+++ b/fab/changes/260730-hbyh-shortcut-macro-riff-bindings/.status.yaml
@@ -1,0 +1,35 @@
+id: hbyh
+name: 260730-hbyh-shortcut-macro-riff-bindings
+created: 2026-07-30T11:20:41Z
+created_by: sahil-noon
+change_type: refactor
+issues: []
+progress:
+    intake: ready
+    apply: pending
+    review: pending
+    hydrate: pending
+    ship: pending
+    review-pr: pending
+plan:
+    generated: false
+    task_count: 0
+    acceptance_count: 0
+    acceptance_completed: 0
+confidence:
+    certain: 2
+    confident: 2
+    tentative: 1
+    unresolved: 0
+    score: 4.1
+    fuzzy: true
+    dimensions:
+        signal: 65.0
+        reversibility: 78.0
+        competence: 75.0
+        disambiguation: 71.0
+stage_metrics:
+    intake: {started_at: "2026-07-30T11:20:41Z", driver: fab-new, iterations: 1}
+prs: []
+# true_impact: lazily created on first stage-finish that computes it (no placeholder here).
+last_updated: 2026-07-30T11:24:00Z

--- a/fab/changes/260730-hbyh-shortcut-macro-riff-bindings/intake.md
+++ b/fab/changes/260730-hbyh-shortcut-macro-riff-bindings/intake.md
@@ -1,0 +1,95 @@
+# Intake: Macro Shortcut Bindings over Riff Presets
+
+**Change**: 260730-hbyh-shortcut-macro-riff-bindings
+**Created**: 2026-07-30
+
+## Origin
+
+Conversational — same `/fab-discuss` session as `260730-g40a-keyboard-shortcut-registry-overlay` (this change is its explicit follow-up; the user chose to draft both together).
+
+> User's raw ask: "Also should we be able to setup shortcuts like this:
+> Cmd + N  [wt create --new-worktree --command \"/fab-dsicuss\"]
+> Cmd + L  [wt create --new --command \"codex /loop\" \"@a\"]
+> i.e. long commands /macros that get executes on typing certain shortcuts? Or should this be picked up as a separate change? Should this also be apart of the keyboard shorctcuts design though?"
+
+Decisions from the discussion:
+
+1. **Separate change, anticipated schema**: the base registry change (g40a) reserves an action `kind` slot (`"builtin" | "macro"`); this change ships the macro kind. User approved this sequencing explicitly.
+2. **Macros target riff presets and palette action ids — never arbitrary shell strings.** Rationale accepted in discussion: a shortcut executing user-typed shell text means a web-reachable endpoint running arbitrary commands, exactly what Constitution I exists to prevent. Both of the user's motivating examples are expressible as `rk riff` invocations (worktree/window spawn + launch command + pane args), and `POST /api/riff` already exists as a validated, argv-sliced, timeout-guarded seam.
+3. The reviewed design mock (g40a's `design-mock.html`) shows the target UI: a CUSTOM section in the shortcuts overlay with macro rows (binding + preset command preview) and a "+ bind a key to a palette action or riff preset…" row.
+
+## Why
+
+The highest-value shortcuts for an operator are not built-ins — they are the operator's own repeated flows: "spawn a worktree with a fab-discuss agent", "spawn a codex loop in window @a". Today those are multi-step CLI invocations (`rk riff` / `wt create`) that cannot be reached from the web UI keyboard at all. Binding them to keys turns run-kit from a viewer into a launcher.
+
+If we don't do this: users script around the UI in tmux, and the shortcut system's CUSTOM tier (already designed into the overlay) stays an empty promise.
+
+Why riff-preset targets instead of raw command strings: the riff engine (`internal/riff`, `POST /api/riff`, fabconfig presets/tiers) already owns spawn-shaping, validation, and security discipline. Reusing it means macros add **zero** new process-execution surface — a macro is just a keyboard route to an existing, validated spawn. Arbitrary-shell macros were considered and rejected on Constitution I grounds.
+
+## What Changes
+
+### 1. Macro action kind in the registry
+
+Extends g40a's registry schema (this change depends on g40a landing first):
+
+```ts
+type MacroAction = {
+  actionId: string;            // "macro:<user-slug>"
+  kind: "macro";
+  label: string;               // user-provided, shown in overlay + palette
+  target:
+    | { type: "riff"; preset: string; args?: string[] }   // → POST /api/riff
+    | { type: "palette"; paletteActionId: string };        // → invoke existing palette action
+};
+```
+
+The user's two examples, expressed in this model (presets defined in fabconfig, where riff presets already live):
+
+- ⇧⌘D → `{ type: "riff", preset: "discuss" }` — preset encodes worktree creation + `/fab-discuss` launch command
+- ⇧⌘G → `{ type: "riff", preset: "codex-loop", args: ["@a"] }` — preset encodes the `codex /loop` launcher; pane arg passes through riff's argv-ordered pane array
+
+### 2. Persistence
+
+Macro definitions are per-device, alongside the override layer: `localStorage["runkit-macros"]` (array of MacroAction) + their bindings in the existing `runkit-keybindings` diff map. No backend storage — the *presets* live server-side in fabconfig (existing mechanism); the *bindings to keys* are client preference. Constitution II holds.
+
+### 3. Overlay CUSTOM section becomes editable
+
+- "+ add binding" flow: pick a target (searchable list = riff presets fetched from the existing fabconfig read seam + all palette actions), name it, capture a key.
+- Macro rows render the resolved command preview (as in the mock: `rk riff --preset discuss`), delete + rebind affordances.
+- Macro actions also appear in the command palette (kind-tagged), so they are reachable without their key.
+
+### 4. Execution path
+
+- `{ type: "palette" }` targets dispatch the existing palette action in-place — pure frontend.
+- `{ type: "riff" }` targets call `POST /api/riff` with `{ preset, args }` exactly as the spawn-agent dialog / riff web frontend does today. Success/failure surfaces as the existing toast pattern; no fire-and-forget.
+- No new backend endpoint, no new exec surface. If a preset named in a macro no longer exists in fabconfig, the macro row shows an error state and the key does nothing (no silent fallback).
+
+## Affected Memory
+
+- `run-kit/rk-riff`: (modify) note the web keyboard-macro consumer of presets + `POST /api/riff`
+- `run-kit/ui-patterns`: (modify) CUSTOM macro section of the shortcuts overlay, palette exposure of macro actions
+
+## Impact
+
+- `app/frontend/src/lib/` — macro types + resolver extension of g40a's registry module
+- `app/frontend/src/components/` — shortcuts-overlay CUSTOM section (add/edit/delete), palette integration
+- `app/frontend/src/api/client.ts` — reuse existing riff/preset endpoints (read presets, POST spawn); add thin wrappers only if missing
+- `app/frontend/tests/` — e2e for add-macro → keypress → riff POST (mocked, with `.spec.md` companion); unit tests for macro resolution + missing-preset error state
+- No Go backend changes expected; if the preset-list read seam turns out not to be exposed over HTTP yet, a read-only GET is in scope (derive-from-fabconfig, Constitution II/X compliant)
+
+## Open Questions
+
+- Should macro definitions be exportable/shareable across devices in v1, or is per-device localStorage enough? (Default assumption: per-device; export rides g40a's later export/import.)
+- Do riff presets as they exist today fully express both motivating examples (launch command + pane-target arg), or does the preset schema need a small extension first? Needs verification against `internal/riff` during planning.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Macro targets are riff presets + palette action ids only — no arbitrary shell strings | Constitution I; reasoning presented and accepted in discussion; both motivating examples expressible via riff | S:85 R:75 A:95 D:85 |
+| 2 | Certain | Depends on g40a's registry `kind` slot; ships as its own change | User explicitly approved the two-change split | S:90 R:80 A:95 D:95 |
+| 3 | Confident | v1 references existing fabconfig presets; no preset-creation UI in the web app | Minimal Surface Area (Constitution IV); presets already have a home + authoring path in fabconfig | S:50 R:85 A:70 D:60 |
+| 4 | Tentative | Current riff preset schema can express both motivating examples (launch command + pane-target passthrough) without extension | Inferred from rk-riff memory (presets, argv-ordered pane arrays, `--print` launcher resolution) but not verified against `internal/riff` source | S:40 R:70 A:35 D:45 |
+| 5 | Confident | Macro definitions persist in per-device localStorage; execution reuses `POST /api/riff` with no new backend surface | Constitution II; mirrors g40a's override-layer decision; existing endpoint already validated | S:60 R:80 A:80 D:70 |
+
+5 assumptions (2 certain, 2 confident, 1 tentative, 0 unresolved).


### PR DESCRIPTION
Two drafted change intakes (no implementation) from a `/fab-discuss` session on keyboard shortcuts — created via `/fab-draft`, both at intake `ready`, neither activated.

## 260730-g40a-keyboard-shortcut-registry-overlay — confidence 4.6/5

- **Tier (B)**: uniform `Shift+CmdOrCtrl+<key>` run-kit action tier on every platform (⇧⌘ mac / ⇧Ctrl win-linux) — the only namespace where N, T, W, H, L coexist; plain Ctrl always reaches the pane
- Starter set: N new session · T new window · W close window · H/L prev/next window · [/] back/forward · A next waiting agent · / cheatsheet
- Declarative registry (`e.code`-matched), one dispatch seam + `attachCustomKeyEventHandler`, legacy chords migrate combo-unchanged
- Per-device overrides in localStorage diffs; steal-with-warning conflicts
- Cheatsheet **overlay** (Constitution IV — no new route); interactive design mock included in the change folder (`design-mock.html`)
- Palette shortcut hints for all registered actions

## 260730-hbyh-shortcut-macro-riff-bindings — confidence 4.1/5

Follow-up (depends on g40a's action-`kind` slot): user-defined macro bindings that target **riff presets and palette action ids — never arbitrary shell strings** (Constitution I). Execution reuses `POST /api/riff`; zero new exec surface. One Tentative assumption flagged: whether today's riff preset schema fully expresses the motivating examples — verify during planning.

After merge: `/fab-switch g40a` then `/fab-continue` (or `/fab-ff`) to start implementation.