### PR TITLE
fix: Mobile Surface Tile Must Size the Terminal (flex-1)

### DIFF
--- a/app/frontend/src/components/surface-layout.tsx
+++ b/app/frontend/src/components/surface-layout.tsx
@@ -675,9 +675,15 @@ export function SurfaceLayout({
       <div
         key={`${kind}${suffix}`}
         data-testid={testId}
+        // Mobile tiles MUST carry flex-1: the single visible slot fills the
+        // column. Without it the tile is content-sized — xterm's own canvas
+        // becomes the measure, a stable fixed point (canvas sizes tile sizes
+        // fit sizes canvas) that pins the terminal at its 80×24 default and
+        // makes it deaf to every viewport change (iOS keyboard collapse).
+        // Desktop tiles are sized by the grid via slotStyle instead.
         className={`group min-w-0 min-h-0 flex-col overflow-hidden ${hidden ? "hidden" : "flex"}${
           mobile
-            ? ""
+            ? " flex-1"
             : ` border rounded ${isFocused ? "border-accent-green" : "border-border"}`
         }`}
         style={hidden || mobile ? undefined : slotStyle(layout.shape, slot, zoomed)}

--- a/app/frontend/tests/e2e/mobile-keyboard-refit.spec.md
+++ b/app/frontend/tests/e2e/mobile-keyboard-refit.spec.md
@@ -1,0 +1,47 @@
+# mobile-keyboard-refit.spec.ts
+
+Mobile keyboard open/collapse refit guardrails. Simulates the iOS on-screen
+keyboard with a width-constant viewport height drop/restore — the exact signal
+`useVisualViewport` keys on (`height` delta > `KEYBOARD_DELTA_PX` at constant
+width) — with `hasTouch: true` so `pointer: coarse` matches. Guards two
+regressions:
+
+1. **Terminal refit** — the surface-layout mobile tile must *size* the
+   terminal. A content-sized tile (no `flex-1` on the mobile tile wrapper)
+   pins xterm at its 80×24 default: the canvas measures the tile, which
+   measures the canvas, so the terminal never expands when the keyboard
+   collapses (the "xterm view doesn't expand" iPhone bug).
+2. **Bottom-bar safe floor** (260805-fi9m) — `--bottom-bar-floor` must be
+   1rem on coarse pointers while the keyboard is collapsed and drop to 6px
+   while `html.kb-open` is set.
+
+## Shared setup
+
+- `test.use` pins an iPhone-sized viewport (375×812) with `hasTouch: true`.
+- `beforeAll`/`afterAll` create and kill a dedicated session; the test adds
+  its own `probe` window (own session — never collides with other specs).
+- Navigation is a direct `page.goto` — `_ready`'s `gotoWindow` waits on the
+  sidebar's Connected dot, which the closed mobile drawer never shows; the
+  terminal-registry rows poll is the mobile-compatible readiness signal.
+
+## Tests
+
+### `keyboard open/collapse: xterm+tmux refit and the bottom-bar floor toggles`
+
+**What it proves:** The terminal grid tracks the viewport through a keyboard
+open/collapse cycle end to end (xterm rows AND the tmux pane), and the
+bottom-bar safe floor toggles with the keyboard signal.
+
+**Steps:**
+1. Create a `probe` window, resolve its windowId, goto the terminal route.
+2. Poll `window.__rkTerminals[windowId].rows > 10` (terminal ready).
+3. Baseline: assert `pointer: coarse` matches, `kb-open` absent, rows > 30
+   (24 is the content-sized-tile fixed point — the regression tripwire), and
+   the toolbar's computed `padding-bottom` is `16px` (raised floor).
+4. Shrink the viewport to 375×512 (−300px, width constant — "keyboard open").
+5. Poll `html.kb-open` present; poll rows < baseline (terminal shrank);
+   assert the floor dropped to `6px`.
+6. Restore the viewport to 375×812 ("keyboard collapsed").
+7. Poll `kb-open` absent; poll rows ≥ baseline (terminal re-expanded); poll
+   tmux `pane_height ≥ rows − 2` (tmux was told — 2 status lines); assert the
+   floor returned to `16px` and `--app-height` is `812px`.

--- a/app/frontend/tests/e2e/mobile-keyboard-refit.spec.ts
+++ b/app/frontend/tests/e2e/mobile-keyboard-refit.spec.ts
@@ -1,0 +1,98 @@
+// Mobile keyboard open/collapse refit — simulates the iOS on-screen keyboard
+// via a width-constant viewport height drop/restore (the exact signal
+// useVisualViewport keys on: height delta > KEYBOARD_DELTA_PX at constant
+// width), with hasTouch for pointer:coarse. Guards two regressions at once:
+// the surface-layout mobile tile must SIZE the terminal (a content-sized tile
+// pins xterm at its 80×24 default — the canvas measures the tile, which
+// measures the canvas — and the terminal goes deaf to every viewport change),
+// and the bottom-bar safe floor must toggle with html.kb-open (260805-fi9m).
+import { test, expect } from "@playwright/test";
+import { execSync } from "node:child_process";
+import { resolveWindow as resolveWindowRaw } from "./_ready";
+import { TMUX_SERVER, createSession, killSession, newWindow } from "./_tmux";
+
+// Own session so this file never collides with other specs (fullyParallel off).
+const TEST_SESSION = `e2e-kbrefit-${Date.now()}`;
+const WINDOW_NAME = "probe";
+const FULL = { width: 375, height: 812 };
+const KEYBOARDED = { width: 375, height: 512 }; // -300px > KEYBOARD_DELTA_PX(150)
+
+test.use({ viewport: FULL, hasTouch: true });
+
+function tmuxPaneHeight(): number {
+  const out = execSync(
+    `tmux -L ${TMUX_SERVER} display-message -p -t "=${TEST_SESSION}:${WINDOW_NAME}" "#{pane_height}"`,
+    { encoding: "utf8" },
+  );
+  return Number(out.trim());
+}
+
+test.beforeAll(() => {
+  createSession(TEST_SESSION);
+});
+
+test.afterAll(() => {
+  killSession(TEST_SESSION);
+});
+
+test("keyboard open/collapse: xterm+tmux refit and the bottom-bar floor toggles", async ({ page }) => {
+  newWindow(TEST_SESSION, WINDOW_NAME);
+  const { windowId } = await resolveWindowRaw(page, TMUX_SERVER, TEST_SESSION, WINDOW_NAME);
+  // Direct goto — _ready's gotoWindow waits on the sidebar's Connected dot,
+  // which a 375px viewport never shows (drawer closed). The rows poll below is
+  // the mobile-compatible readiness signal.
+  await page.goto(`/${TMUX_SERVER}/${encodeURIComponent(windowId)}`);
+
+  // Terminal registered and painted.
+  await expect
+    .poll(() => page.evaluate((wid) => window.__rkTerminals?.[wid]?.rows ?? 0, windowId), {
+      timeout: 15_000,
+    })
+    .toBeGreaterThan(10);
+
+  const snapshot = () =>
+    page.evaluate((wid) => {
+      const term = window.__rkTerminals?.[wid];
+      const toolbar = document.querySelector('[role="toolbar"][aria-label="Terminal keys"]');
+      return {
+        rows: term?.rows ?? -1,
+        appHeight: document.documentElement.style.getPropertyValue("--app-height"),
+        kbOpen: document.documentElement.classList.contains("kb-open"),
+        coarse: window.matchMedia("(pointer: coarse)").matches,
+        toolbarPb: toolbar ? getComputedStyle(toolbar).paddingBottom : "NO-TOOLBAR",
+      };
+    }, windowId);
+
+  const base = await snapshot();
+  expect(base.coarse, "pointer:coarse must match for the floor to apply").toBe(true);
+  expect(base.kbOpen).toBe(false);
+  // The content-sized-tile fixed point is exactly 24 rows (xterm's default);
+  // a properly sized tile at 812px yields far more (~50 at the 11px mobile
+  // font). >30 is the regression tripwire with slack for font-metric drift.
+  expect(base.rows, "mobile tile must size the terminal (24 = the content-sized fixed point)").toBeGreaterThan(30);
+  // coarse + no keyboard → raised 1rem floor
+  expect(base.toolbarPb).toBe("16px");
+
+  // ── Keyboard opens ──
+  await page.setViewportSize(KEYBOARDED);
+  await expect.poll(async () => (await snapshot()).kbOpen, { timeout: 5_000 }).toBe(true);
+  await expect
+    .poll(async () => (await snapshot()).rows, { timeout: 10_000 })
+    .toBeLessThan(base.rows);
+  // keyboard open → floor drops to 6px
+  expect((await snapshot()).toolbarPb).toBe("6px");
+
+  // ── Keyboard collapses ──
+  await page.setViewportSize(FULL);
+  await expect.poll(async () => (await snapshot()).kbOpen, { timeout: 5_000 }).toBe(false);
+  // xterm must re-expand to (at least) its baseline rows…
+  await expect
+    .poll(async () => (await snapshot()).rows, { timeout: 10_000 })
+    .toBeGreaterThanOrEqual(base.rows);
+  // …tmux must have been told (pane_height = xterm rows − 2 tmux status lines)…
+  await expect.poll(() => tmuxPaneHeight(), { timeout: 10_000 }).toBeGreaterThanOrEqual(base.rows - 2);
+  const restored = await snapshot();
+  // …and the raised floor must return, on the restored full-height viewport.
+  expect(restored.toolbarPb).toBe("16px");
+  expect(restored.appHeight).toBe("812px");
+});


### PR DESCRIPTION
## Summary

On mobile viewports the surface-layout tile wrapper rendered with no size of its own (desktop tiles are sized by the grid via `slotStyle`; the mobile branch passed `style: undefined` and no `flex-1`), so the visible tile was **content-sized by xterm's own canvas** — a stable fixed point (canvas sizes tile, tile sizes fit, fit sizes canvas) that pinned the terminal at its 80×24 default and made it deaf to every viewport change. On iPhone this presented as the terminal never expanding after the on-screen keyboard collapsed (dead space between the tmux status line and the bottom bar). Regression from the Surface Layout Core rework (#569).

One-class fix: the mobile tile carries `flex-1` so the single visible slot fills the column. Verified end-to-end with a new e2e spec that simulates the keyboard via width-constant viewport height changes: rows now go 50 → 29 → 50 across an open/collapse cycle with the tmux pane following, where before they sat at 24 throughout.

## Changes

- `surface-layout.tsx` — mobile tiles get `flex-1` (hidden tiles keep `hidden`; desktop branch untouched)
- `mobile-keyboard-refit.spec.ts` + `.spec.md` — keyboard open/collapse refit guardrail: terminal rows track the viewport (24-row fixed point is the regression tripwire), tmux pane follows, and the bottom-bar safe floor (260805-fi9m) toggles 16px → 6px → 16px with `html.kb-open`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
