### PR TITLE
fix: Tip Labels Wrap Instead of Truncating

### DIFF
--- a/app/frontend/src/components/tip.tsx
+++ b/app/frontend/src/components/tip.tsx
@@ -77,9 +77,10 @@ export function TipGroup({ children }: { children: ReactNode }) {
 }
 
 type TipProps = {
-  /** One-line, sentence-cased control name (≤40ch — rewrite longer legacy
-   *  copy at the call site). Falsy → the child renders with no tooltip
-   *  machinery attached (conditional-tooltip call sites). */
+  /** Short, sentence-cased control name (aim for ≤40ch — copy that exceeds
+   *  the 40ch shell cap wraps to a second line, never truncates). Falsy →
+   *  the child renders with no tooltip machinery attached
+   *  (conditional-tooltip call sites). */
   label?: string;
   /** Optional dim modifier note, e.g. "⇧click: force". */
   note?: string;
@@ -153,16 +154,18 @@ export function Tip({ label, note, kbd, placement = "bottom", children }: TipPro
           {/* Quiet-card shell (Variant A): bg-bg-card, 1px border, 5px radius,
               soft shadow, 11px mono. `pointer-events-none` — tier-1 tooltips
               hold no interactive content, so they must never intercept a
-              click. `max-w-[40ch]` + truncate backstop the one-line content
-              cap. No animation: instant show/hide (reduced-motion safe). */}
+              click. `max-w-[40ch]` caps the width; a label that exceeds it
+              (the cap includes the chip and padding) wraps rather than
+              truncates — losing the tail is worse than a second line. No
+              animation: instant show/hide (reduced-motion safe). */}
           <div
             ref={refs.setFloating}
             style={floatingStyles}
             {...getFloatingProps()}
             data-testid="tip"
-            className="z-50 pointer-events-none flex items-center gap-1.5 max-w-[40ch] rounded-[5px] border border-border bg-bg-card px-2 py-1 font-mono text-[11px] shadow-lg select-none whitespace-nowrap"
+            className="z-50 pointer-events-none flex items-center gap-1.5 max-w-[40ch] rounded-[5px] border border-border bg-bg-card px-2 py-1 font-mono text-[11px] shadow-lg select-none"
           >
-            <span className="min-w-0 truncate text-text-primary">{label}</span>
+            <span className="min-w-0 text-text-primary">{label}</span>
             {kbd && (
               // Keycap chip (Variant C): inset bg, 1px border with a 2px
               // bottom edge (the "key" read), 3px radius, 10px type.


### PR DESCRIPTION
## Problem

The tier-1 `Tip` tooltip truncated long labels with an ellipsis (e.g. the compose strip's Insert button showed `Insert line (Alt+Enter: raw i…`).

The 40ch `max-w` budget on the tooltip shell also covers the keycap chip, gap, and padding — so the "Insert line (Alt+Enter: raw insert)" label (36ch, within the documented cap) still lost its tail.

## Fix

Drop `whitespace-nowrap` on the shell and `truncate` on the label span, letting the label wrap within the 40ch cap. The `kbd` chip and `note` stay `shrink-0`, so only the label wraps.

## Verification

- `pnpm exec tsc --noEmit` — clean
- `tip.test.tsx` — 7/7 pass
- `just test-e2e tooltips` — 5/5 pass
- Verified visually via a throwaway e2e spec (not committed): the Insert-line tip renders the full label on two lines with the Enter chip, no overflow (`scrollWidth <= clientWidth` on the label span)

🤖 Generated with [Claude Code](https://claude.com/claude-code)