### PR TITLE
fix: Condense agent-setup Consent Output

### DIFF
--- a/app/backend/cmd/rk/agent_setup.go
+++ b/app/backend/cmd/rk/agent_setup.go
@@ -1076,7 +1076,7 @@ func installTmuxShimFile(sink outputSink, reader *bufio.Reader, home, rkPath str
 	} else if exists {
 		fmt.Fprintf(cons.diffWriter(sink), "tmux guard: will update the rk-owned tmux shim at %s.\n", shimPath)
 	} else {
-		fmt.Fprintf(cons.diffWriter(sink), "tmux guard: will install the tmux shim at %s (rk-owned guard script, %d lines).\n", shimPath, strings.Count(desired, "\n"))
+		fmt.Fprintf(cons.diffWriter(sink), "tmux guard: will install the tmux shim at %s (rk-owned guard script, %d lines).\n", shimPath, len(strings.Split(strings.TrimSuffix(desired, "\n"), "\n")))
 	}
 	ok, err := cons.authorizeWrite(sink.data, reader, "tmux guard: dry run — no shim written.", "\nWrite the tmux shim? [y/N] ")
 	if err != nil {
@@ -1207,8 +1207,13 @@ func applyTmuxGuardPathBlocks(sink outputSink, reader *bufio.Reader, home, zdotd
 		} else if uninstall {
 			fmt.Fprintf(cons.diffWriter(sink), "tmux guard: will remove the %d-line rk tmux guard PATH block from %s.\n", strings.Count(tmuxGuardPathBlock, "\n"), path)
 		} else {
+			// Placement uses the SAME detection upsertMarkerBlock acts on
+			// (markerBlockBounds' trimmed-line match), so the wording can never
+			// disagree with what the write does; a substring-based check could
+			// (e.g. the marker appearing inside a non-marker line). The error
+			// case is unreachable — a malformed block already hit blockErr above.
 			placement := "appended at end"
-			if strings.Contains(current, tmuxGuardBlockBegin) {
+			if _, _, found, _ := markerBlockBounds(strings.Split(current, "\n"), tmuxGuardBlockBegin, tmuxGuardBlockEnd); found {
 				placement = "replaced in position"
 			}
 			out := cons.diffWriter(sink)

--- a/app/backend/cmd/rk/agent_setup.go
+++ b/app/backend/cmd/rk/agent_setup.go
@@ -454,8 +454,18 @@ func applyAgentHooks(sink outputSink, reader *bufio.Reader, ac agentConfig, rkPa
 	//     the invocation silent on success.
 	// The consent prompt itself (prompt suffix / dry-run note) always goes to the
 	// data channel via authorizeWrite.
+	//
+	// WHAT renders splits on --dry-run: the full current+proposed JSON bodies
+	// are the explicitly-requested preview data there; everywhere else the
+	// semantic per-entry summary is what consent needs — the merge preserves
+	// every non-rk entry, so dumping both full documents buries the prompt
+	// (~90 lines fresh-run) without adding information.
 	header := fmt.Sprintf("%s: will %s run-kit agent-state hooks in %s", ac.name, action, ac.settingsPath)
-	renderArtifactDiff(cons.diffWriter(sink), header, beforeJSON, afterJSON)
+	if cons.dryRun {
+		renderArtifactDiff(cons.diffWriter(sink), header, beforeJSON, afterJSON)
+	} else {
+		renderHooksSummary(cons.diffWriter(sink), header, ac.hooks, countRkEntries(current), uninstall)
+	}
 
 	dryRunNote := fmt.Sprintf("%s: dry run — no changes written.", ac.name)
 	ok, err := cons.authorizeWrite(sink.data, reader, dryRunNote, "\nWrite these changes? [y/N] ")
@@ -576,6 +586,56 @@ func readFileIfExists(path string) (string, bool, error) {
 		return "", false, err
 	}
 	return string(data), true, nil
+}
+
+// renderHooksSummary prints the semantic consent summary for the hooks merge on
+// the interactive and --yes paths: one line per rk entry being installed
+// (event, optional matcher, state), plus replace/remove accounting derived from
+// the CURRENT settings via countRkEntries — never hardcoded, so the summary
+// stays honest as the registry grows. The uninstall form is a single removal
+// line. Full current+proposed bodies render only under --dry-run (see
+// applyAgentHooks).
+func renderHooksSummary(out io.Writer, header string, hooks []agentHook, existingRk int, uninstall bool) {
+	fmt.Fprintf(out, "%s\n\n", header)
+	entryWord := "entries"
+	if existingRk == 1 {
+		entryWord = "entry"
+	}
+	if uninstall {
+		fmt.Fprintf(out, "  - removes %d rk-owned hook %s; all other settings and non-rk hooks preserved\n", existingRk, entryWord)
+		return
+	}
+	for _, h := range hooks {
+		label := h.state
+		if h.state == agentHookStampToken {
+			label = "chat stamp"
+		}
+		if h.matcher != "" {
+			fmt.Fprintf(out, "  + %s (%s) → %s\n", h.event, h.matcher, label)
+		} else {
+			fmt.Fprintf(out, "  + %s → %s\n", h.event, label)
+		}
+	}
+	if existingRk > 0 {
+		fmt.Fprintf(out, "  (replaces %d existing rk-owned %s in place; all other settings and non-rk hooks preserved)\n", existingRk, entryWord)
+	} else {
+		fmt.Fprintln(out, "  (all other settings and non-rk hooks preserved)")
+	}
+}
+
+// countRkEntries counts the rk-owned hook entries across every event array in
+// settings — the replace/remove accounting renderHooksSummary reports. Both
+// hook-command generations count (isRkEntry matches either marker).
+func countRkEntries(settings map[string]any) int {
+	n := 0
+	for _, v := range asMap(settings["hooks"]) {
+		for _, e := range asSlice(v) {
+			if isRkEntry(asMap(e)) {
+				n++
+			}
+		}
+	}
+	return n
 }
 
 // renderArtifactDiff prints the shared "will <action> … / --- current / +++
@@ -1006,8 +1066,18 @@ func installTmuxShimFile(sink outputSink, reader *bufio.Reader, home, rkPath str
 		return true, nil
 	}
 
-	header := fmt.Sprintf("tmux guard: will install the tmux shim at %s", shimPath)
-	renderArtifactDiff(cons.diffWriter(sink), header, strings.TrimSuffix(current, "\n"), strings.TrimSuffix(desired, "\n"))
+	// The full script body renders only under --dry-run (the requested preview
+	// data). Elsewhere one summary line suffices: marker-less foreign files were
+	// skipped above, so this diff is only ever fresh-install or rk-owned→rk-owned
+	// — the full-body dump (~135 lines) protects nothing and buries the prompt.
+	if cons.dryRun {
+		header := fmt.Sprintf("tmux guard: will install the tmux shim at %s", shimPath)
+		renderArtifactDiff(cons.diffWriter(sink), header, strings.TrimSuffix(current, "\n"), strings.TrimSuffix(desired, "\n"))
+	} else if exists {
+		fmt.Fprintf(cons.diffWriter(sink), "tmux guard: will update the rk-owned tmux shim at %s.\n", shimPath)
+	} else {
+		fmt.Fprintf(cons.diffWriter(sink), "tmux guard: will install the tmux shim at %s (rk-owned guard script, %d lines).\n", shimPath, strings.Count(desired, "\n"))
+	}
 	ok, err := cons.authorizeWrite(sink.data, reader, "tmux guard: dry run — no shim written.", "\nWrite the tmux shim? [y/N] ")
 	if err != nil {
 		return false, err
@@ -1121,12 +1191,32 @@ func applyTmuxGuardPathBlocks(sink outputSink, reader *bufio.Reader, home, zdotd
 			continue
 		}
 
-		action := "add"
-		if uninstall {
-			action = "remove"
+		// The whole-file current+next render survives only under --dry-run —
+		// startup files are USER-authored, and echoing their full content back
+		// for a 3-line owned block is the worst of the three dumps. The honest
+		// unit of change is exactly the marker-owned block (upsertMarkerBlock
+		// replaces in position or appends; removeMarkerBlock strips exactly it),
+		// so the summary shows that block and where it lands.
+		if cons.dryRun {
+			action := "add"
+			if uninstall {
+				action = "remove"
+			}
+			header := fmt.Sprintf("tmux guard: will %s the rk tmux guard PATH block in %s", action, path)
+			renderArtifactDiff(cons.diffWriter(sink), header, current, next)
+		} else if uninstall {
+			fmt.Fprintf(cons.diffWriter(sink), "tmux guard: will remove the %d-line rk tmux guard PATH block from %s.\n", strings.Count(tmuxGuardPathBlock, "\n"), path)
+		} else {
+			placement := "appended at end"
+			if strings.Contains(current, tmuxGuardBlockBegin) {
+				placement = "replaced in position"
+			}
+			out := cons.diffWriter(sink)
+			fmt.Fprintf(out, "tmux guard: will add the rk tmux guard PATH block in %s (%s):\n", path, placement)
+			for _, line := range strings.Split(strings.TrimSuffix(tmuxGuardPathBlock, "\n"), "\n") {
+				fmt.Fprintf(out, "  %s\n", line)
+			}
 		}
-		header := fmt.Sprintf("tmux guard: will %s the rk tmux guard PATH block in %s", action, path)
-		renderArtifactDiff(cons.diffWriter(sink), header, current, next)
 		dryRunNote := fmt.Sprintf("tmux guard: dry run — %s not modified.", path)
 		ok, err := cons.authorizeWrite(sink.data, reader, dryRunNote, "\nWrite these changes? [y/N] ")
 		if err != nil {

--- a/app/backend/cmd/rk/agent_setup_test.go
+++ b/app/backend/cmd/rk/agent_setup_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -16,20 +17,6 @@ import (
 // installs (the SessionStart stamp-only row included).
 func claudeHooks() []agentHook {
 	return agentRegistry("")[0].hooks
-}
-
-// countRkEntries counts rk-owned entries across all event arrays under hooks.
-func countRkEntries(settings map[string]any) int {
-	n := 0
-	root := asMap(settings["hooks"])
-	for _, ev := range root {
-		for _, e := range asSlice(ev) {
-			if isRkEntry(asMap(e)) {
-				n++
-			}
-		}
-	}
-	return n
 }
 
 func TestMergeHooksAddsEntriesAndPreservesExisting(t *testing.T) {
@@ -1726,5 +1713,245 @@ func TestTmuxShimDeclinedWriteSkipsPathBlock(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "skipping the PATH block") {
 		t.Errorf("expected a PATH-block skip note, got: %q", out.String())
+	}
+}
+
+// --- consent summaries (260812-7a58) ---------------------------------------------
+//
+// On the interactive and --yes paths every pending write renders a SEMANTIC
+// summary — the full current+proposed bodies are --dry-run-only preview data.
+// These tests pin both halves: the summaries carry the honest content (entry
+// list, counts, the owned PATH block) and never dump full bodies or echo user
+// file content; --dry-run still renders the full renderArtifactDiff blocks.
+
+func TestApplyAgentHooksSummaryFreshInstall(t *testing.T) {
+	dir := t.TempDir()
+	ac := agentConfig{name: "Test", settingsPath: filepath.Join(dir, "settings.json"), comm: "claude", hooks: claudeHooks()}
+
+	var out bytes.Buffer
+	if err := applyAgentConfig(newSinkWriters(&out, &out), bufio.NewReader(strings.NewReader("y\n")), ac, "/opt/homebrew/bin/rk", false, consent{stdinIsTTY: true}); err != nil {
+		t.Fatalf("install error: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"+ UserPromptSubmit → active",
+		"+ PreToolUse → active",
+		"+ Notification (permission_prompt|elicitation_dialog|agent_needs_input) → waiting",
+		"+ Notification (idle_prompt) → idle",
+		"+ Stop → idle",
+		"+ SessionStart → chat stamp",
+		"(all other settings and non-rk hooks preserved)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("fresh-install summary missing %q, got: %q", want, got)
+		}
+	}
+	// The full-body diff is dry-run-only.
+	if strings.Contains(got, "--- current") || strings.Contains(got, "+++ proposed") {
+		t.Errorf("interactive consent must not dump full bodies, got: %q", got)
+	}
+	// The installed hook command (the sh -c one-liner) appears only in the file,
+	// never in the summary.
+	if strings.Contains(got, "/bin/sh -c") {
+		t.Errorf("summary must not print hook command bodies, got: %q", got)
+	}
+}
+
+func TestApplyAgentHooksSummaryReplacementCount(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	// Seed ONE legacy-generation rk entry (identified by the inlined option
+	// name) so the merge replaces it in place and the summary must say so with
+	// a count derived from the file — singular form included.
+	seed := map[string]any{
+		"hooks": map[string]any{
+			"Stop": []any{
+				map[string]any{"hooks": []any{
+					map[string]any{"type": "command", "command": "tmux set-option -p " + rkHookMarker + " idle"},
+				}},
+			},
+		},
+	}
+	if err := writeSettings(path, seed); err != nil {
+		t.Fatal(err)
+	}
+	ac := agentConfig{name: "Test", settingsPath: path, comm: "claude", hooks: claudeHooks()}
+
+	var out bytes.Buffer
+	if err := applyAgentConfig(newSinkWriters(&out, &out), bufio.NewReader(strings.NewReader("y\n")), ac, "/opt/homebrew/bin/rk", false, consent{stdinIsTTY: true}); err != nil {
+		t.Fatalf("install error: %v", err)
+	}
+	if !strings.Contains(out.String(), "(replaces 1 existing rk-owned entry in place; all other settings and non-rk hooks preserved)") {
+		t.Errorf("replacement summary missing or count wrong, got: %q", out.String())
+	}
+}
+
+func TestApplyAgentHooksSummaryUninstall(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	ac := agentConfig{name: "Test", settingsPath: path, comm: "claude", hooks: claudeHooks()}
+	var out bytes.Buffer
+	if err := applyAgentConfig(newSinkWriters(&out, &out), bufio.NewReader(strings.NewReader("")), ac, "/opt/homebrew/bin/rk", false, consent{yes: true}); err != nil {
+		t.Fatalf("install error: %v", err)
+	}
+
+	out.Reset()
+	if err := applyAgentConfig(newSinkWriters(&out, &out), bufio.NewReader(strings.NewReader("y\n")), ac, "", true, consent{stdinIsTTY: true}); err != nil {
+		t.Fatalf("uninstall error: %v", err)
+	}
+	got := out.String()
+	// The count derives from the file's actual rk entries — the whole registry
+	// was just installed, so it must equal the registry row count.
+	want := "- removes " + strconv.Itoa(len(claudeHooks())) + " rk-owned hook entries; all other settings and non-rk hooks preserved"
+	if !strings.Contains(got, want) {
+		t.Errorf("uninstall summary missing %q, got: %q", want, got)
+	}
+	if strings.Contains(got, "+++ proposed") {
+		t.Errorf("uninstall consent must not dump full bodies, got: %q", got)
+	}
+}
+
+func TestApplyAgentHooksDryRunFullBodies(t *testing.T) {
+	dir := t.TempDir()
+	ac := agentConfig{name: "Test", settingsPath: filepath.Join(dir, "settings.json"), comm: "claude", hooks: claudeHooks()}
+
+	var out bytes.Buffer
+	if err := applyAgentConfig(newSinkWriters(&out, &out), bufio.NewReader(strings.NewReader("")), ac, "/opt/homebrew/bin/rk", false, consent{dryRun: true}); err != nil {
+		t.Fatalf("dry-run error: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "--- current") || !strings.Contains(got, "+++ proposed") {
+		t.Errorf("--dry-run must keep the full-body diff, got: %q", got)
+	}
+	// The proposed body is the real merged document — hook commands included.
+	if !strings.Contains(got, rkHookMarkerAgentHook) {
+		t.Errorf("--dry-run proposed body should carry the hook commands, got: %q", got)
+	}
+}
+
+func TestTmuxShimConsentSummaries(t *testing.T) {
+	home := t.TempDir()
+	// Seed user content in a startup file — the summary must never echo it.
+	if err := os.WriteFile(filepath.Join(home, ".zshenv"), []byte("# my private zshenv line\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	sink := newSinkWriters(&out, &out)
+	// Interactive: y to the shim, y to each startup file (.zshenv, .bashrc).
+	if err := applyTmuxShim(sink, bufio.NewReader(strings.NewReader("y\ny\ny\n")), home, "", "/opt/homebrew/bin/rk", false, consent{stdinIsTTY: true}); err != nil {
+		t.Fatalf("install error: %v", err)
+	}
+	got := out.String()
+
+	// Shim: one summary line with the path and a line count — never the script.
+	if !strings.Contains(got, "will install the tmux shim at "+tmuxShimPath(home)+" (rk-owned guard script,") {
+		t.Errorf("shim summary line missing, got: %q", got)
+	}
+	if strings.Contains(got, tmuxShimMarker) {
+		t.Errorf("shim script body leaked into consent output, got: %q", got)
+	}
+
+	// PATH block: the owned 3 lines + placement — never the user's content.
+	if !strings.Contains(got, "(appended at end):") {
+		t.Errorf("PATH-block placement wording missing, got: %q", got)
+	}
+	if !strings.Contains(got, `export PATH="$HOME/.local/share/rk/shims:$PATH"`) {
+		t.Errorf("PATH-block excerpt missing the export line, got: %q", got)
+	}
+	if strings.Contains(got, "# my private zshenv line") {
+		t.Errorf("user startup-file content echoed back in consent output, got: %q", got)
+	}
+	if strings.Contains(got, "--- current") {
+		t.Errorf("interactive consent must not render full-body diffs, got: %q", got)
+	}
+}
+
+func TestTmuxShimUpdateSummaryLine(t *testing.T) {
+	home := t.TempDir()
+	installShim(t, home, "/opt/homebrew/bin/rk")
+
+	// Same home, different rk path → rk-owned shim content changes → update line.
+	var out bytes.Buffer
+	sink := newSinkWriters(&out, &out)
+	if err := applyTmuxShim(sink, bufio.NewReader(strings.NewReader("y\n")), home, "", "/usr/local/bin/rk", false, consent{stdinIsTTY: true}); err != nil {
+		t.Fatalf("re-install error: %v", err)
+	}
+	if !strings.Contains(out.String(), "will update the rk-owned tmux shim at "+tmuxShimPath(home)) {
+		t.Errorf("rk-owned update summary line missing, got: %q", out.String())
+	}
+	if strings.Contains(out.String(), "+++ proposed") {
+		t.Errorf("update consent must not dump the script diff, got: %q", out.String())
+	}
+}
+
+func TestTmuxShimPathBlockReplaceInPositionWording(t *testing.T) {
+	home := t.TempDir()
+	// Seed a well-formed but stale rk block (edited inner line) so upsert
+	// replaces it in position.
+	stale := "# user top\n" + tmuxGuardBlockBegin + "\nexport PATH=\"$HOME/old:$PATH\"\n" + tmuxGuardBlockEnd + "\n"
+	if err := os.WriteFile(filepath.Join(home, ".zshenv"), []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Pre-install the shim so the run reaches the PATH blocks directly.
+	installShim(t, home, "/opt/homebrew/bin/rk")
+
+	// installShim used --yes, so the block is already replaced; re-seed the stale
+	// block and run interactively to capture the wording.
+	if err := os.WriteFile(filepath.Join(home, ".zshenv"), []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	sink := newSinkWriters(&out, &out)
+	if err := applyTmuxShim(sink, bufio.NewReader(strings.NewReader("y\n")), home, "", "/opt/homebrew/bin/rk", false, consent{stdinIsTTY: true}); err != nil {
+		t.Fatalf("re-install error: %v", err)
+	}
+	if !strings.Contains(out.String(), "(replaced in position):") {
+		t.Errorf("in-position replace wording missing, got: %q", out.String())
+	}
+	if strings.Contains(out.String(), "# user top") {
+		t.Errorf("user content echoed back, got: %q", out.String())
+	}
+}
+
+func TestTmuxShimUninstallSummaryLine(t *testing.T) {
+	home := t.TempDir()
+	if err := os.WriteFile(filepath.Join(home, ".bashrc"), []byte("# my bashrc\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	installShim(t, home, "/opt/homebrew/bin/rk")
+
+	// Uninstall interactively: y to the shim removal, y per PATH block.
+	var out bytes.Buffer
+	sink := newSinkWriters(&out, &out)
+	if err := applyTmuxShim(sink, bufio.NewReader(strings.NewReader("y\ny\ny\n")), home, "", "", true, consent{stdinIsTTY: true}); err != nil {
+		t.Fatalf("uninstall error: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "will remove the 3-line rk tmux guard PATH block from") {
+		t.Errorf("PATH-block removal summary missing, got: %q", got)
+	}
+	if strings.Contains(got, "# my bashrc") {
+		t.Errorf("user content echoed back on uninstall, got: %q", got)
+	}
+	if strings.Contains(got, "--- current") {
+		t.Errorf("uninstall consent must not render full-body diffs, got: %q", got)
+	}
+}
+
+func TestTmuxShimDryRunFullBodies(t *testing.T) {
+	home := t.TempDir()
+	var out bytes.Buffer
+	sink := newSinkWriters(&out, &out)
+	if err := applyTmuxShim(sink, bufio.NewReader(strings.NewReader("")), home, "", "/opt/homebrew/bin/rk", false, consent{dryRun: true}); err != nil {
+		t.Fatalf("dry-run error: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "--- current") || !strings.Contains(got, "+++ proposed") {
+		t.Errorf("--dry-run must keep the full-body diffs, got: %q", got)
+	}
+	// The shim script itself is the requested preview data on this path.
+	if !strings.Contains(got, tmuxShimMarker) {
+		t.Errorf("--dry-run shim preview should include the script body, got: %q", got)
 	}
 }

--- a/docs/memory/run-kit/agent-state.md
+++ b/docs/memory/run-kit/agent-state.md
@@ -202,7 +202,9 @@ per run in the `RunE` and threaded through `runAgentSetup` → `applyAgentConfig
 The `promptSuffix` (`"Write these changes? [y/N] "` / `"Remove … directory? [y/N] "`)
 is emitted **only** on the interactive path — the auto-answered `--yes`/`--dry-run`
 paths never read it, so printing `[y/N] ` there would read as a hang in an agent's
-transcript. `renderArtifactDiff` does not append the suffix for this reason.
+transcript. The consent-context renderers (`renderHooksSummary` /
+`renderArtifactDiff`) never append the suffix for this reason — only
+`authorizeWrite` emits it.
 
 **TTY detection uses `term.IsTerminal`, NOT a bare `os.ModeCharDevice` check**
 (`isTerminal(r io.Reader)`): a char-device test alone classifies `/dev/null`
@@ -218,8 +220,9 @@ marker-owned `PATH` block that puts `rk tmux-guard` in front of every
 PATH-resolved `tmux` invocation, so `tmux kill-server` without an explicit
 `-L`/`-S` socket is refused. Its install/uninstall contract, decision rule, and
 doctor check live in [tmux-guard-shim](/run-kit/tmux-guard-shim.md); the shim
-reuses this installer's `consent`/`authorizeWrite`/`renderArtifactDiff` machinery
-and its `resolveRkPath`/`validateHookPath` path discipline.
+reuses this installer's `consent`/`authorizeWrite` machinery, its
+summary-on-consent / full-diff-on-`--dry-run` rendering split, and its
+`resolveRkPath`/`validateHookPath` path discipline.
 (`260805-blyf-tmux-guard-path-shim`)
 
 The command surface is `rk agent-setup` / `rk agent-setup --uninstall`, and
@@ -310,12 +313,18 @@ at a TTY or agent passing `--yes` — sees it and acts).
 - `--uninstall` runs `unmergeHooks`, removing exactly the rk-owned entries; an
   event array that empties is deleted, and a `hooks` object that empties is
   deleted.
-- **Diff + confirm before write**: `applyAgentHooks` (the hooks step
-  `applyAgentConfig` runs — see § Installer Structure) renders `current` vs
-  `proposed` as sorted indented JSON via the shared `renderArtifactDiff` helper; a
-  no-op (identical) is reported and skipped without prompting; otherwise it routes
-  the write decision through `consent.authorizeWrite` (see the § `rk agent-setup`
-  consent flags above) — `--dry-run` shows the diff and skips the write,
+- **Consent context + confirm before write**: `applyAgentHooks` (the hooks step
+  `applyAgentConfig` runs — see § Installer Structure) renders a **semantic
+  per-entry summary** on the interactive and `--yes` paths (`renderHooksSummary`:
+  one `+ {event} ({matcher}) → {state}` line per registry row — the SessionStart
+  row displays as `chat stamp` — plus a preservation note and a replace/remove
+  count computed by `countRkEntries` over the CURRENT settings, never hardcoded;
+  the uninstall form is a single `- removes N rk-owned hook entries` line). The
+  **full** `current` vs `proposed` sorted-indented-JSON bodies render only under
+  `--dry-run` (the shared `renderArtifactDiff` helper — the explicitly-requested
+  preview data). A no-op (identical) is reported and skipped without prompting;
+  otherwise the write decision routes through `consent.authorizeWrite` (see the
+  § `rk agent-setup` consent flags above) — `--dry-run` skips the write,
   `--yes`/`-y` writes without prompting, an interactive TTY reads a `[y/N]` answer
   (`confirm`, default No) from the injected `io.Reader` (testable without a TTY),
   and a non-TTY invocation with neither flag **refuses** (error naming `--yes`,
@@ -690,6 +699,27 @@ reads as a hang in a transcript.
 still writes when combined with `--yes` (violates the preview promise); a bare
 `os.ModeCharDevice` TTY check (false-classifies `/dev/null`, refusal never fires).
 *Introduced by*: `260717-c424-toolkit-standards-conformance`
+
+### Consent context is a semantic summary; full bodies are `--dry-run`-only
+**Decision**: on the interactive and `--yes` paths every `agent-setup` pending
+write renders a semantic summary — the per-entry hooks list with computed
+replace/remove counts, a one-line tmux-shim summary, the exact 3-line PATH block
+plus placement — and the full current+proposed bodies render only under
+`--dry-run`. Each render site branches locally on `cons.dryRun`; the writer stays
+`cons.diffWriter(sink)`, so channel routing and the `--yes --quiet` silent-success
+net effect are untouched. Counts derive from the actual current settings
+(`countRkEntries`) and the rendered script, never literals.
+**Why**: a fresh run printed ~230 lines before the first `[y/N]` prompt, drowning
+the consent question the output exists to support (and `shll agent-setup`
+aggregates runs per tool, multiplying the noise). The full dump protected
+nothing: rk never overwrites marker-less files, so the diff only ever showed
+rk-owned or fresh content — and for user-authored startup files the honest unit
+of change is the owned block, not the user's file echoed back.
+**Rejected**: a unified-diff rendering (needs new diff machinery contra
+Constitution III for less legibility than the semantic form); a new `--verbose`
+flag (extra surface for what `--dry-run` already provides); hardcoded entry
+counts (drift the moment the registry grows).
+*Introduced by*: `260812-7a58-condense-agent-setup-consent-output`
 
 ### Whole-file skill ownership by frontmatter marker; thin pointer, not embedded recipe
 **Decision**: the legacy `rk-display` skill is a whole file rk owns outright (no

--- a/docs/memory/run-kit/tmux-guard-shim.md
+++ b/docs/memory/run-kit/tmux-guard-shim.md
@@ -207,16 +207,22 @@ compile-time constant or composed at run time from `$HOME`.
 ### Requirement: `rk agent-setup` install/uninstall contract
 The shim is a **user-global** managed artifact (one shim, one PATH block), applied
 once after the per-agent hook loop rather than per agent. Both pieces follow the
-same contract as the hooks merge: diff + consent before writing (`--dry-run`
-previews, `--yes` writes unprompted, a non-TTY without either refuses), idempotent
-replace-in-place, and exact removal on `--uninstall`.
+same contract as the hooks merge: consent before writing (`--yes` writes
+unprompted, a non-TTY without either flag refuses), idempotent replace-in-place,
+and exact removal on `--uninstall`. The consent context on the interactive and
+`--yes` paths is a **semantic summary** — one line for the shim (install with the
+script's computed line count, or `will update the rk-owned tmux shim`), and for
+each startup file the exact 3-line marker block plus placement (`appended at end`
+/ `replaced in position`; a one-line removal note on uninstall) — the user's file
+content is never echoed back. The full current+proposed body diff renders only
+under `--dry-run` (the requested preview).
 
 - **Shim file** at `~/.local/share/rk/shims/tmux`, mode 0755, carrying the
   `managed-by: rk agent-setup (tmux guard shim)` ownership marker on line 2 and,
   past its probe stage, exec'ing `"<abs-rk>" tmux-guard "$@"` — an absolute path
   resolved by `resolveRkPath` and validated by `validateHookPath`, not the bare
   name `rk`. Rollout of a new script shape is the same idempotent
-  replace-in-place: re-running `rk agent-setup` registers it as a content diff
+  replace-in-place: re-running `rk agent-setup` registers it as a content change
   under the existing consent flow, with no migration and no new file. A pre-existing
   **marker-less** file at that path — including a zero-byte one — is left untouched
   with a skip note; ownership keys on *existence* (`readFileIfExists`), not on

--- a/docs/memory/run-kit/toolkit-standards.md
+++ b/docs/memory/run-kit/toolkit-standards.md
@@ -67,14 +67,16 @@ convention plus the per-command rows):
   (`upgrade.go`), `doctor` (`doctor.go`), `agent-setup` (`agent_setup.go`).
   `update`'s progress lines route to stderr on non-quiet runs — a consequence of
   "decide the convention once", aligning with Principle 2 (stdout is data).
-- **A consent-mode diff-routing nuance in `agent-setup`**: the
-  settings diff routes **per consent mode** via `consent.diffWriter` — on the
+- **A consent-mode diff-routing nuance in `agent-setup`**: the consent context
+  (a semantic summary on the interactive and `--yes` paths; the full body diff
+  under `--dry-run` — see [agent-state](/run-kit/agent-state.md) § the hooks
+  merge) routes **per consent mode** via `consent.diffWriter` — on the
   interactive-prompt and `--dry-run` paths it is **data** (never gated: a consent
-  prompt without the diff it asks about is a dark pattern, and a dry-run's diff is
-  the requested output), while on the **`--yes`** path (write already authorized)
-  it is **chatter**, so `--yes --quiet` is fully silent on success while `--yes`
-  non-quiet still shows the diff on stderr. The interactive prompt itself and the
-  non-TTY refusal are never gated (the refusal is an error).
+  prompt without the context it asks about is a dark pattern, and a dry-run's diff
+  is the requested output), while on the **`--yes`** path (write already
+  authorized) it is **chatter**, so `--yes --quiet` is fully silent on success
+  while `--yes` non-quiet still shows the context on stderr. The interactive
+  prompt itself and the non-TTY refusal are never gated (the refusal is an error).
 - **A brew-stderr-in-error nuance in `update`**: under `--quiet`
   the suppressed brew subprocess stderr is **buffered** (not discarded) and, on a
   non-zero exit, wrapped into the returned error, so a failing `rk update --quiet`

--- a/fab/changes/260812-7a58-condense-agent-setup-consent-output/.history.jsonl
+++ b/fab/changes/260812-7a58-condense-agent-setup-consent-output/.history.jsonl
@@ -7,3 +7,4 @@
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-08-12T16:12:04Z"}
 {"event":"review","result":"passed","ts":"2026-08-12T16:12:04Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-08-12T16:14:35Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-08-12T16:16:01Z"}

--- a/fab/changes/260812-7a58-condense-agent-setup-consent-output/.history.jsonl
+++ b/fab/changes/260812-7a58-condense-agent-setup-consent-output/.history.jsonl
@@ -1,0 +1,9 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-08-12T15:54:49Z"}
+{"args":"agent-setup consent output is pages long (~230 lines fresh-run): stop dumping the full 135-line tmux shim as a diff; renderArtifactDiff prints full current+proposed bodies for settings.json — use a semantic summary, full bodies only under --dry-run; target ~15 lines while keeping the consent prompt honest","cmd":"fab-new","event":"command","ts":"2026-08-12T15:54:49Z"}
+{"delta":"+4.5","event":"confidence","score":4.5,"trigger":"calc-score","ts":"2026-08-12T15:56:39Z"}
+{"cmd":"fab-fff","event":"command","ts":"2026-08-12T15:58:37Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-08-12T15:59:17Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-08-12T16:06:42Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-08-12T16:12:04Z"}
+{"event":"review","result":"passed","ts":"2026-08-12T16:12:04Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-08-12T16:14:35Z"}

--- a/fab/changes/260812-7a58-condense-agent-setup-consent-output/.history.jsonl
+++ b/fab/changes/260812-7a58-condense-agent-setup-consent-output/.history.jsonl
@@ -8,3 +8,4 @@
 {"event":"review","result":"passed","ts":"2026-08-12T16:12:04Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-08-12T16:14:35Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-08-12T16:16:01Z"}
+{"event":"review","result":"passed","ts":"2026-08-12T16:24:42Z"}

--- a/fab/changes/260812-7a58-condense-agent-setup-consent-output/.status.yaml
+++ b/fab/changes/260812-7a58-condense-agent-setup-consent-output/.status.yaml
@@ -10,7 +10,7 @@ progress:
     review: done
     hydrate: done
     ship: done
-    review-pr: active
+    review-pr: done
 plan:
     generated: true
     task_count: 4
@@ -34,7 +34,7 @@ stage_metrics:
     review: {started_at: "2026-08-12T16:06:42Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-12T16:12:04Z"}
     hydrate: {started_at: "2026-08-12T16:12:04Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-12T16:14:35Z"}
     ship: {started_at: "2026-08-12T16:14:35Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-12T16:16:01Z"}
-    review-pr: {started_at: "2026-08-12T16:16:01Z", driver: git-pr, iterations: 1}
+    review-pr: {started_at: "2026-08-12T16:16:01Z", driver: git-pr, iterations: 1, completed_at: "2026-08-12T16:24:42Z"}
 prs:
     - https://github.com/sahil87/run-kit/pull/570
 change_type_source: explicit
@@ -54,4 +54,4 @@ true_impact:
     computed_at_stage: ship
 summary: agent-setup consent renders semantic summaries (hooks entry list, one-line shim, 3-line PATH block) on interactive/--yes; full bodies are --dry-run-only
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-08-12T16:16:01Z
+last_updated: 2026-08-12T16:24:42Z

--- a/fab/changes/260812-7a58-condense-agent-setup-consent-output/.status.yaml
+++ b/fab/changes/260812-7a58-condense-agent-setup-consent-output/.status.yaml
@@ -1,0 +1,55 @@
+id: 7a58
+name: 260812-7a58-condense-agent-setup-consent-output
+created: 2026-08-12T15:54:49Z
+created_by: sahil-noon
+change_type: fix
+issues: []
+progress:
+    intake: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+plan:
+    generated: true
+    task_count: 4
+    acceptance_count: 11
+    acceptance_completed: 11
+confidence:
+    certain: 2
+    confident: 3
+    tentative: 0
+    unresolved: 0
+    score: 4.5
+    fuzzy: true
+    dimensions:
+        signal: 69.0
+        reversibility: 87.0
+        competence: 78.0
+        disambiguation: 70.0
+stage_metrics:
+    intake: {started_at: "2026-08-12T15:54:49Z", driver: fab-new, iterations: 1, completed_at: "2026-08-12T15:59:17Z"}
+    apply: {started_at: "2026-08-12T15:59:17Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-12T16:06:42Z"}
+    review: {started_at: "2026-08-12T16:06:42Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-12T16:12:04Z"}
+    hydrate: {started_at: "2026-08-12T16:12:04Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-12T16:14:35Z"}
+    ship: {started_at: "2026-08-12T16:14:35Z", driver: fab-fff, iterations: 1}
+prs: []
+change_type_source: explicit
+true_impact:
+    added: 0
+    deleted: 0
+    net: 0
+    excluding:
+        added: 0
+        deleted: 0
+        net: 0
+    tests:
+        added: 0
+        deleted: 0
+        net: 0
+    computed_at: "2026-08-12T16:14:35Z"
+    computed_at_stage: hydrate
+summary: agent-setup consent renders semantic summaries (hooks entry list, one-line shim, 3-line PATH block) on interactive/--yes; full bodies are --dry-run-only
+# true_impact: lazily created on first stage-finish that computes it (no placeholder here).
+last_updated: 2026-08-12T16:14:35Z

--- a/fab/changes/260812-7a58-condense-agent-setup-consent-output/.status.yaml
+++ b/fab/changes/260812-7a58-condense-agent-setup-consent-output/.status.yaml
@@ -9,8 +9,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 plan:
     generated: true
     task_count: 4
@@ -33,23 +33,25 @@ stage_metrics:
     apply: {started_at: "2026-08-12T15:59:17Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-12T16:06:42Z"}
     review: {started_at: "2026-08-12T16:06:42Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-12T16:12:04Z"}
     hydrate: {started_at: "2026-08-12T16:12:04Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-12T16:14:35Z"}
-    ship: {started_at: "2026-08-12T16:14:35Z", driver: fab-fff, iterations: 1}
-prs: []
+    ship: {started_at: "2026-08-12T16:14:35Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-12T16:16:01Z"}
+    review-pr: {started_at: "2026-08-12T16:16:01Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/sahil87/run-kit/pull/570
 change_type_source: explicit
 true_impact:
-    added: 0
-    deleted: 0
-    net: 0
+    added: 697
+    deleted: 42
+    net: 655
     excluding:
-        added: 0
-        deleted: 0
-        net: 0
+        added: 339
+        deleted: 22
+        net: 317
     tests:
-        added: 0
-        deleted: 0
-        net: 0
-    computed_at: "2026-08-12T16:14:35Z"
-    computed_at_stage: hydrate
+        added: 241
+        deleted: 14
+        net: 227
+    computed_at: "2026-08-12T16:16:01Z"
+    computed_at_stage: ship
 summary: agent-setup consent renders semantic summaries (hooks entry list, one-line shim, 3-line PATH block) on interactive/--yes; full bodies are --dry-run-only
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-08-12T16:14:35Z
+last_updated: 2026-08-12T16:16:01Z

--- a/fab/changes/260812-7a58-condense-agent-setup-consent-output/intake.md
+++ b/fab/changes/260812-7a58-condense-agent-setup-consent-output/intake.md
@@ -1,0 +1,101 @@
+# Intake: Condense agent-setup Consent Output
+
+**Change**: 260812-7a58-condense-agent-setup-consent-output
+**Created**: 2026-08-12
+
+## Origin
+
+One-shot `/fab-new 7a58` from the backlog entry:
+
+> [7a58] 2026-08-12: agent-setup consent output is pages long (~230 lines fresh-run, surfaced via shll agent-setup): 1) stop dumping the full 135-line rk-owned tmux shim as a diff — diff/confirm exists to protect user-authored files, one summary line with the path suffices; 2) renderArtifactDiff prints full current+proposed bodies for settings.json — use a unified diff or semantic summary (adds 6 rk-owned hook entries: SessionStart, PreToolUse, UserPromptSubmit, Stop, Notification x2), full bodies only under --dry-run/verbose. Target ~15 lines while keeping the consent prompt honest
+
+No prior conversation context — the intake is grounded in the backlog text plus a read of `app/backend/cmd/rk/agent_setup.go` and the affected memory files.
+
+## Why
+
+1. **The pain point**: a fresh `rk agent-setup` run prints ~230 lines before the first `[y/N]` prompt. `renderArtifactDiff` (`agent_setup.go:592`) prints the **complete** current and proposed bodies at three call sites: the settings.json hooks merge (`applyAgentHooks`, `:458` — two full JSON documents, ~90 lines fresh-run), the tmux guard shim (`installTmuxShimFile`, `:1010` — the full ~135-line shim script), and each startup-file PATH block (`applyTmuxGuardPathBlocks`, `:1129` — the **entire** `.zshenv`/`.bashrc` content, current and next, even though the owned change is a 3-line block). The consent question drowns in the dump, and `shll agent-setup` (which aggregates per-tool setup runs) multiplies the noise per tool.
+
+2. **The consequence if unfixed**: users scroll pages to find each prompt, stop reading the diffs entirely (which defeats the honesty the diff exists for), and the aggregated `shll agent-setup` transcript becomes unusable as more tools adopt the pattern.
+
+3. **Why this approach**: the full-body diff's protective value is misplaced. rk **never overwrites files it does not own** — marker-less files are skipped before any diff renders (`installTmuxShimFile:983`, `skillHasMarker`) — so the shim diff only ever shows rk-owned→rk-owned or fresh-install content; for user-authored startup files the honest unit of change is the exactly-known 3-line marker block, not the surrounding user content; and for settings.json the semantic content of the merge ("adds these 6 rk-owned hook entries, preserves everything else") is what a consenting user actually needs to know. Full bodies stay available where they are explicitly requested data: `--dry-run`.
+
+## What Changes
+
+All changes are presentation-only in `app/backend/cmd/rk/agent_setup.go`. Consent semantics (`consent`, `authorizeWrite`, non-TTY refusal), channel routing (`consent.diffWriter` — chatter on `--yes`, data on interactive/`--dry-run`), write behavior, idempotence, and marker-ownership rules are all unchanged.
+
+### 1. Settings hooks merge — semantic summary instead of full JSON bodies
+
+`applyAgentHooks` currently renders `mustMarshalIndent(current)` vs `mustMarshalIndent(next)` — two complete settings.json documents. Replace the interactive/`--yes` rendering with a per-entry semantic summary derived from the registry rows plus the merge's replace/remove accounting, e.g. (fresh install):
+
+```
+Claude Code: will install run-kit agent-state hooks in ~/.claude/settings.json
+  + UserPromptSubmit → active
+  + PreToolUse → active
+  + Notification (permission_prompt|elicitation_dialog|agent_needs_input) → waiting
+  + Notification (idle_prompt) → idle
+  + Stop → idle
+  + SessionStart → chat stamp
+  (all other settings and non-rk hooks preserved)
+```
+
+On a re-run that replaces old-generation entries, the summary notes it (e.g. `(replaces 6 existing rk-owned entries in place)`); on `--uninstall` the lines flip to `- removes 6 rk-owned hook entries (…)`. The count and event names come from the actual computed merge, not a hardcoded string.
+
+### 2. tmux shim — one summary line
+
+`installTmuxShimFile` currently diffs the full ~135-line shim script. Replace with a single line, e.g.:
+
+- fresh install: `tmux guard: will install the tmux shim at ~/.local/share/rk/shims/tmux (rk-owned guard script, ~135 lines).`
+- rk-owned content update (e.g. embedded rk path changed): `tmux guard: will update the rk-owned tmux shim at ~/.local/share/rk/shims/tmux.`
+
+Marker-less foreign files never reach this point (skipped earlier with the existing note), so no protective information is lost.
+
+### 3. Startup-file PATH blocks — show the owned block, not the whole file
+
+`applyTmuxGuardPathBlocks` currently renders the entire startup-file content as current+proposed. Replace with the exact 3-line marker block plus target and placement, e.g.:
+
+```
+tmux guard: will add the rk PATH block to ~/.zshenv (appended at end):
+  # >>> rk tmux guard >>>
+  export PATH="$HOME/.local/share/rk/shims:$PATH"
+  # <<< rk tmux guard <<<
+```
+
+On uninstall: `tmux guard: will remove the 3-line rk PATH block from ~/.bashrc.` These files are user-authored, but the change shown is byte-exactly the region rk owns (replace-in-position or append per `upsertMarkerBlock`), so the consent prompt stays fully honest without printing the user's file back at them.
+
+### 4. `--dry-run` keeps the full bodies
+
+The `--dry-run` path retains today's full `renderArtifactDiff` output at all three sites — it is the explicitly-requested preview data (and already routes to the never-gated data channel). No new `--verbose` flag is added; the backlog's "--dry-run/verbose" is satisfied by the existing flag. Interactive and `--yes` paths get the summaries above; `--yes --quiet` stays fully silent on success (R5 net-effect unchanged).
+
+### 5. Tests
+
+`agent_setup_test.go` assertions that match the current full-body output are updated to the new summary forms; new/updated cases cover: fresh-install summary content (entry count + event names from the real merge), uninstall summary, `--dry-run` still emitting full bodies, and the PATH-block excerpt rendering (append vs in-position replace wording). Per constitution Test Integrity, tests follow the new spec.
+
+Fresh-run interactive total lands at roughly 15–25 lines across the three consent stops (vs ~230 today).
+
+## Affected Memory
+
+- `run-kit/agent-state`: (modify) — the installer's diff/consent presentation: semantic hook-entry summary on interactive/`--yes`, full bodies only under `--dry-run`
+- `run-kit/tmux-guard-shim`: (modify) — install contract's presentation: one-line shim summary and 3-line PATH-block excerpt replace whole-file diffs
+
+## Impact
+
+- `app/backend/cmd/rk/agent_setup.go` — the three `renderArtifactDiff` call sites, new summary helper(s), `renderArtifactDiff` retained for `--dry-run`
+- `app/backend/cmd/rk/agent_setup_test.go` — output assertions
+- No API, frontend, or tmux-behavior changes; no changes to what is written, only to what is printed before the prompt
+- Verification: `go test ./...` in `app/backend`
+
+## Open Questions
+
+None — the backlog entry is specific, and the remaining choices grade Confident or above (see Assumptions).
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | The tmux shim diff collapses to a one-line summary (path + rk-owned description) | Backlog states it directly ("one summary line with the path suffices"); display-only and trivially reversible | S:90 R:90 A:85 D:85 |
+| 2 | Confident | settings.json uses a **semantic per-entry summary**, not a unified diff | Backlog offers both but spells out the semantic summary's content inline; a unified-diff engine is new machinery contra Constitution III (wrap, don't reinvent) and the summary is more legible for a JSON merge | S:70 R:85 A:75 D:65 |
+| 3 | Confident | Full bodies live behind the existing `--dry-run` only; no new `--verbose` flag | Minimal surface (Constitution IV posture for CLI too); `--dry-run` already routes the diff to the never-gated data channel as requested output; "--dry-run/verbose" in the backlog reads as one gate, not two flags | S:55 R:90 A:70 D:55 |
+| 4 | Confident | The startup-file PATH-block sites are in scope, compacted to the exact 3-line marker block + target file + placement | Not one of the backlog's two numbered items, but the ~15-line fresh-run target is unreachable while whole-file dumps remain, and the owned block is the honest unit of change for user-authored files | S:45 R:80 A:70 D:60 |
+| 5 | Certain | Consent semantics, channel routing, and write behavior are untouched — presentation only | The backlog asks to keep "the consent prompt honest"; `consent`/`authorizeWrite`/`diffWriter` machinery is orthogonal to what is rendered | S:85 R:90 A:90 D:85 |
+
+5 assumptions (2 certain, 3 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260812-7a58-condense-agent-setup-consent-output/plan.md
+++ b/fab/changes/260812-7a58-condense-agent-setup-consent-output/plan.md
@@ -1,0 +1,135 @@
+# Plan: Condense agent-setup Consent Output
+
+**Change**: 260812-7a58-condense-agent-setup-consent-output
+**Intake**: `intake.md`
+
+## Requirements
+
+### CLI: agent-setup consent rendering
+
+#### R1: Hooks-merge consent shows a semantic summary
+On the interactive and `--yes` paths, `applyAgentHooks` SHALL render a per-entry semantic summary of the hooks merge instead of the full current+proposed JSON bodies: one line per rk hook entry (event, matcher when present, state token), derived from the registry rows actually being installed, plus a preservation note (`all other settings and non-rk hooks preserved`). When the merge replaces existing rk-owned entries, the summary SHALL state the replaced count derived from the actual current settings (never hardcoded). On `--uninstall`, the summary SHALL state the count of rk-owned entries being removed, derived from the actual current settings.
+
+- **GIVEN** a fresh machine (no `~/.claude/settings.json`) and an interactive TTY
+- **WHEN** `rk agent-setup` reaches the hooks-merge consent
+- **THEN** the output lists the 6 rk entries semantically (e.g. `+ UserPromptSubmit → active`, `+ Notification (idle_prompt) → idle`, `+ SessionStart → chat stamp`) and does NOT contain the `--- current` / `+++ proposed` full-body block
+
+- **GIVEN** settings.json carrying 6 old-generation rk entries plus user hooks
+- **WHEN** `rk agent-setup` re-runs
+- **THEN** the summary notes the in-place replacement count (6) and the preservation of non-rk hooks
+
+- **GIVEN** settings.json carrying 6 rk entries
+- **WHEN** `rk agent-setup --uninstall` reaches the hooks consent
+- **THEN** the summary states 6 rk-owned entries will be removed and does not dump full bodies
+
+#### R2: tmux shim consent is one summary line
+On the interactive and `--yes` paths, `installTmuxShimFile` SHALL render a single summary line instead of the full shim-script diff: on fresh install, the shim path plus an rk-owned description with the actual script line count (computed from the rendered script, not hardcoded); on an rk-owned content update, an "update the rk-owned tmux shim" line naming the path. Marker-less foreign files keep today's earlier skip note and never reach this rendering.
+
+- **GIVEN** no shim at `~/.local/share/rk/shims/tmux`
+- **WHEN** install reaches the shim consent
+- **THEN** exactly one summary line names the path and the rk-owned script (with its line count); the script body is not printed
+
+#### R3: PATH-block consent shows the owned block, not the whole file
+On the interactive and `--yes` paths, `applyTmuxGuardPathBlocks` SHALL render the exact marker-owned block (the 3 lines: begin marker, `export PATH=…`, end marker) plus the target file and placement — `appended at end` when no block exists, `replaced in position` when an existing block is being updated — instead of the full current+next file contents. On uninstall, a single line SHALL name the removal (`will remove the 3-line rk PATH block from {file}`) without echoing file contents.
+
+- **GIVEN** a `~/.zshenv` with user content and no rk block
+- **WHEN** install reaches that file's consent
+- **THEN** the output shows the 3 block lines and `appended at end`, and the user's own file content is not echoed back
+
+- **GIVEN** a startup file carrying the rk block
+- **WHEN** `--uninstall` reaches that file's consent
+- **THEN** one line names the block removal; no file contents are printed
+
+#### R4: `--dry-run` retains the full-body diffs
+Under `--dry-run`, all three sites SHALL keep today's full `renderArtifactDiff` rendering (complete current+proposed bodies) as the explicitly-requested preview data, routed to the data channel as today.
+
+- **GIVEN** any pending write at any of the three sites
+- **WHEN** `rk agent-setup --dry-run` runs
+- **THEN** the output contains the `--- current` / `+++ proposed` full-body block followed by the existing dry-run note, and nothing is written
+
+#### R5: Consent semantics and channel routing are unchanged
+The change SHALL NOT alter `consent`/`authorizeWrite` behavior (non-TTY refusal, `--dry-run` wins over `--yes`, `[y/N]` default-No), channel routing (`consent.diffWriter`: chatter on `--yes`, data on interactive/`--dry-run`; `--yes --quiet` fully silent on success), what is written, idempotence, or marker-ownership rules. Summary rendering SHALL write to the same `cons.diffWriter(sink)` writer the full diff uses today.
+
+- **GIVEN** `rk agent-setup --yes --quiet` on a fresh machine
+- **WHEN** the run completes
+- **THEN** stdout/stderr are silent on success, exactly as today
+
+### Design Decisions
+
+#### Summary-vs-full keyed on `cons.dryRun` at each render site
+**Decision**: each of the three sites branches locally — `if cons.dryRun` → today's `renderArtifactDiff` full bodies, else the new semantic summary — with the writer unchanged (`cons.diffWriter(sink)`).
+**Why**: `--dry-run` is the one path where the full body is the requested output; the consent flags already encode that, so no new flag or plumbing is needed.
+**Rejected**: a new `--verbose` flag (extra surface for a need `--dry-run` already covers); changing `diffWriter` routing (orthogonal, and `--yes --quiet` net-effect must hold).
+*Introduced by*: 260812-7a58-condense-agent-setup-consent-output
+
+#### Counts derived from the computed merge, never hardcoded
+**Decision**: replaced/removed rk-entry counts come from counting `isRkEntry` matches in the current settings at the call site; the entry list comes from the `agentRegistry` rows being installed; the shim line count from the rendered script.
+**Why**: the summary must stay honest as the registry grows (new agents/events) without a stale literal.
+**Rejected**: hardcoding "6 entries" (drifts the moment the registry changes).
+*Introduced by*: 260812-7a58-condense-agent-setup-consent-output
+
+### Non-Goals
+
+- No unified-diff engine (intake assumption #2 — semantic summary chosen)
+- No changes to `rk agent-setup` write behavior, flags, or the legacy rk-display cleanup path (its prompts are already one-liners)
+
+## Tasks
+
+### Phase 1: Core Implementation
+
+- [x] T001 In `app/backend/cmd/rk/agent_setup.go`, add the hooks-merge semantic summary: a `countRkEntries(settings map[string]any) int` helper and a summary renderer over `ac.hooks` (event, matcher, state per line; replaced/removed counts; preservation note); branch `applyAgentHooks` on `cons.dryRun` — full `renderArtifactDiff` on dry-run, summary otherwise, same `cons.diffWriter(sink)` writer <!-- R1, R4, R5 -->
+- [x] T002 In `installTmuxShimFile` (`agent_setup.go`), branch on `cons.dryRun`: keep the full diff on dry-run; otherwise render one summary line (fresh install with computed script line count vs rk-owned update), path included <!-- R2, R4 -->
+- [x] T003 In `applyTmuxGuardPathBlocks` (`agent_setup.go`), branch on `cons.dryRun`: keep the full diff on dry-run; otherwise render the 3-line marker block + target file + placement (append vs in-position replace, derived from whether the block exists in `current`), and the one-line removal form on uninstall <!-- R3, R4 -->
+
+### Phase 2: Tests
+
+- [x] T004 Update `app/backend/cmd/rk/agent_setup_test.go`: adjust any assertions relying on full-body output; add cases for the fresh-install hooks summary (entry lines present, `+++ proposed` absent), re-run replacement count, uninstall removal count, shim one-liner (script body absent), PATH-block excerpt (user content not echoed, block lines present), and `--dry-run` still emitting full bodies at all three sites; run `go test ./...` in `app/backend` <!-- R1, R2, R3, R4, R5 -->
+
+## Acceptance
+
+### Functional Completeness
+
+- [x] A-001 R1: Interactive/`--yes` hooks-merge consent renders the per-entry semantic summary with preservation note; full JSON bodies no longer appear on those paths
+- [x] A-002 R2: Interactive/`--yes` shim consent is a single summary line naming the path; the shim script body no longer appears on those paths
+- [x] A-003 R3: Interactive/`--yes` PATH-block consent shows exactly the owned 3-line block + placement; user file contents are never echoed
+
+### Behavioral Correctness
+
+- [x] A-004 R1: Replacement and removal counts are computed from the actual current settings (verified by a test with pre-existing rk entries)
+- [x] A-005 R4: `--dry-run` output at all three sites still contains the full `--- current` / `+++ proposed` bodies and writes nothing
+
+### Scenario Coverage
+
+- [x] A-006 R1: Tests cover fresh install, re-run replacement, and uninstall summary forms for the hooks merge
+- [x] A-007 R5: `--yes --quiet` remains fully silent on success (existing net-effect test still passes unmodified or equivalent coverage exists)
+
+### Edge Cases & Error Handling
+
+- [x] A-008 R3: Placement wording is correct for both the append case and the in-position replace case
+- [x] A-009 R5: Non-TTY refusal, marker-less skip notes, and no-op reports are byte-identical to today (no assertions on those paths needed changing except where they asserted full bodies)
+
+### Code Quality
+
+- [x] A-010 Pattern consistency: New rendering helpers follow the file's existing comment density and doc-comment style; output goes through `outputSink` channels per Toolkit Principle 9
+- [x] A-011 No unnecessary duplication: `renderArtifactDiff` is reused for the dry-run path rather than duplicated; no new diff machinery introduced
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All acceptance items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] A-NNN **N/A**: {reason}`
+
+## Deletion Candidates
+
+- `countRkEntries` test helper (`agent_setup_test.go`) — was a test-only duplicate of the count logic; the change moved it into production (`agent_setup.go`) and deleted the test copy, so the redundancy is already resolved within this change
+- None otherwise — presentation-only change; all three `renderArtifactDiff` call sites remain live on the `--dry-run` path, so no existing symbol became unused
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Confident | Shim update line ("will update the rk-owned tmux shim") carries no line count — only the fresh-install line does | The update case is rare (rk path change); the count matters for conveying bulk on first install | S:50 R:90 A:75 D:70 |
+| 2 | Confident | The legacy rk-display cleanup and no-op/skip notes are untouched | Already one-line prompts; the backlog targets the three diff dumps only | S:60 R:90 A:85 D:75 |
+| 3 | Certain | Summary output writes to `cons.diffWriter(sink)` exactly as the diff does today | R5 requires unchanged channel routing; the writer selection already encodes the `--yes`/interactive/dry-run split | S:80 R:90 A:90 D:85 |
+
+3 assumptions (1 certain, 2 confident, 0 tentative).


### PR DESCRIPTION
## Meta

| Change ID | Type | Confidence | Plan | Review |
|-----------|------|------------|------|--------|
| `7a58` | fix | 4.5/5.0 | 4/4 tasks, 11/11 acceptance ✓ | ✓ 1 cycle |

| Impact | +/− | Net |
|--------|----:|----:|
| raw | +697 / −42 | +655 |
| **true** | **+339 / −22** | **+317** |
| └ impl | +98 / −8 | +90 |
| └ tests | +241 / −14 | +227 |

<sub>excludes `fab/`, `docs/` · generated by fab-kit v2.19.6</sub>

**Pipeline:** [intake](https://github.com/sahil87/run-kit/blob/260812-7a58-condense-agent-setup-consent-output/fab/changes/260812-7a58-condense-agent-setup-consent-output/intake.md) ✓ → [apply](https://github.com/sahil87/run-kit/blob/260812-7a58-condense-agent-setup-consent-output/fab/changes/260812-7a58-condense-agent-setup-consent-output/plan.md) ✓ → review ✓ → hydrate ✓ → ship → review-pr

## Summary

A fresh `rk agent-setup` run printed ~230 lines of full-body diffs before the first consent prompt — the complete settings.json current+proposed documents, the entire ~135-line tmux guard shim, and each startup file's whole content for a 3-line PATH block. Consent now renders semantic summaries on the interactive and `--yes` paths (~15–25 lines fresh-run), while `--dry-run` retains the full-body diffs as the explicitly requested preview. Write behavior, consent gating, and channel routing are unchanged.

## Changes

- **Settings hooks merge — semantic summary instead of full JSON bodies**: per-entry `+ {event} ({matcher}) → {state}` lines with replace/remove counts computed from the actual current settings
- **tmux shim — one summary line**: fresh install with computed script line count, or an rk-owned update line
- **Startup-file PATH blocks — show the owned block, not the whole file**: the exact 3-line marker block + placement; user file content is never echoed
- **`--dry-run` keeps the full bodies** at all three sites; no new flag
- **Tests**: 8 new consent-summary tests; duplicate test helper promoted to production `countRkEntries`