### PR TITLE
docs: Add one-time `tailscale set --operator` step to Tailscale guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,9 @@ Pin state lives in tmux (via the `@rk_board` window option) so it follows the wi
 Some browser features (clipboard, secure context) require HTTPS. Accessing run-kit from another machine on your tailnet also requires HTTPS:
 
 1. Enable HTTPS at [DNS > HTTPS Certificates](https://login.tailscale.com/admin/dns).
-2. Run `tailscale serve --bg http://localhost:3000`.
-3. Open `https://<machine>.<tailnet>.ts.net` on your phone or another laptop.
+2. Run `sudo tailscale set --operator=$USER` (one-time — lets `tailscale serve` run without sudo).
+3. Run `tailscale serve --bg http://localhost:3000`.
+4. Open `https://<machine>.<tailnet>.ts.net` on your phone or another laptop.
 
 For a stable custom hostname or public access via Funnel, see the [Tailscale guide](docs/site/install.md).
 

--- a/docs/site/install.md
+++ b/docs/site/install.md
@@ -94,6 +94,12 @@ run-kit binds to `127.0.0.1` by default. Some browser features (e.g., copy to cl
 
 Enable HTTPS on your tailnet in the [Tailscale admin console](https://login.tailscale.com/admin/dns) under **DNS > HTTPS Certificates**.
 
+Then let your user manage Tailscale without sudo (one-time — `tailscale serve` needs root or the designated operator):
+
+```sh
+sudo tailscale set --operator=$USER
+```
+
 ### Quickstart
 
 ```sh
@@ -121,7 +127,7 @@ Services need a tagged node. Do these in order:
 
 1. **Define the `tag:server` tag.** In [Access controls](https://login.tailscale.com/admin/acls), Visual editor → **Tags** → add a tag named `server`. Owners can be left empty.
 
-2. **Re-register the node with the tag** (`--operator` lets you manage Tailscale without sudo afterward):
+2. **Re-register the node with the tag.** Tags can only be requested via `tailscale up` (there is no `tailscale set --advertise-tags`), and `up` errors unless every non-default pref is re-stated — so `--operator` is repeated here, not newly set:
 
    ```sh
    sudo tailscale up --advertise-tags=tag:server --operator=$USER


### PR DESCRIPTION
## Summary

`tailscale serve` requires root or the designated operator, so the Quickstart's bare `tailscale serve --bg` failed with access-denied for non-operator users. This adds a one-time `sudo tailscale set --operator=$USER` step to the Tailscale prerequisites (install guide) and the README phone quickstart, and rewords the custom-hostname step 2 to explain that `--operator` on `tailscale up` is re-stated (not newly set) — `up` errors unless every non-default pref is mentioned, and tags have no `tailscale set` equivalent (verified on tailscale 1.102.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)