### PR TITLE
feat: StatusDot Compositional Vocabulary (PR Eviction)

### DIFF
--- a/fab/changes/260810-aqo6-statusdot-compositional-vocabulary/.history.jsonl
+++ b/fab/changes/260810-aqo6-statusdot-compositional-vocabulary/.history.jsonl
@@ -4,3 +4,5 @@
 {"delta":"+0.0","event":"confidence","score":3.8,"trigger":"calc-score","ts":"2026-08-10T03:26:04Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"ship","ts":"2026-08-10T03:28:25Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-08-10T03:29:07Z"}
+{"action":"re-entry","event":"stage-transition","stage":"ship","ts":"2026-08-10T03:29:43Z"}
+{"action":"re-entry","event":"stage-transition","stage":"intake","ts":"2026-08-10T03:29:54Z"}

--- a/fab/changes/260810-aqo6-statusdot-compositional-vocabulary/.history.jsonl
+++ b/fab/changes/260810-aqo6-statusdot-compositional-vocabulary/.history.jsonl
@@ -3,3 +3,4 @@
 {"delta":"+3.8","event":"confidence","score":3.8,"trigger":"calc-score","ts":"2026-08-10T03:25:41Z"}
 {"delta":"+0.0","event":"confidence","score":3.8,"trigger":"calc-score","ts":"2026-08-10T03:26:04Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"ship","ts":"2026-08-10T03:28:25Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-08-10T03:29:07Z"}

--- a/fab/changes/260810-aqo6-statusdot-compositional-vocabulary/.history.jsonl
+++ b/fab/changes/260810-aqo6-statusdot-compositional-vocabulary/.history.jsonl
@@ -1,0 +1,5 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-08-10T03:23:52Z"}
+{"args":"evict PR from the StatusDot to the row glyph, retire the done square and skipped shape, blue=building/green=PR-ready fab hues, add yellow checks-running glyph state, replace the doc matrix with the compositional reference","cmd":"fab-new","event":"command","ts":"2026-08-10T03:23:52Z"}
+{"delta":"+3.8","event":"confidence","score":3.8,"trigger":"calc-score","ts":"2026-08-10T03:25:41Z"}
+{"delta":"+0.0","event":"confidence","score":3.8,"trigger":"calc-score","ts":"2026-08-10T03:26:04Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"ship","ts":"2026-08-10T03:28:25Z"}

--- a/fab/changes/260810-aqo6-statusdot-compositional-vocabulary/.status.yaml
+++ b/fab/changes/260810-aqo6-statusdot-compositional-vocabulary/.status.yaml
@@ -9,8 +9,8 @@ progress:
     apply: pending
     review: pending
     hydrate: pending
-    ship: done
-    review-pr: active
+    ship: pending
+    review-pr: pending
 plan:
     generated: false
     task_count: 0
@@ -29,9 +29,9 @@ confidence:
         competence: 79.6
         disambiguation: 75.0
 stage_metrics:
-    intake: {started_at: "2026-08-10T03:23:52Z", driver: fab-new, iterations: 1}
-    ship: {started_at: "2026-08-10T03:28:25Z", driver: git-pr, iterations: 1, completed_at: "2026-08-10T03:29:07Z"}
-    review-pr: {started_at: "2026-08-10T03:29:07Z", driver: git-pr, iterations: 1}
+    intake: {started_at: "2026-08-10T03:29:54Z", iterations: 2}
+    ship: {iterations: 2}
+    review-pr: {iterations: 1}
 prs:
     - https://github.com/sahil87/run-kit/pull/545
 change_type_source: explicit
@@ -50,4 +50,4 @@ true_impact:
     computed_at: "2026-08-10T03:29:07Z"
     computed_at_stage: ship
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-08-10T03:29:07Z
+last_updated: 2026-08-10T03:29:54Z

--- a/fab/changes/260810-aqo6-statusdot-compositional-vocabulary/.status.yaml
+++ b/fab/changes/260810-aqo6-statusdot-compositional-vocabulary/.status.yaml
@@ -1,0 +1,37 @@
+id: aqo6
+name: 260810-aqo6-statusdot-compositional-vocabulary
+created: 2026-08-10T03:23:52Z
+created_by: sahil-noon
+change_type: feat
+issues: []
+progress:
+    intake: ready
+    apply: pending
+    review: pending
+    hydrate: pending
+    ship: active
+    review-pr: pending
+plan:
+    generated: false
+    task_count: 0
+    acceptance_count: 0
+    acceptance_completed: 0
+confidence:
+    certain: 6
+    confident: 6
+    tentative: 0
+    unresolved: 0
+    score: 3.8
+    fuzzy: true
+    dimensions:
+        signal: 69.6
+        reversibility: 79.6
+        competence: 79.6
+        disambiguation: 75.0
+stage_metrics:
+    intake: {started_at: "2026-08-10T03:23:52Z", driver: fab-new, iterations: 1}
+    ship: {started_at: "2026-08-10T03:28:25Z", driver: git-pr, iterations: 1}
+prs: []
+change_type_source: explicit
+# true_impact: lazily created on first stage-finish that computes it (no placeholder here).
+last_updated: 2026-08-10T03:28:25Z

--- a/fab/changes/260810-aqo6-statusdot-compositional-vocabulary/.status.yaml
+++ b/fab/changes/260810-aqo6-statusdot-compositional-vocabulary/.status.yaml
@@ -9,8 +9,8 @@ progress:
     apply: pending
     review: pending
     hydrate: pending
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 plan:
     generated: false
     task_count: 0
@@ -30,8 +30,24 @@ confidence:
         disambiguation: 75.0
 stage_metrics:
     intake: {started_at: "2026-08-10T03:23:52Z", driver: fab-new, iterations: 1}
-    ship: {started_at: "2026-08-10T03:28:25Z", driver: git-pr, iterations: 1}
-prs: []
+    ship: {started_at: "2026-08-10T03:28:25Z", driver: git-pr, iterations: 1, completed_at: "2026-08-10T03:29:07Z"}
+    review-pr: {started_at: "2026-08-10T03:29:07Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/sahil87/run-kit/pull/545
 change_type_source: explicit
+true_impact:
+    added: 719
+    deleted: 0
+    net: 719
+    excluding:
+        added: 0
+        deleted: 0
+        net: 0
+    tests:
+        added: 0
+        deleted: 0
+        net: 0
+    computed_at: "2026-08-10T03:29:07Z"
+    computed_at_stage: ship
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-08-10T03:28:25Z
+last_updated: 2026-08-10T03:29:07Z

--- a/fab/changes/260810-aqo6-statusdot-compositional-vocabulary/intake.md
+++ b/fab/changes/260810-aqo6-statusdot-compositional-vocabulary/intake.md
@@ -1,0 +1,231 @@
+# Intake: StatusDot Compositional Vocabulary (PR Eviction)
+
+**Change**: 260810-aqo6-statusdot-compositional-vocabulary
+**Created**: 2026-08-10
+
+## Origin
+
+Conversational — a `/fab-discuss` session (2026-08-09/10) that walked the full design space with
+visual mocks before this intake was drafted via `/fab-draft`.
+
+> I want to relook all of StatusDot's states, now that PR state has been moved to separate icon on
+> the right. The separation of PR state should allow us simplify the StatusDots a bit, maybe remove
+> one visual dimension from StatusDot (I am trying to remove the square shape).
+
+The session compared four configurations side by side (Current / A: full PR eviction / B:
+square-only removal / C: eviction + square kept), iterated on hue semantics, and locked the final
+vocabulary. **The user's decisions, in order:**
+
+1. Chose configuration **A** (full PR eviction, square retired) over B and C.
+2. **Blue = building** (intake · apply · review), **green = PR-ready/landed/done** (ship ·
+   review-pr · done) — apply/review turn blue; green is reserved for a change that has completed
+   its local work ("PR is ready"). Explicitly capped at these TWO fab hues — the maximal
+   one-fab-hue reduction was offered and **rejected**.
+3. Parked-done changes render **green** (not gray floor fall-through) — "green denoting done fab
+   changes" — as the resting **ring**, since the square is retired.
+4. The **yellow checks-running glyph state is kept** — "actually a good idea, very informational"
+   (it had been offered as a cut; the user overrode).
+5. Accepted the remaining recommendations: the doc matrix is replaced by the **compositional
+   legend reference**, and the code reductions below.
+
+**Binding visual reference** (in this change folder — the execution agent MUST match these rather
+than re-deriving the design):
+
+- `reference-status-dot-final.svg` — the final compositional reference diagram (4 hue strips,
+  3 shape strips, 5-state glyph strip, halo, composed examples). This file is the intended
+  replacement content for the doc diagram.
+- `reference-mock.html` — the full comparison mock; its "A" column is the authoritative
+  row-by-row rendering for all 18 representative window states, and its "FINAL reference" section
+  embeds the SVG above.
+
+## Why
+
+The sidebar window row now carries a rest-state git-pull-request glyph at its right edge
+(93dy / PR #452-era work), colored from the shared PR vocabulary. This made the StatusDot's PR
+tier **redundant**: a merged fab PR renders a purple `done` square on the dot AND a purple glyph
+on the same row — the same fact encoded twice, two pixels apart (user's screenshot showed 4 such
+rows at once). Beyond the duplication:
+
+1. **The dot is overloaded.** Palette v3 packs 6 hues × 5 shapes into a 7px dot, where the PR
+   tier displaces live pipeline state (a fab window with a PR never shows its stage on the dot).
+2. **The vocabulary is non-compositional.** Shape meaning shifts per row (pending = "checks
+   running" only on PR rows; done = "merged" there, "parked" elsewhere), so the doc needs a 6×5
+   matrix with per-cell captions and two special-cased rows.
+3. **If we don't fix it**: every new PR-adjacent state (draft, pending) pressures the dot further,
+   and the double-encoding grows with the glyph's vocabulary.
+
+**The chosen approach**: split by *story*, not by precedence — the **dot tells the local story**
+(what runs in this pane: which journey, is it healthy, does it need me) and the **glyph tells the
+remote story** (the branch's PR on GitHub). This removes two hues (purple, orange) and two shapes
+(done square, skipped ring) from the dot, makes shape meaning uniform across every hue
+(fully compositional), and lets the doc replace the matrix with four small legend strips.
+Alternatives rejected: square-only removal (keeps the double-encoding and makes merged
+indistinguishable from open on the dot), one-fab-hue maximal reduction (loses the "still cooking
+vs out the door" glance the user explicitly wants).
+
+## What Changes
+
+### 1. Dot model — `app/frontend/src/components/pr-status-model.ts`
+
+The ladder loses its PR branches entirely:
+
+```
+fabChange ?  (stage ∈ {intake, apply, review} ? blue-building : green-prReady, shape by fabDisplayState)
+          :  (fresh agentState ? yellow agent (solid mid-turn / ring idle) : gray floor)
+waiting   →  additive yellow halo, unchanged
+```
+
+- **`DotPhase`** shrinks 6 → 4: `building | prReady | agent | none` (replacing
+  `intake | apply | pr | agent | agentPr | none`). `PHASE_HUE`:
+  `building: text-blue-400`, `prReady: text-accent-green`, `agent: text-yellow-400`,
+  `none: text-text-secondary`. `text-purple-400` / `text-orange-400` leave the dot's hue map
+  (purple stays in the glyph/segment vocabularies).
+- **`fabPhase(stage)`** becomes the two-stop split: `intake`/`apply`/`review` → `building`;
+  `ship`/`review-pr`/`done` and unknown/absent → `prReady`. The split is **stage-based, never
+  `prNumber`-based** — the dot must not consult PR fields (alignment with PR existence stays
+  emergent, since `/git-pr` creates the PR mid-ship, mirroring the old spec's "emergent, not a
+  stage check" fact).
+- **`DotShape`** shrinks 5 → 3: `ring | solid | failed`. **`done` and `skipped` are deleted.**
+- **`fabShape(displayState)`**: `pending` → `ring`, `failed` → `failed`, **`done` → `ring`**
+  (parked = resting), `active`/`ready`/unknown → `solid`. A `skipped` display-state no longer maps
+  to a shape — see the ladder note below.
+- A **`skipped`** fabDisplayState falls through to the **gray floor** in `statusDotState` (a
+  skipped change has left its journey; the old behavior forced gray anyway — now it simply isn't a
+  fab-owned dot). <!-- assumed: skipped-displayState → floor fall-through rather than a green/gray fab ring — matches the old forced-gray rendering with less machinery -->
+- **`prShape()` is deleted.** `prDotState()` is retained (the glyph color logic and PR text
+  surfaces consume its semantics).
+- **`prOwnsDot()` is retained as the glyph gate only** (`prNumber` present and not
+  closed-unmerged) and SHOULD be renamed to reflect that (e.g. `prOwnsGlyph`), updating its
+  import sites. <!-- assumed: rename prOwnsDot→prOwnsGlyph since it no longer gates any dot; keeping the old name is acceptable if the rename churns too many sites -->
+- **`statusDotState()`** loses both `prOwnsDot(...)` branches; the fab arm becomes
+  `{ phase: fabPhase(win.fabStage), shape: fabShape(win.fabDisplayState), waiting }` (plus the
+  skipped fall-through), the agent arm becomes
+  `{ phase: "agent", shape: idle ? "ring" : "solid", waiting }` with no `agentPr` case.
+
+### 2. Glyph vocabulary — `prGlyphColor()` gains a pending state
+
+New five-way mapping (branch order IS the design; first match wins):
+
+1. `text-red-400` — fail-ish (`prDotState` → `fail`): checks fail / changes requested. Fail stays
+   on top.
+2. `text-text-secondary` — open draft (unchanged; draft stays muted-gray even while its checks
+   run, matching GitHub's draft-gray treatment). <!-- assumed: draft outranks the new pending-yellow — drafts are deliberately muted today and pending would un-mute them -->
+3. **`text-yellow-400` — open with `prChecks === "pending"` (NEW: checks running).** The row-level
+   compensation for losing the purple pending ring; reuses the established
+   `PR_CHECKS_COLORS.pending` token choice.
+4. `text-accent-green` — open, checks pass or no decisive signal.
+5. `text-purple-400` — merged.
+
+Closed never reaches the glyph (gate unchanged). No dot involvement.
+
+### 3. Dot rendering — `app/frontend/src/components/status-dot.tsx`
+
+- Delete the `done` (sharp square) and implicit `skipped` branches; three renderers remain:
+  `solid`, `ring`, `failed` (dotted 9px ring + 3px red center — unchanged), plus the additive
+  waiting halo (unchanged, including reduced-motion static ring).
+- The `skipped`-forces-gray color special case in `StatusDot` is deleted along with the shape.
+- Header comment rewritten to the compositional model (dot = local story, glyph = remote story).
+
+### 4. Labels — `status-dot-label.ts`
+
+`dotLabel` composes from the new vocabulary: phase word (`building` / `PR-ready` / `agent` /
+floor-bare) + status word (`active`·`ready` / `pending`·`idle`·`parked` / `failed`) + the waiting
+suffix. PR-specific labels (`"PR — merged"` etc.) leave the dot's label space — the PR facts live
+in the flyout/register surfaces, which already render them. Exact wording is apply's to settle;
+the composition rule (hue-word + shape-word, no PR words) is the requirement.
+
+### 5. Glyph surfaces — parity where the dot renders without a register view
+
+- `sidebar/window-row.tsx` — glyph already present; picks up the yellow pending state via
+  `prGlyphColor`.
+- `session-tiles/session-tiles.tsx` — **add the rest-state glyph** to the window-row line (same
+  gate, same color fn, same `aria-hidden` decoration semantics), since evicting PR from the dot
+  would otherwise leave board/dashboard tiles with no PR signal at all.
+  <!-- assumed: session tiles get the glyph for parity; the pane panel does NOT (its register view already shows the full PR line) -->
+- `sidebar/status-panel.tsx` (pane panel) — no glyph; its register view is the detail surface.
+- `board-pane.tsx` — inspect at apply: if its header renders a StatusDot without any PR register,
+  add the glyph under the same rule; otherwise leave untouched.
+
+### 6. Documentation — `docs/site/status-dot.md` + `docs/img/`
+
+- Replace `docs/img/status-dot-matrix.svg` with the **compositional reference** — content is this
+  change folder's `reference-status-dot-final.svg`, verbatim (minus any final polish apply needs
+  for rendering fidelity). SHOULD be renamed to `status-dot-reference.svg` (it is no longer a
+  matrix), updating the image reference in `docs/site/status-dot.md`; keeping the old filename is
+  the fallback if external links matter. <!-- assumed: rename the SVG to status-dot-reference.svg + update referencing markdown; overwrite-in-place is the fallback -->
+- Rewrite `docs/site/status-dot.md` to the compositional structure: the four legend strips (hue /
+  shape / glyph / halo) replace the precedence prose + 6×5 matrix. Specifically:
+  - The ladder section drops both PR branches; D1 (per-family PR ownership) **dissolves** — no
+    family owns the dot via PR; the glyph is un-family-gated as it already is today.
+  - D2 (merged durability via `--state all` derivation) **survives untouched** but is reworded:
+    it feeds the **glyph's** durable purple merged state, not a dot square.
+  - "Red is used in exactly one way" becomes the honest split: **dot-red appears only as the
+    failed center; glyph-red = failing PR** (the glyph already uses red today — the old absolute
+    claim was stale).
+  - The Row Minimalism "survives as" table updates: `done`-parking → green resting ring;
+    PR states → the glyph column.
+- Update `docs/specs/status-pyramid.md` (the design authority): channel-model table, tier ladder,
+  and the decision table collapse to the compositional vocabulary (rows 6–10 and 17–20 rewrite;
+  the fab family becomes blue building → green PR-ready). Mark the palette-v3 sections as
+  superseded rather than deleting the rationale history.
+
+### 7. Tests
+
+- `status-dot.test.tsx`, `status-dot-label` coverage, `window-row.test.tsx`,
+  `sidebar.test.tsx`, `row-flyout-card.test.tsx` — update expectations to the new
+  phases/shapes/labels and the glyph's pending state; add session-tiles glyph coverage.
+- Playwright specs asserting dot/glyph rendering (e.g. `pr-status-sidebar`, `status-dot-tip`
+  lineage) — update per the new vocabulary, and update sibling `.spec.md` companions in the same
+  commit (constitution: Test Companion Docs).
+
+### 8. Explicitly unchanged
+
+- The waiting halo (additive, constant-yellow, reduced-motion static ring) — mechanism and CSS.
+- The two-family top of the ladder (fabChange > fresh agent > floor) and #314 freshness rules.
+- The backend D2 branch→PR derivation, default-branch carve-out (#389), and all `WindowInfo`
+  fields — **zero backend changes**.
+- The register view (`out`/`agt`/`fab`/`pr`), flyout card, and pane-panel PR segments.
+- `PR_STATE_COLORS` / `PR_CHECKS_COLORS` / `PR_REVIEW_COLORS` and `prDotState`.
+
+## Affected Memory
+
+- `run-kit/ui-patterns`: (modify) StatusDot vocabulary — replace the palette-v3 6-hue/5-shape
+  model with the compositional 4-hue/3-shape + glyph-channel model; record the dot=local /
+  glyph=remote ownership split and the blue→green two-stop fab hue.
+
+## Impact
+
+- **Frontend only.** Core: `pr-status-model.ts`, `status-dot.tsx`, `status-dot-label.ts`,
+  `sidebar/window-row.tsx`, `session-tiles/session-tiles.tsx` (+ `board-pane.tsx` inspection).
+  Consumers to sweep for `DotPhase`/`DotShape`/`prShape`/`prOwnsDot` imports:
+  `sidebar/registers.ts`, `sidebar/row-flyout-card.tsx`, `sidebar/status-panel.tsx`.
+- **Docs**: `docs/site/status-dot.md`, `docs/img/status-dot-matrix.svg` (replaced/renamed),
+  `docs/specs/status-pyramid.md`.
+- **Tests**: unit tests colocated with the components above; Playwright specs + `.spec.md`
+  companions covering dot/glyph rendering.
+- **No backend, no API, no SSE payload changes.** No new routes (Constitution IV untouched).
+- Note: `session-tiles.tsx` contains a deliberate NUL byte at line ~63 — plain `grep` sweeps skip
+  it silently; use `grep -a` or perl when sweeping import sites.
+
+## Open Questions
+
+- None — all decision points were resolved in the originating discussion or graded below.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | PR is fully evicted from the dot; the right-edge glyph is the row's only PR channel (config A over B/C) | User chose A explicitly after viewing all four mocked configurations | S:95 R:60 A:90 D:95 |
+| 2 | Certain | Fab hues: blue = building (intake·apply·review), green = PR-ready/landed/done (ship·review-pr·done); exactly two fab hues | User directed the blue/green split across two iterations and explicitly rejected the one-hue reduction | S:95 R:70 A:90 D:90 |
+| 3 | Certain | Done square + skipped shape retired; parked-done = green resting ring | User: "green denoting done fab changes" after choosing A (square gone); ring is the only resting shape left | S:90 R:70 A:90 D:85 |
+| 4 | Certain | Glyph gains yellow checks-running state (`text-yellow-400`, open + checks pending) | User overrode the offered cut: "actually a good idea, keep it - very informational" | S:95 R:90 A:90 D:95 |
+| 5 | Certain | Doc matrix replaced by the compositional legend reference; `reference-status-dot-final.svg` in this folder is the binding artwork | User approved the final reference render and asked for it to ride with the intake | S:90 R:85 A:90 D:90 |
+| 6 | Certain | blue↔green split is stage-based (`fabStage`), never `prNumber`-based | Recommended with rationale (dot must not consult PR fields; alignment stays emergent) and accepted in "ok with the rest" | S:80 R:75 A:90 D:85 |
+| 7 | Confident | `skipped` fabDisplayState falls through to the gray floor | Old rendering already forced gray; fall-through achieves it with less machinery; state is rare | S:55 R:85 A:75 D:70 |
+| 8 | Confident | Glyph precedence: fail > draft > pending-yellow > open-green > merged-purple (draft outranks pending) | Draft is deliberately muted today; letting pending un-mute drafts would contradict the e30p draft-gray decision | S:50 R:90 A:75 D:65 |
+| 9 | Confident | Session tiles gain the rest-state PR glyph; pane panel does not (register view covers it); board-pane inspected at apply | Discussed as the coverage gap ("glyph is sidebar-only"); parity rule follows the dot=local/glyph=remote split; easily reversed | S:60 R:85 A:70 D:65 |
+| 10 | Confident | `docs/specs/status-pyramid.md` is updated in this same change (supersede palette-v3 sections, keep rationale history) | Spec is the named design authority; shipping code that contradicts it violates the repo's spec-first testing posture | S:55 R:80 A:80 D:75 |
+| 11 | Confident | Rename `prOwnsDot` → `prOwnsGlyph` (import sites updated) | Name becomes false after eviction; trivially reversible naming call with a clear front-runner | S:35 R:90 A:60 D:45 |
+| 12 | Confident | Rename `docs/img/status-dot-matrix.svg` → `status-dot-reference.svg` + update markdown refs | It is no longer a matrix; external raw-path links are the only risk and overwrite-in-place is the documented fallback | S:35 R:75 A:55 D:40 |
+
+12 assumptions (6 certain, 6 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260810-aqo6-statusdot-compositional-vocabulary/reference-mock.html
+++ b/fab/changes/260810-aqo6-statusdot-compositional-vocabulary/reference-mock.html
@@ -1,0 +1,357 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>StatusDot configurations</title>
+<style>
+  :root {
+    --bg: #0f0f13;
+    --panel: #17171d;
+    --panel-2: #1c1c24;
+    --row: #1a1a21;
+    --text: #d6d6d6;
+    --dim: #8a8f98;
+    --dimmer: #5c6068;
+    --border: #2a2a33;
+    --gray: #9ca3af;
+    --blue: #60a5fa;
+    --green: #4ade80;
+    --purple: #c084fc;
+    --yellow: #facc15;
+    --orange: #fb923c;
+    --red: #f87171;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
+    font-size: 13px;
+    padding: 28px 32px 64px;
+  }
+  h1 { font-size: 16px; font-weight: 600; letter-spacing: .02em; margin-bottom: 4px; }
+  .sub { color: var(--dim); font-size: 12px; margin-bottom: 24px; max-width: 900px; line-height: 1.5; }
+
+  /* ---------- shape vocabulary legend ---------- */
+  .legend { display: flex; gap: 28px; flex-wrap: wrap; margin-bottom: 28px; padding: 12px 16px; background: var(--panel); border: 1px solid var(--border); border-radius: 6px; width: fit-content; }
+  .legend .item { display: flex; align-items: center; gap: 8px; color: var(--dim); font-size: 11px; }
+
+  /* ---------- dots (mirrors status-dot.tsx) ---------- */
+  .dot { display: inline-block; width: 7px; height: 7px; border-radius: 9999px; flex: none; }
+  .dot.solid { background: currentColor; }
+  .dot.ring { border: 1.8px solid currentColor; background: transparent; }
+  .dot.done { border-radius: 0; background: currentColor; }
+  .dot.failed {
+    width: 9px; height: 9px;
+    border: 1.2px dotted currentColor; background: transparent;
+    position: relative;
+  }
+  .dot.failed::after {
+    content: ""; position: absolute; left: 50%; top: 50%;
+    width: 3px; height: 3px; margin: -1.5px 0 0 -1.5px;
+    border-radius: 9999px; background: var(--red);
+  }
+  .dot.halo { animation: halo 1.6s ease-in-out infinite; }
+  @keyframes halo {
+    0%, 100% { box-shadow: 0 0 0 2px rgba(250, 204, 21, .18); }
+    50%      { box-shadow: 0 0 0 3.5px rgba(250, 204, 21, .45); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .dot.halo { animation: none; box-shadow: 0 0 0 2.5px rgba(250, 204, 21, .38); }
+  }
+
+  .c-gray { color: var(--gray); } .c-blue { color: var(--blue); } .c-green { color: var(--green); }
+  .c-purple { color: var(--purple); } .c-yellow { color: var(--yellow); } .c-orange { color: var(--orange); }
+
+  /* ---------- comparison grid ---------- */
+  table { border-collapse: collapse; }
+  th, td { padding: 0; }
+  thead th {
+    text-align: left; font-size: 12px; font-weight: 600; color: var(--text);
+    padding: 8px 14px 10px; vertical-align: bottom;
+  }
+  thead th .tag { display: block; font-weight: 400; color: var(--dim); font-size: 10.5px; margin-top: 3px; line-height: 1.45; max-width: 230px; }
+  thead th.state-col { color: var(--dimmer); font-weight: 400; font-size: 11px; }
+  tbody td.state {
+    color: var(--dim); font-size: 11px; padding: 0 18px 0 14px; white-space: nowrap;
+  }
+  tbody td.state .layer { color: var(--dimmer); }
+  tr.group td {
+    padding: 20px 14px 6px; color: var(--dimmer); font-size: 10px;
+    text-transform: uppercase; letter-spacing: .14em;
+  }
+  tr.group:first-child td { padding-top: 4px; }
+
+  /* mini sidebar row */
+  .cell { padding: 2px 10px; }
+  .mrow {
+    display: flex; align-items: center; gap: 9px;
+    background: var(--row); border: 1px solid var(--border);
+    border-radius: 4px; padding: 6px 9px; width: 240px; height: 30px;
+    position: relative;
+  }
+  .mrow .name { color: var(--text); font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; }
+  .mrow .glyph { flex: none; display: flex; align-items: center; }
+  .mrow .glyph svg { display: block; }
+  .mrow.hi { outline: 1px solid rgba(250,204,21,.25); outline-offset: 1px; }
+  .fn { color: var(--dimmer); font-size: 9px; vertical-align: super; margin-left: 3px; }
+
+  /* ---------- per-config summary ---------- */
+  .summaries { display: grid; grid-template-columns: repeat(4, 260px); gap: 12px; margin-top: 34px; margin-left: 258px; }
+  .summary { background: var(--panel); border: 1px solid var(--border); border-radius: 6px; padding: 12px 14px; font-size: 11px; line-height: 1.55; color: var(--dim); }
+  .summary b { color: var(--text); display: block; margin-bottom: 6px; font-size: 11.5px; }
+  .summary .vocab { color: var(--text); }
+  .summary .warn { color: var(--orange); }
+  .summary .good { color: var(--green); }
+
+  .notes { margin-top: 30px; max-width: 940px; color: var(--dim); font-size: 11.5px; line-height: 1.7; }
+  .notes b { color: var(--text); }
+  .scroller { overflow-x: auto; }
+</style>
+</head>
+<body>
+
+<h1>StatusDot configurations — PR glyph era</h1>
+<p class="sub">
+  Same 18 window states under four configurations. The right-edge git-pull-request glyph is the
+  rest-state PR indicator that already shipped (93dy) — the question is what the <em>dot</em> still owes
+  once the glyph carries the PR story. Waiting rows pulse (static ring under reduced motion).
+</p>
+
+<div class="legend">
+  <span class="item"><span class="dot solid c-gray"></span> solid = live/healthy</span>
+  <span class="item"><span class="dot ring c-gray"></span> ring = pending/idle</span>
+  <span class="item"><span class="dot failed c-gray"></span> failed = dotted + red center</span>
+  <span class="item"><span class="dot done c-gray"></span> done = sharp square</span>
+  <span class="item"><span class="dot solid c-yellow halo"></span> halo = waiting (additive)</span>
+</div>
+
+<div class="scroller">
+<table>
+  <thead>
+    <tr>
+      <th class="state-col">window state</th>
+      <th>CURRENT<span class="tag">6 hues · 5 shapes · PR owns the dot per family</span></th>
+      <th>A — PR evicted, square retired<span class="tag">4 hues · 3 shapes · glyph-only PR channel (+ yellow pending glyph) · blue = building (intake→review), green = PR-ready · done falls to floor</span></th>
+      <th>B — square-only removal<span class="tag">6 hues · 4 shapes · PR keeps the dot; merged→solid, done→solid</span></th>
+      <th>C — PR evicted, square kept<span class="tag">4 hues · 4 shapes · blue = building, green = PR-ready · square survives for parked-done fab only</span></th>
+    </tr>
+  </thead>
+  <tbody id="rows"></tbody>
+</table>
+</div>
+
+<div class="summaries">
+  <div class="summary">
+    <b>Current</b>
+    <span class="vocab">blue · green · purple · yellow · orange · gray × solid · ring · failed · done · skipped</span><br><br>
+    <span class="warn">Merged is double-encoded</span> — purple square <em>and</em> purple glyph on the same row (rows 16–17).
+    PR health lives in two places at once.
+  </div>
+  <div class="summary">
+    <b>A — full eviction</b>
+    <span class="vocab">blue · green · yellow · gray × solid · ring · failed</span><br><br>
+    <span class="good">Dot = local story, glyph = remote story.</span>
+    <span class="vocab">Blue = building (intake→review), green = PR-ready/landed/done</span> — hue is a two-stop progress bar, not a stage map.
+    Parked-done = <span class="vocab">green ring</span> (resting, journey complete) — no square needed, but done and a rare ship-pending share the ring.
+  </div>
+  <div class="summary">
+    <b>B — trim the shape only</b>
+    <span class="vocab">blue · green · purple · yellow · orange · gray × solid · ring · failed</span><br><br>
+    <span class="warn">Merged = open on the dot</span> (rows 13 vs 16) and <span class="warn">done = active</span> (rows 11 vs 18):
+    the glyph must disambiguate anyway, yet purple/orange and the double-encoding all stay.
+  </div>
+  <div class="summary">
+    <b>C — eviction, square for parked</b>
+    <span class="vocab">blue · green · yellow · gray × solid · ring · failed · done</span><br><br>
+    Same two-stop hue as A (blue building → green PR-ready), and rows 17–18 keep a distinct green
+    "done, archive me" square — green's "completed" meaning extends naturally to it.
+    <span class="warn">A whole shape retained for one rare-ish state</span> — the square's only remaining tenant.
+  </div>
+</div>
+
+<h1 style="margin-top:56px">FINAL reference — replaces docs/img/status-dot-matrix.svg</h1>
+<p class="sub">
+  The A-vocabulary is fully compositional (shape means the same thing in every hue), so the 6×5 matrix
+  retires in favor of four legend strips + composed examples. Decisions locked: PR evicted to the glyph
+  (incl. the NEW yellow checks-running glyph state) · square + skipped retired · blue = building,
+  green = PR-ready/done · halo unchanged.
+</p>
+<div class="scroller">
+  <img src="status-dot-final-reference.svg" width="760" height="620" alt="Final compositional reference" style="border:1px solid var(--border); border-radius:6px;">
+</div>
+
+<h1 style="margin-top:56px">Superseded — the before / matrix-draft pair kept for the record</h1>
+<p class="sub">
+  Left: the shipped palette-v3 matrix. Right: the intermediate matrix-form draft of configuration A
+  (superseded by the compositional reference above).
+</p>
+
+<div class="scroller" style="display:flex; gap:20px; align-items:flex-start;">
+  <img src="status-dot-matrix-current.svg" width="760" height="620" alt="Current matrix" style="flex:none; border:1px solid var(--border); border-radius:6px;">
+
+  <svg xmlns="http://www.w3.org/2000/svg" width="760" height="620" viewBox="0 0 760 620"
+       font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
+       style="flex:none; border:1px solid var(--border); border-radius:6px;">
+    <rect x="0" y="0" width="760" height="620" fill="#1a1b26"/>
+
+    <!-- title -->
+    <text x="24" y="30" font-size="16" font-weight="700" fill="#c0caf5">StatusDot — family × status matrix (draft: PR evicted)</text>
+    <text x="24" y="48" font-size="11" fill="#787c99">Core hue = journey (cool = fab: blue building → green PR-ready · warm = agent: yellow · gray = floor) · Shape = status · Halo = waiting</text>
+    <text x="24" y="64" font-size="11" fill="#787c99">The dot never speaks PR — the PR story lives on the row's right-edge glyph (strip below).</text>
+
+    <!-- column headers -->
+    <text x="60"  y="96" font-size="10" letter-spacing=".04em" fill="#787c99">FAMILY \ STATUS</text>
+    <text x="330" y="96" font-size="10" letter-spacing=".04em" fill="#787c99" text-anchor="middle">PENDING</text>
+    <text x="450" y="96" font-size="10" letter-spacing=".04em" fill="#787c99" text-anchor="middle">ACTIVE / READY</text>
+    <text x="570" y="96" font-size="10" letter-spacing=".04em" fill="#787c99" text-anchor="middle">FAILED</text>
+    <text x="680" y="96" font-size="10" letter-spacing=".04em" fill="#787c99" text-anchor="middle">DONE · PARKED</text>
+    <line x1="24" y1="106" x2="740" y2="106" stroke="#2f3549" stroke-width="1"/>
+
+    <!-- Row: fab building (blue) -->
+    <text x="24" y="128" font-size="10" letter-spacing=".05em" fill="#787c99">COOL · FAB · BUILDING — blue (pre-PR work)</text>
+    <text x="60" y="154" font-size="12" fill="#c0caf5">intake · apply · review</text>
+    <circle cx="330" cy="149" r="5" fill="none" stroke="#60a5fa" stroke-width="1.8"/>
+    <circle cx="450" cy="149" r="5" fill="#60a5fa"/>
+    <circle cx="570" cy="149" r="6" fill="none" stroke="#60a5fa" stroke-width="1.8" stroke-linecap="round" stroke-dasharray="0.1 3"/>
+    <circle cx="570" cy="149" r="2.2" fill="#f87171"/>
+    <text x="680" y="153" font-size="8.5" fill="#565a73" text-anchor="middle">— ⇒ green row —</text>
+    <line x1="24" y1="170" x2="740" y2="170" stroke="#2f3549" stroke-width="1"/>
+
+    <!-- Row: fab PR-ready (green) -->
+    <text x="24" y="192" font-size="10" letter-spacing=".05em" fill="#787c99">COOL · FAB · PR-READY — green (/git-pr creates the PR mid-ship; PR health = the glyph)</text>
+    <text x="60" y="218" font-size="12" fill="#c0caf5">ship · review-pr · done</text>
+    <circle cx="330" cy="213" r="5" fill="none" stroke="#9ece6a" stroke-width="1.8"/>
+    <circle cx="450" cy="213" r="5" fill="#9ece6a"/>
+    <circle cx="570" cy="213" r="6" fill="none" stroke="#9ece6a" stroke-width="1.8" stroke-linecap="round" stroke-dasharray="0.1 3"/>
+    <circle cx="570" cy="213" r="2.2" fill="#f87171"/>
+    <circle cx="680" cy="213" r="5" fill="none" stroke="#9ece6a" stroke-width="1.8"/>
+    <text x="330" y="233" font-size="8.5" fill="#565a73" text-anchor="middle">stage pending</text>
+    <text x="450" y="233" font-size="8.5" fill="#565a73" text-anchor="middle">shipping / landing</text>
+    <text x="570" y="233" font-size="8.5" fill="#565a73" text-anchor="middle">review-pr failed</text>
+    <text x="680" y="233" font-size="8.5" fill="#565a73" text-anchor="middle">parked — resting ring</text>
+    <line x1="24" y1="244" x2="740" y2="244" stroke="#2f3549" stroke-width="1"/>
+
+    <!-- Row: ad-hoc agent (yellow) -->
+    <text x="24" y="266" font-size="10" letter-spacing=".05em" fill="#787c99">WARM · AD-HOC AGENT — yellow (a fresh @rk_agent_state, no fab change)</text>
+    <text x="60" y="292" font-size="12" fill="#c0caf5">agent</text>
+    <circle cx="330" cy="287" r="5" fill="none" stroke="#facc15" stroke-width="1.8"/>
+    <circle cx="450" cy="287" r="5" fill="#facc15"/>
+    <text x="330" y="307" font-size="8.5" fill="#565a73" text-anchor="middle">idle</text>
+    <text x="450" y="307" font-size="8.5" fill="#565a73" text-anchor="middle">active / mid-turn</text>
+    <text x="625" y="291" font-size="9" fill="#565a73" text-anchor="middle">— the agent's PR shows on the glyph; no orange tier —</text>
+    <line x1="24" y1="318" x2="740" y2="318" stroke="#2f3549" stroke-width="1"/>
+
+    <!-- Row: floor (gray) -->
+    <text x="24" y="340" font-size="10" letter-spacing=".05em" fill="#787c99">FLOOR · TMUX — monochrome (no fab change, no fresh agent) — color reserved for a journey</text>
+    <text x="60" y="366" font-size="12" fill="#c0caf5">plain window</text>
+    <circle cx="330" cy="361" r="5" fill="none" stroke="#787c99" stroke-width="1.8"/>
+    <circle cx="450" cy="361" r="5" fill="#787c99"/>
+    <text x="330" y="381" font-size="8.5" fill="#565a73" text-anchor="middle">idle</text>
+    <text x="450" y="381" font-size="8.5" fill="#565a73" text-anchor="middle">active (output)</text>
+    <text x="625" y="365" font-size="8.5" fill="#565a73" text-anchor="middle">a plain pane's PR never owns the dot</text>
+    <line x1="24" y1="392" x2="740" y2="392" stroke="#2f3549" stroke-width="1"/>
+
+    <!-- PR glyph strip -->
+    <text x="24" y="420" font-size="11" font-weight="700" fill="#787c99">PR — the right-edge row glyph (one channel, five states; never the dot):</text>
+    <g fill="#9ece6a" transform="translate(38,432) scale(0.9)"><path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z"/></g>
+    <text x="60" y="443" font-size="9" fill="#565a73">open</text>
+    <g fill="#facc15" transform="translate(128,432) scale(0.9)"><path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z"/></g>
+    <text x="150" y="443" font-size="9" fill="#565a73">checks running (new)</text>
+    <g fill="#f87171" transform="translate(300,432) scale(0.9)"><path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z"/></g>
+    <text x="322" y="443" font-size="9" fill="#565a73">checks fail / changes req.</text>
+    <g fill="#c084fc" transform="translate(494,432) scale(0.9)"><path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z"/></g>
+    <text x="516" y="443" font-size="9" fill="#565a73">merged</text>
+    <g fill="#787c99" transform="translate(580,432) scale(0.9)"><path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z"/></g>
+    <text x="602" y="443" font-size="9" fill="#565a73">draft · closed → none</text>
+    <line x1="24" y1="462" x2="740" y2="462" stroke="#2f3549" stroke-width="1"/>
+
+    <!-- Waiting overlay callout -->
+    <text x="24" y="490" font-size="11" font-weight="700" fill="#787c99">Waiting = an ADDITIVE constant-yellow halo (over any core; core hue + shape kept):</text>
+    <circle cx="40" cy="514" r="8.5" fill="none" stroke="#facc15" stroke-width="1.6" opacity="0.9"/>
+    <circle cx="40" cy="514" r="5" fill="#60a5fa"/>
+    <text x="54" y="518" font-size="10" fill="#565a73">blue building + halo = "fab agent asking"</text>
+    <circle cx="360" cy="514" r="9.5" fill="none" stroke="#facc15" stroke-width="1.6" opacity="0.9"/>
+    <circle cx="360" cy="514" r="6" fill="none" stroke="#60a5fa" stroke-width="1.8" stroke-linecap="round" stroke-dasharray="0.1 3"/>
+    <circle cx="360" cy="514" r="2.2" fill="#f87171"/>
+    <text x="376" y="518" font-size="10" fill="#565a73">blue failed + halo = "review failed, agent asking"</text>
+
+    <!-- retirements -->
+    <text x="24" y="548" font-size="10" fill="#565a73">Retired: the purple + orange hues (PR is the glyph's) · the done square (parked = green ring) · the SKIPPED column (a skipped change renders the gray floor ring).</text>
+    <text x="24" y="566" font-size="10" fill="#565a73">Vocabulary: 4 hues (blue · green · yellow · gray) × 3 shapes (solid · ring · failed). Reduced motion: the halo is a static yellow ring.</text>
+    <text x="24" y="584" font-size="10" fill="#565a73">On the DOT red stays failed-center-only; the glyph reuses the shared PR vocabulary (red = failing) as it already does today.</text>
+  </svg>
+</div>
+
+<div class="notes">
+  <b>Footnotes</b> —
+  ¹ Config A/C extend the glyph with a <span style="color:var(--yellow)">yellow pending</span> state (checks running), compensating for the lost purple ring; today's glyph shows plain green while checks run.
+  · ² In A/C a failing PR keeps a healthy local dot — the <span style="color:var(--red)">red glyph</span> alone carries remote failure. The dot's <em>failed</em> shape becomes fab-review-failed only.
+  · ³ In A the parked-done change stays green (green = done fab change) but drops to a ring — resting, journey complete; the purple merged glyph says how it ended.
+  · Glyph is currently sidebar-only — session tiles &amp; board panes render just the dot, so A–C need the glyph ported there (or accept the loss on those surfaces).
+</div>
+
+<script>
+const D = (hue, shape, opts = {}) => ({ hue, shape, ...opts });
+const G = { green: "var(--green)", purple: "var(--purple)", red: "var(--red)", yellow: "var(--yellow)", gray: "var(--gray)" };
+
+const GLYPH = c => c ? `<span class="glyph" style="color:${G[c]}">
+  <svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+    <path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z"/>
+  </svg></span>` : "";
+
+const CELL = (name, d) => {
+  if (!d) return `<td class="cell"></td>`;
+  const halo = d.halo ? " halo" : "";
+  const fn = d.fn ? `<span class="fn">${d.fn}</span>` : "";
+  return `<td class="cell"><div class="mrow${d.halo ? " hi" : ""}">
+    <span class="dot ${d.shape} c-${d.hue}${halo}"></span>
+    <span class="name">${name}${fn}</span>${GLYPH(d.glyph)}
+  </div></td>`;
+};
+
+// rows: [group | [label, stateDesc, current, A, B, C]]
+const rows = [
+  "floor — plain terminal",
+  ["htop", "output flowing", D("gray","solid"), D("gray","solid"), D("gray","solid"), D("gray","solid")],
+  ["scratch-shell", "quiet 23m", D("gray","ring"), D("gray","ring"), D("gray","ring"), D("gray","ring")],
+  ["old-branch-shell", "no agent · branch has open PR", D("gray","ring",{glyph:"green"}), D("gray","ring",{glyph:"green"}), D("gray","ring",{glyph:"green"}), D("gray","ring",{glyph:"green"})],
+
+  "ad-hoc agent",
+  ["riff-glazed-heron", "agent active", D("yellow","solid"), D("yellow","solid"), D("yellow","solid"), D("yellow","solid")],
+  ["riff-brisk-minnow", "agent idle 12m", D("yellow","ring"), D("yellow","ring"), D("yellow","ring"), D("yellow","ring")],
+  ["wise-weasel", "agent WAITING", D("yellow","solid",{halo:1}), D("yellow","solid",{halo:1}), D("yellow","solid",{halo:1}), D("yellow","solid",{halo:1})],
+  ["roaming-wolf", "agent · PR open healthy", D("orange","solid",{glyph:"green"}), D("yellow","solid",{glyph:"green"}), D("orange","solid",{glyph:"green"}), D("yellow","solid",{glyph:"green"})],
+  ["loyal-lemur", "agent idle · PR merged", D("orange","done",{glyph:"purple"}), D("yellow","ring",{glyph:"purple"}), D("orange","solid",{glyph:"purple"}), D("yellow","ring",{glyph:"purple"})],
+
+  "fab pipeline — pre-PR",
+  ["c4-intake-draft", "intake active", D("blue","solid"), D("blue","solid"), D("blue","solid"), D("blue","solid")],
+  ["c5-clarify", "intake WAITING (asking)", D("blue","solid",{halo:1}), D("blue","solid",{halo:1}), D("blue","solid",{halo:1}), D("blue","solid",{halo:1})],
+  ["c2-config-verbs", "apply→review-pr active", D("green","solid"), D("blue","solid"), D("green","solid"), D("blue","solid")],
+  ["c3-dispatch-mode", "review FAILED", D("green","failed"), D("blue","failed"), D("green","failed"), D("blue","failed")],
+
+  "fab pipeline — PR exists",
+  ["c6-ship-ready", "PR open · checks pass", D("purple","solid",{glyph:"green"}), D("green","solid",{glyph:"green"}), D("purple","solid",{glyph:"green"}), D("green","solid",{glyph:"green"})],
+  ["c7-just-pushed", "PR open · checks running", D("purple","ring",{glyph:"green"}), D("green","solid",{glyph:"yellow",fn:"1"}), D("purple","ring",{glyph:"green"}), D("green","solid",{glyph:"yellow",fn:"1"})],
+  ["c8-ci-broken", "PR open · checks FAIL", D("purple","failed",{glyph:"red"}), D("green","solid",{glyph:"red",fn:"2"}), D("purple","failed",{glyph:"red"}), D("green","solid",{glyph:"red",fn:"2"})],
+  ["c9-landing", "PR merged · change live", D("purple","done",{glyph:"purple"}), D("green","solid",{glyph:"purple"}), D("purple","solid",{glyph:"purple"}), D("green","solid",{glyph:"purple"})],
+
+  "parked — change done",
+  ["riff-tempered-mantis", "PR merged · change done", D("purple","done",{glyph:"purple"}), D("green","ring",{glyph:"purple",fn:"3"}), D("purple","solid",{glyph:"purple"}), D("green","done",{glyph:"purple"})],
+  ["c1-no-pr-done", "change done · no PR", D("green","done"), D("green","ring",{fn:"3"}), D("green","solid"), D("green","done")],
+];
+
+let n = 0;
+document.getElementById("rows").innerHTML = rows.map(r => {
+  if (typeof r === "string") return `<tr class="group"><td colspan="5">${r}</td></tr>`;
+  n++;
+  const [label, desc, ...cfgs] = r;
+  return `<tr>
+    <td class="state"><span class="layer">${String(n).padStart(2,"0")}</span>&nbsp; ${desc}</td>
+    ${cfgs.map(d => CELL(label, d)).join("")}
+  </tr>`;
+}).join("");
+</script>
+</body>
+</html>

--- a/fab/changes/260810-aqo6-statusdot-compositional-vocabulary/reference-status-dot-final.svg
+++ b/fab/changes/260810-aqo6-statusdot-compositional-vocabulary/reference-status-dot-final.svg
@@ -1,0 +1,89 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="620" viewBox="0 0 760 620" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
+  <defs>
+    <!-- Hues (ref): blue #60a5fa (fab building) · green #9ece6a (fab PR-ready/done)
+         yellow #facc15 (ad-hoc agent + waiting halo) · gray #787c99 (floor)
+         red #f87171 (failed center on the DOT; failing state on the GLYPH)
+         purple #c084fc (merged — GLYPH ONLY; the dot never renders purple) -->
+    <path id="pr" d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z"/>
+  </defs>
+
+  <rect x="0" y="0" width="760" height="620" fill="#1a1b26"/>
+
+  <!-- title -->
+  <text x="24" y="30" font-size="16" font-weight="700" fill="#c0caf5">StatusDot — the compositional reference</text>
+  <text x="24" y="48" font-size="11" fill="#787c99">No matrix: hue × shape compose freely and no cell is special. Read hue (which journey), then shape (health), then glyph (PR).</text>
+
+  <!-- 1 · HUE -->
+  <text x="24" y="82" font-size="11" font-weight="700" fill="#787c99">1 · CORE HUE = journey (4)</text>
+  <circle cx="40" cy="106" r="5" fill="#60a5fa"/>
+  <text x="56" y="110" font-size="12" fill="#c0caf5">FAB · BUILDING</text>
+  <text x="220" y="110" font-size="10" fill="#565a73">intake · apply · review — pre-PR work</text>
+  <circle cx="40" cy="132" r="5" fill="#9ece6a"/>
+  <text x="56" y="136" font-size="12" fill="#c0caf5">FAB · PR-READY / DONE</text>
+  <text x="220" y="136" font-size="10" fill="#565a73">ship · review-pr · done — /git-pr creates the PR mid-ship</text>
+  <circle cx="40" cy="158" r="5" fill="#facc15"/>
+  <text x="56" y="162" font-size="12" fill="#c0caf5">AD-HOC AGENT</text>
+  <text x="220" y="162" font-size="10" fill="#565a73">a fresh @rk_agent_state, no fab change</text>
+  <circle cx="40" cy="184" r="5" fill="#787c99"/>
+  <text x="56" y="188" font-size="12" fill="#c0caf5">FLOOR</text>
+  <text x="220" y="188" font-size="10" fill="#565a73">plain terminal — color reserved for a journey</text>
+  <line x1="24" y1="206" x2="740" y2="206" stroke="#2f3549" stroke-width="1"/>
+
+  <!-- 2 · SHAPE -->
+  <text x="24" y="232" font-size="11" font-weight="700" fill="#787c99">2 · SHAPE = status (3 — the same meaning in every hue)</text>
+  <circle cx="40" cy="256" r="5" fill="#60a5fa"/>
+  <text x="56" y="260" font-size="12" fill="#c0caf5">solid</text>
+  <text x="220" y="260" font-size="10" fill="#565a73">running / live</text>
+  <circle cx="40" cy="282" r="5" fill="none" stroke="#60a5fa" stroke-width="1.8"/>
+  <text x="56" y="286" font-size="12" fill="#c0caf5">ring</text>
+  <text x="220" y="286" font-size="10" fill="#565a73">at rest — stage pending · parked done · idle agent · quiet shell</text>
+  <circle cx="40" cy="308" r="6" fill="none" stroke="#60a5fa" stroke-width="1.8" stroke-linecap="round" stroke-dasharray="0.1 3"/>
+  <circle cx="40" cy="308" r="2.2" fill="#f87171"/>
+  <text x="56" y="312" font-size="12" fill="#c0caf5">failed</text>
+  <text x="220" y="312" font-size="10" fill="#565a73">dotted ring + red center — review / review-pr failed (dot-red appears ONLY here)</text>
+  <line x1="24" y1="330" x2="740" y2="330" stroke="#2f3549" stroke-width="1"/>
+
+  <!-- 3 · GLYPH -->
+  <text x="24" y="356" font-size="11" font-weight="700" fill="#787c99">3 · PR = the right-edge row glyph (one channel, five states — never the dot)</text>
+  <g fill="#9ece6a" transform="translate(34,368) scale(0.9)"><use href="#pr"/></g>
+  <text x="56" y="379" font-size="10" fill="#565a73">open</text>
+  <g fill="#facc15" transform="translate(124,368) scale(0.9)"><use href="#pr"/></g>
+  <text x="146" y="379" font-size="10" fill="#565a73">checks running</text>
+  <g fill="#f87171" transform="translate(272,368) scale(0.9)"><use href="#pr"/></g>
+  <text x="294" y="379" font-size="10" fill="#565a73">checks fail / changes req.</text>
+  <g fill="#c084fc" transform="translate(478,368) scale(0.9)"><use href="#pr"/></g>
+  <text x="500" y="379" font-size="10" fill="#565a73">merged</text>
+  <g fill="#787c99" transform="translate(572,368) scale(0.9)"><use href="#pr"/></g>
+  <text x="594" y="379" font-size="10" fill="#565a73">draft · closed → none</text>
+  <line x1="24" y1="398" x2="740" y2="398" stroke="#2f3549" stroke-width="1"/>
+
+  <!-- 4 · HALO -->
+  <text x="24" y="424" font-size="11" font-weight="700" fill="#787c99">4 · ATTENTION = the waiting halo (additive over any hue × shape; reduced-motion: static ring)</text>
+  <circle cx="40" cy="450" r="8.5" fill="none" stroke="#facc15" stroke-width="1.6" opacity="0.9"/>
+  <circle cx="40" cy="450" r="5" fill="#60a5fa"/>
+  <text x="56" y="454" font-size="10" fill="#565a73">agent waiting on you — core hue + shape kept · yellow core = an agent lives here, yellow halo = an agent needs you now</text>
+  <line x1="24" y1="472" x2="740" y2="472" stroke="#2f3549" stroke-width="1"/>
+
+  <!-- Composed examples -->
+  <text x="24" y="498" font-size="11" font-weight="700" fill="#787c99">Composes freely — read hue, then shape, then glyph:</text>
+  <circle cx="52" cy="526" r="5" fill="#60a5fa"/>
+  <text x="52" y="550" font-size="9" fill="#565a73" text-anchor="middle">building</text>
+  <circle cx="164" cy="526" r="8.5" fill="none" stroke="#facc15" stroke-width="1.6" opacity="0.9"/>
+  <circle cx="164" cy="526" r="6" fill="none" stroke="#60a5fa" stroke-width="1.8" stroke-linecap="round" stroke-dasharray="0.1 3"/>
+  <circle cx="164" cy="526" r="2.2" fill="#f87171"/>
+  <text x="164" y="550" font-size="9" fill="#565a73" text-anchor="middle">review failed · asking</text>
+  <circle cx="296" cy="526" r="5" fill="#9ece6a"/>
+  <g fill="#9ece6a" transform="translate(306,519) scale(0.9)"><use href="#pr"/></g>
+  <text x="306" y="550" font-size="9" fill="#565a73" text-anchor="middle">PR open · landing</text>
+  <circle cx="432" cy="526" r="5" fill="none" stroke="#9ece6a" stroke-width="1.8"/>
+  <g fill="#c084fc" transform="translate(442,519) scale(0.9)"><use href="#pr"/></g>
+  <text x="446" y="550" font-size="9" fill="#565a73" text-anchor="middle">merged · parked — archive me</text>
+  <circle cx="576" cy="526" r="5" fill="#facc15"/>
+  <text x="576" y="550" font-size="9" fill="#565a73" text-anchor="middle">ad-hoc mid-turn</text>
+  <circle cx="672" cy="526" r="5" fill="none" stroke="#787c99" stroke-width="1.8"/>
+  <text x="672" y="550" font-size="9" fill="#565a73" text-anchor="middle">quiet shell</text>
+
+  <!-- bottom notes -->
+  <text x="24" y="584" font-size="10" fill="#565a73">Vocabulary: 4 hues × 3 shapes + 5 glyph states + 1 overlay. Retired: purple/orange dot hues, the done square, the skipped shape/column.</text>
+  <text x="24" y="602" font-size="10" fill="#565a73">Dot = the local story (what runs in the pane) · glyph = the remote story (the branch's PR on GitHub). Merged stays durable via the state-all derivation (D2).</text>
+</svg>


### PR DESCRIPTION
## Meta

| Change ID | Type | Confidence | Plan | Review |
|-----------|------|------------|------|--------|
| `aqo6` | feat | 3.8/5.0 | — | — |


**Pipeline:** [intake](https://github.com/sahil87/run-kit/blob/260810-aqo6-statusdot-compositional-vocabulary/fab/changes/260810-aqo6-statusdot-compositional-vocabulary/intake.md) → apply → review → hydrate → ship → review-pr

## Summary

Intake + binding visual reference for the StatusDot compositional vocabulary. The row's rest-state PR glyph made the dot's PR tier redundant (merged renders a purple square AND a purple glyph on the same row), so the design evicts PR from the dot entirely: the dot tells the local story (blue = building, green = PR-ready/done, yellow = ad-hoc agent, gray = floor; solid/ring/failed shapes), the glyph tells the remote PR story (gaining a yellow checks-running state). Intake-only — no implementation in this PR; `reference-status-dot-final.svg` / `reference-mock.html` in the change folder are the binding design artifacts for the execution agent.

## Changes

- Dot model — `pr-status-model.ts`: ladder loses its PR branches; `DotPhase` 6→4, `DotShape` 5→3
- Glyph vocabulary — `prGlyphColor()` gains a yellow checks-running state
- Dot rendering — `status-dot.tsx`: done square + skipped branches deleted
- Labels — `status-dot-label.ts`: hue-word + shape-word composition
- Glyph surfaces — parity where the dot renders without a register view (session tiles)
- Documentation — `docs/site/status-dot.md` + the matrix SVG replaced by the compositional reference
- Tests — unit + Playwright expectations, `.spec.md` companions
- Explicitly unchanged — waiting halo, ladder top, D2 derivation, backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)
