### PR TITLE
fix: fall back to `gh auth token` for GitHub API headroom

### DIFF
--- a/app/backend/internal/desktop/desktop.go
+++ b/app/backend/internal/desktop/desktop.go
@@ -92,7 +92,7 @@ type Installer struct {
 	// APIBase is the GitHub API origin (overridden by tests with httptest).
 	APIBase string
 	// Token, when non-empty, is sent as a Bearer token — purely for rate-limit
-	// headroom on the public repo (GITHUB_TOKEN).
+	// headroom on the public repo (see githubToken).
 	Token string
 	// InstallDir is the target application directory.
 	InstallDir string
@@ -115,12 +115,35 @@ func New() *Installer {
 		Repo:       DefaultRepo,
 		Arch:       runtime.GOARCH,
 		APIBase:    defaultAPIBase,
-		Token:      os.Getenv("GITHUB_TOKEN"),
+		Token:      githubToken(),
 		InstallDir: DefaultInstallDir,
 		Progress:   io.Discard,
 		QuitWait:   quitWaitTimeout,
 		QuitPoll:   quitPollInterval,
 	}
+}
+
+// githubToken resolves a token for rate-limit headroom, preferring the
+// environment (GITHUB_TOKEN, then GH_TOKEN — the pair gh itself honours) and
+// falling back to the gh CLI's stored credential. The fallback exists because
+// an interactive `gh auth login` is the common way a Mac has GitHub
+// credentials at all, and without it a plain `rk desktop install` shares the
+// 60 req/hour-per-IP unauthenticated budget with every other tool on the
+// network. Every outcome is optional: no gh, gh not logged in, or gh timing
+// out all yield "" and the request simply goes out unauthenticated.
+func githubToken() string {
+	for _, env := range []string{"GITHUB_TOKEN", "GH_TOKEN"} {
+		if v := os.Getenv(env); v != "" {
+			return v
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "gh", "auth", "token").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // AppPath returns the install target bundle path

--- a/app/backend/internal/desktop/release.go
+++ b/app/backend/internal/desktop/release.go
@@ -101,7 +101,7 @@ func (ins *Installer) ResolveRelease(ctx context.Context, tag string) (Release, 
 		// fall through to decode
 	case http.StatusForbidden, http.StatusTooManyRequests:
 		return Release{}, fmt.Errorf(
-			"GitHub API request denied (HTTP %d) — likely the unauthenticated rate limit (60 requests/hour per IP); set GITHUB_TOKEN for more headroom",
+			"GitHub API request denied (HTTP %d) — likely the unauthenticated rate limit (60 requests/hour per IP); run `gh auth login` or set GITHUB_TOKEN for more headroom",
 			resp.StatusCode)
 	case http.StatusNotFound:
 		if tag != "" {


### PR DESCRIPTION
`rk desktop install|update|status` resolved releases unauthenticated unless `GITHUB_TOKEN` was exported. A Mac whose GitHub credentials come from `gh auth login` — the common case — therefore shared the 60 req/hour-per-IP unauthenticated budget and hit:

```
Error: GitHub API request denied (HTTP 403) — likely the unauthenticated rate limit (60 requests/hour per IP); set GITHUB_TOKEN for more headroom
```

## Change

- `desktop.New()` resolves the token through a new `githubToken()`: `GITHUB_TOKEN`, then `GH_TOKEN` (the pair gh itself honours), then `gh auth token`. One place, so the API resolve *and* the asset download both inherit it.
- The `gh` exec is bounded by the existing `probeTimeout`. No gh installed, gh not logged in, or a timeout all yield `""` and the request goes out unauthenticated exactly as before — the fallback is additive, never a new failure mode.
- The 403 message now names `gh auth login` alongside `GITHUB_TOKEN`.

No new dependencies.

## Verification

`go test ./internal/desktop/...` passes. End-to-end with **both** env vars unset, the authenticated core budget decrements — proving the gh-CLI token reached the request:

```
$ env -u GITHUB_TOKEN -u GH_TOKEN rk desktop status
Installed: v3.13.0
Latest:    v3.13.0
Up to date.
# gh api rate_limit .resources.core.used: 2 -> 3
```
