### PR TITLE
fix: slim the rail to 46px — dividers are minor seams, edges are major

### DIFF
--- a/app/frontend/src/components/right-panel.tsx
+++ b/app/frontend/src/components/right-panel.tsx
@@ -63,13 +63,15 @@ export function RightPanel({ available, open, onToggle }: RightPanelProps) {
   return (
     <div
       data-testid="right-panel-rail"
-      // The rail is the top-bar cluster's vertical twin, so it maps the bar's
-      // spacing vocabulary axis-for-axis: 52px = 28px button + 12px inset each
-      // side (centering the w-7 buttons puts their right edge co-linear with
-      // the top-bar chips, which sit 12px from the window edge — one vertical
-      // seam down the right side); gap-3 = the bar's 12px inter-chip gap; and
-      // py-2 = the 8px the bar's chips keep from its own top/bottom edges.
-      className="w-[52px] shrink-0 border-l border-border flex flex-col items-center py-2 gap-3"
+      // The rail is the top-bar cluster's vertical twin, mapping the bar's
+      // spacing vocabulary: right-aligned chips at pr-3 keep their right edge
+      // 12px from the window edge — co-linear with the top-bar chips (the
+      // MAJOR seam); gap-3 = the bar's 12px inter-chip gap; py-2 = the 8px the
+      // bar's chips keep from its own top/bottom edges. The left side hugs the
+      // tile divider at ~6px — dividers are MINOR seams (6px air on both
+      // sides, matching the tile-header verbs' inset on the other side), which
+      // is what keeps the column at 46px instead of a symmetric-12 52px band.
+      className="w-[46px] shrink-0 border-l border-border flex flex-col items-end pr-3 py-2 gap-3"
     >
       {shown.map((surface) => {
         const isOpen = open.includes(surface);

--- a/app/frontend/src/components/surface-layout.tsx
+++ b/app/frontend/src/components/surface-layout.tsx
@@ -690,11 +690,11 @@ export function SurfaceLayout({
         onPointerDownCapture={slot >= 0 ? () => focusSlot(slot) : undefined}
         onFocus={slot >= 0 ? () => focusSlot(slot) : undefined}
       >
-        {/* Header pr-3 (not px-1.5's 6px on both sides): the trailing verb
-            cluster keeps the same 12px air against the rail divider that the
-            rail's chips keep on their side — 12 · divider · 12 (PR #595). */}
+        {/* Header px-1.5: the rail divider is a MINOR seam with ~6px air on
+            both sides (the rail's chips hug it at the same distance on their
+            side) — only the window edge carries the 12px major-seam inset. */}
         {!mobile && (
-          <div className="flex items-center gap-1.5 pl-1.5 pr-3 h-[30px] shrink-0 border-b border-border bg-bg-card font-mono text-[11px] text-text-secondary select-none">
+          <div className="flex items-center gap-1.5 px-1.5 h-[30px] shrink-0 border-b border-border bg-bg-card font-mono text-[11px] text-text-secondary select-none">
             {kind === "tty" && statusWindow && <StatusDot win={statusWindow} />}
             <span
               aria-hidden="true"


### PR DESCRIPTION
Follow-up to #595: the symmetric 12px insets made the rail a 52px column that reads as a thick dead band below its two chips (user report, verified against side-by-side width studies).

**Variant B — 46px (6 · 28 · 12):**

- The chips' **right edge stays co-linear with the top-bar column** — the 12px inset at the window edge is the *major seam* and is untouched (`items-end pr-3` instead of `items-center`).
- The tile/rail **divider is demoted to a minor seam**: ~6px of air on both of its sides. The rail chips hug it from the right, and the tile-header verb cluster returns to its original `px-1.5` (reverting #595's `pr-3`), so the divider's symmetry survives at the smaller value.
- Net rule: **12px at edges, 6px around internal dividers.** The column slims 52 → 46px and gives the terminal 6px back.

## Verification

- `tsc --noEmit` clean; `just test-frontend` 2766/2766
- `just test-e2e "right-panel"` 15/15, `just test-e2e "surface-layout"` 11/11
- Pure class changes; nothing asserts the rail width (specs select by testid)
