### PR TITLE
chore: Menu Check Button Runs the Incl.-Patches Check

### DIFF
--- a/app/frontend/src/components/top-bar-overflow-menu.test.tsx
+++ b/app/frontend/src/components/top-bar-overflow-menu.test.tsx
@@ -80,12 +80,14 @@ describe("version-row check affordance (260720-ml7k)", () => {
     expect(within(menu).queryByLabelText("Check for updates")).not.toBeInTheDocument();
   });
 
-  it("click runs the plain notable check and reports via the existing info toast; the menu stays open", async () => {
-    checkForUpdatesMock.mockResolvedValue(emptyResult);
+  it("click runs the incl.-patches check and reports via the existing info toast; the menu stays open", async () => {
+    checkForUpdatesMock.mockResolvedValue({ ...emptyResult, source: "github" });
     renderMenu({ daemonVersion: "0.6.2", updateAvailable: null });
     const menu = openMenu();
     fireEvent.click(within(menu).getByLabelText("Check for updates"));
-    expect(checkForUpdatesMock).toHaveBeenCalledTimes(1);
+    // The menu affordance mirrors the palette's incl.-patches command: the
+    // fresh GitHub release-tags source, not the released-manifest check.
+    expect(checkForUpdatesMock).toHaveBeenCalledExactlyOnceWith("github");
     // Result reports through the existing composeCheckToast flow.
     expect(await screen.findByText("All tools up to date")).toBeInTheDocument();
     // The ⟳ is not a role="menuitem", so the container's terminal-action close

--- a/app/frontend/src/components/top-bar-overflow-menu.tsx
+++ b/app/frontend/src/components/top-bar-overflow-menu.tsx
@@ -151,7 +151,8 @@ type Props = {
  * row doubles as the update surface (R11); only the undismissed-overflowed case
  * also lights the chevron's accent attention badge (R7). At rest the row is the
  * unified update button's resting form (260720-ml7k): version + a dev-gated ⟳
- * "Check for updates" affordance running the plain notable check — placement
+ * "Check for updates" affordance running the incl.-patches check (the palette's
+ * `run-kit: Check for Updates (incl. patches)` behavior) — placement
  * between this row and the in-bar chip is always DERIVED from the verdict
  * state, never imperatively moved.
  */
@@ -399,7 +400,7 @@ export function TopBarOverflowMenu({ rows, updateOverflowed }: Props) {
           type="button"
           tabIndex={-1}
           disabled={checking}
-          onClick={() => runUpdateCheck(false)}
+          onClick={() => runUpdateCheck(true)}
           aria-label="Check for updates"
           className={`${TOP_BAR_BUTTON_BASE} ${TOP_BAR_BUTTON_REST} hover:text-text-primary disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:border-border`}
         >


### PR DESCRIPTION
## Summary

The top-bar overflow menu's ⟳ "Check for updates" button previously ran the plain notable check (the `run-kit: Check for Updates` palette command). It now runs the incl.-patches check (`run-kit: Check for Updates (incl. patches)`) — querying the fresh GitHub release-tags source and reporting every pending update, with sub-threshold rows annotated. The two palette commands themselves are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)