### PR TITLE
fix: Widen Split Popover So Rows Don't Wrap

### DIFF
--- a/app/frontend/src/components/top-bar.tsx
+++ b/app/frontend/src/components/top-bar.tsx
@@ -1998,7 +1998,11 @@ function SplitControl({
         <div
           role="menu"
           aria-label="Split direction"
-          className="absolute top-full right-0 mt-1 min-w-[150px] bg-bg-primary border border-border rounded-lg shadow-2xl py-1 z-50"
+          // 170px floor: the leading direction glyph (14px + 8px gap) pushes
+          // "Split horizontal" past the old 150px, wrapping it to two lines —
+          // the absolutely-positioned menu shrink-wraps against the tiny chip
+          // container, so the min-width is the effective width.
+          className="absolute top-full right-0 mt-1 min-w-[170px] bg-bg-primary border border-border rounded-lg shadow-2xl py-1 z-50"
         >
           <button
             type="button"


### PR DESCRIPTION
## Summary
Follow-up to #512. The leading direction glyphs (14px icon + 8px gap) push "Split horizontal" past the split popover's `min-w-[150px]`, wrapping the label onto two lines. Because the absolutely-positioned menu shrink-wraps against the tiny chip container, the min-width is the effective width — bumped to `min-w-[170px]`.

## Changes
- `top-bar.tsx`: SplitControl popover `min-w-[150px]` → `min-w-[170px]` (one line + explanatory comment)

## Testing
- `tsc --noEmit` clean
- `just test-frontend`: 2187/2187 passed