### PR TITLE
chore: CSI-u Extended-Keys Format in tmux Configs

### DIFF
--- a/configs/tmux/byobu.conf
+++ b/configs/tmux/byobu.conf
@@ -165,6 +165,7 @@ set -gq allow-passthrough on
 set -as terminal-features ',xterm-256color:sync'
 set -g extended-keys on
 set -as terminal-features 'xterm*:extkeys'
+set -gq extended-keys-format csi-u
 set -g set-clipboard on
 set -g focus-events on
 set -ag terminal-overrides ",xterm-256color:RGB:Tc"

--- a/configs/tmux/default.conf
+++ b/configs/tmux/default.conf
@@ -37,6 +37,10 @@ set -as terminal-features ',xterm-256color:sync'
 # Modifier key combos (Ctrl+Shift+key etc.) in TUI apps
 set -g extended-keys on
 set -as terminal-features 'xterm*:extkeys'
+# Report extended keys in kitty CSI-u form — what crossterm/kitty-protocol
+# TUIs (Kimi Code, neovim, helix, fish 4) expect; tmux's default xterm form
+# breaks their modifier decoding. -q: no-op on tmux < 3.5.
+set -gq extended-keys-format csi-u
 
 # OSC 52 clipboard — works across relay and nested tmux
 set -g set-clipboard on

--- a/configs/tmux/poweruser.conf
+++ b/configs/tmux/poweruser.conf
@@ -150,6 +150,8 @@ set -as terminal-features ',xterm-256color:sync'
 # Modifier key combos (Ctrl+Shift+key etc.) in TUI apps
 set -g extended-keys on
 set -as terminal-features 'xterm*:extkeys'
+# Kitty CSI-u form for extended keys (crossterm/kitty-protocol TUIs); -q: no-op on tmux < 3.5
+set -gq extended-keys-format csi-u
 
 # Zero escape delay — removes 500ms lag on Escape (huge for vim)
 set -sg escape-time 0


### PR DESCRIPTION
## Summary

The embedded tmux configs enable extended keys but leave `extended-keys-format` at tmux's default `xterm` (legacy modifyOtherKeys form), which breaks modifier decoding for kitty-keyboard-protocol TUIs — Kimi Code warns about it on startup, and crossterm-based tools, neovim, helix, and fish 4 expect the CSI-u form. Adds `set -gq extended-keys-format csi-u` to all three configs carrying the extended-keys block (`default.conf`, `byobu.conf`, `poweruser.conf`); `-q` makes it a silent no-op on tmux < 3.5. Apps that never opt into extended keys are unaffected.