### PR TITLE
fix: Pin Sidebar Drag Ghost Under the Grab Point

### DIFF
--- a/app/frontend/src/components/sidebar/index.tsx
+++ b/app/frontend/src/components/sidebar/index.tsx
@@ -6,6 +6,7 @@ import { useSessionContext, useUpdateNotification } from "@/contexts/session-con
 import { useFocusedPane } from "@/contexts/focused-pane-context";
 import { resolveFocusedWindow, thinWindowFromFocusedPane } from "@/lib/focused-pane-window";
 import { finalizeSafeName } from "@/lib/names";
+import { pinDragImage } from "@/lib/drag-image";
 import { useOptimisticAction } from "@/hooks/use-optimistic-action";
 import { useOptimisticContext } from "@/contexts/optimistic-context";
 import { useToast } from "@/components/toast";
@@ -626,6 +627,7 @@ export function Sidebar({
   }, [handleRenameCommit]);
 
   const handleDragStart = useCallback((e: React.DragEvent, server: string, sessionName: string, windowIndex: number, windowId: string, windowName: string) => {
+    pinDragImage(e);
     setDragSource({ server, session: sessionName, index: windowIndex });
     e.dataTransfer.setData(
       "application/json",
@@ -719,6 +721,7 @@ export function Sidebar({
   // Per-server session drag-reorder. Source carries server so the drag is
   // confined to one server's group.
   const handleSessionReorderStart = useCallback((e: React.DragEvent, server: string, name: string, orderedNames: string[]) => {
+    pinDragImage(e);
     setSessionDragSource({ server, name });
     e.dataTransfer.setData("application/x-session-reorder", `${server}:${name}`);
     e.dataTransfer.effectAllowed = "move";

--- a/app/frontend/src/hooks/use-board-list-reorder.ts
+++ b/app/frontend/src/hooks/use-board-list-reorder.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useReducer, useRef } from "react";
 import { setBoardOrder, type BoardSummary } from "@/api/boards";
+import { pinDragImage } from "@/lib/drag-image";
 
 /** Debounce for the reorder POST, mirroring useServerReorder's
  *  SERVER_ORDER_DEBOUNCE_MS (250ms) — coalesces a rapid drag-over sweep into
@@ -106,6 +107,7 @@ export function useBoardListReorder(
   }
 
   const onDragStart = useCallback((e: React.DragEvent, name: string) => {
+    pinDragImage(e);
     dragNameRef.current = name;
     e.dataTransfer.setData(BOARD_LIST_REORDER_MIME, name);
     e.dataTransfer.effectAllowed = "move";

--- a/app/frontend/src/hooks/use-server-reorder.ts
+++ b/app/frontend/src/hooks/use-server-reorder.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useReducer, useRef } from "react";
 import { isInfraServer, setServerOrder, type ServerInfo } from "@/api/client";
+import { pinDragImage } from "@/lib/drag-image";
 
 /** Debounce for the reorder POST, mirroring the sidebar session-reorder
  *  SESSION_ORDER_DEBOUNCE_MS (250ms) — coalesces a rapid drag-over sweep into
@@ -110,6 +111,7 @@ export function useServerReorder(
 
   const onDragStart = useCallback((e: React.DragEvent, name: string) => {
     if (isInfraServer(name)) return;
+    pinDragImage(e);
     dragNameRef.current = name;
     e.dataTransfer.setData(SERVER_REORDER_MIME, name);
     e.dataTransfer.effectAllowed = "move";

--- a/app/frontend/src/lib/drag-image.test.ts
+++ b/app/frontend/src/lib/drag-image.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { pinDragImage } from "./drag-image";
+
+/** Minimal synthetic dragstart event — mirrors the mock-dataTransfer-bag
+ *  pattern of use-server-reorder.test.ts, plus the geometry pinDragImage
+ *  reads (currentTarget rect + client coords). */
+function makeDragStartEvent(opts: {
+  setDragImage?: ReturnType<typeof vi.fn>;
+  rect?: { left: number; top: number };
+  clientX?: number;
+  clientY?: number;
+}) {
+  const currentTarget = {
+    getBoundingClientRect: () => ({
+      left: opts.rect?.left ?? 0,
+      top: opts.rect?.top ?? 0,
+      right: 0,
+      bottom: 0,
+      width: 0,
+      height: 0,
+      x: opts.rect?.left ?? 0,
+      y: opts.rect?.top ?? 0,
+      toJSON: () => ({}),
+    }),
+  };
+  return {
+    currentTarget,
+    clientX: opts.clientX ?? 0,
+    clientY: opts.clientY ?? 0,
+    dataTransfer: opts.setDragImage ? { setDragImage: opts.setDragImage } : {},
+  } as unknown as React.DragEvent;
+}
+
+describe("pinDragImage", () => {
+  it("declares the dispatching element as the drag image, anchored at the grab offset", () => {
+    const setDragImage = vi.fn();
+    const e = makeDragStartEvent({
+      setDragImage,
+      rect: { left: 10, top: 200 },
+      clientX: 55,
+      clientY: 212,
+    });
+
+    pinDragImage(e);
+
+    expect(setDragImage).toHaveBeenCalledExactlyOnceWith(e.currentTarget, 45, 12);
+  });
+
+  it("no-ops when setDragImage is unavailable (jsdom / mock dataTransfer bags)", () => {
+    expect(() => pinDragImage(makeDragStartEvent({}))).not.toThrow();
+  });
+});

--- a/app/frontend/src/lib/drag-image.ts
+++ b/app/frontend/src/lib/drag-image.ts
@@ -1,0 +1,20 @@
+/**
+ * Pin the native HTML5 drag ghost under the exact grab point.
+ *
+ * Without `setDragImage`, the browser snapshots the draggable element and
+ * chooses the ghost's initial anchor itself — and when that anchor disagrees
+ * with the grab point (scrolled `overflow` ancestors, macOS's drag-image snap
+ * animation, Chromium-version drift), the ghost visibly "falls in" from above
+ * the cursor at drag start. Re-declaring the same element as the drag image
+ * with the measured cursor-to-element offset renders the ghost under the
+ * cursor from the first frame, so there is nothing to animate.
+ *
+ * Call first in a `dragstart` handler (while `currentTarget` is still bound
+ * to the dispatching element). No-op where `setDragImage` is unavailable
+ * (jsdom and the synthetic dataTransfer bags unit tests build).
+ */
+export function pinDragImage(e: React.DragEvent): void {
+  if (typeof e.dataTransfer?.setDragImage !== "function") return;
+  const rect = e.currentTarget.getBoundingClientRect();
+  e.dataTransfer.setDragImage(e.currentTarget, e.clientX - rect.left, e.clientY - rect.top);
+}


### PR DESCRIPTION
## Summary

At drag start, the browser chooses the native drag ghost's initial anchor itself, and when that anchor disagrees with the grab point (scrolled `overflow` ancestors, macOS's drag-image snap animation, Chromium-version drift) the dragged row visibly "falls in" from above the cursor. A new `pinDragImage` helper re-declares the dragged element as its own drag image with the measured cursor-to-element offset, so the ghost renders under the cursor from the first frame — wired into all four sidebar drag sources (window rows, session rows, board rows, server tiles; the latter also covers the Host overview grid via the shared hook).

## Changes

- New `app/frontend/src/lib/drag-image.ts` — `pinDragImage(e)` with a capability guard (no-op where `setDragImage` is unavailable: jsdom, mock dataTransfer bags)
- Wired as the first action in `handleDragStart` / `handleSessionReorderStart` (sidebar/index.tsx), `use-board-list-reorder.ts`, and `use-server-reorder.ts` (after the infra-server guard)
- New `drag-image.test.ts` — grab-offset math + missing-`setDragImage` no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)