### PR TITLE
docs: Two-Track Quick Start (Desktop App as a Front Door)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,28 @@ Installs the entire shll toolkit via Homebrew, handling tap trust automatically.
 
 ## Quick start
 
-From install to a working dashboard with one agent running:
+From install to a working dashboard with one agent running. Two front doors to the same dashboard — pick one:
+
+**In the browser** (any platform):
+
+```bash
+run-kit daemon start            # start the dashboard daemon on :3000
+open http://localhost:3000      # open the dashboard in your browser
+```
+
+**Or the desktop app** (macOS):
+
+```bash
+run-kit desktop install         # once: install Run Kit.app to /Applications, quarantine-free
+open -a "Run Kit"               # then click "Start & connect" — the app starts the daemon for you
+```
+
+The app's welcome page detects your local install and starts the daemon in one click — no `daemon start` needed. It can also connect to run-kit on other machines, including bootstrapping one over SSH (see [Desktop app](#desktop-app-macos)).
+
+Either way, spawn your first agent workspace:
 
 ```bash
 run-kit agent-setup             # optional, once per machine: agent busy/waiting/idle in the dashboard
-run-kit daemon start            # start the dashboard daemon on :3000
-open http://localhost:3000      # open the dashboard in your browser
 
 # in a tmux session (tmux new -s work if you aren't in one):
 run-kit riff                    # spawn an agent workspace (--skill /name picks the slash-command)
@@ -31,11 +47,11 @@ run-kit riff                    # spawn an agent workspace (--skill /name picks 
 
 `run-kit riff` also needs [`wt`](https://github.com/sahil87/wt) on your `PATH` — included with the full-toolkit install, or `shll install wt` — and your agent CLI available. When something fails, `run-kit doctor` prints per-dependency status.
 
-The new workspace appears in the sidebar; click into it to drive the agent — or any command — from the browser.
+The new workspace appears in the sidebar; click into it to drive the agent — or any command — from the dashboard.
 
 The formula also installs `rk` as a fully interchangeable short alias of `run-kit`, so every command here works the same whether you type `run-kit` or `rk`.
 
-To upgrade later, run `run-kit update` — pulls the latest version via Homebrew and restarts the daemon so the new binary takes effect immediately.
+To upgrade later, run `run-kit update` — pulls the latest version via Homebrew and restarts the daemon so the new binary takes effect immediately. The desktop app updates separately: `run-kit desktop update`, or the app's **Restart to Update** menu item when it detects a new release.
 
 > **Coming from the old `rk` formula?** run-kit was originally published as `sahil87/tap/rk`. If brew warns that `sahil87/tap/rk was renamed to sahil87/tap/run-kit`, you have a keg installed under the old name — remove it with a benign `brew uninstall sahil87/tap/rk` (your config and the `rk` command alias are unaffected), then `brew install sahil87/tap/run-kit` if `run-kit` is no longer on your `PATH`.
 
@@ -204,6 +220,14 @@ run-kit desktop status     # installed vs latest version (read-only)
 
 Installing through the CLI matters: the desktop DMGs are ad-hoc signed (no notarization), so a **browser** download gets stamped with `com.apple.quarantine` and Gatekeeper blocks the app on every install and every update ("Apple could not verify…"). Quarantine is applied by the *downloading application* — command-line tools don't apply it — so `run-kit desktop install` produces a quarantine-free install that opens cleanly, first time and every time. The installer does its own verification instead: it checks the DMG's SHA256 against the GitHub release digest (when available) and runs `codesign --verify --deep --strict` on the app before installing.
 
+Once installed, the app's welcome page replaces the terminal steps for getting connected, in three rungs:
+
+- **This Mac** — detects your local install and daemon state; one **Start & connect** button starts the daemon (when needed) and connects. Afterwards, daemon control lives in the menu under **Hosts → Local Daemon** (Connect / Restart / Stop).
+- **Over SSH** — type `user@host` and the app registers it via [`run-kit remote`](#command-reference), installs run-kit on the machine if missing, starts its daemon, and opens a tunnel — a remote host with zero manual setup on the box.
+- **A URL** — point at any reachable `run-kit serve` instance (e.g. a Tailscale HTTPS endpoint).
+
+The app never starts, stops, or updates anything on its own — every daemon action is an explicit click, and your tmux sessions survive all of them (the daemon layer never touches your sessions).
+
 **Manual fallback** (no run-kit CLI on the machine): download the DMG for your architecture from [GitHub Releases](https://github.com/sahil87/run-kit/releases), drag **Run Kit.app** into Applications, then clear the quarantine flag — via System Settings → Privacy & Security → **Open Anyway**, or:
 
 ```sh
@@ -275,6 +299,7 @@ Supports `zsh`, `bash`, `fish`, and `powershell`. Completion-only — run-kit ha
 | `run-kit init-conf` | Scaffold default `tmux.conf` and `tmux.d/` drop-in directory to `~/.rk/`. Optional. |
 | `run-kit update` | Upgrade via Homebrew and restart the daemon. |
 | `run-kit desktop` | Install/update the macOS desktop app from GitHub Releases, quarantine-free (`install`, `update`, `status` — see [Desktop app](#desktop-app-macos)). |
+| `run-kit remote` | Use SSH-only machines as run-kit hosts — register, bootstrap, tunnel, connect (`add`, `connect`, `list`, `status`, `disconnect`, `remove`). |
 | `run-kit completion` | Generate shell completion scripts (or use `run-kit shell-init` for eval-safe output). |
 | `run-kit help` | Help about any command. |
 

--- a/docs/site/install.md
+++ b/docs/site/install.md
@@ -21,6 +21,8 @@ open http://localhost:3000      # open the dashboard in your browser
 run-kit riff                    # spawn an agent workspace (--skill /name picks the slash-command)
 ```
 
+On a Mac, the [desktop app](#desktop-app-macos) is an alternative front door: `run-kit desktop install`, then open **Run Kit.app** — its welcome page starts the daemon for you (one **Start & connect** click) and can also connect to run-kit on other machines over SSH or a URL, so the `daemon start` and `open` steps above collapse into opening the app.
+
 The last step also needs [`wt`](https://github.com/sahil87/wt) and your agent CLI on `PATH` — see [Prerequisites](#prerequisites) below.
 
 `run-kit agent-setup` installs agent-harness hooks into your user-global agent config (v1: Claude Code, `~/.claude/settings.json`) so windows running an agent report live **active/waiting/idle** state in the dashboard. It shows the settings diff and asks before writing; re-running is idempotent, and `run-kit agent-setup --uninstall` removes exactly the run-kit-owned entries. Until it's run (and agent sessions are restarted so new sessions pick up the hooks), agent state shows `—`. See [Agent state in the README](https://github.com/sahil87/run-kit/blob/main/README.md#agent-state--run-kit-agent-setup) for how the hooks work.
@@ -31,7 +33,7 @@ The last step also needs [`wt`](https://github.com/sahil87/wt) and your agent CL
 run-kit update
 ```
 
-`run-kit update` pulls the latest version via Homebrew and restarts the daemon so the new binary takes effect immediately.
+`run-kit update` pulls the latest version via Homebrew and restarts the daemon so the new binary takes effect immediately. It covers the CLI and daemon only — the desktop app updates separately, via `run-kit desktop update` or the app's **Restart to Update** menu item (see [Desktop app (macOS)](#desktop-app-macos)).
 
 > **Upgrading from an earlier run-kit?** Older installs had the agent-hook *logic* inlined in `~/.claude/settings.json`. Run `run-kit agent-setup` once more to swap in the new delegating wrapper, then restart your agent sessions. Future hook fixes ship in the binary and track `run-kit update` with no re-setup.
 
@@ -48,6 +50,8 @@ run-kit desktop status     # installed vs latest version (read-only)
 The CLI path is the primary one for a reason: the DMGs are ad-hoc signed (no notarization), so a browser download is stamped with `com.apple.quarantine` and Gatekeeper blocks the app on every install and update. Quarantine comes from the *downloading application* — command-line tools don't apply it — so the CLI produces a quarantine-free install that opens cleanly every time, verifying the download itself (SHA256 against the release digest when available, plus `codesign --verify --deep --strict`) before installing. Use `--path <dir>` to install somewhere other than `/Applications`, and `--version <tag>` to pin a specific release.
 
 Without the CLI, the fallback is manual: download the DMG for your architecture from [GitHub Releases](https://github.com/sahil87/run-kit/releases), drag **Run Kit.app** into Applications, and clear quarantine via System Settings → Privacy & Security → **Open Anyway** (or `xattr -dr com.apple.quarantine "/Applications/Run Kit.app"`) — repeated on every manual update.
+
+Inside the app, the welcome page offers three ways to connect, in descending order of "already have it here": **This Mac** (detects the local install and daemon state; one **Start & connect** button starts the daemon when needed — post-connect control lives under **Hosts → Local Daemon** in the menu), **over SSH** (`run-kit remote` under the hood: registers the machine, installs run-kit there if missing, starts its daemon, opens a tunnel), and **a URL** (any reachable `run-kit serve` instance, e.g. the Tailscale HTTPS endpoint below). The app never starts or stops the daemon on its own — every daemon action is an explicit click, and your tmux sessions survive all of them.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Restructures the install narrative around the desktop app: Quick start now offers two front doors — the browser flow (any platform) and the desktop app (macOS), where the welcome page's **Start & connect** replaces `daemon start` + `open`. The Desktop app section now documents the welcome page's three connection rungs (This Mac / over SSH / a URL), including the SSH rung's zero-touch remote bootstrap via `run-kit remote`, which also gains a command-reference row. Clarifies the two update surfaces (`run-kit update` for CLI+daemon vs `run-kit desktop update` / Restart to Update for the app); `docs/site/install.md` mirrors the same story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)