### PR TITLE
fix: _tmux helper follow-ups from Copilot review of #490

### DIFF
--- a/app/frontend/tests/e2e/_tmux.ts
+++ b/app/frontend/tests/e2e/_tmux.ts
@@ -36,12 +36,19 @@ export interface WindowSpec {
 }
 
 /** Run a tmux command against the given server and return its stdout.
- *  Throws on non-zero exit — lifecycle helpers wrap this in best-effort
- *  try/catch; mid-test callers usually want the error. */
-export function tmux(args: string[], opts: TmuxOptions = {}): string {
-  return execFileSync("tmux", ["-L", opts.server ?? TMUX_SERVER, ...args], {
-    stdio: ["ignore", "pipe", "ignore"],
-  }).toString();
+ *  Throws on non-zero exit (with tmux's stderr appended to the message) —
+ *  lifecycle helpers wrap this in best-effort try/catch; mid-test callers
+ *  usually want the error. Module-private: specs use the named helpers. */
+function tmux(args: string[], opts: TmuxOptions = {}): string {
+  try {
+    return execFileSync("tmux", ["-L", opts.server ?? TMUX_SERVER, ...args], {
+      stdio: ["ignore", "pipe", "pipe"],
+    }).toString();
+  } catch (err) {
+    const stderr = (err as { stderr?: Buffer }).stderr?.toString().trim();
+    if (err instanceof Error && stderr) err.message += `\ntmux: ${stderr}`;
+    throw err;
+  }
 }
 
 export interface CreateSessionOptions extends TmuxOptions {

--- a/fab/changes/260731-yc7n-e2e-tmux-fixture-readiness/.history.jsonl
+++ b/fab/changes/260731-yc7n-e2e-tmux-fixture-readiness/.history.jsonl
@@ -9,3 +9,5 @@
 {"event":"review","result":"passed","ts":"2026-07-31T09:45:18Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-07-31T09:48:33Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-07-31T09:51:48Z"}
+{"cmd":"git-pr-review","event":"command","ts":"2026-07-31T09:52:43Z"}
+{"event":"review","result":"passed","ts":"2026-07-31T10:04:22Z"}

--- a/fab/changes/260731-yc7n-e2e-tmux-fixture-readiness/.status.yaml
+++ b/fab/changes/260731-yc7n-e2e-tmux-fixture-readiness/.status.yaml
@@ -10,7 +10,7 @@ progress:
     review: done
     hydrate: done
     ship: done
-    review-pr: active
+    review-pr: done
 plan:
     generated: true
     task_count: 12
@@ -34,7 +34,7 @@ stage_metrics:
     review: {started_at: "2026-07-31T09:38:16Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-31T09:45:18Z"}
     hydrate: {started_at: "2026-07-31T09:45:18Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-31T09:48:33Z"}
     ship: {started_at: "2026-07-31T09:48:33Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-31T09:51:48Z"}
-    review-pr: {started_at: "2026-07-31T09:51:48Z", driver: git-pr, iterations: 1}
+    review-pr: {started_at: "2026-07-31T09:51:48Z", driver: git-pr, iterations: 1, completed_at: "2026-07-31T10:04:22Z"}
 prs:
     - https://github.com/sahil87/run-kit/pull/490
 change_type_source: explicit
@@ -54,4 +54,4 @@ true_impact:
     computed_at_stage: ship
 summary: 'E2E specs seed tmux through a shared _tmux.ts fixture (single TMUX_SERVER, =name: exact-match targets) and gate readiness through _ready.ts''s CI-widened READY_TIMEOUT + full-window resolveWindow.'
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-07-31T09:51:48Z
+last_updated: 2026-07-31T10:04:22Z


### PR DESCRIPTION
Follow-up to the Copilot review of #490, which landed one minute after the PR was merged.

- Make `tmux()` module-private in `app/frontend/tests/e2e/_tmux.ts` — no spec imports it; the named lifecycle helpers are the public surface.
- Pipe tmux stderr instead of discarding it, appending it to thrown errors so mid-test failures (e.g. `newWindow()`) carry tmux's own message.

Verified: `npx tsc --noEmit` clean; `just test-e2e "host-health-home.spec.ts:16"` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)