### PR TITLE
feat: flyout card polish — pr register line is the Open-PR anchor + row connection cues

### DIFF
--- a/app/frontend/src/components/sidebar/row-flyout-card.test.tsx
+++ b/app/frontend/src/components/sidebar/row-flyout-card.test.tsx
@@ -109,14 +109,6 @@ describe("RowFlyout card content", () => {
     expect(screen.getByTestId("row-flyout-fab")).toHaveTextContent("fab 93dy row-flyout · apply · active");
     const pr = screen.getByTestId("row-flyout-pr");
     expect(pr).toHaveTextContent("#386");
-    // The pr prefix is EXACTLY "pr" + 2 NBSPs — the 4-advance column the
-    // `out `/`agt `/`fab ` prefixes (and status-panel.tsx's pr rows) use. Pin
-    // the codepoints so a mojibake re-encode (the cycle-1 `prÂ  ` regression,
-    // U+00C2 U+00A0) can never silently return.
-    const prPrefix = pr.querySelector("span")!.textContent!;
-    expect(Array.from(prPrefix).map((c) => c.codePointAt(0))).toEqual([
-      0x70, 0x72, 0x00a0, 0x00a0,
-    ]);
     // Register lines ellipsize INSIDE the max-w-xs card (panel parity —
     // status-panel.tsx `min-w-0 truncate`); jsdom has no layout, so the
     // classes are pinned here and the real no-overflow box is asserted in
@@ -128,11 +120,23 @@ describe("RowFlyout card content", () => {
     expect(pr).toHaveTextContent("checks pass");
     expect(pr).toHaveTextContent("review: approved");
     expect(screen.getByTestId("row-flyout-checked")).toHaveTextContent("checked 30s ago");
+    // The pr register LINE is the open-first anchor (PrLinkRow idiom): the
+    // segments live inside it, with the always-visible inline ↗ after them.
     const link = screen.getByTestId("row-flyout-pr-link");
-    expect(link).toHaveTextContent("Open PR #386 ↗");
+    expect(link).toContainElement(pr);
+    expect(link).toHaveTextContent("↗");
+    expect(link).toHaveAttribute("aria-label", "Open PR #386 in a new tab");
     expect(link).toHaveAttribute("href", "https://github.com/o/r/pull/386");
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    // The anchor's prefix is EXACTLY "pr" + 2 NBSPs — the 4-advance column the
+    // `out `/`agt `/`fab ` prefixes (and status-panel.tsx's pr rows) use. Pin
+    // the codepoints so a mojibake re-encode (the cycle-1 `prÂ  ` regression,
+    // U+00C2 U+00A0) can never silently return.
+    const prPrefix = link.querySelector("span")!.textContent!;
+    expect(Array.from(prPrefix).map((c) => c.codePointAt(0))).toEqual([
+      0x70, 0x72, 0x00a0, 0x00a0,
+    ]);
   });
 
   it("colors the PR segments via the shared vocabulary (fail → red)", () => {
@@ -149,12 +153,22 @@ describe("RowFlyout card content", () => {
     );
     expect(fail).toBeTruthy();
     expect(fail!.className).toContain("text-red-400");
+    // No URL → the line stays plain read-only text, no anchor. Its RegisterLine
+    // prefix carries the same pinned "pr" + 2-NBSP codepoints.
+    expect(screen.queryByTestId("row-flyout-pr-link")).toBeNull();
+    const plainPrefix = pr.querySelector("span")!.textContent!;
+    expect(Array.from(plainPrefix).map((c) => c.codePointAt(0))).toEqual([
+      0x70, 0x72, 0x00a0, 0x00a0,
+    ]);
   });
 
-  it("omits the #N in the PR link when prUrl exists without prNumber", () => {
+  it("renders a bare 'open PR' anchor when prUrl exists without prNumber", () => {
     renderOpen(makeWindow({ prUrl: "https://github.com/o/r/pull/9" }));
-    expect(screen.getByTestId("row-flyout-pr-link")).toHaveTextContent("Open PR ↗");
-    // No pr register without a prNumber (getPrSegments gate).
+    const link = screen.getByTestId("row-flyout-pr-link");
+    expect(link).toHaveTextContent("open PR");
+    expect(link).toHaveTextContent("↗");
+    expect(link).toHaveAttribute("aria-label", "Open PR in a new tab");
+    // No segment span without a prNumber (getPrSegments gate).
     expect(screen.queryByTestId("row-flyout-pr")).toBeNull();
   });
 

--- a/app/frontend/src/components/sidebar/row-flyout-card.test.tsx
+++ b/app/frontend/src/components/sidebar/row-flyout-card.test.tsx
@@ -137,6 +137,8 @@ describe("RowFlyout card content", () => {
     expect(Array.from(prPrefix).map((c) => c.codePointAt(0))).toEqual([
       0x70, 0x72, 0x00a0, 0x00a0,
     ]);
+    // Row-aligned notch (E1): the arrow SVG renders inside the card.
+    expect(screen.getByTestId("row-flyout-arrow")).toBeInTheDocument();
   });
 
   it("colors the PR segments via the shared vocabulary (fail → red)", () => {
@@ -259,6 +261,8 @@ describe("Flyout warm-window delay group (module-scoped)", () => {
       vi.advanceTimersByTime(FLYOUT_OPEN_DELAY_MS + 50);
     });
     expect(screen.getAllByTestId("row-flyout-card")).toHaveLength(1);
+    // Cold open carries the slide-out entrance class (E1 base cue)…
+    expect(screen.getByTestId("row-flyout-card").className).toContain("rk-flyout-in");
     act(() => {
       fireEvent.pointerEnter(rows[1], { pointerType: "mouse" });
       fireEvent.mouseEnter(rows[1]);
@@ -266,6 +270,8 @@ describe("Flyout warm-window delay group (module-scoped)", () => {
       vi.advanceTimersByTime(50);
     });
     expect(screen.getAllByTestId("row-flyout-card")).toHaveLength(1);
+    // …but a warm retarget snaps — no re-animation on every sweep.
+    expect(screen.getByTestId("row-flyout-card").className).not.toContain("rk-flyout-in");
   });
 });
 

--- a/app/frontend/src/components/sidebar/row-flyout-card.tsx
+++ b/app/frontend/src/components/sidebar/row-flyout-card.tsx
@@ -4,6 +4,8 @@ import {
   offset,
   flip,
   shift,
+  arrow,
+  FloatingArrow,
   useHover,
   useFocus,
   useDismiss,
@@ -297,6 +299,10 @@ type RowFlyout = {
   referenceProps: Record<string, unknown>;
   /** The portalled card, or null while closed. Render inside the row. */
   card: ReactNode;
+  /** True while the card is open. The row reads this to HOLD its hover tint
+   *  while the pointer travels onto the card (the held-row continuity cue) —
+   *  the state is row-local, so the open/close re-render never leaves the row. */
+  open: boolean;
   /** Imperative open — the coarse-pointer dot-tap trigger. */
   openNow: () => void;
   /** Imperative close — the row calls this on drag start. */
@@ -330,10 +336,20 @@ export function useRowFlyout(win: WindowInfo, { suppressed = false }: UseRowFlyo
     selfRef.current = { close: () => setOpen(false) };
   }
 
+  // True when this open was COLD (no card open, warm window expired) — gates
+  // the slide-out entrance so warm retargets between rows snap instead of
+  // re-animating on every sweep. Captured at the closed→open transition, BEFORE
+  // the coordinator update makes the module state warm.
+  const coldOpenRef = useRef(false);
+
   const handleOpenChange = useCallback((next: boolean) => {
     const self = selfRef.current;
     if (!self) return;
     if (next) {
+      // `useFocus` re-fires onOpenChange(true) for focusin bubbling from the
+      // card, so only a transition where this card was NOT already the active
+      // one counts as a fresh open for the entrance animation.
+      if (activeFlyout !== self) coldOpenRef.current = !flyoutIsWarm();
       // Single-open: opening this card closes any other open card (the
       // FloatingDelayGroup "currentId" behavior, module-scoped).
       if (activeFlyout && activeFlyout !== self) activeFlyout.close();
@@ -375,6 +391,12 @@ export function useRowFlyout(win: WindowInfo, { suppressed = false }: UseRowFlyo
     };
   }, []);
 
+  // Row-aligned notch (E1): the arrow middleware pins a pointer on the card's
+  // row-side edge at the ROW's vertical center — the geometric "whose card is
+  // this" cue. `shift()` may slide the card along the cross axis at viewport
+  // edges; the arrow stays locked to the reference either way.
+  const arrowRef = useRef<SVGSVGElement | null>(null);
+
   const { refs, floatingStyles, context } = useFloating({
     open,
     onOpenChange: handleOpenChange,
@@ -389,7 +411,9 @@ export function useRowFlyout(win: WindowInfo, { suppressed = false }: UseRowFlyo
     // off-viewport edge clips instead of widening the page; flip()/shift()
     // keep positioning against the viewport as before.
     strategy: "fixed",
-    middleware: [offset(6), flip(), shift({ padding: 8 })],
+    // arrow() runs after shift() so the notch is positioned against the final
+    // shifted card rect (the floating-ui documented order).
+    middleware: [offset(6), flip(), shift({ padding: 8 }), arrow({ element: arrowRef })],
     whileElementsMounted: autoUpdate,
   });
 
@@ -450,8 +474,29 @@ export function useRowFlyout(win: WindowInfo, { suppressed = false }: UseRowFlyo
           // any focusable descendant, i.e. the PR/docs links).
           onFocusCapture={() => setFocusInsideCard(true)}
           data-testid="row-flyout-card"
-          className="z-50 flex flex-col gap-1 bg-bg-primary border border-border rounded-md shadow-lg px-2 py-1.5 text-xs font-mono w-max max-w-xs"
+          // `rk-flyout-in` (cold opens only — warm retargets snap) slides the
+          // card out of the row via margin-left + opacity: floating-ui owns
+          // this element's `transform` for positioning, so the entrance must
+          // never animate transform (it would clobber the translate).
+          className={`z-50 flex flex-col gap-1 bg-bg-primary border border-border rounded-md shadow-lg px-2 py-1.5 text-xs font-mono w-max max-w-xs${
+            coldOpenRef.current ? " rk-flyout-in" : ""
+          }`}
         >
+          {/* Row-aligned notch (E1): pinned by the arrow() middleware to the
+              hovered row's vertical center on the card's row-side edge —
+              fill/stroke match the card surface so it reads as one shape. */}
+          <FloatingArrow
+            ref={arrowRef}
+            context={context}
+            width={10}
+            height={5}
+            tipRadius={1}
+            fill="var(--color-bg-primary)"
+            stroke="var(--color-border)"
+            strokeWidth={1}
+            aria-hidden="true"
+            data-testid="row-flyout-arrow"
+          />
           <RowFlyoutContent win={win} />
         </div>
       </FloatingFocusManager>
@@ -462,6 +507,7 @@ export function useRowFlyout(win: WindowInfo, { suppressed = false }: UseRowFlyo
     setReference: refs.setReference,
     referenceProps: getReferenceProps(),
     card,
+    open,
     openNow,
     close,
   } satisfies RowFlyout;

--- a/app/frontend/src/components/sidebar/row-flyout-card.tsx
+++ b/app/frontend/src/components/sidebar/row-flyout-card.tsx
@@ -184,6 +184,14 @@ function RowFlyoutContent({ win }: { win: WindowInfo }) {
   const agentLine = getAgentLine(win);
   const fabLine = getFabLine(win);
   const prSegments = getPrSegments(win);
+  // Single-sourced segment JSX shared by the anchor and plain branches below
+  // (the panel's segmentSpans idiom — the two renderings can't drift).
+  const segmentSpans = prSegments?.map((seg, i) => (
+    <span key={seg.text}>
+      {i > 0 && <span className="text-text-secondary">{" · "}</span>}
+      <span className={seg.color}>{seg.text}</span>
+    </span>
+  ));
   const fetchedAtEpoch = prFetchedAtEpoch(win);
 
   return (
@@ -206,9 +214,11 @@ function RowFlyoutContent({ win }: { win: WindowInfo }) {
         </a>
       </div>
       {/* The four orthogonal signal registers (status-pyramid.md), promoted
-          from the PANE panel via the shared resolvers. Read-only text — the
-          panel keeps its icons + copy interactions; the card is glance-only.
-          The tip's former standalone `agent:` line is subsumed by `agt`. */}
+          from the PANE panel via the shared resolvers. Read-only text except
+          the `pr` register, which is open-first (the line is a real anchor)
+          exactly like the panel's PrLinkRow — the register is open-first
+          everywhere it renders. The tip's former standalone `agent:` line is
+          subsumed by `agt`. */}
       <RegisterLine prefix="out " testid="row-flyout-out">
         <span className="text-text-secondary">{outputLine}</span>
       </RegisterLine>
@@ -222,40 +232,52 @@ function RowFlyoutContent({ win }: { win: WindowInfo }) {
           <span className="text-text-primary">{fabLine}</span>
         </RegisterLine>
       )}
-      {prSegments && (
-        // "pr" + 2 NBSPs = the same 4-advance prefix column as `out `/`agt `/
-        // `fab ` (and status-panel.tsx's pr rows). Escape sequences, never
-        // literal NBSPs - a literal survives careless re-encoding badly (the
-        // cycle-1 mojibake). Codepoints pinned by a unit test.
-        <RegisterLine prefix={"pr\u00a0\u00a0"} testid="row-flyout-pr">
-          {prSegments.map((seg, i) => (
-            <span key={seg.text}>
-              {i > 0 && <span className="text-text-secondary">{" · "}</span>}
-              <span className={seg.color}>{seg.text}</span>
-            </span>
-          ))}
-        </RegisterLine>
-      )}
-      {/* Ambient "PR checked Xs ago" trust signal; omitted without a joined
-          PR-status timestamp. Leaf-scoped clock inside the open card. */}
-      <FreshnessLine fetchedAtEpoch={fetchedAtEpoch} />
-      {/* Open-first PR affordance — the rest glyph is informational (it swaps
-          away under the pointer), so THIS anchor is the click path. Anchor,
-          not button (native middle/Ctrl+click); stopPropagation so opening
-          the PR never selects the underlying row. `prUrl` and `prNumber` are
-          independently optional — omit `#N` rather than render "#undefined". */}
-      {win.prUrl && (
+      {/* `pr` register — open-first when a URL exists (the panel's PrLinkRow
+          idiom): the WHOLE line is a real anchor (native middle/Ctrl+click,
+          right-click → copy link) with an always-visible inline `↗` sitting
+          shrink-0 after the truncating segment span, so it hugs the text end
+          and is never eaten by truncation. stopPropagation so opening the PR
+          never selects the underlying row. Without a URL the line stays plain
+          read-only text (`prUrl`/`prNumber` are independently optional — a
+          URL-less number gets the plain line, a number-less URL a bare
+          "open PR" anchor).
+          Prefix: "pr" + 2 NBSPs = the same 4-advance column as `out `/`agt `/
+          `fab ` (and status-panel.tsx's pr rows). Escape sequences, never
+          literal NBSPs - a literal survives careless re-encoding badly (the
+          cycle-1 mojibake). Codepoints pinned by a unit test. */}
+      {win.prUrl ? (
         <a
           href={win.prUrl}
           target="_blank"
           rel="noopener noreferrer"
+          title={win.prUrl}
+          aria-label={win.prNumber ? `Open PR #${win.prNumber} in a new tab` : "Open PR in a new tab"}
           onClick={(e) => e.stopPropagation()}
-          className="text-text-secondary hover:text-text-primary hover:underline whitespace-nowrap coarse:py-1"
+          className="group/pr flex items-center min-w-0 hover:bg-bg-inset focus-visible:outline focus-visible:outline-1 focus-visible:outline-accent coarse:py-1"
           data-testid="row-flyout-pr-link"
         >
-          {win.prNumber ? `Open PR #${win.prNumber} ↗` : "Open PR ↗"}
+          <span className="text-text-secondary shrink-0">{"pr\u00a0\u00a0"}</span>
+          {segmentSpans ? (
+            <span data-testid="row-flyout-pr" className="min-w-0 truncate">
+              {segmentSpans}
+            </span>
+          ) : (
+            <span className="min-w-0 truncate text-text-secondary">open PR</span>
+          )}
+          {/* NBSP inside the span — the anchor is a flex container, so a
+              whitespace-only text node between flex items would be dropped. */}
+          <span className="shrink-0 text-text-secondary group-hover/pr:text-text-primary">{"\u00a0↗"}</span>
         </a>
+      ) : (
+        segmentSpans && (
+          <RegisterLine prefix={"pr\u00a0\u00a0"} testid="row-flyout-pr">
+            {segmentSpans}
+          </RegisterLine>
+        )
       )}
+      {/* Ambient "PR checked Xs ago" trust signal; omitted without a joined
+          PR-status timestamp. Leaf-scoped clock inside the open card. */}
+      <FreshnessLine fetchedAtEpoch={fetchedAtEpoch} />
     </>
   );
 }

--- a/app/frontend/src/components/sidebar/window-row.test.tsx
+++ b/app/frontend/src/components/sidebar/window-row.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import { useState } from "react";
-import { render, screen, cleanup, act } from "@testing-library/react";
+import { render, screen, cleanup, act, fireEvent } from "@testing-library/react";
 import { WindowRow } from "./window-row";
+import { FLYOUT_OPEN_DELAY_MS, resetFlyoutWarmState } from "./row-flyout-card";
 import { ToastProvider } from "@/components/toast";
 import { ThemeProvider } from "@/contexts/theme-context";
 import * as optimisticContext from "@/contexts/optimistic-context";
@@ -1177,5 +1178,39 @@ describe("WindowRow", () => {
       expect(icon!.style.left).toBe("12px");
       expect(icon!.style.width).toBe("12px");
     });
+  });
+});
+
+describe("held-row continuity while the flyout is open (E1)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetFlyoutWarmState();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    resetFlyoutWarmState();
+  });
+
+  it("the row button HOLDS the hover shade + bright text while its card is open", () => {
+    renderRow(makeWindow({ name: "held-win" }));
+    const root = screen.getByRole("treeitem");
+    const button = root.querySelector("button")!;
+    // At rest the shade/brightening exist only as hover: variants — no bare
+    // tokens (the regexes reject the `hover:`-prefixed copies via the
+    // preceding-space requirement).
+    expect(button.className).not.toMatch(/(?:^| )bg-bg-card\/50/);
+    expect(button.className).not.toMatch(/(?:^| )text-text-primary/);
+
+    act(() => {
+      fireEvent.pointerEnter(root, { pointerType: "mouse" });
+      fireEvent.mouseEnter(root);
+      vi.advanceTimersByTime(FLYOUT_OPEN_DELAY_MS + 50);
+    });
+    expect(screen.getByTestId("row-flyout-card")).toBeInTheDocument();
+    // Open card ⇒ the held-row cue: the shade + brightening become
+    // UNCONDITIONAL classes, so they survive the pointer traveling onto the
+    // card (where CSS :hover on the row is lost).
+    expect(button.className).toMatch(/(?:^| )bg-bg-card\/50/);
+    expect(button.className).toMatch(/(?:^| )text-text-primary/);
   });
 });

--- a/app/frontend/src/components/sidebar/window-row.tsx
+++ b/app/frontend/src/components/sidebar/window-row.tsx
@@ -222,15 +222,18 @@ function WindowRowInner({
   }, [color, rowBorders]);
 
   // Compute inline style for the button (background tint only — no left border).
+  // While the flyout card is open the row HOLDS its hover shade (the held-row
+  // continuity cue): the pointer traveling onto the card drops CSS :hover, and
+  // without the hold the card visibly "detaches" from its row.
   const buttonStyle = useMemo(() => {
     const style: React.CSSProperties = {};
     if (tint) {
-      style.backgroundColor = isSelected ? tint.selected : tint.base;
+      style.backgroundColor = isSelected ? tint.selected : flyout.open ? tint.hover : tint.base;
     } else if (uncoloredSelectedTint) {
       style.backgroundColor = uncoloredSelectedTint.selected;
     }
     return Object.keys(style).length > 0 ? style : undefined;
-  }, [tint, uncoloredSelectedTint, isSelected]);
+  }, [tint, uncoloredSelectedTint, isSelected, flyout.open]);
 
   // Build className for the button. The row box is FULL-BLEED — it starts at
   // the physical sidebar edge (the former 12px group `ml-3` indent moved into
@@ -256,12 +259,16 @@ function WindowRowInner({
       return `${base} text-text-primary font-medium`;
     }
     if (tint) {
-      // Colored non-selected: inline bg via buttonStyle, hover via JS
-      return `${base} text-text-secondary hover:text-text-primary`;
+      // Colored non-selected: inline bg via buttonStyle, hover via JS. Held
+      // (flyout open): the text brightening persists off-:hover too.
+      return `${base} text-text-secondary hover:text-text-primary${flyout.open ? " text-text-primary" : ""}`;
     }
-    // Uncolored non-selected
-    return `${base} text-text-secondary hover:text-text-primary hover:bg-bg-card/50`;
-  }, [tint, isSelected, showPinIcon]);
+    // Uncolored non-selected. Held (flyout open): the hover shade + text
+    // brightening persist while the pointer is on the card (held-row cue).
+    return `${base} text-text-secondary hover:text-text-primary hover:bg-bg-card/50${
+      flyout.open ? " text-text-primary bg-bg-card/50" : ""
+    }`;
+  }, [tint, isSelected, showPinIcon, flyout.open]);
 
   // ── Left-edge label zone ────────────────────────────────────────────────
   // The 26px left of the status dot is ONE target opening the combined Label
@@ -398,7 +405,10 @@ function WindowRowInner({
         style={buttonStyle}
         aria-current={isSelected ? "page" : undefined}
         onMouseEnter={tint && !isSelected ? (e) => { (e.currentTarget as HTMLElement).style.backgroundColor = tint.hover; } : undefined}
-        onMouseLeave={tint && !isSelected ? (e) => { (e.currentTarget as HTMLElement).style.backgroundColor = tint.base; } : undefined}
+        // Held-row cue: while the flyout is open, leaving the row (the pointer
+        // traveling onto the card) must NOT drop the hover shade — the close
+        // re-render restores tint.base via buttonStyle when the card goes.
+        onMouseLeave={tint && !isSelected ? (e) => { if (!flyout.open) (e.currentTarget as HTMLElement).style.backgroundColor = tint.base; } : undefined}
       >
         {/* No `truncate` on this wrapper: the dot's waiting halo is a
             box-shadow that paints OUTSIDE the 7px dot, and `truncate`'s

--- a/app/frontend/src/globals.css
+++ b/app/frontend/src/globals.css
@@ -504,6 +504,18 @@ summary {
 
 /* Reduced-motion gate — disable EVERY treatment above (Parts A and B). The
    decode scramble is skipped in JS (top-bar.tsx reads the same media query). */
+/* ── Row-flyout card entrance (window-row register flyout, E1) ─────────────
+   Cold opens slide the card out of its row (6px) with a fade; warm retargets
+   between rows do NOT carry the class (they snap — see row-flyout-card.tsx
+   coldOpenRef). margin-left, NOT transform: floating-ui owns the element's
+   transform for positioning, and animating it would clobber the translate.
+   Zeroed under prefers-reduced-motion (below). */
+@keyframes rk-flyout-in {
+  from { opacity: 0; margin-left: -6px; }
+  to { opacity: 1; margin-left: 0; }
+}
+.rk-flyout-in { animation: rk-flyout-in 140ms ease-out; }
+
 @media (prefers-reduced-motion: reduce) {
   .rk-glint::after,
   .rk-glint:hover::after { animation: none; opacity: 0; }
@@ -531,6 +543,8 @@ summary {
   /* Dashed-marker data rain: motion-only overlay — hidden entirely (the
      static label cue is the dashed stripe itself, which always remains). */
   .rk-dash-rain::before { animation: none; display: none; }
+  /* Flyout-card entrance: pure flourish — the card simply appears. */
+  .rk-flyout-in { animation: none; }
 }
 
 /* Prevent iOS Safari page scroll/bounce — fullbleed always on in single-view. */

--- a/app/frontend/tests/e2e/row-flyout.spec.md
+++ b/app/frontend/tests/e2e/row-flyout.spec.md
@@ -39,15 +39,19 @@ git-pull-request glyph that swaps for the pin/✕ actions on hover.
 **What it proves:** whole-row hover (350ms delay) opens the flyout card
 anchored at the sidebar's right edge and vertically aligned to the hovered row,
 carrying the dot-label header, the four registers (`out`/`agt`/`fab`/`pr`),
-the "checked Xs ago" freshness line, the "Open PR #N ↗" link (new tab,
-`noopener noreferrer`), and the always-present docs link.
+the "checked Xs ago" freshness line, and the always-present docs link. The
+`pr` register line is itself the open-first anchor (the panel's PrLinkRow
+idiom): it wraps the colored segments, ends in an always-visible inline `↗`,
+and opens the PR in a new tab (`noopener noreferrer`).
 
 **Steps:**
 1. Hover the `@1` row; assert the card is visible.
 2. Assert the card contains "PR — open" (the dot label) and each register
    testid shows its expected content (`waiting 3m`, the fab id·slug·stage·state
    line, `#386`, the freshness line).
-3. Assert the PR link text/href/target/rel and the docs link href.
+3. Assert the pr-register anchor wraps the segments (`#386`, `↗`), carries
+   the "Open PR #386 in a new tab" aria-label + href/target/rel, and the docs
+   link href.
 4. Compare bounding boxes: the card's x ≥ the sidebar `<aside>`'s right edge,
    and the card vertically overlaps the hovered row (±8px).
 5. Assert no line paints outside the `max-w-xs` card box: the card's

--- a/app/frontend/tests/e2e/row-flyout.spec.md
+++ b/app/frontend/tests/e2e/row-flyout.spec.md
@@ -52,6 +52,9 @@ and opens the PR in a new tab (`noopener noreferrer`).
 3. Assert the pr-register anchor wraps the segments (`#386`, `↗`), carries
    the "Open PR #386 in a new tab" aria-label + href/target/rel, and the docs
    link href.
+4. Assert the row-aligned notch: the card's arrow SVG is present and its
+   vertical center falls inside the hovered row's band (the E1 connection
+   cue — the notch points at the row that owns the card).
 4. Compare bounding boxes: the card's x ≥ the sidebar `<aside>`'s right edge,
    and the card vertically overlaps the hovered row (±8px).
 5. Assert no line paints outside the `max-w-xs` card box: the card's

--- a/app/frontend/tests/e2e/row-flyout.spec.ts
+++ b/app/frontend/tests/e2e/row-flyout.spec.ts
@@ -128,8 +128,12 @@ test.describe("Row flyout card (fine pointer)", () => {
     );
     await expect(page.getByTestId("row-flyout-pr")).toContainText("#386");
     await expect(page.getByTestId("row-flyout-checked")).toContainText(/checked \d+\w+ ago/);
+    // The pr register LINE itself is the open-first anchor (PrLinkRow idiom):
+    // it wraps the segments and carries an always-visible inline ↗.
     const prLink = page.getByTestId("row-flyout-pr-link");
-    await expect(prLink).toHaveText("Open PR #386 ↗");
+    await expect(prLink).toContainText("#386");
+    await expect(prLink).toContainText("↗");
+    await expect(prLink).toHaveAttribute("aria-label", "Open PR #386 in a new tab");
     await expect(prLink).toHaveAttribute("href", "https://github.com/o/r/pull/386");
     await expect(prLink).toHaveAttribute("target", "_blank");
     await expect(prLink).toHaveAttribute("rel", "noopener noreferrer");

--- a/app/frontend/tests/e2e/row-flyout.spec.ts
+++ b/app/frontend/tests/e2e/row-flyout.spec.ts
@@ -137,6 +137,14 @@ test.describe("Row flyout card (fine pointer)", () => {
     await expect(prLink).toHaveAttribute("href", "https://github.com/o/r/pull/386");
     await expect(prLink).toHaveAttribute("target", "_blank");
     await expect(prLink).toHaveAttribute("rel", "noopener noreferrer");
+    // Row-aligned notch (E1): the arrow renders on the card's row-side edge,
+    // vertically inside the hovered row's band (its center ≈ the row's center).
+    const arrowBox = await page.getByTestId("row-flyout-arrow").boundingBox();
+    const anchorRowBox = await prRow(page).boundingBox();
+    expect(arrowBox).not.toBeNull();
+    const arrowCenterY = arrowBox!.y + arrowBox!.height / 2;
+    expect(arrowCenterY).toBeGreaterThanOrEqual(anchorRowBox!.y - 1);
+    expect(arrowCenterY).toBeLessThanOrEqual(anchorRowBox!.y + anchorRowBox!.height + 1);
     const docsLink = page.getByTestId("row-flyout-docs-link");
     await expect(docsLink).toBeVisible();
     await expect(docsLink).toHaveAttribute(


### PR DESCRIPTION
Follow-on to #522. Two flyout-card refinements:

## 1. The `pr` register line is the Open-PR anchor

The card carried a separate "Open PR #N ↗" line that duplicated the `pr` register right above it. The register line itself is now the open-first anchor — the PANE panel's `PrLinkRow` idiom applied to the card, so the `pr` register is open-first everywhere it renders:

- The whole line is a real `<a>` (native middle/Ctrl+click, right-click → copy link) wrapping the colored segments, with an always-visible inline `↗` sitting shrink-0 after the truncating segment span (never eaten by truncation).
- `aria-label` "Open PR #N in a new tab"; `stopPropagation` so opening never selects the row; panel-parity hover (`hover:bg-bg-inset`) + focus-visible outline.
- No URL → the line stays plain read-only text. URL without a number → a bare "open PR" anchor.
- Segment JSX single-sourced via a shared `segmentSpans` const; the mojibake codepoint pin now covers both branches.

## 2. Row ↔ card connection cues (the E1 design study)

The card floated 6px off the sidebar with nothing tying it back to its row:

- **Row-aligned notch** — `arrow()` middleware + `FloatingArrow` pin a pointer on the card's row-side edge at the hovered row's vertical center, fill/stroke matching the card surface.
- **Held-row tint** — while its card is open the row keeps its hover shade + text brightening, so the pair stays joined while the pointer travels onto the card (where CSS `:hover` drops). The hook re-exposes `open` for this (dropped as zero-reader in #522's review; it now has a reader).
- **Slide-out entrance** — cold opens animate 140ms margin-left+opacity (`rk-flyout-in` — margin, never transform, which floating-ui owns); warm retargets snap; zeroed under `prefers-reduced-motion`.

Tests: unit 2246/2246 (arrow presence, cold-vs-warm animation gating, held-tint class holds), e2e `row-flyout` 6/6 with a new notch-alignment assertion (+ `.spec.md` updated), `top-bar-overflow` 375px sweep still green, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)