### PR TITLE
fix: flush operator slab under group header + align right rail with top-bar chips

### DIFF
--- a/app/frontend/src/components/right-panel.tsx
+++ b/app/frontend/src/components/right-panel.tsx
@@ -11,7 +11,7 @@ import {
  * docs/specs/surface-layout.md § Verbs — "Rail semantics change"). The panel
  * slot (surface mount + width drag, 260811-2r1w) is SUBSUMED by layout tiles —
  * the divider logic lives in `surface-layout.tsx` now; what remains of this
- * component is the fixed ~38px vertical rail on the terminal route's right
+ * component is the fixed 52px vertical rail on the terminal route's right
  * edge — rendered inside the Shell grid's full-height third column
  * (260812-nm4p), which the top-bar rail toggle collapses; layout tiles live in
  * the content column and survive a rail collapse. The file name and the
@@ -63,7 +63,10 @@ export function RightPanel({ available, open, onToggle }: RightPanelProps) {
   return (
     <div
       data-testid="right-panel-rail"
-      className="w-[38px] shrink-0 border-l border-border flex flex-col items-center py-1 gap-1"
+      // 52px = 28px button + 12px inset each side: centering the w-7 buttons
+      // makes their right edge co-linear with the top-bar chips above (which
+      // sit 12px from the window edge) — one vertical seam down the right side.
+      className="w-[52px] shrink-0 border-l border-border flex flex-col items-center py-1 gap-1"
     >
       {shown.map((surface) => {
         const isOpen = open.includes(surface);

--- a/app/frontend/src/components/right-panel.tsx
+++ b/app/frontend/src/components/right-panel.tsx
@@ -63,10 +63,13 @@ export function RightPanel({ available, open, onToggle }: RightPanelProps) {
   return (
     <div
       data-testid="right-panel-rail"
-      // 52px = 28px button + 12px inset each side: centering the w-7 buttons
-      // makes their right edge co-linear with the top-bar chips above (which
-      // sit 12px from the window edge) — one vertical seam down the right side.
-      className="w-[52px] shrink-0 border-l border-border flex flex-col items-center py-1 gap-1"
+      // The rail is the top-bar cluster's vertical twin, so it maps the bar's
+      // spacing vocabulary axis-for-axis: 52px = 28px button + 12px inset each
+      // side (centering the w-7 buttons puts their right edge co-linear with
+      // the top-bar chips, which sit 12px from the window edge — one vertical
+      // seam down the right side); gap-3 = the bar's 12px inter-chip gap; and
+      // py-2 = the 8px the bar's chips keep from its own top/bottom edges.
+      className="w-[52px] shrink-0 border-l border-border flex flex-col items-center py-2 gap-3"
     >
       {shown.map((surface) => {
         const isOpen = open.includes(surface);

--- a/app/frontend/src/components/sidebar/index.tsx
+++ b/app/frontend/src/components/sidebar/index.tsx
@@ -2401,13 +2401,18 @@ function ServerGroupInner(props: ServerGroupProps) {
       </div>
 
       {isOpen && (
-        <div className="pt-1 pb-1">
+        <>
           {/* Pinned operator row (260813-ifya): the ordinary WindowRow for this
               server's `role === "operator"` window, MOVED to the top of the
               group's session area (and excluded from its session group below).
               Placement is the ONLY difference — no badge, frame, or divider.
               Not draggable (it does not participate in window drag-reorder);
-              it still joins the roving-tabindex tree via rowKey/tabIndex. */}
+              it still joins the roving-tabindex tree via rowKey/tabIndex.
+              It sits OUTSIDE the pt-1 session-list container: its full-width
+              tinted slab (scanlines) must share an edge with the tinted group
+              header above — the 4px padding reads as a bare-background slice
+              between two colored bands there, while below the slab it reads as
+              intentional breathing room before the first session group. */}
           {operatorEntry && (
             <WindowRow
               win={operatorEntry.win}
@@ -2451,6 +2456,7 @@ function ServerGroupInner(props: ServerGroupProps) {
               onForkWindow={onForkWindow}
             />
           )}
+          <div className="pt-1 pb-1">
           {sessions.length === 0 ? (
             <button
               onClick={() => onCreateSession(server)}
@@ -2639,7 +2645,8 @@ function ServerGroupInner(props: ServerGroupProps) {
               );
             })
           )}
-        </div>
+          </div>
+        </>
       )}
     </section>
   );

--- a/app/frontend/src/components/surface-layout.tsx
+++ b/app/frontend/src/components/surface-layout.tsx
@@ -690,8 +690,11 @@ export function SurfaceLayout({
         onPointerDownCapture={slot >= 0 ? () => focusSlot(slot) : undefined}
         onFocus={slot >= 0 ? () => focusSlot(slot) : undefined}
       >
+        {/* Header pr-3 (not px-1.5's 6px on both sides): the trailing verb
+            cluster keeps the same 12px air against the rail divider that the
+            rail's chips keep on their side — 12 · divider · 12 (PR #595). */}
         {!mobile && (
-          <div className="flex items-center gap-1.5 px-1.5 h-[30px] shrink-0 border-b border-border bg-bg-card font-mono text-[11px] text-text-secondary select-none">
+          <div className="flex items-center gap-1.5 pl-1.5 pr-3 h-[30px] shrink-0 border-b border-border bg-bg-card font-mono text-[11px] text-text-secondary select-none">
             {kind === "tty" && statusWindow && <StatusDot win={statusWindow} />}
             <span
               aria-hidden="true"


### PR DESCRIPTION
Spacing nitpicks from a pixel review of the dashboard (follow-up to #590) — four fixes unifying the chrome's spacing vocabulary:

## 1. Operator row slab flush under the server-group header

The pinned operator row's full-width scanline slab sat 4px below the tinted group header — the session list's `pt-1` showed as a bare-background slice between two colored bands (measured 8 retina px). The operator row now renders **outside** the padded container, flush under the header; the `pt-1`/`pb-1` stays for the session list, where it reads as intentional breathing room (and is invisible under untinted rows).

## 2. Right rail aligned to the top-bar button column

The rail was `w-[38px]` with centered 28px buttons → a 5px right inset, while every top-bar chip sits 12px from the window edge — the rail pair jutted ~7px past the panel-toggle chip directly above it. The rail is now `w-[52px]` (28 + 12 + 12), so the rail buttons' right edge is co-linear with the top-bar chips: one vertical seam down the right side. No hardcoded 38px consumers existed (grid column is content-sized; specs select by testid).

## 3. Rail spacing maps the bar's vocabulary axis-for-axis

The rail stacked its chips at `gap-1` (4px) beside the bar's `gap-3` (12px) — two spacing systems on the same corner. Now `gap-3` (the bar's inter-chip gap) and `py-2` (the 8px the bar's chips keep from its own top/bottom edges): the rail is the top-bar cluster's vertical twin — same chip size token, same right seam, same insets, same gaps.

## 4. Tile-header verb cluster keeps 12px air against the rail divider

With the rail aligned, the tile/rail divider had 12px of air on the rail side but only 6px on the tile side (`px-1.5`) — the verb cluster leaned on the wall. The tile-header row's `px-1.5` splits into `pl-1.5 pr-3`: the corner reads **12 · divider · 12**. Verb sizes are untouched — the 22px verbs stay deliberately quieter than the bar's 28px chips (hierarchy); only the inset rhythm unifies.

## Verification

- `tsc --noEmit` clean; `just test-frontend` 2757/2757 (re-run after each commit)
- `just test-e2e "operator-pinned-row"` 1/1, `just test-e2e "right-panel"` 15/15, `just test-e2e "surface-layout"` 10 passed + 1 pass-on-retry (known 10s-timeout flake class)
- Pure class/structure changes — no behavior, no API, no new tests warranted
