### PR TITLE
fix: shell strip host-switcher follow-ups (menuitemradio, Tip, functional toggle)

### DIFF
--- a/app/frontend/src/components/shell-titlebar-strip.test.tsx
+++ b/app/frontend/src/components/shell-titlebar-strip.test.tsx
@@ -180,15 +180,18 @@ describe("ShellTitlebarStrip host switcher (260731-4bqi)", () => {
     fireEvent.click(screen.getByRole("button", { name: "Switch host" }));
     expect(bridge.list).toHaveBeenCalledTimes(2); // refetch on open
     expect(screen.getByRole("menu")).toBeInTheDocument();
-    expect(screen.getAllByRole("menuitem")).toHaveLength(2);
+    expect(screen.getAllByRole("menuitemradio")).toHaveLength(2);
   });
 
   it("renders row anatomy: accent ✓ on the active host, dimmed origin, darwin accelerator hints", async () => {
     await renderInteractive();
     fireEvent.click(screen.getByRole("button", { name: "Switch host" }));
-    const rows = screen.getAllByRole("menuitem");
-    // Active row: ✓ marker + accent color + name + origin + ⌥⌘1.
+    const rows = screen.getAllByRole("menuitemradio");
+    // Active row: ✓ marker + accent color + name + origin + ⌥⌘1, with the
+    // single-select state exposed to AT via aria-checked (menuitemradio).
     expect(rows[0].textContent).toContain("✓");
+    expect(rows[0]).toHaveAttribute("aria-checked", "true");
+    expect(rows[1]).toHaveAttribute("aria-checked", "false");
     expect(rows[0].className).toContain("text-accent");
     expect(rows[0].textContent).toContain("studio-mac");
     expect(rows[0].textContent).toContain("http://a:3000");
@@ -204,7 +207,7 @@ describe("ShellTitlebarStrip host switcher (260731-4bqi)", () => {
   it("renders ⇧Ctrl hints on non-darwin platforms (from the bridge's platform field)", async () => {
     await renderInteractive(hosts, "win32");
     fireEvent.click(screen.getByRole("button", { name: "Switch host" }));
-    const rows = screen.getAllByRole("menuitem");
+    const rows = screen.getAllByRole("menuitemradio");
     expect(rows[0].textContent).toContain("⇧Ctrl+1");
     expect(rows[1].textContent).toContain("⇧Ctrl+2");
   });
@@ -212,7 +215,7 @@ describe("ShellTitlebarStrip host switcher (260731-4bqi)", () => {
   it("selecting a host closes the menu and hands off to servers.switch (no optimistic UI)", async () => {
     const bridge = await renderInteractive();
     fireEvent.click(screen.getByRole("button", { name: "Switch host" }));
-    fireEvent.click(screen.getAllByRole("menuitem")[1]);
+    fireEvent.click(screen.getAllByRole("menuitemradio")[1]);
     expect(bridge.switch).toHaveBeenCalledWith("b");
     expect(screen.queryByRole("menu")).not.toBeInTheDocument();
     // The label still names the active host — the page swap is shell-side.
@@ -234,7 +237,7 @@ describe("ShellTitlebarStrip host switcher (260731-4bqi)", () => {
   it("moves focus with ArrowDown, wrapping over the row set", async () => {
     await renderInteractive();
     fireEvent.click(screen.getByRole("button", { name: "Switch host" }));
-    const rows = screen.getAllByRole("menuitem");
+    const rows = screen.getAllByRole("menuitemradio");
     // Focus lands on the active row (index 0) on open.
     await waitFor(() => {
       expect(document.activeElement).toBe(rows[0]);
@@ -274,7 +277,7 @@ describe("ShellTitlebarStrip host switcher (260731-4bqi)", () => {
     // The denied refetch resolves null shell-wrapper-side; the menu keeps the
     // mount-time rows rather than blanking.
     await waitFor(() => {
-      expect(screen.getAllByRole("menuitem")).toHaveLength(2);
+      expect(screen.getAllByRole("menuitemradio")).toHaveLength(2);
     });
   });
 
@@ -303,11 +306,11 @@ describe("ShellTitlebarStrip host switcher (260731-4bqi)", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: "Switch host" }));
     await waitFor(() => {
-      expect(screen.getAllByRole("menuitem")).toHaveLength(1);
+      expect(screen.getAllByRole("menuitemradio")).toHaveLength(1);
     });
     // The seat clamps onto the surviving row: it stays the roving-tabindex
     // stop and receives focus.
-    const row = screen.getAllByRole("menuitem")[0];
+    const row = screen.getAllByRole("menuitemradio")[0];
     await waitFor(() => {
       expect(row).toHaveAttribute("tabindex", "0");
       expect(document.activeElement).toBe(row);
@@ -372,13 +375,13 @@ describe("ShellTitlebarStrip host switcher (260731-4bqi)", () => {
     await act(async () => {
       resolvers[2]({ ok: true, servers: fresh });
     });
-    expect(screen.getAllByRole("menuitem")).toHaveLength(3);
+    expect(screen.getAllByRole("menuitemradio")).toHaveLength(3);
     // The STALE open-#1 refetch resolves LAST — the sequence guard drops it
     // (review cycle 1, should-fix c: freshest list stays rendered).
     await act(async () => {
       resolvers[1]({ ok: true, servers: hosts });
     });
-    expect(screen.getAllByRole("menuitem")).toHaveLength(3);
+    expect(screen.getAllByRole("menuitemradio")).toHaveLength(3);
   });
 
   it("surfaces an error toast when the switch is denied", async () => {
@@ -394,7 +397,7 @@ describe("ShellTitlebarStrip host switcher (260731-4bqi)", () => {
       expect(screen.getByRole("button", { name: "Switch host" })).toBeInTheDocument();
     });
     fireEvent.click(screen.getByRole("button", { name: "Switch host" }));
-    fireEvent.click(screen.getAllByRole("menuitem")[1]);
+    fireEvent.click(screen.getAllByRole("menuitemradio")[1]);
     await waitFor(() => {
       expect(screen.getByText("Shell server switch failed")).toBeInTheDocument();
     });

--- a/app/frontend/src/components/shell-titlebar-strip.tsx
+++ b/app/frontend/src/components/shell-titlebar-strip.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useInstanceAccent } from "@/contexts/instance-accent-context";
 import { useTheme } from "@/contexts/theme-context";
+import { Tip } from "@/components/tip";
 import { useToast } from "@/components/toast";
 import { listShellServers, shellInfo, switchShellServer } from "@/lib/shell";
 import type { ShellServer } from "@/lib/shell";
@@ -87,12 +88,13 @@ export function ShellTitlebarStrip() {
     };
   }, [fetchServers]);
 
+  const toggle = useCallback(() => setOpen((v) => !v), []);
+
   // Refetch on every open (260731-4bqi): the native `Hosts → Remove "<name>"…`
   // menu mutates the list without a page reload, so a mount-time-only list can
   // go stale.
-  const toggle = useCallback(() => {
-    if (!open) fetchServers();
-    setOpen(!open);
+  useEffect(() => {
+    if (open) fetchServers();
   }, [open, fetchServers]);
 
   const interactive = stripSwitcherEnabled(servers);
@@ -212,23 +214,28 @@ export function ShellTitlebarStrip() {
     >
       {interactive ? (
         <div ref={containerRef} className="rk-shell-no-drag relative flex min-w-0 items-center">
-          <button
-            ref={triggerRef}
-            type="button"
-            aria-haspopup="menu"
-            aria-expanded={open}
-            aria-label="Switch host"
-            onClick={toggle}
-            // Subtle hover pill: a currentColor tint so it reads on any
-            // accent-blended strip background (the label color is already
-            // contrast-derived against it).
-            className="flex min-w-0 items-center gap-1 rounded px-1.5 py-0.5 text-xs transition-colors hover:bg-current/15"
-          >
-            <span className="min-w-0 truncate">{hostLabel}</span>
-            <span aria-hidden="true" className="shrink-0 opacity-60">
-              {"▾"}
-            </span>
-          </button>
+          {/* Tip reveals the full host name — the label truncates by design
+              inside the platform insets. Suppressed while open, the standard
+              dropdown-trigger treatment (BreadcrumbDropdown, OpenButton). */}
+          <Tip label={open ? undefined : hostLabel}>
+            <button
+              ref={triggerRef}
+              type="button"
+              aria-haspopup="menu"
+              aria-expanded={open}
+              aria-label="Switch host"
+              onClick={toggle}
+              // Subtle hover pill: a currentColor tint so it reads on any
+              // accent-blended strip background (the label color is already
+              // contrast-derived against it).
+              className="flex min-w-0 items-center gap-1 rounded px-1.5 py-0.5 text-xs transition-colors hover:bg-current/15"
+            >
+              <span className="min-w-0 truncate">{hostLabel}</span>
+              <span aria-hidden="true" className="shrink-0 opacity-60">
+                {"▾"}
+              </span>
+            </button>
+          </Tip>
           {open && rows.length > 0 && (
             <div
               role="menu"
@@ -247,7 +254,12 @@ export function ShellTitlebarStrip() {
                     itemRefs.current[i] = el;
                   }}
                   type="button"
-                  role="menuitem"
+                  // menuitemradio + aria-checked: the active host is a
+                  // single-select state AT must hear, not a color-only cue
+                  // (the view-switcher precedent; aria-pressed is invalid on
+                  // a menu item).
+                  role="menuitemradio"
+                  aria-checked={row.active}
                   tabIndex={focusedIndex === i ? 0 : -1}
                   onClick={() => selectHost(row.id)}
                   className={`flex w-full items-baseline gap-2 px-3 py-2 text-left text-sm transition-colors ${

--- a/fab/changes/260731-4bqi-shell-strip-host-switcher-dropdown/.history.jsonl
+++ b/fab/changes/260731-4bqi-shell-strip-host-switcher-dropdown/.history.jsonl
@@ -16,3 +16,5 @@
 {"cmd":"fab-continue","event":"command","ts":"2026-07-31T19:24:43Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-07-31T19:30:47Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-07-31T19:32:17Z"}
+{"cmd":"git-pr-review","event":"command","ts":"2026-07-31T19:33:31Z"}
+{"event":"review","result":"passed","ts":"2026-08-01T03:49:09Z"}

--- a/fab/changes/260731-4bqi-shell-strip-host-switcher-dropdown/.status.yaml
+++ b/fab/changes/260731-4bqi-shell-strip-host-switcher-dropdown/.status.yaml
@@ -10,7 +10,7 @@ progress:
     review: done
     hydrate: done
     ship: done
-    review-pr: active
+    review-pr: done
 plan:
     generated: true
     task_count: 6
@@ -34,7 +34,7 @@ stage_metrics:
     review: {started_at: "2026-07-31T19:13:24Z", driver: fab-fff, iterations: 2, completed_at: "2026-07-31T19:24:05Z"}
     hydrate: {started_at: "2026-07-31T19:24:05Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-31T19:30:47Z"}
     ship: {started_at: "2026-07-31T19:30:47Z", driver: fab-fff, iterations: 1, completed_at: "2026-07-31T19:32:17Z"}
-    review-pr: {started_at: "2026-07-31T19:32:17Z", driver: git-pr, iterations: 1}
+    review-pr: {started_at: "2026-07-31T19:32:17Z", driver: git-pr, iterations: 1, completed_at: "2026-08-01T03:49:09Z"}
 prs:
     - https://github.com/sahil87/run-kit/pull/496
 change_type_source: explicit
@@ -54,4 +54,4 @@ true_impact:
     computed_at_stage: ship
 summary: Desktop-shell titlebar strip's host label became a bridge-gated host-switcher dropdown — one scoped rk-shell-no-drag island in the drag band
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-07-31T19:32:17Z
+last_updated: 2026-08-01T03:49:09Z


### PR DESCRIPTION
Follow-up to #496 (merged before its internal-review should-fix items were applied). Applies the three findings recorded in the change's review:

1. **`role="menuitemradio"` + `aria-checked`** on the host rows — the active host's single-select state was color-only for assistive tech (plain `menuitem` with an `aria-hidden` ✓). Follows the `view-switcher.tsx` precedent.
2. **`Tip` wrapper on the trigger** (suppressed while open) — the host label truncates by design inside the platform insets, and every other dropdown trigger in the repo reveals its full value via `Tip` (BreadcrumbDropdown, OpenButton, top-bar overflow menu).
3. **`setOpen((v) => !v)` functional updater** — the toggle was the repo's only `setOpen(!open)` outlier; the refetch-on-open moved to an effect keyed on `open`, which also removes the redundant callback dep.

Tests updated for the role change plus new `aria-checked` assertions. `just test-frontend` 2097/2097 green, `tsc --noEmit` clean.

Also carries the `review-pr` stage bookkeeping for change `260731-4bqi` (closed as no-reviews: Copilot never delivered on #496 before merge).