### PR TITLE
chore: Frontend TypeScript 7 Bump

### DIFF
--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -41,7 +41,7 @@
     "postcss": "^8.5.10",
     "sharp": "^0.35.0",
     "tailwindcss": "^4.2.2",
-    "typescript": "^6.0.3",
+    "typescript": "^7.0.2",
     "vite": "^8.0.16",
     "vitest": "^4.1.4",
     "yaml": "^2.8.4"

--- a/app/frontend/pnpm-lock.yaml
+++ b/app/frontend/pnpm-lock.yaml
@@ -80,7 +80,7 @@ importers:
         version: 29.0.2
       msw:
         specifier: ^2.13.4
-        version: 2.13.4(@types/node@25.6.0)(typescript@6.0.3)
+        version: 2.13.4(@types/node@25.6.0)(typescript@7.0.2)
       postcss:
         specifier: ^8.5.10
         version: 8.5.10
@@ -91,14 +91,14 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vite:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@25.6.0)(jsdom@29.0.2)(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
+        version: 4.1.4(@types/node@25.6.0)(jsdom@29.0.2)(msw@2.13.4(@types/node@25.6.0)(typescript@7.0.2))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
       yaml:
         specifier: ^2.8.4
         version: 2.8.4
@@ -923,6 +923,126 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
 
   '@ungap/structured-clone@1.3.3':
     resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
@@ -1796,9 +1916,9 @@ packages:
     resolution: {integrity: sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==}
     engines: {node: '>=20'}
 
-  typescript@6.0.3:
-    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
-    engines: {node: '>=14.17'}
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   undici-types@7.19.2:
@@ -2614,6 +2734,66 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
   '@ungap/structured-clone@1.3.3': {}
 
   '@vitejs/plugin-react@6.0.1(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))':
@@ -2630,13 +2810,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))':
+  '@vitest/mocker@4.1.4(msw@2.13.4(@types/node@25.6.0)(typescript@7.0.2))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.13.4(@types/node@25.6.0)(typescript@6.0.3)
+      msw: 2.13.4(@types/node@25.6.0)(typescript@7.0.2)
       vite: 8.0.16(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
 
   '@vitest/pretty-format@4.1.4':
@@ -3373,7 +3553,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.13.4(@types/node@25.6.0)(typescript@6.0.3):
+  msw@2.13.4(@types/node@25.6.0)(typescript@7.0.2):
     dependencies:
       '@inquirer/confirm': 6.0.11(@types/node@25.6.0)
       '@mswjs/interceptors': 0.41.3
@@ -3394,7 +3574,7 @@ snapshots:
       until-async: 3.0.2
       yargs: 17.7.2
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - '@types/node'
 
@@ -3723,7 +3903,28 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
-  typescript@6.0.3: {}
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   undici-types@7.19.2: {}
 
@@ -3794,10 +3995,10 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.4
 
-  vitest@4.1.4(@types/node@25.6.0)(jsdom@29.0.2)(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)):
+  vitest@4.1.4(@types/node@25.6.0)(jsdom@29.0.2)(msw@2.13.4(@types/node@25.6.0)(typescript@7.0.2))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(msw@2.13.4(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
+      '@vitest/mocker': 4.1.4(msw@2.13.4(@types/node@25.6.0)(typescript@7.0.2))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4

--- a/fab/changes/260731-lu5e-frontend-typescript-7-bump/.history.jsonl
+++ b/fab/changes/260731-lu5e-frontend-typescript-7-bump/.history.jsonl
@@ -1,0 +1,13 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-07-31T14:21:30Z"}
+{"args":"Migrate the frontend from TypeScript 6 to TypeScript 7 (native Go compiler): bump app/frontend typescript devDependency ^6.0.3 -\u003e ^7.0.2, update pnpm-lock.yaml, fix stale TypeScript 5.7+ line in fab/project/context.md","cmd":"fab-new","event":"command","ts":"2026-07-31T14:21:30Z"}
+{"delta":"+0.0","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-07-31T14:22:40Z"}
+{"delta":"+0.0","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-07-31T14:23:11Z"}
+{"cmd":"fab-proceed","event":"command","ts":"2026-07-31T14:23:18Z"}
+{"cmd":"fab-fff","event":"command","ts":"2026-07-31T14:26:05Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-07-31T14:26:05Z"}
+{"cmd":"fab-continue","event":"command","ts":"2026-07-31T14:27:15Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-07-31T15:06:05Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-07-31T15:13:02Z"}
+{"event":"review","result":"passed","ts":"2026-07-31T15:13:02Z"}
+{"cmd":"fab-continue","event":"command","ts":"2026-07-31T15:13:36Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-07-31T15:14:40Z"}

--- a/fab/changes/260731-lu5e-frontend-typescript-7-bump/.history.jsonl
+++ b/fab/changes/260731-lu5e-frontend-typescript-7-bump/.history.jsonl
@@ -12,3 +12,5 @@
 {"cmd":"fab-continue","event":"command","ts":"2026-07-31T15:13:36Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-07-31T15:14:40Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-07-31T15:16:40Z"}
+{"cmd":"git-pr-review","event":"command","ts":"2026-07-31T15:18:00Z"}
+{"event":"review","result":"passed","ts":"2026-07-31T15:23:54Z"}

--- a/fab/changes/260731-lu5e-frontend-typescript-7-bump/.history.jsonl
+++ b/fab/changes/260731-lu5e-frontend-typescript-7-bump/.history.jsonl
@@ -11,3 +11,4 @@
 {"event":"review","result":"passed","ts":"2026-07-31T15:13:02Z"}
 {"cmd":"fab-continue","event":"command","ts":"2026-07-31T15:13:36Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-07-31T15:14:40Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-07-31T15:16:40Z"}

--- a/fab/changes/260731-lu5e-frontend-typescript-7-bump/.status.yaml
+++ b/fab/changes/260731-lu5e-frontend-typescript-7-bump/.status.yaml
@@ -1,0 +1,55 @@
+id: lu5e
+name: 260731-lu5e-frontend-typescript-7-bump
+created: 2026-07-31T14:21:30Z
+created_by: Sahil Ahuja
+change_type: chore
+issues: []
+progress:
+    intake: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+plan:
+    generated: true
+    task_count: 6
+    acceptance_count: 10
+    acceptance_completed: 10
+confidence:
+    certain: 7
+    confident: 0
+    tentative: 0
+    unresolved: 0
+    score: 5.0
+    fuzzy: true
+    dimensions:
+        signal: 88.6
+        reversibility: 92.1
+        competence: 95.0
+        disambiguation: 92.1
+stage_metrics:
+    intake: {started_at: "2026-07-31T14:21:30Z", driver: fab-new, iterations: 1, completed_at: "2026-07-31T14:26:05Z"}
+    apply: {started_at: "2026-07-31T14:26:05Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-31T15:06:05Z"}
+    review: {started_at: "2026-07-31T15:06:05Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-31T15:13:02Z"}
+    hydrate: {started_at: "2026-07-31T15:13:02Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-31T15:14:40Z"}
+    ship: {started_at: "2026-07-31T15:14:40Z", driver: fab-fff, iterations: 1}
+prs: []
+change_type_source: explicit
+true_impact:
+    added: 0
+    deleted: 0
+    net: 0
+    excluding:
+        added: 0
+        deleted: 0
+        net: 0
+    tests:
+        added: 0
+        deleted: 0
+        net: 0
+    computed_at: "2026-07-31T15:14:40Z"
+    computed_at_stage: hydrate
+summary: Frontend typescript devDependency bumped 6.0.3 → ^7.0.2 (TS 7 native Go compiler) with lockfile refresh; converges app/frontend onto app/desktop's TS major. No memory changes — tooling-only, no documented behavior pins the frontend TS version.
+# true_impact: lazily created on first stage-finish that computes it (no placeholder here).
+last_updated: 2026-07-31T15:14:40Z

--- a/fab/changes/260731-lu5e-frontend-typescript-7-bump/.status.yaml
+++ b/fab/changes/260731-lu5e-frontend-typescript-7-bump/.status.yaml
@@ -9,8 +9,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 plan:
     generated: true
     task_count: 6
@@ -33,23 +33,25 @@ stage_metrics:
     apply: {started_at: "2026-07-31T14:26:05Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-31T15:06:05Z"}
     review: {started_at: "2026-07-31T15:06:05Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-31T15:13:02Z"}
     hydrate: {started_at: "2026-07-31T15:13:02Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-31T15:14:40Z"}
-    ship: {started_at: "2026-07-31T15:14:40Z", driver: fab-fff, iterations: 1}
-prs: []
+    ship: {started_at: "2026-07-31T15:14:40Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-31T15:16:40Z"}
+    review-pr: {started_at: "2026-07-31T15:16:40Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/sahil87/run-kit/pull/495
 change_type_source: explicit
 true_impact:
-    added: 0
-    deleted: 0
-    net: 0
+    added: 478
+    deleted: 16
+    net: 462
     excluding:
-        added: 0
-        deleted: 0
-        net: 0
+        added: 216
+        deleted: 15
+        net: 201
     tests:
         added: 0
         deleted: 0
         net: 0
-    computed_at: "2026-07-31T15:14:40Z"
-    computed_at_stage: hydrate
+    computed_at: "2026-07-31T15:16:40Z"
+    computed_at_stage: ship
 summary: Frontend typescript devDependency bumped 6.0.3 → ^7.0.2 (TS 7 native Go compiler) with lockfile refresh; converges app/frontend onto app/desktop's TS major. No memory changes — tooling-only, no documented behavior pins the frontend TS version.
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-07-31T15:14:40Z
+last_updated: 2026-07-31T15:16:40Z

--- a/fab/changes/260731-lu5e-frontend-typescript-7-bump/.status.yaml
+++ b/fab/changes/260731-lu5e-frontend-typescript-7-bump/.status.yaml
@@ -10,7 +10,7 @@ progress:
     review: done
     hydrate: done
     ship: done
-    review-pr: active
+    review-pr: done
 plan:
     generated: true
     task_count: 6
@@ -34,7 +34,7 @@ stage_metrics:
     review: {started_at: "2026-07-31T15:06:05Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-31T15:13:02Z"}
     hydrate: {started_at: "2026-07-31T15:13:02Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-31T15:14:40Z"}
     ship: {started_at: "2026-07-31T15:14:40Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-31T15:16:40Z"}
-    review-pr: {started_at: "2026-07-31T15:16:40Z", driver: git-pr, iterations: 1}
+    review-pr: {started_at: "2026-07-31T15:16:40Z", driver: git-pr, iterations: 1, completed_at: "2026-07-31T15:23:54Z"}
 prs:
     - https://github.com/sahil87/run-kit/pull/495
 change_type_source: explicit
@@ -54,4 +54,4 @@ true_impact:
     computed_at_stage: ship
 summary: Frontend typescript devDependency bumped 6.0.3 → ^7.0.2 (TS 7 native Go compiler) with lockfile refresh; converges app/frontend onto app/desktop's TS major. No memory changes — tooling-only, no documented behavior pins the frontend TS version.
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-07-31T15:16:40Z
+last_updated: 2026-07-31T15:23:54Z

--- a/fab/changes/260731-lu5e-frontend-typescript-7-bump/intake.md
+++ b/fab/changes/260731-lu5e-frontend-typescript-7-bump/intake.md
@@ -1,0 +1,89 @@
+# Intake: Frontend TypeScript 7 Bump
+
+**Change**: 260731-lu5e-frontend-typescript-7-bump
+**Created**: 2026-07-31
+
+## Origin
+
+Promptless dispatch (fab-proceed create-intake subagent, `{questioning-mode} = promptless-defer`), synthesized from a live conversation in which the migration was empirically pre-verified on 2026-07-31.
+
+> Migrate the frontend from TypeScript 6 to TypeScript 7 (native Go compiler). Bump `app/frontend/package.json` devDependency `typescript` from `^6.0.3` to `^7.0.2`, run `pnpm install` to update `pnpm-lock.yaml`, and fix the stale "TypeScript 5.7+" line in `fab/project/context.md`. Keep the change minimal — no tsconfig changes, no new TS-API-dependent tooling.
+
+Key facts verified in the originating session (all empirical, 2026-07-31):
+
+- TypeScript 7.0 (the native Go-port compiler, formerly `tsgo`) went GA on 2026-07-08 and ships as standard `tsc` in the `typescript` npm package.
+- TypeScript 7.0.2 `tsc --noEmit` was run against `app/frontend` with its real tsconfig — **zero errors**; wall time 0.6s vs 5.0s on TS 6.0.3 (~8× faster; 2.7s vs 8.5s CPU).
+- `app/desktop/package.json` is already on `"typescript": "^7.0.2"` and uses `tsc` for real emit — this change converges the repo on one TS major. (Re-verified during intake: `app/frontend/package.json:44` pins `^6.0.3`; `app/desktop/package.json:24` pins `^7.0.2`.)
+- The only `tsc` consumer in the frontend is the `tsc --noEmit` step in the `build` script (`tsc --noEmit && vite build`). Vite/esbuild does the transpile, Vitest uses the Vite transform, Playwright self-transpiles.
+- There are NO TypeScript-API consumers anywhere in `app/` or `scripts/` — no typescript-eslint, no ts-node, no router codegen, no programmatic `import "typescript"`. The known TS 7 ecosystem caveat (stable programmatic API lands in 7.1; typescript-eslint blocked until then) therefore does not apply to this repo.
+
+## Why
+
+1. **Problem**: The frontend is pinned to TypeScript 6.0.3 while `app/desktop` already runs TypeScript 7.0.2 — two TS majors in one repo. The frontend typecheck (`tsc --noEmit`, the first half of every `build`) takes 5.0s on TS 6 vs 0.6s on TS 7 (~8× faster wall, ~3× less CPU), a tax paid on every production build and every code-quality verification pass.
+2. **If not fixed**: The repo stays split across TS majors (divergent language behavior and diagnostics between frontend and desktop), and every build/typecheck cycle keeps paying the 8× speed penalty for no benefit.
+3. **Why this approach**: TS 7 is GA in the standard `typescript` npm package, and the migration was already proven green empirically — zero type errors on the real tsconfig, no config changes needed, no blocked tooling in the dependency graph. A caret bump plus lockfile refresh is the entire migration surface; anything larger (tsconfig rework, tooling swaps) would be gold-plating.
+
+## What Changes
+
+### 1. `app/frontend/package.json` — typescript devDependency bump
+
+Change the `typescript` entry in `devDependencies` (currently line 44):
+
+```diff
+-    "typescript": "^6.0.3",
++    "typescript": "^7.0.2",
+```
+
+Then run `pnpm install` from `app/frontend/` to update `pnpm-lock.yaml`. Expected lockfile delta: the `typescript` resolution moves from 6.0.3 to a 7.0.x release; no other dependency changes are intended.
+
+No tsconfig changes: current options (`moduleResolution: bundler`, `jsx: react-jsx`, `paths`, `allowJs`, `isolatedModules`) are all supported by TS 7 and were verified in the pre-check.
+
+### 2. `fab/project/context.md` — fix stale TS version line
+
+The Frontend section (`## Frontend — app/frontend/`, line 41) currently reads:
+
+```markdown
+- **Language**: TypeScript 5.7+
+```
+
+Update it to reflect TypeScript 7, e.g.:
+
+```markdown
+- **Language**: TypeScript 7 (native Go compiler)
+```
+
+### Non-changes (explicit scope exclusions)
+
+- `app/desktop/package.json` — untouched (already `^7.0.2`).
+- `app/frontend/tsconfig*.json` — untouched (verified compatible).
+- No TS-API-dependent tooling (typescript-eslint, ts-node, etc.) is added.
+- Build script stays `tsc --noEmit && vite build` — the `tsc` binary simply resolves to the TS 7 native compiler.
+
+## Affected Memory
+
+None — implementation-only tooling bump. No `docs/memory/` file pins the frontend TypeScript version (verified by grep: `desktop-shell.md` mentions `typescript` as an app/desktop devDependency without a version pin, which this change does not touch). No spec-level behavior changes.
+
+## Impact
+
+- **Files**: `app/frontend/package.json` (1 line), `app/frontend/pnpm-lock.yaml` (typescript resolution), `fab/project/context.md` (1 line).
+- **Systems**: frontend typecheck/build path only. Runtime bundle output is unaffected (Vite/esbuild transpiles; `tsc` is check-only in this package).
+- **Dependencies**: `typescript` 6.0.3 → 7.0.x. No transitive tooling depends on the TypeScript programmatic API.
+- **Verification** (agreed in the originating conversation, matching `fab/project/code-quality.md` gates): `just test` (backend + frontend + e2e) and `just build`. The typecheck itself is already proven green on TS 7.0.2.
+
+## Open Questions
+
+None — the migration surface was fully enumerated and empirically verified in the originating session.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Bump to `^7.0.2` (caret range) in `app/frontend/package.json` devDependencies; no tsconfig changes | Explicit in the change description; TS 7.0.2 `tsc --noEmit` empirically verified zero-errors against the real tsconfig; matches app/desktop's existing pin style | S:95 R:95 A:100 D:100 |
+| 2 | Certain | Migration surface is the single `tsc --noEmit` build step — no TS-API consumers exist to break | Verified in the originating session: no typescript-eslint/ts-node/codegen/programmatic imports in `app/` or `scripts/`; Vite/Vitest/Playwright do not invoke `tsc` | S:95 R:90 A:100 D:100 |
+| 3 | Certain | Leave `app/desktop` untouched | Already on `^7.0.2` (verified at `app/desktop/package.json:24`); touching it would be scope creep | S:90 R:95 A:100 D:95 |
+| 4 | Certain | Verification = `just test` + `just build` | Explicitly agreed in the originating conversation and identical to the code-quality.md verification gates | S:95 R:90 A:95 D:95 |
+| 5 | Certain | Change type is `chore` (dependency/tooling bump) | Matches the change-types taxonomy for dependency bumps; description says "likely chore" | S:90 R:95 A:95 D:95 |
+| 6 | Certain | `context.md` line becomes "TypeScript 7 (native Go compiler)" — exact wording is agent's choice | Description mandates fixing the stale "5.7+" line but not the exact replacement text; trivially reversible one-line doc edit with an obvious default | S:85 R:95 A:90 D:80 |
+| 7 | Certain | No new tests required; existing gates (typecheck, `just test`, `just build`) cover the change | code-quality.md requires tests for "features and bug fixes" — a toolchain version bump changes no behavior to test; the typecheck IS the test | S:70 R:85 A:85 D:80 |
+
+7 assumptions (7 certain, 0 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260731-lu5e-frontend-typescript-7-bump/plan.md
+++ b/fab/changes/260731-lu5e-frontend-typescript-7-bump/plan.md
@@ -74,7 +74,7 @@ With TS 7 installed, the frontend typecheck (`tsc --noEmit`) MUST pass with zero
 ### Scenario Coverage
 
 - [x] A-004 R3: `just test` (backend + frontend + e2e) passes, with any e2e failure triaged against the known-flaky-on-main signatures — apply ran the full `just test` green (T005, 1 iteration, no rework). Review re-ran the scoped gate `just test-frontend`: 118 files / 2071 tests passed. Full e2e deliberately not re-run at review (already green at apply; the suite is a 3-shard SSE/tmux-contended gate)
-- [x] A-005 R3: `just build` succeeds (the build script's `tsc --noEmit` half runs the TS 7 binary) — **partially N/A, pre-existing failure**: the change-relevant half is verified green (`pnpm build` = `tsc --noEmit && vite build` exits 0 on TS 7). The `just build` recipe still fails at `scripts/build.sh:19` (`cat "$REPO_ROOT/VERSION"`) because `VERSION` was deleted by `ea750837` (PR #193, tag-driven release port) and is absent at the merge-base — confirmed pre-existing on main, independent of this change
+- [x] A-005 R3: the change-relevant build steps pass — `pnpm build` (`tsc --noEmit && vite build`) exits 0 with the typecheck half running the TS 7 binary. The full `just build` recipe was NOT verified end-to-end: it fails at `scripts/build.sh:19` (`cat "$REPO_ROOT/VERSION"`) because `VERSION` was deleted by `ea750837` (PR #193, tag-driven release port) — a pre-existing failure on main, independent of this change
 
 ### Edge Cases & Error Handling
 

--- a/fab/changes/260731-lu5e-frontend-typescript-7-bump/plan.md
+++ b/fab/changes/260731-lu5e-frontend-typescript-7-bump/plan.md
@@ -1,0 +1,104 @@
+# Plan: Frontend TypeScript 7 Bump
+
+**Change**: 260731-lu5e-frontend-typescript-7-bump
+**Intake**: `intake.md`
+
+## Requirements
+
+### Frontend Toolchain: TypeScript 7 Bump
+
+#### R1: Frontend typescript devDependency moves to TS 7
+The `typescript` entry in `app/frontend/package.json` `devDependencies` MUST be `^7.0.2` (caret range, matching `app/desktop`'s existing pin style), and `app/frontend/pnpm-lock.yaml` MUST be refreshed via `pnpm install` so the `typescript` resolution moves from 6.0.3 to a 7.0.x release. No other dependency changes SHALL be introduced, and `app/frontend/tsconfig*.json` SHALL remain untouched.
+
+- **GIVEN** `app/frontend/package.json` pins `"typescript": "^6.0.3"` (line 44)
+- **WHEN** the devDependency is changed to `^7.0.2` and `pnpm install` is run from `app/frontend/`
+- **THEN** `pnpm-lock.yaml` resolves `typescript` to a 7.0.x release
+- **AND** the lockfile delta contains no other dependency changes
+
+#### R2: Project context doc reflects TypeScript 7
+The `- **Language**: TypeScript 5.7+` line in the `## Frontend — app/frontend/` section of `fab/project/context.md` (line 41) MUST be updated to reflect TypeScript 7 (the native Go compiler).
+
+- **GIVEN** `fab/project/context.md` line 41 reads `- **Language**: TypeScript 5.7+`
+- **WHEN** the stale line is corrected
+- **THEN** it reads `- **Language**: TypeScript 7 (native Go compiler)`
+
+#### R3: Verification gates stay green on TS 7
+With TS 7 installed, the frontend typecheck (`tsc --noEmit`) MUST pass with zero errors, and the project gates `just test` (backend + frontend + e2e) and `just build` MUST succeed. Tests SHALL be run only via `just` recipes (port isolation), never raw `go test`/`pnpm test`/`playwright test`.
+
+- **GIVEN** the bumped dependency is installed in `app/frontend/node_modules`
+- **WHEN** `./node_modules/.bin/tsc --noEmit` is run from `app/frontend/`, followed by `just test` and `just build` from the repo root
+- **THEN** the typecheck reports zero errors and both `just` gates succeed
+- **AND** any e2e failure matching a known pre-existing flaky signature on main (max-update-depth console errors in window-heading/window-switch-transition/sync-latency; window-heading "◀ ▶ arrows" forward-nav timeout; multi-server-sidebar:70) is judged against that signature rather than attributed to this check-only compiler bump
+
+### Non-Goals
+
+- `app/desktop/package.json` — already on `^7.0.2`; touching it would be scope creep
+- `app/frontend/tsconfig*.json` changes — current options verified compatible with TS 7
+- Adding TS-API-dependent tooling (typescript-eslint, ts-node, codegen) — none exists in the repo and TS 7's programmatic API lands in 7.1
+- Build script changes — stays `tsc --noEmit && vite build`; the `tsc` binary simply resolves to the TS 7 native compiler
+
+## Tasks
+
+### Phase 1: Setup
+
+- [x] T001 Bump `typescript` devDependency from `^6.0.3` to `^7.0.2` in `app/frontend/package.json` <!-- R1 -->
+- [x] T002 Run `pnpm install` from `app/frontend/` to refresh `pnpm-lock.yaml`; verify the delta is limited to the typescript resolution <!-- R1 -->
+
+### Phase 2: Core Implementation
+
+- [x] T003 [P] Update `fab/project/context.md` line 41 (`## Frontend — app/frontend/` section) from `- **Language**: TypeScript 5.7+` to `- **Language**: TypeScript 7 (native Go compiler)` <!-- R2 -->
+
+### Phase 3: Integration & Edge Cases
+
+- [x] T004 Run the frontend typecheck: `cd app/frontend && ./node_modules/.bin/tsc --noEmit` — MUST report zero errors on TS 7 <!-- R3 -->
+- [x] T005 Run `just test` (backend + frontend + e2e) from the repo root; triage any e2e failure against the known pre-existing flaky signatures before attributing it to the bump <!-- R3 -->
+- [x] T006 Run `just build` from the repo root — MUST succeed <!-- R3 --> <!-- rework-note: the change-relevant half (tsc --noEmit && vite build on TS 7, plus dist→embed copy) succeeded; the recipe then fails at scripts/build.sh:19 `cat VERSION` — pre-existing on main since ea750837 (PR #193) deleted the VERSION file, unrelated to this change. Go compile of cmd/rk with the TS-7-built embedded frontend verified manually (CGO_ENABLED=0 go build ./cmd/rk → OK). -->
+
+## Execution Order
+
+- T001 blocks T002 (install reads the bumped manifest)
+- T002 blocks T004–T006 (gates run against the installed TS 7)
+- T003 is independent, can run alongside T001–T002
+
+## Acceptance
+
+### Functional Completeness
+
+- [x] A-001 R1: `app/frontend/package.json` devDependencies pin `"typescript": "^7.0.2"` and `pnpm-lock.yaml` resolves typescript to a 7.0.x release — verified: `package.json:44` reads `"typescript": "^7.0.2"`; lockfile importer specifier `^7.0.2` / version `7.0.2`; installed binary reports `Version 7.0.2`
+- [x] A-002 R2: `fab/project/context.md` Frontend section reads `- **Language**: TypeScript 7 (native Go compiler)` (no stale `5.7+` remains) — verified at `context.md:41`; repo-wide grep finds no remaining live `5.7+`/TS-6 claim (only archived change artifacts, correctly untouched)
+
+### Behavioral Correctness
+
+- [x] A-003 R3: `./node_modules/.bin/tsc --noEmit` in `app/frontend/` exits 0 with zero type errors under TS 7 — re-verified at review: exit 0, zero diagnostics, 0.593s wall / 577% CPU. CI's exact `npx tsc --noEmit` invocation also resolves to 7.0.2 and exits 0. `strace` confirms `tsc` execs the native Go binary (`@typescript/typescript-linux-x64@7.0.2/lib/tsc`), so the native compiler is genuinely in use
+
+### Scenario Coverage
+
+- [x] A-004 R3: `just test` (backend + frontend + e2e) passes, with any e2e failure triaged against the known-flaky-on-main signatures — apply ran the full `just test` green (T005, 1 iteration, no rework). Review re-ran the scoped gate `just test-frontend`: 118 files / 2071 tests passed. Full e2e deliberately not re-run at review (already green at apply; the suite is a 3-shard SSE/tmux-contended gate)
+- [x] A-005 R3: `just build` succeeds (the build script's `tsc --noEmit` half runs the TS 7 binary) — **partially N/A, pre-existing failure**: the change-relevant half is verified green (`pnpm build` = `tsc --noEmit && vite build` exits 0 on TS 7). The `just build` recipe still fails at `scripts/build.sh:19` (`cat "$REPO_ROOT/VERSION"`) because `VERSION` was deleted by `ea750837` (PR #193, tag-driven release port) and is absent at the merge-base — confirmed pre-existing on main, independent of this change
+
+### Edge Cases & Error Handling
+
+- [x] A-006 R1: The `pnpm-lock.yaml` delta is limited to the typescript resolution — no other dependency versions change — verified by enumerating every added/removed lockfile key. The 215/-14 line count is fully explained: 20 new `@typescript/typescript-{platform}@7.0.2` optional deps (TS 7 ships per-platform native Go binaries) plus mechanical peer-dep re-keying of the 3 snapshots that take `typescript` as a peer (`msw`, `vitest`, `@vitest/mocker` — same versions, only the `(typescript@6.0.3)` → `(typescript@7.0.2)` hash segment changes). Zero foreign packages, zero unrelated version bumps
+
+### Code Quality
+
+- [x] A-007 Pattern consistency: the caret pin style (`^7.0.2`) matches the existing `app/desktop/package.json` typescript pin — verified byte-identical: `app/frontend/package.json:44` and `app/desktop/package.json:24` both read `"typescript": "^7.0.2"`. The repo is now converged on one TS major
+- [x] A-008 No unnecessary duplication: no new tooling, scripts, or config duplicated — the change is confined to the manifest, lockfile, and one doc line — verified: the working tree touches exactly 3 files (`package.json`, `pnpm-lock.yaml`, `context.md`); no new scripts, config, or dependencies
+- [x] A-009 No scope creep: `app/desktop/`, `tsconfig*.json`, and the build script are untouched (intake's explicit scope exclusions hold) — verified via `git status`: `app/desktop/`, `app/frontend/tsconfig*.json`, `scripts/`, and `justfile` all clean. The `build` script still reads `tsc --noEmit && vite build`
+- [x] A-010 **N/A**: Tests-for-changes principle — a check-only compiler bump changes no runtime behavior to test. `tsc` never emits in this package (Vite/esbuild transpiles, Vitest uses the Vite transform, Playwright self-transpiles), so the typecheck IS the test; existing gates (2071 unit tests, e2e, typecheck) are the coverage. Matches intake assumption 7 and `code-quality.md`'s scoping of the rule to "features and bug fixes"
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All acceptance items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] A-NNN **N/A**: {reason}`
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Use the intake's suggested wording verbatim for the context.md line: `TypeScript 7 (native Go compiler)` | Intake assumption 6 delegates exact wording to the agent with this as the offered default; one-line doc edit, trivially reversible | S:85 R:95 A:95 D:90 |
+| 2 | Certain | Run the typecheck via `./node_modules/.bin/tsc --noEmit` (local binary) rather than `npx tsc` | Guarantees the project-pinned TS 7 binary is exercised, not a globally cached tsc; equivalent intent to code-quality.md's `npx tsc --noEmit` gate | S:80 R:95 A:95 D:90 |
+| 3 | Confident | A `just test` e2e failure matching a known-flaky-on-main signature does not fail the change; it is reported with reasoning, not bisected | Dispatch instructions enumerate the known signatures and state a check-only compiler bump cannot change runtime behavior (Vite/esbuild transpiles, tsc never emits); judgment call on live test output keeps this below Certain | S:75 R:70 A:80 D:75 |
+
+3 assumptions (2 certain, 1 confident, 0 tentative).

--- a/fab/project/context.md
+++ b/fab/project/context.md
@@ -39,7 +39,7 @@ Task runner: `just` (see `justfile`). Frontend deps managed by pnpm (in `app/fro
 ## Frontend — `app/frontend/`
 
 - **Language**: TypeScript 7 (native Go compiler)
-- **Framework**: Vite 7 + React 19 (SPA, no SSR)
+- **Framework**: Vite 8 + React 19 (SPA, no SSR)
 - **Routing**: TanStack Router — routes: `/` (redirect), `/$session/$window`
 - **UI**: Tailwind CSS 4
 - **Terminal**: xterm.js 5 (`@xterm/xterm`) with FitAddon and WebLinks addon

--- a/fab/project/context.md
+++ b/fab/project/context.md
@@ -38,7 +38,7 @@ Task runner: `just` (see `justfile`). Frontend deps managed by pnpm (in `app/fro
 
 ## Frontend — `app/frontend/`
 
-- **Language**: TypeScript 5.7+
+- **Language**: TypeScript 7 (native Go compiler)
 - **Framework**: Vite 7 + React 19 (SPA, no SSR)
 - **Routing**: TanStack Router — routes: `/` (redirect), `/$session/$window`
 - **UI**: Tailwind CSS 4


### PR DESCRIPTION
## Meta

| Change ID | Type | Confidence | Plan | Review |
|-----------|------|------------|------|--------|
| `lu5e` | chore | 5.0/5.0 | 6/6 tasks, 10/10 acceptance ✓ | ✓ 1 cycle |

| Impact | +/− | Net |
|--------|----:|----:|
| raw | +478 / −16 | +462 |
| **true** | **+216 / −15** | **+201** |
| └ impl | +216 / −15 | +201 |
| └ tests | +0 / −0 | +0 |

<sub>excludes `fab/`, `docs/` · generated by fab-kit v2.16.10</sub>

**Pipeline:** [intake](https://github.com/sahil87/run-kit/blob/260731-lu5e-frontend-typescript-7-bump/fab/changes/260731-lu5e-frontend-typescript-7-bump/intake.md) ✓ → [apply](https://github.com/sahil87/run-kit/blob/260731-lu5e-frontend-typescript-7-bump/fab/changes/260731-lu5e-frontend-typescript-7-bump/plan.md) ✓ → review ✓ → hydrate ✓ → ship → review-pr

## Summary

The frontend is pinned to TypeScript 6.0.3 while `app/desktop` already runs TypeScript 7.0.2 (GA 2026-07-08, native Go compiler) — two TS majors in one repo. TS 7 was empirically pre-verified against the real frontend tsconfig with zero type errors, and typechecks ~8× faster (0.6s vs 5.0s wall). This bumps the frontend to converge on one TS major with no config or behavior changes.

## Changes

- `app/frontend/package.json` — bump `typescript` devDependency `^6.0.3` → `^7.0.2`
- `app/frontend/pnpm-lock.yaml` — lockfile refresh: TS resolution move plus per-platform `@typescript/typescript-*` native-binary optional deps and peer-hash re-keying (msw/vitest/@vitest/mocker, same versions)
- `fab/project/context.md` — fix stale "TypeScript 5.7+" line to "TypeScript 7 (native Go compiler)"
- No tsconfig changes; `app/desktop` untouched (already on `^7.0.2`); no TS-API-dependent tooling added

## Verification

- Typecheck: `tsc --noEmit` on TS 7.0.2 against the real tsconfig — 0 errors, 0.6s vs 5.0s wall (~8×)
- `just test`: backend OK, Vitest 2071/2071, e2e 204 passed / 1 known-flaky retry-passed / 2 skipped
- `just build`: frontend half (`tsc --noEmit && vite build`) passes, plus a manual `CGO_ENABLED=0 go build ./cmd/rk` with the TS-7-built embed. The `scripts/build.sh:19` (`cat VERSION`) failure in the full recipe is pre-existing on `main` since PR #193 — unrelated to this change.
