### PR TITLE
fix: Re-enable Empty Compose Send as Bare Enter

### DIFF
--- a/app/frontend/src/components/compose-strip.test.tsx
+++ b/app/frontend/src/components/compose-strip.test.tsx
@@ -562,11 +562,10 @@ describe("ComposeStrip", () => {
       </ChromeProvider>,
     );
     act(() => fireEvent.click(screen.getByTestId("set-focus")));
-    // Empty draft: Insert follows Enter's empty no-op (disabled) — and Send is
-    // disabled too (260813-kvk7): the bare-\r "Enter in the pane" empty case is
-    // chord-only now, so an empty composer offers no button at all.
+    // Empty draft: Insert follows Enter's empty no-op (disabled) — but Send
+    // stays enabled: its chord's empty case is the bare-\r "Enter in the pane".
     expect(insertBtn().disabled).toBe(true);
-    expect(sendBtn().disabled).toBe(true);
+    expect(sendBtn().disabled).toBe(false);
     act(() => fireEvent.change(input(), { target: { value: "via button" } }));
     expect(insertBtn().disabled).toBe(false);
     act(() => fireEvent.click(insertBtn()));
@@ -574,7 +573,7 @@ describe("ComposeStrip", () => {
     expect(input().value).toBe("");
   });
 
-  it("the Send button is disabled on an empty/whitespace-only composer; with text it sends text + \\r (260813-kvk7)", () => {
+  it("the Send button mirrors its chord's empty case: enabled with a target in the secondary face, an empty click sends bare \\r", () => {
     const { ref, sent } = makeWs();
     render(
       <ChromeProvider>
@@ -585,22 +584,28 @@ describe("ComposeStrip", () => {
       </ChromeProvider>,
     );
     act(() => fireEvent.click(screen.getByTestId("set-focus")));
-    // Empty draft: Send is disabled (no primary fill — `disabled:opacity-40`)
-    // even though a target exists; the bare-\r empty case is chord-only now
-    // (pinned by "empty Cmd/Ctrl+Enter sends a bare \r" above).
-    expect(sendBtn().disabled).toBe(true);
-    expect(sendBtn().className).toContain("disabled:opacity-40");
-    // Whitespace-only counts as empty too.
-    act(() => fireEvent.change(input(), { target: { value: "   " } }));
-    expect(sendBtn().disabled).toBe(true);
-    expect(insertBtn().disabled).toBe(true);
-    // With text both buttons enable; Send transmits text + trailing \r.
-    act(() => fireEvent.change(input(), { target: { value: "via send" } }));
+    // Empty draft: Send stays enabled (target exists) but wears the neutral
+    // secondary face, not the lit accent fill (260814 revision of kvk7 —
+    // touch devices have no Cmd/Ctrl+Enter chord, so the button is the only
+    // bare-Enter path there).
     expect(sendBtn().disabled).toBe(false);
+    expect(sendBtn().className).toContain("border-border");
+    expect(sendBtn().className).not.toContain("border-accent");
+    // Whitespace-only counts as empty too — enabled, still secondary.
+    act(() => fireEvent.change(input(), { target: { value: "   " } }));
+    expect(sendBtn().disabled).toBe(false);
+    expect(sendBtn().className).toContain("border-border");
+    expect(insertBtn().disabled).toBe(true);
+    // With text the accent fill returns and Send transmits text + trailing \r.
+    act(() => fireEvent.change(input(), { target: { value: "via send" } }));
+    expect(sendBtn().className).toContain("border-accent");
     expect(insertBtn().disabled).toBe(false);
     act(() => fireEvent.click(sendBtn()));
     expect(sent).toEqual(["via send\r"]);
     expect(input().value).toBe("");
+    // The empty click itself sends the bare \r (the chord's empty case).
+    act(() => fireEvent.click(sendBtn()));
+    expect(sent).toEqual(["via send\r", "\r"]);
   });
 
   it("a guard-blocked insert (stream not OPEN) preserves the draft", () => {

--- a/app/frontend/src/components/compose-strip.tsx
+++ b/app/frontend/src/components/compose-strip.tsx
@@ -678,18 +678,21 @@ export function ComposeStrip({
   /** Prevent mousedown from stealing focus away from the terminal/textarea. */
   const preventFocusSteal = (e: React.MouseEvent) => e.preventDefault();
 
-  // Per-button enablement (260802-lj98, revised 260813-kvk7): Insert and Send
-  // share ONE rule on a terminal target — no text → both disabled (the lit
-  // primary Send over an empty composer read as a broken affordance). The
-  // Cmd/Ctrl+Enter chord deliberately DIVERGES here: its empty-composer
-  // bare-`\r` send ("press Enter in the pane") stays — button state answers
-  // "is there text to send", the chord is a power-user pane keystroke.
+  // Per-button enablement (260802-lj98, revised 260813-kvk7, re-revised
+  // 260814): Insert follows Enter's empty no-op — disabled with no text. Send
+  // mirrors its Cmd/Ctrl+Enter chord INCLUDING the empty bare-`\r` case
+  // ("press Enter in the pane") — on touch devices the chord doesn't exist,
+  // so the button is the ONLY way to send a bare Enter there. kvk7's
+  // complaint (a lit primary Send over an empty composer read as broken) is
+  // answered by STYLE, not state: an empty composer renders Send in the
+  // neutral secondary face; the accent fill returns with text.
   // Selection-broadcast targets keep their own rule (text required, Insert
   // always disabled there).
-  const canInsert = !isSelectionTarget && hasTarget && text.trim() !== "";
+  const composerEmpty = text.trim() === "";
+  const canInsert = !isSelectionTarget && hasTarget && !composerEmpty;
   const canSubmit = isSelectionTarget
-    ? text.trim() !== "" && !selectionSending
-    : hasTarget && text.trim() !== "";
+    ? !composerEmpty && !selectionSending
+    : hasTarget;
 
   return (
     <div data-testid="compose-strip">
@@ -854,7 +857,9 @@ export function ComposeStrip({
               </button>
             </Tip>
             {/* Send mirrors its chord including the empty bare-`\r` case, so
-                it is enabled whenever a target exists. */}
+                it is enabled whenever a target exists — in the neutral
+                secondary face while the composer is empty (see the enablement
+                comment above). */}
             <Tip label="Send" kbd={composeSubmitKeycap()} placement="top">
               <button
                 type="button"
@@ -863,7 +868,11 @@ export function ComposeStrip({
                 onMouseDown={preventFocusSteal}
                 onClick={() => send("submit")}
                 data-testid="compose-strip-send"
-                className="rk-glint shrink-0 rounded border border-accent bg-accent/20 px-3 py-1.5 text-xs text-accent transition-colors hover:bg-accent/30 disabled:opacity-40 disabled:cursor-not-allowed coarse:min-h-[36px]"
+                className={`rk-glint shrink-0 rounded border px-3 py-1.5 text-xs transition-colors disabled:opacity-40 disabled:cursor-not-allowed coarse:min-h-[36px] ${
+                  composerEmpty && !isSelectionTarget
+                    ? "border-border text-text-secondary hover:border-text-secondary"
+                    : "border-accent bg-accent/20 text-accent hover:bg-accent/30"
+                }`}
               >
                 {selectionSending ? "Sending…" : "Send"}
               </button>


### PR DESCRIPTION
## Summary

PR #590 (260813-kvk7) disabled the compose strip's Send button on an empty composer, leaving the empty bare-`\r` send ("press Enter in the pane") chord-only — but Cmd/Ctrl+Enter doesn't exist on touch devices, so mobile lost the affordance entirely. This re-enables Send whenever a terminal target exists, and answers kvk7's original complaint (a lit primary Send over an empty composer reads broken) with style instead of state: the button wears the neutral secondary face while the composer is empty and regains the accent fill with text. Selection-broadcast targets keep requiring text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)