### PR TITLE
fix: allow intra-tree `../` symlinks in code-server tarball extraction

### DIFF
--- a/app/backend/internal/codeserver/install.go
+++ b/app/backend/internal/codeserver/install.go
@@ -298,9 +298,13 @@ func extractTarball(src, dest string) error {
 				return closeErr
 			}
 		case tar.TypeSymlink:
+			// Relative targets with ".." components are legitimate and
+			// ubiquitous (node_modules/.bin/x -> ../pkg/bin/x.js), so a prefix
+			// ban would refuse every real code-server tarball. The lexical
+			// check is CONTAINMENT: resolve the target against the link's own
+			// (already-resolved) parent dir and require it to stay under dest.
 			link := hdr.Linkname
-			cleanLink := filepath.ToSlash(filepath.Clean(link))
-			if filepath.IsAbs(link) || cleanLink == ".." || strings.HasPrefix(cleanLink, "../") {
+			if filepath.IsAbs(link) || !within(realDest, filepath.Clean(filepath.Join(parentDir, link))) {
 				return fmt.Errorf("refusing symlink escaping the install dir: %q -> %q", hdr.Name, link)
 			}
 			if err := os.Symlink(link, target); err != nil {

--- a/app/backend/internal/codeserver/install_test.go
+++ b/app/backend/internal/codeserver/install_test.go
@@ -371,3 +371,56 @@ func TestExtractStaysUnderDest(t *testing.T) {
 	// Silences the io import check if the payload shape changes.
 	var _ io.Reader
 }
+
+// Regression for the production failure on the REAL code-server tarball:
+// node_modules/.bin is full of up-and-back-down relative symlinks
+// (.bin/esvalidate -> ../esprima/bin/esvalidate.js). These resolve INSIDE the
+// tree and must extract — a "../" prefix ban refuses every genuine release.
+func TestExtractAllowsIntraTreeDotDotSymlink(t *testing.T) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	top := "code-server-1-linux-amd64"
+	script := "#!/usr/bin/env node\n"
+	for _, hdr := range []*tar.Header{
+		{Name: top + "/node_modules/esprima/bin", Typeflag: tar.TypeDir, Mode: 0o755},
+		{Name: top + "/node_modules/esprima/bin/esvalidate.js", Typeflag: tar.TypeReg, Mode: 0o755, Size: int64(len(script))},
+		{Name: top + "/node_modules/.bin", Typeflag: tar.TypeDir, Mode: 0o755},
+		{Name: top + "/node_modules/.bin/esvalidate", Typeflag: tar.TypeSymlink, Linkname: "../esprima/bin/esvalidate.js"},
+	} {
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if hdr.Typeflag == tar.TypeReg {
+			if _, err := tw.Write([]byte(script)); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	src := filepath.Join(t.TempDir(), "real-shape.tar.gz")
+	if err := os.WriteFile(src, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dest := t.TempDir()
+	if err := extractTarball(src, dest); err != nil {
+		t.Fatalf("intra-tree ../ symlink must extract, got: %v", err)
+	}
+	resolved, err := filepath.EvalSymlinks(filepath.Join(dest, "node_modules", ".bin", "esvalidate"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := filepath.EvalSymlinks(filepath.Join(dest, "node_modules", "esprima", "bin", "esvalidate.js"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved != want {
+		t.Errorf("link resolves to %q, want %q", resolved, want)
+	}
+}

--- a/app/backend/internal/codeserver/real_tarball_manual_test.go
+++ b/app/backend/internal/codeserver/real_tarball_manual_test.go
@@ -1,0 +1,31 @@
+package codeserver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Throwaway manual verification against the REAL release tarball (the
+// synthetic-fixture lesson). Runs only when RK_REAL_TARBALL points at one.
+func TestExtractRealTarballManual(t *testing.T) {
+	src := os.Getenv("RK_REAL_TARBALL")
+	if src == "" {
+		t.Skip("RK_REAL_TARBALL not set")
+	}
+	dest := t.TempDir()
+	if err := extractTarball(src, dest); err != nil {
+		t.Fatalf("real tarball extraction failed: %v", err)
+	}
+	bin := filepath.Join(dest, "bin", "code-server")
+	fi, err := os.Stat(bin)
+	if err != nil {
+		t.Fatalf("bin/code-server missing after extraction: %v", err)
+	}
+	if fi.Mode().Perm()&0o111 == 0 {
+		t.Errorf("bin/code-server not executable: %v", fi.Mode())
+	}
+	if _, err := filepath.EvalSymlinks(filepath.Join(dest, "node_modules", ".bin", "esvalidate")); err != nil {
+		t.Errorf("the reported .bin symlink did not survive extraction: %v", err)
+	}
+}

--- a/app/backend/internal/codeserver/release.go
+++ b/app/backend/internal/codeserver/release.go
@@ -15,8 +15,12 @@ const (
 	// defaultAPIBase is the GitHub REST API origin (the Installer's APIBase
 	// overrides it — tests point at httptest).
 	defaultAPIBase = "https://api.github.com"
-	// resolveTimeout bounds the release-listing API call.
-	resolveTimeout = 10 * time.Second
+	// resolveTimeout bounds the release-listing API call. 30s, not 10:
+	// api.github.com routinely takes >10s on slow or flaky links (observed
+	// in production: back-to-back context-deadline failures at 10s that
+	// succeeded on retry), and a longer bound on a read-only GET costs
+	// nothing — it is a bound on failure, not an expected duration.
+	resolveTimeout = 30 * time.Second
 	// downloadTimeout bounds the tarball transfer — network-transfer-sized for
 	// a ~100MB asset on a slow link (an upper bound on failure, not an
 	// expected duration).


### PR DESCRIPTION
## Summary

`rk code-server install` failed on every REAL release tarball: the symlink hardening from the #582 review banned any linkname starting `../`, but `node_modules/.bin` is full of legitimate up-and-back-down relative links (`.bin/esvalidate -> ../esprima/bin/esvalidate.js`) that resolve safely inside the tree. Observed in production (install attempt failed at 227MB extraction). #584 merged before this fix commit was pushed to its branch, so it re-lands here.

## Changes

- **Lexical symlink check is now containment, not a prefix ban** — the target resolved against the link's own (already-resolved) parent dir must stay under dest; the post-creation `EvalSymlinks` verification remains the backstop for chains. All escape regressions (absolute, `../../../etc/passwd`, chained traversal, bare `..`) still refuse
- **Regression test with the exact reported shape** plus an env-gated manual test (`RK_REAL_TARBALL=…`) verified against the real 227MB v4.132.0 linux-amd64 tarball — clean extraction, executable `bin/code-server`, the reported link resolving
- **Release-resolve bound 10s → 30s** — back-to-back `context deadline exceeded` on `api.github.com` observed in production before a third attempt succeeded