### PR TITLE
feat: make Split Horizontal the top-bar split default

### DIFF
--- a/app/frontend/src/components/top-bar-icons.tsx
+++ b/app/frontend/src/components/top-bar-icons.tsx
@@ -61,7 +61,7 @@ function ControlGlyph({
 }
 
 /** Split vertical — lucide square-split-vertical (top/bottom brackets +
- *  horizontal divider). The SplitControl primary segment's glyph. */
+ *  horizontal divider), the 90°-rotated sibling of SplitHorizontalGlyph. */
 export function SplitVerticalGlyph() {
   return (
     <ControlGlyph name="split-vertical">
@@ -73,7 +73,7 @@ export function SplitVerticalGlyph() {
 }
 
 /** Split horizontal — lucide square-split-horizontal (side brackets +
- *  vertical divider), the 90°-rotated sibling of SplitVerticalGlyph. */
+ *  vertical divider). The SplitControl primary segment's glyph. */
 export function SplitHorizontalGlyph() {
   return (
     <ControlGlyph name="split-horizontal">

--- a/app/frontend/src/components/top-bar.test.tsx
+++ b/app/frontend/src/components/top-bar.test.tsx
@@ -844,28 +844,28 @@ describe("TopBar", () => {
     it("renders the merged split control on board mode, wired to the focused tile", async () => {
       const { splitWindow } = await import("@/api/client");
       renderBoard();
-      // ONE merged control (260731-oiho): primary = split vertical; the ▾
-      // opens the direction menu carrying the horizontal action.
-      const vsplit = screen.getByLabelText("Split vertically");
-      expect(vsplit).toBeInTheDocument();
-      expect(screen.queryByLabelText("Split horizontally")).not.toBeInTheDocument();
+      // ONE merged control (260731-oiho): primary = split horizontal; the ▾
+      // opens the direction menu carrying the vertical action.
+      const hsplit = screen.getByLabelText("Split horizontally");
+      expect(hsplit).toBeInTheDocument();
+      expect(screen.queryByLabelText("Split vertically")).not.toBeInTheDocument();
       await act(async () => {
-        fireEvent.click(vsplit);
+        fireEvent.click(hsplit);
       });
-      expect(splitWindow).toHaveBeenCalledWith("runkit", "@7", false, "~/code/x");
-      // ▾ → Split horizontal fires the horizontal split on the same target.
+      expect(splitWindow).toHaveBeenCalledWith("runkit", "@7", true, "~/code/x");
+      // ▾ → Split vertical fires the vertical split on the same target.
       // (Attribute query: jsdom keeps the control in the aria-hidden probe.)
       act(() => fireEvent.click(screen.getByLabelText("Split… (choose direction)")));
       const dirMenu = document.querySelector<HTMLElement>('[role="menu"][aria-label="Split direction"]');
       await act(async () => {
-        fireEvent.click(within(dirMenu!).getByText("Split horizontal"));
+        fireEvent.click(within(dirMenu!).getByText("Split vertical"));
       });
-      expect(splitWindow).toHaveBeenCalledWith("runkit", "@7", true, "~/code/x");
+      expect(splitWindow).toHaveBeenCalledWith("runkit", "@7", false, "~/code/x");
     });
 
     it("renders no split control on an empty board (no focused tile)", () => {
       renderBoard({ focusedPane: null, paneCount: 0 });
-      expect(screen.queryByLabelText("Split vertically")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Split horizontally")).not.toBeInTheDocument();
       expect(screen.queryByLabelText("Split… (choose direction)")).not.toBeInTheDocument();
     });
 
@@ -998,12 +998,12 @@ describe("TopBar", () => {
     const splitDirectionMenu = () =>
       document.querySelector<HTMLElement>('[role="menu"][aria-label="Split direction"]');
 
-    it("renders ONE split control when a window is selected: primary = vertical, ▾ = direction menu", () => {
+    it("renders ONE split control when a window is selected: primary = horizontal, ▾ = direction menu", () => {
       renderTopBar();
       // Primary segment + ▾ segment; no second per-direction button.
-      expect(screen.getByLabelText("Split vertically")).toBeInTheDocument();
+      expect(screen.getByLabelText("Split horizontally")).toBeInTheDocument();
       expect(screen.getByLabelText("Split… (choose direction)")).toBeInTheDocument();
-      expect(screen.queryByLabelText("Split horizontally")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Split vertically")).not.toBeInTheDocument();
       // The ▾ carries menu-trigger a11y and opens the direction menu with BOTH
       // actions (the complete option set, split-button convention).
       const chevron = screen.getByLabelText("Split… (choose direction)");
@@ -1022,27 +1022,27 @@ describe("TopBar", () => {
 
     it("does not render the split control on dashboard (no window)", () => {
       renderTopBar({ currentWindow: null, windowName: "" });
-      expect(screen.queryByLabelText("Split vertically")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Split horizontally")).not.toBeInTheDocument();
       expect(screen.queryByLabelText("Split… (choose direction)")).not.toBeInTheDocument();
     });
 
-    it("primary click fires a VERTICAL split with the window's coordinates", async () => {
+    it("primary click fires a HORIZONTAL split with the window's coordinates", async () => {
       const { splitWindow } = await import("@/api/client");
       renderTopBar();
       await act(async () => {
-        fireEvent.click(screen.getByLabelText("Split vertically"));
+        fireEvent.click(screen.getByLabelText("Split horizontally"));
       });
-      expect(splitWindow).toHaveBeenCalledWith("runkit", "@0", false, "~/code/run-kit");
+      expect(splitWindow).toHaveBeenCalledWith("runkit", "@0", true, "~/code/run-kit");
     });
 
-    it("▾ → Split horizontal fires a HORIZONTAL split and closes the direction menu", async () => {
+    it("▾ → Split vertical fires a VERTICAL split and closes the direction menu", async () => {
       const { splitWindow } = await import("@/api/client");
       renderTopBar();
       act(() => fireEvent.click(screen.getByLabelText("Split… (choose direction)")));
       await act(async () => {
-        fireEvent.click(within(splitDirectionMenu()!).getByText("Split horizontal"));
+        fireEvent.click(within(splitDirectionMenu()!).getByText("Split vertical"));
       });
-      expect(splitWindow).toHaveBeenCalledWith("runkit", "@0", true, "~/code/run-kit");
+      expect(splitWindow).toHaveBeenCalledWith("runkit", "@0", false, "~/code/run-kit");
       expect(splitDirectionMenu()).toBeNull();
     });
 
@@ -1070,7 +1070,7 @@ describe("TopBar", () => {
       vi.mocked(splitWindow).mockImplementation(() => new Promise((r) => { resolveAction = () => r({ ok: true, pane_id: "%1" }); }));
 
       renderTopBar();
-      const btn = screen.getByLabelText("Split vertically");
+      const btn = screen.getByLabelText("Split horizontally");
       await act(async () => {
         fireEvent.click(btn);
         await Promise.resolve();
@@ -1334,7 +1334,7 @@ describe("TopBar", () => {
       const probe = cluster.querySelector('[aria-hidden="true"][inert]');
       expect(probe).not.toBeNull();
       expect(probe!.querySelector('[data-testid="view-toggle"]')).toBeNull();
-      expect(probe!.querySelector('[aria-label="Split vertically"]')).not.toBeNull();
+      expect(probe!.querySelector('[aria-label="Split horizontally"]')).not.toBeNull();
       // Registry order: the view-switcher is the FIRST registry entry, so its
       // `View:` rows lead the menu-row order (before the split rows that jsdom's
       // zero widths also overflow).
@@ -1422,11 +1422,11 @@ describe("TopBar", () => {
       expect(fontGlyph).toHaveAttribute("aria-hidden", "true");
     });
 
-    it("SplitControl popover rows lead with direction glyphs; the primary segment shares the split-vertical definition", () => {
+    it("SplitControl popover rows lead with direction glyphs; the primary segment shares the split-horizontal definition", () => {
       renderTopBar();
       // In-bar primary segment renders the SAME shared glyph (one definition).
       expect(
-        screen.getByLabelText("Split vertically").querySelector('[data-icon="split-vertical"]'),
+        screen.getByLabelText("Split horizontally").querySelector('[data-icon="split-horizontal"]'),
       ).not.toBeNull();
       act(() => fireEvent.click(screen.getByLabelText("Split… (choose direction)")));
       const dirMenu = document.querySelector<HTMLElement>(
@@ -1447,7 +1447,7 @@ describe("TopBar", () => {
       const probe = cluster.querySelector('[aria-hidden="true"][inert]');
       expect(probe).not.toBeNull();
       expect(probe!.querySelector('[data-icon="refresh"]')).not.toBeNull();
-      expect(probe!.querySelector('[data-icon="split-vertical"]')).not.toBeNull();
+      expect(probe!.querySelector('[data-icon="split-horizontal"]')).not.toBeNull();
     });
 
     it("Fixed width row keeps a STATIC identity glyph across toggle states — the trailing ✓ is the sole state marker (R5)", () => {

--- a/app/frontend/src/components/top-bar.tsx
+++ b/app/frontend/src/components/top-bar.tsx
@@ -553,9 +553,10 @@ export function TopBar({
     },
     // L1 — the ONE merged split control (terminal+board, 260731-oiho): the two
     // per-direction SplitButtons collapsed into a single split-button chip —
-    // primary click = split vertical (the long-standing default), a small ▾
+    // primary click = split horizontal (side-by-side, the default), a small ▾
     // affordance opens the direction menu (the OpenButton pattern). The
-    // overflow menu keeps BOTH directions as one-action-per-row rows.
+    // overflow menu keeps BOTH directions as one-action-per-row rows,
+    // default (horizontal) first.
     {
       id: "split",
       modes: ["terminal", "board"],
@@ -573,14 +574,14 @@ export function TopBar({
         mode === "board" ? (
           focusedPane ? (
             <>
-              <SplitMenuRow server={focusedPane.server} windowId={focusedPane.windowId} cwd={focusedPane.cwd} />
               <SplitMenuRow horizontal server={focusedPane.server} windowId={focusedPane.windowId} cwd={focusedPane.cwd} />
+              <SplitMenuRow server={focusedPane.server} windowId={focusedPane.windowId} cwd={focusedPane.cwd} />
             </>
           ) : null
         ) : currentWindow ? (
           <>
-            <SplitMenuRow server={server} windowId={currentWindow.windowId} cwd={currentWindow.worktreePath} />
             <SplitMenuRow horizontal server={server} windowId={currentWindow.windowId} cwd={currentWindow.worktreePath} />
+            <SplitMenuRow server={server} windowId={currentWindow.windowId} cwd={currentWindow.worktreePath} />
           </>
         ) : null,
     },
@@ -1892,13 +1893,13 @@ function BoardSwitcher({
  * precedent — primary + ▾ share one bordered chip so the pair reads as ONE
  * control at cluster scale):
  *
- *  - PRIMARY segment: split VERTICAL (the long-standing default) — the
- *    square-split-vertical glyph, optimistic `splitWindow` call, spinner while
- *    pending.
+ *  - PRIMARY segment: split HORIZONTAL (side-by-side, the default) — the
+ *    square-split-horizontal glyph, optimistic `splitWindow` call, spinner
+ *    while pending.
  *  - ▾ segment: `aria-haspopup="menu"`/`aria-expanded`, opens a small direction
- *    menu listing BOTH `Split vertical` and `Split horizontal` (the complete
- *    option set, split-button convention). Outside `mousedown` and Escape
- *    close; Escape refocuses the ▾.
+ *    menu listing BOTH `Split horizontal` and `Split vertical` (the complete
+ *    option set, split-button convention, default first). Outside `mousedown`
+ *    and Escape close; Escape refocuses the ▾.
  *
  * Segments use the segment height (`TOP_BAR_SEGMENT_H` — 2px shorter than the
  * squares, compensating the bordered wrapper) so the chip's TOTAL box matches
@@ -1961,15 +1962,15 @@ function SplitControl({
   return (
     <div ref={containerRef} className="relative inline-flex items-center">
       <span className="inline-flex items-stretch rounded border border-border overflow-hidden">
-        <Tip label="Split vertically">
+        <Tip label="Split horizontally">
           <button
             type="button"
-            onClick={() => run(false)}
+            onClick={() => run(true)}
             disabled={isPending}
-            aria-label="Split vertically"
+            aria-label="Split horizontally"
             className={segmentClass}
           >
-            {isPending ? <LogoSpinner size={14} /> : <SplitVerticalGlyph />}
+            {isPending ? <LogoSpinner size={14} /> : <SplitHorizontalGlyph />}
           </button>
         </Tip>
         {/* Tip suppressed while the menu is open (trigger convention). */}
@@ -2013,22 +2014,22 @@ function SplitControl({
           <button
             type="button"
             role="menuitem"
-            onClick={() => run(false)}
-            disabled={isPending}
-            className={POPOVER_ROW_CLASS}
-          >
-            <SplitVerticalGlyph />
-            Split vertical
-          </button>
-          <button
-            type="button"
-            role="menuitem"
             onClick={() => run(true)}
             disabled={isPending}
             className={POPOVER_ROW_CLASS}
           >
             <SplitHorizontalGlyph />
             Split horizontal
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => run(false)}
+            disabled={isPending}
+            className={POPOVER_ROW_CLASS}
+          >
+            <SplitVerticalGlyph />
+            Split vertical
           </button>
         </div>
       )}

--- a/app/frontend/tests/e2e/open-in-app.spec.md
+++ b/app/frontend/tests/e2e/open-in-app.spec.md
@@ -34,7 +34,7 @@ gate, all covered by Vitest (`lib/open-in-app.test.ts`,
   - `**/api/windows/*/select*` → `{ok:true}` (trailing `*` — the query string).
   - the `/ws/terminals` mux WebSocket is accepted and held open.
 - Each test navigates to the percent-encoded window route `/default/%401` and
-  anchors on the **Split vertically** primary segment (the `currentWindow` gate; the ✕ left the bar in 260731-oiho) before
+  anchors on the **Split horizontally** primary segment (the `currentWindow` gate; the ✕ left the bar in 260731-oiho) before
   asserting — the Open entry additionally waits on its own async registry
   fetch, so it gets its own visibility wait where needed.
 

--- a/app/frontend/tests/e2e/open-in-app.spec.ts
+++ b/app/frontend/tests/e2e/open-in-app.spec.ts
@@ -91,7 +91,7 @@ const openChevron = (page: Page) =>
   page.getByRole("button", { name: "Open in… (choose app)" });
 // The currentWindow-gated sync anchor: the ✕ left the bar (menuOnly, 260731-oiho),
 // so the merged split control's primary segment is the anchor now.
-const splitAnchor = (page: Page) => page.getByRole("button", { name: "Split vertically" });
+const splitAnchor = (page: Page) => page.getByRole("button", { name: "Split horizontally" });
 
 test.describe("Open-in-App split-button (260722-6d0f)", () => {
   test("renders with a stubbed registry; menu lists the host apps; launching POSTs the pane cwd", async ({

--- a/app/frontend/tests/e2e/top-bar-overflow.spec.md
+++ b/app/frontend/tests/e2e/top-bar-overflow.spec.md
@@ -17,7 +17,7 @@ connection dot left the bar in 260724-6j1v — it lives in the sidebar footer);
 demoted controls (fixed-width, Aa, close-pane — `menuOnly` since 260731-oiho)
 render in-bar NOWHERE at any width while their rows are ALWAYS in the menu.
 Since 260731-oiho the terminal fit tiers are: L1 = the ONE merged split control
-(primary segment `Split vertically`), L2 = empty, L3 = Refresh — the in-bar end
+(primary segment `Split horizontally`), L2 = empty, L3 = Refresh — the in-bar end
 state is Open · Split(▾) · Refresh · chevron.
 
 ## Shared setup
@@ -109,7 +109,7 @@ into the menu.
 
 **Steps:**
 1. Navigate to the terminal window; set 1280×800; gate on the in-bar
-   `Split vertically` segment.
+   `Split horizontally` segment.
 2. Assert the in-bar count of the `MENU_ONLY` trio is 0.
 3. Open the menu; assert the Fixed width checkbox row, the Terminal font stepper
    group, and the Close pane row are present; assert NO `Split vertical` row
@@ -164,10 +164,10 @@ rows are present in the chevron menu at both extremes of the sweep.
    `View: Terminal` and `View: Web` rows are visible; Escape-close between
    widths.
 
-### `split-vertical is the first fit candidate to yield — the menuOnly pill costs zero fit pixels`
+### `the split control is the first fit candidate to yield — the menuOnly pill costs zero fit pixels`
 
 **What it proves:** with the view-switcher excluded from the fit, the leftmost L1
-split is the new FIRST fit candidate — whenever `Split vertically` is still
+split is the new FIRST fit candidate — whenever `Split horizontally` (the primary segment) is still
 in-bar, nothing has dropped yet, so every L1/L2/L3 control is also in-bar (the
 surviving set is a suffix of the fit order). Retargets the former first-to-drop
 coverage (the pre-n2n4 pill) onto the new first candidate.
@@ -175,10 +175,10 @@ coverage (the pre-n2n4 pill) onto the new first candidate.
 **Steps:**
 1. Navigate to the web-capable window.
 2. Sweep `[1440, ...WIDTHS]`, gating on the renamable heading each iteration; at
-   1440px gate on a RETRYING `Split vertically` visibility expect (post-resize
-   re-fit settle). At each width, if `Split vertically` is in-bar assert the full
+   1440px gate on a RETRYING `Split horizontally` visibility expect (post-resize
+   re-fit settle). At each width, if `Split horizontally` is in-bar assert the full
    L1+L2+L3 in-bar count.
-3. Assert split-vertical was seen in-bar at some wide width; then at 375px assert
+3. Assert the split control was seen in-bar at some wide width; then at 375px assert
    a RETRYING in-bar count of 0 (definitely dropped at the mobile leaf).
 
 ### `a `View:` row activation switches the lens and closes the menu — even at a wide width`

--- a/app/frontend/tests/e2e/top-bar-overflow.spec.ts
+++ b/app/frontend/tests/e2e/top-bar-overflow.spec.ts
@@ -47,7 +47,7 @@ function intersects(
 // NOT work: the probe sits off-screen at -9999px but Playwright still considers
 // a sized off-screen element "visible").
 type NameMatcher = string | RegExp;
-const L1: NameMatcher[] = ["Split vertically"];
+const L1: NameMatcher[] = ["Split horizontally"];
 const L2: NameMatcher[] = [];
 const L3: NameMatcher[] = ["Refresh page"];
 // The three demoted controls (260731-oiho, the n2n4 menuOnly mechanism): their
@@ -277,7 +277,7 @@ test.describe("Top-bar overflow chevron menu (260715-h1ck)", () => {
     await page.setViewportSize({ width: 1280, height: 800 });
     await expect(heading).toBeVisible({ timeout: 10_000 });
     // The bar carries the split control (in-bar at this width)…
-    await expect(byRoleName(page, "Split vertically")).toBeVisible({ timeout: 10_000 });
+    await expect(byRoleName(page, "Split horizontally")).toBeVisible({ timeout: 10_000 });
     // …but never the demoted three.
     expect(await inBarCount(page, MENU_ONLY)).toBe(0);
 
@@ -352,7 +352,7 @@ test.describe("Top-bar overflow chevron menu (260715-h1ck)", () => {
 // no measurement-probe copy — the `view-toggle` testid is absent from the DOM at
 // ANY width), the per-view `View:` menuitemradio rows are ALWAYS in the chevron
 // menu, a row activation switches the lens even at a wide width, and the fit
-// pyramid over the remaining candidates is intact with `split-vertical` as the
+// pyramid over the remaining candidates is intact with the split control as the
 // new first-to-yield candidate.
 const VIEW_WINDOW_NAME = `overflow-view-long-worktree-${Date.now().toString().slice(-6)}`;
 const VIEW_URL = "http://localhost:8080/";
@@ -427,7 +427,7 @@ test.describe("Top-bar overflow: ViewSwitcher is menu-only (260722-n2n4)", () =>
     }
   });
 
-  test("split-vertical is the first fit candidate to yield — the menuOnly pill costs zero fit pixels", async ({
+  test("the split control is the first fit candidate to yield — the menuOnly pill costs zero fit pixels", async ({
     page,
   }) => {
     await gotoViewWindow(page);
@@ -435,11 +435,11 @@ test.describe("Top-bar overflow: ViewSwitcher is menu-only (260722-n2n4)", () =>
 
     // With the view-switcher out of the fit entirely, the FIRST fit candidate is
     // the leftmost L1 split. The invariant across the sweep: whenever `Split
-    // vertically` is still in-bar nothing has dropped yet, so every L1/L2/L3
-    // control must also be in-bar (the surviving set is a suffix of the fit
-    // order). This retargets the former first-to-drop coverage (the pre-n2n4
-    // pill) onto the new first candidate.
-    const splitVertical = () => byRoleName(page, "Split vertically");
+    // horizontally` (the primary segment) is still in-bar nothing has dropped
+    // yet, so every L1/L2/L3 control must also be in-bar (the surviving set is
+    // a suffix of the fit order). This retargets the former first-to-drop
+    // coverage (the pre-n2n4 pill) onto the new first candidate.
+    const splitPrimary = () => byRoleName(page, "Split horizontally");
     let sawInBar = false;
     for (const width of [1440, ...WIDTHS]) {
       await page.setViewportSize({ width, height: 800 });
@@ -448,24 +448,24 @@ test.describe("Top-bar overflow: ViewSwitcher is menu-only (260722-n2n4)", () =>
       // visibility expect so the post-resize re-fit (ResizeObserver → layout
       // effect) has settled before the plain `count()` reads below.
       if (width === 1440) {
-        await expect(splitVertical()).toBeVisible({ timeout: 10_000 });
+        await expect(splitPrimary()).toBeVisible({ timeout: 10_000 });
       }
-      const inBar = (await splitVertical().count()) > 0;
+      const inBar = (await splitPrimary().count()) > 0;
       if (inBar) {
         sawInBar = true;
         expect(
           await inBarCount(page, [...L1, ...L2, ...L3]),
-          `every fit candidate in-bar while split-vertical survives at ${width}px`,
+          `every fit candidate in-bar while the split control survives at ${width}px`,
         ).toBe(L1.length + L2.length + L3.length);
       }
     }
     // The sweep genuinely exercised both sides of the drop threshold: in-bar at
     // some wide width (gated above), and definitely dropped at the mobile leaf —
     // a RETRYING count so a still-settling re-fit can't flake the dropped side.
-    expect(sawInBar, "split-vertical was in-bar at some (wide) width").toBe(true);
+    expect(sawInBar, "the split control was in-bar at some (wide) width").toBe(true);
     await page.setViewportSize({ width: 375, height: 800 });
     await expect(heading).toBeVisible({ timeout: 10_000 });
-    await expect(splitVertical()).toHaveCount(0, { timeout: 10_000 });
+    await expect(splitPrimary()).toHaveCount(0, { timeout: 10_000 });
   });
 
   test("a `View:` row activation switches the lens and closes the menu — even at a wide width", async ({

--- a/app/frontend/tests/e2e/top-bar-refresh.spec.md
+++ b/app/frontend/tests/e2e/top-bar-refresh.spec.md
@@ -37,7 +37,7 @@ spec also asserts their absence.
   - the `/ws/terminals` mux WebSocket is stubbed (accepted and held open) so the terminal
     route mounts without a backend.
 - `beforeEach` installs the routes, navigates to the percent-encoded terminal
-  window route `/default/%401` (`@1`), and waits for the **Split vertically** primary segment (the ✕ left the bar in 260731-oiho) to
+  window route `/default/%401` (`@1`), and waits for the **Split horizontally** primary segment (the ✕ left the bar in 260731-oiho) to
   be visible — the signal the state-socket payload has landed and `currentWindow` is set.
   The Refresh button cannot be this anchor: it rides the L3 always-block
   (260704-9o7k) and is visible at first paint, before the mocked state-socket event is

--- a/app/frontend/tests/e2e/top-bar-refresh.spec.ts
+++ b/app/frontend/tests/e2e/top-bar-refresh.spec.ts
@@ -104,7 +104,7 @@ const refreshButton = (page: Page) => page.getByRole("button", { name: "Refresh 
 // 260731-oiho), so the merged split control's primary segment — still
 // terminal-gated on `currentWindow` and in-bar at the default wide viewport —
 // is the anchor now.
-const splitButton = (page: Page) => page.getByRole("button", { name: "Split vertically" });
+const splitButton = (page: Page) => page.getByRole("button", { name: "Split horizontally" });
 
 test.describe("Top-bar RefreshButton", () => {
   let selectHits: () => number;


### PR DESCRIPTION
## Summary

Flips the top-bar merged split control's primary segment from Split Vertical to Split Horizontal (side-by-side panes, tmux `-h`) — glyph, tooltip, and aria-label follow, and the ▾ direction menu plus the overflow-menu rows now list the horizontal default first. Unit tests, the e2e specs that anchor on the primary segment's accessible name (`open-in-app`, `top-bar-refresh`, `top-bar-overflow`), and their `.spec.md` companions are updated to match.

Note: the command palette's divider-convention split labels (`Window: Split Vertical` = side-by-side) remain the documented cross-surface divergence (see `board-page.tsx`) — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)