### PR TITLE
fix: Desktop shell fallback strip covers the SPA top bar

### DIFF
--- a/app/desktop/src/main.ts
+++ b/app/desktop/src/main.ts
@@ -759,32 +759,54 @@ function openMainWindow(): void {
       additionalArguments: [`--runkit-shell-version=${app.getVersion()}`],
     },
   });
+  // Key of the fallback strip CSS injected into the CURRENT page load (null
+  // when none). Tracked so a theme-color report landing AFTER the injection
+  // can recolor the band — `did-finish-load` only sees `lastThemeColor`, which
+  // at that point may still be the PREVIOUS page's color (a stale-tint band).
+  let fallbackCssKey: string | null = null;
+  const refreshFallbackStrip = async (): Promise<void> => {
+    const url = win.webContents.getURL();
+    if (!shouldInjectFallbackStrip(url, registeredOrigins())) return;
+    const stale = fallbackCssKey;
+    fallbackCssKey = null;
+    try {
+      if (stale != null) await win.webContents.removeInsertedCSS(stale);
+      fallbackCssKey = await win.webContents.insertCSS(fallbackStripCss(lastThemeColor));
+    } catch {
+      // A navigation raced the injection — the next did-finish-load re-runs.
+    }
+  };
+  // Inserted CSS does not survive a main-frame navigation; drop the dead key.
+  win.webContents.on("did-navigate", () => {
+    fallbackCssKey = null;
+  });
   // Keep the win/linux window-controls overlay in sync with the page's
   // theme-color meta — the same seam the installed-PWA titlebar uses, so no
   // new SPA→shell color API exists. Linux WCO support is partial; a throwing
   // setTitleBarOverlay degrades silently.
   win.webContents.on("did-change-theme-color", (_event, color) => {
     lastThemeColor = color ?? DEFAULT_STRIP_COLOR;
-    if (process.platform === "darwin") return;
-    try {
-      win.setTitleBarOverlay({
-        color: lastThemeColor,
-        symbolColor: symbolColorFor(lastThemeColor),
-        height: STRIP_HEIGHT_PX,
-      });
-    } catch {
-      // Partial window-controls-overlay support (linux) — degrade silently.
+    if (process.platform !== "darwin") {
+      try {
+        win.setTitleBarOverlay({
+          color: lastThemeColor,
+          symbolColor: symbolColorFor(lastThemeColor),
+          height: STRIP_HEIGHT_PX,
+        });
+      } catch {
+        // Partial window-controls-overlay support (linux) — degrade silently.
+      }
     }
+    // Recolor an already-injected fallback band (all platforms — the band is
+    // the visible titlebar on darwin too).
+    if (fallbackCssKey != null) void refreshFallbackStrip();
   });
   // Version-skew fallback: an older SPA (no strip) under this hidden-titlebar
   // shell would have no drag surface. Registered-host pages get a minimal
   // draggable band whose CSS no-ops when the SPA-drawn strip marks
   // `html.rk-shell-strip` (CSS is live, so injecting unconditionally is safe).
   win.webContents.on("did-finish-load", () => {
-    const url = win.webContents.getURL();
-    if (shouldInjectFallbackStrip(url, registeredOrigins())) {
-      void win.webContents.insertCSS(fallbackStripCss(lastThemeColor));
-    }
+    void refreshFallbackStrip();
   });
   // Capture-on-quit: cold-start restore reflects the route at close, not just
   // the last switch-away (webContents is still readable during 'close').

--- a/app/desktop/src/strip.test.ts
+++ b/app/desktop/src/strip.test.ts
@@ -41,6 +41,18 @@ test("fallback CSS is keyed on the marker class and carries the strip geometry",
   assert.ok(css.includes("-webkit-app-region: drag"));
 });
 
+test("fallback CSS pins the fullbleed app root below the band", () => {
+  // The rk SPA's `.app-root` is position:fixed under `html.fullbleed` — body
+  // padding alone cannot reserve the band's space there, so the CSS must pin
+  // the root down with !important overrides (else the band covers the top bar).
+  const css = fallbackStripCss("#123456");
+  assert.ok(css.includes(`html.fullbleed:not(.${STRIP_MARKER_CLASS}) .app-root`));
+  assert.ok(css.includes(`top: ${STRIP_HEIGHT_PX}px !important`));
+  assert.ok(
+    css.includes(`height: calc(var(--app-height, 100vh) - ${STRIP_HEIGHT_PX}px) !important`),
+  );
+});
+
 test("fallback CSS falls back to the default color on junk input", () => {
   const css = fallbackStripCss("javascript:alert(1)");
   assert.ok(css.includes(`background: ${DEFAULT_STRIP_COLOR}`));

--- a/app/desktop/src/strip.ts
+++ b/app/desktop/src/strip.ts
@@ -57,6 +57,15 @@ export function symbolColorFor(bgHex: string): string {
  * Version-skew fallback: minimal CSS giving an older (strip-less) SPA a
  * draggable titlebar band under the hidden native titlebar. Keyed on
  * `html:not(.rk-shell-strip)` so a strip-drawing SPA no-ops it.
+ *
+ * Space reservation is two-pronged because the rk SPA pins its layout root to
+ * the viewport (`html.fullbleed .app-root { position: fixed; inset: 0 }` —
+ * `fullbleed` is added unconditionally on mount): body padding cannot move a
+ * fixed-position element, so on its own the fixed band would paint OVER the
+ * SPA's top bar. The `.fullbleed .app-root` override pins the root below the
+ * band instead (`!important` beats both the SPA stylesheet's
+ * `top: var(--app-offset-top)` and the inline `height` style); the body
+ * padding remains for non-fullbleed pages in normal flow.
  */
 export function fallbackStripCss(bgHex: string): string {
   const color = /^#([0-9a-fA-F]{6})$/.test(bgHex.trim()) ? bgHex.trim() : DEFAULT_STRIP_COLOR;
@@ -70,6 +79,10 @@ export function fallbackStripCss(bgHex: string): string {
     `  background: ${color};`,
     `  -webkit-app-region: drag;`,
     `  z-index: 2147483647;`,
+    `}`,
+    `html.fullbleed:not(.${STRIP_MARKER_CLASS}) .app-root {`,
+    `  top: ${STRIP_HEIGHT_PX}px !important;`,
+    `  height: calc(var(--app-height, 100vh) - ${STRIP_HEIGHT_PX}px) !important;`,
     `}`,
   ].join("\n");
 }


### PR DESCRIPTION
## Summary

The desktop shell's version-skew fallback titlebar strip (introduced in #487) painted over the SPA's top bar instead of above it: the fallback reserved space with `body { padding-top: 28px }`, but every rk SPA pins its layout root to the viewport (`html.fullbleed .app-root { position: fixed; inset: 0 }`), which body padding cannot move — so the fixed 28px band covered the top bar's first 28px, hiding the breadcrumb, heading, and controls. The band also kept a stale `lastThemeColor` tint (the previous page's theme-color) because the injected CSS was never recolored after a `did-change-theme-color` report.

## Changes

- `strip.ts` — `fallbackStripCss()` now also pins the fullbleed app root below the band (`html.fullbleed:not(.rk-shell-strip) .app-root { top: 28px !important; height: calc(var(--app-height, 100vh) - 28px) !important }`); body padding is kept for non-fullbleed pages in normal flow
- `main.ts` — the fallback injection tracks its `insertCSS` key and re-injects with the fresh color when the page reports `did-change-theme-color` (all platforms; key dropped on `did-navigate`)
- `strip.test.ts` — new test asserting the fullbleed-root override geometry

Verified with Playwright against the live SPA: the old CSS reproduces the cover (header at y=2 under the band), the fixed CSS pins the root at y=28 with the top bar fully visible, and a new SPA with the shell bridge still mounts the real strip (marker class no-ops the fallback). All 87 desktop `node --test` tests pass.
