### PR TITLE
fix: absolute /bin/sh interpreter in rk agent-setup hook template

### DIFF
--- a/app/backend/cmd/rk/agent_hook.go
+++ b/app/backend/cmd/rk/agent_hook.go
@@ -22,7 +22,7 @@ import (
 // docs/specs/agent-state.md). It replaces the former self-contained shell
 // one-liner: the harness config now carries only a thin
 //
-//	sh -c '[ -n "$TMUX_PANE" ] || exit 0; "<abs-rk>" agent-hook --agent claude <state> 2>/dev/null || true'
+//	/bin/sh -c '[ -n "$TMUX_PANE" ] || exit 0; "<abs-rk>" agent-hook --agent claude <state> 2>/dev/null || true'
 //
 // wrapper (installed by `run-kit agent-setup`), and ALL logic — the comm-validated
 // ancestor walk, the value formatting — lives here in Go where it is testable and

--- a/app/backend/cmd/rk/agent_setup.go
+++ b/app/backend/cmd/rk/agent_setup.go
@@ -90,8 +90,12 @@ const (
 // every session was restarted (the #320↔#321 skew). Delegating to the binary
 // lifts that freeze.
 //
-//	sh -c '[ -n "$TMUX_PANE" ] || exit 0; "<abs-rk>" agent-hook --agent <comm> <state> 2>/dev/null || true'
+//	/bin/sh -c '[ -n "$TMUX_PANE" ] || exit 0; "<abs-rk>" agent-hook --agent <comm> <state> 2>/dev/null || true'
 //
+// The interpreter is absolute for the same reason rkPath is (below): hooks fire
+// under the HARNESS's environment, and an agent session launched with a PATH
+// missing /bin and /usr/bin cannot resolve a bare `sh` — every hook fire then
+// fails loudly ("sh: not found") before the $TMUX_PANE guard can even run.
 // The $TMUX_PANE guard stays in the wrapper as a cheap short-circuit (no binary
 // spawn outside tmux). `|| true` preserves the never-fail contract even if the
 // binary is missing or moved. rkPath is the absolute rk path resolved at install
@@ -105,7 +109,7 @@ const (
 // (Constitution §I).
 func agentStateHookCommand(rkPath, state, comm string) string {
 	return fmt.Sprintf(
-		`sh -c '[ -n "$TMUX_PANE" ] || exit 0; "%s" agent-hook --agent %s %s 2>/dev/null || true'`,
+		`/bin/sh -c '[ -n "$TMUX_PANE" ] || exit 0; "%s" agent-hook --agent %s %s 2>/dev/null || true'`,
 		rkPath, comm, state,
 	)
 }

--- a/app/backend/cmd/rk/agent_setup_test.go
+++ b/app/backend/cmd/rk/agent_setup_test.go
@@ -414,6 +414,11 @@ func TestAgentStateHookCommandShape(t *testing.T) {
 	// The NEW stable form: self-locate via $TMUX_PANE, no-op outside tmux, never
 	// fail the agent, and DELEGATE to `rk agent-hook` (all logic — the walk, the
 	// value formatting — lives in the binary, so it tracks `brew upgrade rk`).
+	// The interpreter must be absolute: hooks fire under the harness's
+	// environment, and a bare `sh` fails on sessions whose PATH lacks /bin.
+	if !strings.HasPrefix(cmd, `/bin/sh -c '`) {
+		t.Errorf("hook command must start with /bin/sh -c: %s", cmd)
+	}
 	for _, want := range []string{
 		`[ -n "$TMUX_PANE" ] || exit 0`,
 		`"/opt/homebrew/bin/rk"`,      // absolute path, embedded quoted

--- a/docs/memory/run-kit/agent-state.md
+++ b/docs/memory/run-kit/agent-state.md
@@ -253,8 +253,11 @@ delegating wrapper** that keeps all logic in the rk binary (see § `rk agent-hoo
 below) —
 
 ```sh
-sh -c '[ -n "$TMUX_PANE" ] || exit 0; "<abs-rk>" agent-hook --agent claude <state> 2>/dev/null || true'
+/bin/sh -c '[ -n "$TMUX_PANE" ] || exit 0; "<abs-rk>" agent-hook --agent claude <state> 2>/dev/null || true'
 ```
+
+The interpreter is absolute like `<abs-rk>` itself: hooks fire under the
+harness's environment, and a bare `sh` fails on sessions whose PATH lacks /bin.
 
 The `$TMUX_PANE` guard stays in the wrapper as a cheap short-circuit (no binary
 spawn outside tmux); `|| true` preserves the never-fail contract even if the
@@ -581,7 +584,7 @@ The Claude `agentRegistry` carries a SessionStart entry:
 - The installed command uses the standard `agentStateHookCommand(rkPath, state, comm)`
   wrapper — the positional-token `state` parameter carries the
   `stamp` literal from `h.state = agentHookStampToken`, producing
-  `sh -c '[ -n "$TMUX_PANE" ] || exit 0; "<abs-rk>" agent-hook --agent claude stamp 2>/dev/null || true'`.
+  `/bin/sh -c '[ -n "$TMUX_PANE" ] || exit 0; "<abs-rk>" agent-hook --agent claude stamp 2>/dev/null || true'`.
   The `isRkEntry` marker
   (`" agent-hook "`) matches it, so idempotent re-run replacement and
   `--uninstall` need no marker changes.

--- a/docs/specs/agent-state.md
+++ b/docs/specs/agent-state.md
@@ -105,10 +105,12 @@ Hook commands that write the option MUST:
 Canonical command — the stable delegating wrapper installed by `rk agent-setup`
 (state and comm are fixed registry literals; nothing user-provided is
 interpolated; `<abs-rk>` is the absolute rk path resolved at install time, a
-stable symlink rather than a version-pinned path):
+stable symlink rather than a version-pinned path; the interpreter is absolute
+for the same reason — hooks fire under the harness's environment, and a bare
+`sh` fails on sessions whose PATH lacks /bin):
 
 ```sh
-sh -c '[ -n "$TMUX_PANE" ] || exit 0; "<abs-rk>" agent-hook --agent claude <state> 2>/dev/null || true'
+/bin/sh -c '[ -n "$TMUX_PANE" ] || exit 0; "<abs-rk>" agent-hook --agent claude <state> 2>/dev/null || true'
 ```
 
 All logic — the comm-validated ancestor walk, the value formatting, the


### PR DESCRIPTION
## Problem

Installed agent-state hooks are written as bare `sh -c '…'`. When the agent harness runs with a broken PATH missing `/bin` and `/usr/bin` (observed with a Claude Code session whose PATH carried only the rk shims dir, `/usr/local/bin`, the worktree, and a plugin bin), the interpreter itself can't be resolved — every tool call surfaces `/bin/sh: 1: sh: not found`. The failures are harmless (the hooks only stamp `@rk_agent_state` and are non-blocking) but noisy on every hook fire.

The template already embeds the rk binary by **absolute path** for exactly this reason (`resolveRkPath`: "a bare-name fallback would reintroduce the PATH dependency") — the interpreter one token earlier had that exact dependency.

## Fix

- `agentStateHookCommand` now emits `/bin/sh -c` (`agent_setup.go`)
- Doc comments quoting the template updated (`agent_setup.go`, `agent_hook.go`)
- `TestAgentStateHookCommandShape` asserts the `/bin/sh -c` prefix so bare `sh` can't regress
- Spec + memory docs updated (`docs/specs/agent-state.md`, `docs/memory/run-kit/agent-state.md`)

## Migration

None needed beyond re-running `rk agent-setup`: `isRkEntry` matches on the ` agent-hook ` substring, not the interpreter prefix, so existing bare-sh entries are replaced in place. `/bin/sh` is guaranteed on both run-kit targets (macOS + Linux).

## Testing

`go test ./cmd/rk/` — pass (includes the strengthened shape test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
