### PR TITLE
fix: Restart-to-Update follow-ups from Copilot review of #482

### DIFF
--- a/app/desktop/src/main.ts
+++ b/app/desktop/src/main.ts
@@ -544,6 +544,11 @@ async function refreshUpdateMenu(): Promise<void> {
   if (!isUpdateCheckDue(lastUpdateCheckAt, Date.now())) return;
   lastUpdateCheckAt = Date.now();
   const run = await runRk(["desktop", "status"], RK_STATUS_TIMEOUT_MS);
+  // Re-check after the await: "Restart to Update" may have been clicked while
+  // the status probe was in flight — writing here would clobber the updating
+  // state and re-enable the item mid-update (same invariant as the pre-await
+  // guard above).
+  if (updateMenuInfo?.updating) return;
   const latest = run.ok ? availableUpdateVersion(run.stdout) : null;
   setUpdateMenuInfo(latest === null ? null : { latestVersion: latest, updating: false });
 }

--- a/app/desktop/src/update-check.test.ts
+++ b/app/desktop/src/update-check.test.ts
@@ -102,3 +102,9 @@ test("a timestamp at or past the interval is due", () => {
   assert.equal(isUpdateCheckDue(now - UPDATE_CHECK_INTERVAL_MS, now), true);
   assert.equal(isUpdateCheckDue(now - 2 * UPDATE_CHECK_INTERVAL_MS, now), true);
 });
+
+test("a clock that moved backwards is due (negative delta must not suppress checks)", () => {
+  const now = 10 * UPDATE_CHECK_INTERVAL_MS;
+  assert.equal(isUpdateCheckDue(now + 1, now), true);
+  assert.equal(isUpdateCheckDue(now + UPDATE_CHECK_INTERVAL_MS, now), true);
+});

--- a/app/desktop/src/update-check.ts
+++ b/app/desktop/src/update-check.ts
@@ -73,5 +73,10 @@ export const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
  * count requests, not successes); null means never checked.
  */
 export function isUpdateCheckDue(lastCheckedAt: number | null, now: number): boolean {
-  return lastCheckedAt === null || now - lastCheckedAt >= UPDATE_CHECK_INTERVAL_MS;
+  if (lastCheckedAt === null) return true;
+  // A clock that moved backwards (now earlier than the recorded attempt) is
+  // due — a negative delta would otherwise suppress checks until the clock
+  // re-passes the stale timestamp.
+  if (now < lastCheckedAt) return true;
+  return now - lastCheckedAt >= UPDATE_CHECK_INTERVAL_MS;
 }

--- a/fab/changes/260731-vvco-desktop-menu-restart-update/.history.jsonl
+++ b/fab/changes/260731-vvco-desktop-menu-restart-update/.history.jsonl
@@ -9,3 +9,5 @@
 {"event":"review","result":"passed","ts":"2026-07-31T08:24:57Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-07-31T08:29:51Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-07-31T08:33:01Z"}
+{"cmd":"git-pr-review","event":"command","ts":"2026-07-31T08:34:44Z"}
+{"event":"review","result":"passed","ts":"2026-07-31T08:43:18Z"}

--- a/fab/changes/260731-vvco-desktop-menu-restart-update/.status.yaml
+++ b/fab/changes/260731-vvco-desktop-menu-restart-update/.status.yaml
@@ -10,7 +10,7 @@ progress:
     review: done
     hydrate: done
     ship: done
-    review-pr: active
+    review-pr: done
 plan:
     generated: true
     task_count: 7
@@ -34,7 +34,7 @@ stage_metrics:
     review: {started_at: "2026-07-31T08:17:12Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-31T08:24:57Z"}
     hydrate: {started_at: "2026-07-31T08:24:57Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-31T08:29:51Z"}
     ship: {started_at: "2026-07-31T08:29:51Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-31T08:33:01Z"}
-    review-pr: {started_at: "2026-07-31T08:33:01Z", driver: git-pr, iterations: 1}
+    review-pr: {started_at: "2026-07-31T08:33:01Z", driver: git-pr, iterations: 1, completed_at: "2026-07-31T08:43:18Z"}
 prs:
     - https://github.com/sahil87/run-kit/pull/482
 change_type_source: explicit
@@ -54,4 +54,4 @@ true_impact:
     computed_at_stage: ship
 summary: Desktop shell gets a detection-gated, accelerator-less App-menu 'Restart to Update' item that spawns rk desktop update detached, backed by a new electron-free update-check module (rk desktop status parsing + 1h throttle)
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-07-31T08:33:01Z
+last_updated: 2026-07-31T08:43:18Z


### PR DESCRIPTION
## Summary

PR #482 was merged while its Copilot review was still pending. The review landed afterwards and both comments were fixed on the recreated branch — this PR lands those two fixes.

## Changes

- `app/desktop/src/update-check.ts` — `isUpdateCheckDue` treats a backwards clock (`now < lastCheckedAt`) as due, with a regression test (69/69 desktop tests pass, tsc clean)
- `app/desktop/src/main.ts` — `refreshUpdateMenu` re-checks `updateMenuInfo?.updating` after the awaited `runRk` so an in-flight status probe can't clobber the `Updating…` state

Follow-up to #482; both Copilot comments there have disposition replies.