### PR TITLE
feat: Add Host footer in the titlebar host-switcher dropdown

### DIFF
--- a/app/desktop/src/main.ts
+++ b/app/desktop/src/main.ts
@@ -464,6 +464,19 @@ function switchToHost(id: string): IpcResult {
   return { ok: true };
 }
 
+/**
+ * Navigate to the welcome page in add mode — the ONE add-host entry path,
+ * shared by the Hosts menu's `Add Host…` item and the `servers:add` IPC
+ * handler (the SPA dropdown's `+ Add Host…` footer). The outgoing view stays
+ * alive (welcome only detaches it) — lastPath capture happens at window
+ * close / view destroy, not here.
+ */
+function openAddHost(): IpcResult {
+  if (!mainWindow) return { ok: false, error: "No window" };
+  showWelcome(mainWindow, { mode: "add" });
+  return { ok: true };
+}
+
 function rebuildMenu(): void {
   const list = loadHosts(userDataDir());
   const callbacks: MenuCallbacks = {
@@ -471,10 +484,7 @@ function rebuildMenu(): void {
       switchToHost(id);
     },
     onAddHost: () => {
-      if (!mainWindow) return;
-      // The outgoing view stays alive (welcome only detaches it) — lastPath
-      // capture happens at window close / view destroy, not here.
-      showWelcome(mainWindow, { mode: "add" });
+      openAddHost();
     },
     onRemoveHost: (id) => {
       void confirmAndRemoveHost(id);
@@ -940,6 +950,16 @@ function registerIpcHandlers(): void {
     if (!isHostsSender(event)) return { ok: false, error: "Not allowed" };
     if (typeof id !== "string") return { ok: false, error: "Invalid request" };
     return switchToHost(id);
+  });
+
+  // servers:add — the SPA dropdown's `+ Add Host…` footer. Navigation-only
+  // (no payload, no store write): it opens the welcome page in add mode via
+  // the same openAddHost path the Hosts menu item takes; the actual
+  // registration still happens through the welcome page's own gated
+  // `welcome:add-host` flow.
+  ipcMain.handle("servers:add", (event): IpcResult => {
+    if (!isHostsSender(event)) return { ok: false, error: "Not allowed" };
+    return openAddHost();
   });
 
   // badge:* — the SPA's waiting-agent count report, gated exactly like

--- a/app/desktop/src/preload.ts
+++ b/app/desktop/src/preload.ts
@@ -5,7 +5,8 @@
  *   - `version` / `platform`: readable by EVERY page (including pages loaded
  *     from registered rk servers) — this is the SPA's shell-detection seam
  *     (`app/frontend/src/lib/shell.ts`).
- *   - `servers`: list/switch invokers for the SPA command palette. The group
+ *   - `servers`: list/switch/add invokers for the SPA command palette and
+ *     titlebar-strip host switcher. The group
  *     name and its `servers:*` channels are the web SPA's contract and keep
  *     their server naming (the entries are hosts — rk instances — shell-side).
  *     Privileged for registered host origins AND the welcome page — main.ts
@@ -42,6 +43,7 @@ contextBridge.exposeInMainWorld("runkitShell", {
   servers: {
     list: (): Promise<unknown> => ipcRenderer.invoke("servers:list"),
     switch: (id: string): Promise<unknown> => ipcRenderer.invoke("servers:switch", id),
+    add: (): Promise<unknown> => ipcRenderer.invoke("servers:add"),
   },
   badge: {
     set: (count: number): Promise<unknown> => ipcRenderer.invoke("badge:set", count),

--- a/app/frontend/src/components/shell-titlebar-strip.test.tsx
+++ b/app/frontend/src/components/shell-titlebar-strip.test.tsx
@@ -44,21 +44,23 @@ function accentValue(overrides: Partial<InstanceAccent> = {}): InstanceAccent {
 }
 
 /** Install a bridge whose `servers.list` resolves the given list (`null` =
- *  rejected call, i.e. an older shell / denial). Returns the list/switch
- *  spies for call-count and payload assertions. */
-function shellBridge(servers: unknown[] | null, platform = "darwin") {
+ *  rejected call, i.e. an older shell / denial). `withAdd` includes the
+ *  optional `add` invoker (newer shells — drives the `+ Add Host…` footer).
+ *  Returns the list/switch/add spies for call-count and payload assertions. */
+function shellBridge(servers: unknown[] | null, platform = "darwin", withAdd = false) {
   const list = vi.fn(() =>
     servers === null
       ? Promise.reject(new Error("ipc gone"))
       : Promise.resolve({ ok: true, servers }),
   );
   const switchFn = vi.fn(() => Promise.resolve({ ok: true }));
+  const add = vi.fn(() => Promise.resolve({ ok: true }));
   window.runkitShell = {
     version: "1.2.3",
     platform,
-    servers: { list, switch: switchFn },
+    servers: withAdd ? { list, switch: switchFn, add } : { list, switch: switchFn },
   };
-  return { list, switch: switchFn };
+  return { list, switch: switchFn, add };
 }
 
 function renderStrip(accent: InstanceAccent = accentValue()) {
@@ -80,8 +82,8 @@ const hosts = [
 
 /** Render with a populated bridge and wait for the mount fetch to enable the
  *  switcher trigger. */
-async function renderInteractive(list: unknown[] = hosts, platform = "darwin") {
-  const bridge = shellBridge(list, platform);
+async function renderInteractive(list: unknown[] = hosts, platform = "darwin", withAdd = false) {
+  const bridge = shellBridge(list, platform, withAdd);
   renderStrip();
   await waitFor(() => {
     expect(screen.getByRole("button", { name: "Switch host" })).toBeInTheDocument();
@@ -400,6 +402,48 @@ describe("ShellTitlebarStrip host switcher (260731-4bqi)", () => {
     fireEvent.click(screen.getAllByRole("menuitemradio")[1]);
     await waitFor(() => {
       expect(screen.getByText("Shell server switch failed")).toBeInTheDocument();
+    });
+  });
+
+  it("omits the Add Host footer when the bridge lacks the add invoker (older shell)", async () => {
+    await renderInteractive();
+    fireEvent.click(screen.getByRole("button", { name: "Switch host" }));
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Add Host…" })).not.toBeInTheDocument();
+  });
+
+  it("renders the Add Host footer when the bridge carries add; click closes and invokes it", async () => {
+    const bridge = await renderInteractive(hosts, "darwin", true);
+    fireEvent.click(screen.getByRole("button", { name: "Switch host" }));
+    const footer = screen.getByRole("menuitem", { name: "Add Host…" });
+    fireEvent.click(footer);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(bridge.add).toHaveBeenCalledTimes(1);
+    expect(bridge.switch).not.toHaveBeenCalled();
+  });
+
+  it("includes the Add Host footer in the arrow-key roving cycle", async () => {
+    await renderInteractive(hosts, "darwin", true);
+    fireEvent.click(screen.getByRole("button", { name: "Switch host" }));
+    const rows = screen.getAllByRole("menuitemradio");
+    const footer = screen.getByRole("menuitem", { name: "Add Host…" });
+    await waitFor(() => {
+      expect(document.activeElement).toBe(rows[0]);
+    });
+    // ArrowUp from the first row wraps to the footer (the cycle's last stop).
+    fireEvent.keyDown(document, { key: "ArrowUp" });
+    expect(document.activeElement).toBe(footer);
+    fireEvent.keyDown(document, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(rows[0]);
+  });
+
+  it("surfaces an error toast when the add call is denied", async () => {
+    const bridge = await renderInteractive(hosts, "darwin", true);
+    bridge.add.mockResolvedValue({ ok: false });
+    fireEvent.click(screen.getByRole("button", { name: "Switch host" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Add Host…" }));
+    await waitFor(() => {
+      expect(screen.getByText("Shell add host failed")).toBeInTheDocument();
     });
   });
 });

--- a/app/frontend/src/components/shell-titlebar-strip.tsx
+++ b/app/frontend/src/components/shell-titlebar-strip.tsx
@@ -3,7 +3,7 @@ import { useInstanceAccent } from "@/contexts/instance-accent-context";
 import { useTheme } from "@/contexts/theme-context";
 import { Tip } from "@/components/tip";
 import { useToast } from "@/components/toast";
-import { listShellServers, shellInfo, switchShellServer } from "@/lib/shell";
+import { addShellHost, canAddShellHost, listShellServers, shellInfo, switchShellServer } from "@/lib/shell";
 import type { ShellServer } from "@/lib/shell";
 import {
   activeShellHostName,
@@ -44,6 +44,12 @@ import {
  * host hands off to the shell's `switchToHost` seam (a full page swap with
  * lastPath restore), so there is no optimistic UI. On an older shell without
  * the `servers` group the label stays today's static, non-interactive span.
+ *
+ * When the shell's `servers` group carries the optional `add` invoker, the
+ * menu ends with a `+ Add Host…` footer that opens the shell's welcome page
+ * in add mode (`servers:add` → the same main-side path as the native
+ * `Hosts → Add Host…` menu item). Older shells without the invoker render
+ * the menu without the footer.
  */
 export function ShellTitlebarStrip() {
   const { titlebarHex } = useInstanceAccent();
@@ -99,6 +105,9 @@ export function ShellTitlebarStrip() {
 
   const interactive = stripSwitcherEnabled(servers);
   const rows = interactive ? shellHostMenuRows(servers, shellInfo()?.platform ?? "") : [];
+  // The `+ Add Host…` footer rides the optional `servers.add` invoker — older
+  // shells expose only list/switch and render the menu without it.
+  const canAdd = canAddShellHost();
 
   // An open-time refetch can EMPTY the list: the trigger and menu unmount
   // (interactive flips false) while `open` would otherwise stay true, leaving
@@ -125,7 +134,10 @@ export function ShellTitlebarStrip() {
   // handler — the focused row is a native <button>.
   useEffect(() => {
     if (!open) return;
-    const count = rows.length;
+    const hostCount = rows.length;
+    // The roving set spans the host rows PLUS the Add-Host footer when the
+    // bridge carries it — the footer is the last stop in the arrow cycle.
+    const count = hostCount + (canAdd ? 1 : 0);
     function handleKey(e: KeyboardEvent) {
       if (e.key === "Escape") {
         e.stopPropagation();
@@ -137,8 +149,9 @@ export function ShellTitlebarStrip() {
         // Never swallow arrows the menu cannot act on: an emptied-list
         // refetch unmounts the rows one render before the close-on-empty
         // effect flips `open`, and this capture-phase handler must not
-        // preventDefault app-wide during that window.
-        if (count === 0) return;
+        // preventDefault app-wide during that window. Keyed on the HOST
+        // count — the menu (footer included) unmounts when it hits zero.
+        if (hostCount === 0) return;
         e.preventDefault();
         e.stopPropagation();
         const delta = e.key === "ArrowDown" ? 1 : -1;
@@ -151,7 +164,7 @@ export function ShellTitlebarStrip() {
     }
     document.addEventListener("keydown", handleKey, { capture: true });
     return () => document.removeEventListener("keydown", handleKey, { capture: true });
-  }, [open, rows.length]);
+  }, [open, rows.length, canAdd]);
 
   // Focus lands on the active row on open.
   useEffect(() => {
@@ -175,13 +188,14 @@ export function ShellTitlebarStrip() {
   // effect above stays open-transition-only for the same reason).
   useEffect(() => {
     if (!open || rows.length === 0) return;
+    const itemCount = rows.length + (canAdd ? 1 : 0);
     setFocusedIndex((prev) => {
-      if (prev < rows.length) return prev;
-      const clamped = rows.length - 1;
+      if (prev < itemCount) return prev;
+      const clamped = itemCount - 1;
       itemRefs.current[clamped]?.focus();
       return clamped;
     });
-  }, [open, rows.length]);
+  }, [open, rows.length, canAdd]);
 
   // Hand off to the shell's single switch seam. The whole page navigates
   // (lastPath capture/restore is shell-side), so there is nothing to update
@@ -195,6 +209,15 @@ export function ShellTitlebarStrip() {
     },
     [addToast],
   );
+
+  // Open the shell's Add Host flow (welcome page in add mode) — a full page
+  // swap, same as selecting a host, so the menu just closes first.
+  const openAddHost = useCallback(() => {
+    setOpen(false);
+    void addShellHost().then((ok) => {
+      if (!ok) addToast("Shell add host failed", "error");
+    });
+  }, [addToast]);
 
   const bg = titlebarHex ?? theme.palette.background;
   const insets = stripInsets(shellInfo()?.platform ?? "");
@@ -285,6 +308,26 @@ export function ShellTitlebarStrip() {
                   )}
                 </button>
               ))}
+              {canAdd && (
+                <button
+                  ref={(el) => {
+                    itemRefs.current[rows.length] = el;
+                  }}
+                  type="button"
+                  // Plain menuitem — an action, not a member of the host
+                  // radio group. Last roving-tabindex stop (index rows.length).
+                  role="menuitem"
+                  tabIndex={focusedIndex === rows.length ? 0 : -1}
+                  onClick={openAddHost}
+                  className="mt-1 flex w-full items-baseline gap-2 border-t border-border px-3 py-2 text-left text-sm text-text-secondary transition-colors hover:bg-bg-card hover:text-text-primary"
+                >
+                  {/* Aligned with the rows' fixed marker column. */}
+                  <span aria-hidden="true" className="w-3 shrink-0">
+                    +
+                  </span>
+                  <span className="min-w-0 truncate">Add Host…</span>
+                </button>
+              )}
             </div>
           )}
         </div>

--- a/app/frontend/src/lib/shell.test.ts
+++ b/app/frontend/src/lib/shell.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { isShell, listShellServers, setShellBadge, shellInfo, switchShellServer } from "./shell";
+import {
+  addShellHost,
+  canAddShellHost,
+  isShell,
+  listShellServers,
+  setShellBadge,
+  shellInfo,
+  switchShellServer,
+} from "./shell";
 
 // The desktop shell injects window.runkitShell at runtime via its preload
 // contextBridge — nothing type-level guarantees the shape, so these tests
@@ -136,6 +144,64 @@ describe("switchShellServer", () => {
       switch: () => Promise.reject(new Error("ipc gone")),
     });
     expect(await switchShellServer("a")).toBe(false);
+  });
+});
+
+// The add invoker is ADDITIVE to the servers group (older shells expose only
+// list/switch): canAddShellHost gates the UI affordance on its presence, and
+// addShellHost degrades exactly like its siblings — false for plain browser,
+// pre-add shells, a non-function member, denial, and rejected invokes.
+
+describe("canAddShellHost / addShellHost", () => {
+  it("resolves true on an { ok: true } ack when the group carries add", async () => {
+    let called = false;
+    bridgeWith({
+      list: () => Promise.resolve({ ok: true, servers: [] }),
+      switch: () => Promise.resolve({ ok: true }),
+      add: () => {
+        called = true;
+        return Promise.resolve({ ok: true });
+      },
+    });
+    expect(canAddShellHost()).toBe(true);
+    expect(await addShellHost()).toBe(true);
+    expect(called).toBe(true);
+  });
+
+  it("reads as unavailable in a plain browser and on a shell without add (older shell)", async () => {
+    expect(canAddShellHost()).toBe(false);
+    expect(await addShellHost()).toBe(false);
+    bridgeWith({
+      list: () => Promise.resolve({ ok: true, servers: [serverA, serverB] }),
+      switch: () => Promise.resolve({ ok: true }),
+    });
+    expect(canAddShellHost()).toBe(false);
+    expect(await addShellHost()).toBe(false);
+  });
+
+  it("reads as unavailable when add is not a function", async () => {
+    bridgeWith({
+      list: () => Promise.resolve({ ok: true, servers: [] }),
+      switch: () => Promise.resolve({ ok: true }),
+      add: "welcome?mode=add",
+    });
+    expect(canAddShellHost()).toBe(false);
+    expect(await addShellHost()).toBe(false);
+  });
+
+  it("resolves false on a denied result and on a rejected invoke", async () => {
+    bridgeWith({
+      list: () => Promise.resolve({ ok: true, servers: [] }),
+      switch: () => Promise.resolve({ ok: true }),
+      add: () => Promise.resolve({ ok: false, error: "Not allowed" }),
+    });
+    expect(await addShellHost()).toBe(false);
+    bridgeWith({
+      list: () => Promise.resolve({ ok: true, servers: [] }),
+      switch: () => Promise.resolve({ ok: true }),
+      add: () => Promise.reject(new Error("ipc gone")),
+    });
+    expect(await addShellHost()).toBe(false);
   });
 });
 

--- a/app/frontend/src/lib/shell.ts
+++ b/app/frontend/src/lib/shell.ts
@@ -32,6 +32,11 @@ interface ShellServersBridge {
   switch: (id: string) => Promise<unknown>;
 }
 
+/** A `servers` group that also carries the optional `add` invoker (newer shells). */
+interface ShellServersAddBridge extends ShellServersBridge {
+  add: () => Promise<unknown>;
+}
+
 declare global {
   interface Window {
     /** Injected by the desktop shell's preload; absent in plain browsers. */
@@ -123,6 +128,42 @@ export async function switchShellServer(id: string): Promise<boolean> {
   let result: unknown;
   try {
     result = await bridge.switch(id);
+  } catch {
+    return false;
+  }
+  return (
+    typeof result === "object" && result !== null && "ok" in result && result.ok === true
+  );
+}
+
+/**
+ * The `add` invoker is additive to the `servers` group (shells older than the
+ * dropdown's `+ Add Host…` footer expose only list/switch), so it is narrowed
+ * separately from `isServersBridge` — the group stays usable without it.
+ */
+function isServersAddBridge(bridge: ShellServersBridge): bridge is ShellServersAddBridge {
+  return "add" in bridge && typeof Reflect.get(bridge, "add") === "function";
+}
+
+/** True when the shell can open its Add Host flow (`servers.add` present). */
+export function canAddShellHost(): boolean {
+  const bridge = serversBridge();
+  return bridge !== null && isServersAddBridge(bridge);
+}
+
+/**
+ * Ask the shell to open its Add Host flow — the welcome page in add mode, a
+ * full page swap away from the SPA (the same path as the native
+ * `Hosts → Add Host…` menu item). Resolves `false` in a plain browser, on an
+ * older shell whose `servers` group lacks the `add` invoker, or when the
+ * shell rejects/denies the call. Never throws.
+ */
+export async function addShellHost(): Promise<boolean> {
+  const bridge = serversBridge();
+  if (!bridge || !isServersAddBridge(bridge)) return false;
+  let result: unknown;
+  try {
+    result = await bridge.add();
   } catch {
     return false;
   }


### PR DESCRIPTION
Completes the mock approved for #496: the host-switcher dropdown in the desktop shell's titlebar strip gains the `+ Add Host…` footer. This was deliberately excluded from #496 (recorded as the intake's deferred decision) because it needs one new IPC channel — this PR adds exactly that and nothing more.

## Shell side (`app/desktop`)

- **`servers:add`** — one new sender-gated channel, gated with `isHostsSender` exactly like `servers:list`/`servers:switch`. Navigation-only: no payload, no store write — it opens the welcome page in add mode; actual registration still flows through the welcome page's own gated `welcome:add-host`.
- **`openAddHost()`** — the shared main-side path: the Hosts menu's `Add Host…` item and the new handler both route through it (the `switchToHost` one-seam precedent).
- Preload: `servers.add` invoker added to the bridge group.

## SPA side (`app/frontend`)

- **`lib/shell.ts`**: `canAddShellHost()` (capability probe) + `addShellHost()` (never-throws wrapper, same degradation contract as its siblings). The `add` invoker is narrowed separately from the frozen list/switch shape — older shells keep a fully working dropdown, just without the footer.
- **Strip menu**: `+ Add Host…` footer row (plain `menuitem` — an action, not part of the host radio group), separated by a top border, participating as the last stop in the arrow-key roving cycle. Click closes the menu and hands off to the shell; denial surfaces the toast precedent.

## Tests

- `shell.test.ts`: presence/absence/non-function/denial/rejection matrix for the new wrappers.
- `shell-titlebar-strip.test.tsx`: footer omitted on an add-less bridge (older shell), rendered + invoked with `withAdd`, included in the arrow cycle (ArrowUp from the first row wraps to it), denial toast.
- `just test-frontend` 2125/2125 green, `tsc --noEmit` clean, desktop package compiles and its 109 node tests pass.

Manual verification in the real shell (open the dropdown → `+ Add Host…` → welcome `?mode=add`) still applies before release, as with the rest of the strip.