### PR TITLE
refactor: Reduce Code Comment Density

### DIFF
--- a/app/backend/api/sessions.go
+++ b/app/backend/api/sessions.go
@@ -28,7 +28,6 @@ func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Tightened new-name rule (no spaces) — this names a to-be-created session.
 	if errMsg := validate.ValidateNewName(body.Name, "Session name"); errMsg != "" {
 		writeError(w, http.StatusBadRequest, errMsg)
 		return
@@ -71,10 +70,9 @@ func (s *Server) handleSessionRename(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Tightened new-name rule (no spaces) — this is the renamed-TO name. The
-	// URL-param `session` above stays on the permissive ValidateName so a
-	// pre-existing spacey session (created outside run-kit) can still be the
-	// rename SOURCE.
+	// Only the renamed-TO name gets the tightened new-name rule: the URL-param
+	// source above stays on permissive ValidateName so a pre-existing spacey
+	// session (created outside run-kit) can still be renamed.
 	if errMsg := validate.ValidateNewName(body.Name, "Session name"); errMsg != "" {
 		writeError(w, http.StatusBadRequest, errMsg)
 		return
@@ -89,30 +87,25 @@ func (s *Server) handleSessionRename(w http.ResponseWriter, r *http.Request) {
 }
 
 // sessionStringOption describes one session-scoped string-option channel for
-// handleSessionStringOption: how to decode the value from the JSON body, the
-// shared validation rule, and the tmux set/unset pair. Adding a channel is a
-// new descriptor plus a route registration — not a new handler.
+// handleSessionStringOption. Adding a channel is a new descriptor plus a
+// route registration — not a new handler.
 type sessionStringOption struct {
-	// decode extracts the channel's value pointer from the request body via a
-	// per-channel struct decode, so encoding/json's field-matching semantics
-	// (unknown keys ignored, case-insensitive key fold) are preserved exactly
-	// as the old dedicated handlers had them. A json error means 400.
+	// decode extracts the channel's value pointer via a per-channel struct
+	// decode, deliberately preserving encoding/json's field-matching semantics
+	// (unknown keys ignored, case-insensitive key fold).
 	decode func(r *http.Request) (*string, error)
-	// validate is the channel's shared value rule (empty return = valid). It
-	// also decides whether an explicit "" is settable at all: a channel whose
-	// closed set admits "" (flair) falls through to the unset arm below, while
-	// a channel that rejects it (color) 400s here — so null is color's only
-	// clear form.
+	// validate is the channel's value rule (empty return = valid). It also
+	// decides whether an explicit "" is settable: a closed set admitting ""
+	// (flair) falls through to the unset arm, while one rejecting it (color)
+	// 400s — so null is color's only clear form.
 	validate func(value string) string
-	// set / unset are the channel's tmux session-option pair.
-	set   func(session, value, server string) error
-	unset func(session, server string) error
+	set      func(session, value, server string) error
+	unset    func(session, server string) error
 }
 
 // handleSessionStringOption is the shared handler behind the session-scoped
-// string-option endpoints (color, flair): validate the session name, decode
-// {"<field>": <string|null>} (an absent field reads as null), validate the
-// value, then set (non-empty value) or unset (null or empty).
+// string-option endpoints (color, flair): decode {"<field>": <string|null>}
+// (an absent field reads as null), then set (non-empty) or unset (null/empty).
 func (s *Server) handleSessionStringOption(w http.ResponseWriter, r *http.Request, opt sessionStringOption) {
 	session := chi.URLParam(r, "session")
 	if errMsg := validate.ValidateName(session, "Session name"); errMsg != "" {
@@ -145,12 +138,9 @@ func (s *Server) handleSessionStringOption(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Wake the SSE hub so the option change surfaces on the next poll pass
-	// instead of the 12s safety tick — set-option is invisible to the tmuxctl
-	// control-mode parser, so no subscriber notification fires. Mirrors
-	// handleSessionOrderPost's initSSEHub-then-hub-call pattern; initSSEHub is
-	// idempotent. Only reached on a successful tmux write (validation/tmux
-	// errors returned early above).
+	// Wake the SSE hub: set-option is invisible to the tmuxctl control-mode
+	// parser, so without this the change waits for the 12s safety tick.
+	// initSSEHub is idempotent.
 	s.initSSEHub()
 	s.sseHub.wake(server)
 
@@ -158,8 +148,7 @@ func (s *Server) handleSessionStringOption(w http.ResponseWriter, r *http.Reques
 }
 
 // handleSessionColor sets or clears the @session_color session option.
-// POST /api/sessions/{session}/color ← {"color": "1+3"} sets; null clears
-// ("" is rejected by the color-value rule).
+// POST /api/sessions/{session}/color ← {"color": "1+3"} sets; null clears.
 func (s *Server) handleSessionColor(w http.ResponseWriter, r *http.Request) {
 	s.handleSessionStringOption(w, r, sessionStringOption{
 		decode: func(r *http.Request) (*string, error) {
@@ -177,8 +166,7 @@ func (s *Server) handleSessionColor(w http.ResponseWriter, r *http.Request) {
 
 // handleSessionFlair sets or clears the @rk_session_flair session option
 // (scope-split from the window @rk_flair — see tmux.SetSessionFlair).
-// POST /api/sessions/{session}/flair ← {"flair": "onepiece"} sets; null or ""
-// clears (the flair closed set admits "", mirroring @rk_marker).
+// POST /api/sessions/{session}/flair ← {"flair": "onepiece"} sets; null/"" clears.
 func (s *Server) handleSessionFlair(w http.ResponseWriter, r *http.Request) {
 	s.handleSessionStringOption(w, r, sessionStringOption{
 		decode: func(r *http.Request) (*string, error) {
@@ -238,8 +226,7 @@ func (s *Server) handleSessionOrderPost(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Broadcast to any connected SSE clients on this server. initSSEHub is
-	// idempotent — a hub created here will pick up future SSE clients normally.
+	// initSSEHub is idempotent — a hub created here picks up future clients.
 	s.initSSEHub()
 	s.sseHub.broadcastSessionOrder(server, body.Order)
 

--- a/app/backend/api/settings.go
+++ b/app/backend/api/settings.go
@@ -32,7 +32,6 @@ func (s *Server) handleSetTheme(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "Invalid JSON body")
 		return
 	}
-	// Normalize: treat whitespace-only values as absent
 	if body.Theme != nil {
 		v := strings.TrimSpace(*body.Theme)
 		if v == "" {
@@ -155,7 +154,6 @@ func (s *Server) handleSetSSHHost(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "Invalid JSON body")
 		return
 	}
-	// Trim; treat a trimmed-to-empty value as a clear (same as null).
 	if body.SSHHost != nil {
 		v := strings.TrimSpace(*body.SSHHost)
 		if v == "" {

--- a/app/frontend/src/components/swatch-popover.tsx
+++ b/app/frontend/src/components/swatch-popover.tsx
@@ -21,97 +21,65 @@ type SwatchPopoverProps = {
    *  undefined when uncolored. Legacy values are normalized to their family
    *  (normal shade) so the correct swatch highlights. */
   selectedColor?: string;
-  /** Called with the value to STORE. The popover maps a picked NORMAL-shade
-   *  family name to its legacy numeric/blend descriptor (familyToLegacy)
-   *  before invoking this, so pre-existing stored color values stay in the
-   *  legacy vocabulary (zero migration). DARK-shade picks ("orange-dark") have
-   *  no legacy form and pass through verbatim — the backend validators accept
-   *  the family-name vocabulary alongside the numeric forms. `null` clears the
-   *  color. This is the single write seam every color-picking surface
-   *  (window/session/server rows + the palette "Set Color" actions) funnels
-   *  through. */
+  /** Called with the value to STORE — the single write seam every
+   *  color-picking surface (window/session/server rows + the palette "Set
+   *  Color" actions) funnels through. A picked NORMAL-shade family name is
+   *  mapped to its legacy numeric/blend descriptor (familyToLegacy) first, so
+   *  pre-existing stored values stay in the legacy vocabulary (zero
+   *  migration); DARK-shade picks ("orange-dark") have no legacy form and
+   *  pass through verbatim — the backend validators accept both
+   *  vocabularies. `null` clears the color. */
   onSelect: (color: string | null) => void;
-  /** Dismissal model (260723): selection NEVER dismisses — the picker stays
-   *  open so color + marker combos can be toggled and previewed live against
-   *  the row. It closes only via the explicit ✕ cell (row 0, col 4), a click
-   *  outside, or Escape. Callers therefore must NOT close in their
-   *  onSelect/onSelectMarker handlers — closing is this component's contract,
-   *  funneled through onClose. */
+  /** Dismissal model: selection NEVER dismisses — the picker stays open so
+   *  color + marker combos can be previewed live against the row. It closes
+   *  only via the explicit ✕ cell, a click outside, or Escape; callers must
+   *  NOT close in their onSelect/onSelectMarker handlers. */
   onClose: () => void;
-  /** ── Combined-label extension ── When `onSelectMarker` is supplied, the
-   *  popover renders the side-by-side Label picker: a marker column (∅ /
-   *  dotted / dashed / solid / double / thick) LEFT of a vertical hairline,
-   *  beside the color grid. Each non-∅ marker cell is a LIVE ROW PREVIEW — a
-   *  miniature window row rendered for the currently selected color:
-   *  background = that value's `tint.base` (gray sentinel when uncolored),
-   *  stripe in the guarded border color with a 2px left inset (so the marker
-   *  does not kiss the cell edge and the cell reads as a mini row), plus the
-   *  paired row texture: hazard weave on thick (mask dropped via
-   *  rk-hazard-preview — the 18px cell reads as the row's full-strength left
-   *  corner), scanline wash on double, data rain on dashed. Picking a
-   *  different swatch repaints the marker column immediately. PREVIEWS MIRROR
-   *  THE ROW'S RESTING LOOK: the dashed rain animates (it is always-on on real
-   *  rows), but the double cell never gets the scanline crawl — that is
-   *  selected-state motion, absent even when double is selected.
-   *  Selection calls `onSelectMarker` DIRECTLY (no cycling — any state is one
-   *  click) with `""` clearing the marker. Keyboard nav crosses the hairline
-   *  (ArrowLeft/Right). When `onSelectMarker` is ABSENT the component renders
-   *  the pure color grid (session/server rows + the palette color actions) —
-   *  same square style, no marker column, no hairline. */
+  /** When `onSelectMarker` is supplied, the popover renders the side-by-side
+   *  Label picker: a marker column (∅ / dotted / dashed / solid / double /
+   *  thick) LEFT of a vertical hairline. Non-∅ cells are LIVE ROW PREVIEWS of
+   *  the currently selected color, mirroring the row's RESTING look (details
+   *  at the marker-column JSX). Selection calls `onSelectMarker` DIRECTLY —
+   *  any state is one click, `""` clears. Keyboard nav crosses the hairline
+   *  (ArrowLeft/Right). When ABSENT, the pure color grid renders — same
+   *  square style, no marker column, no hairline. */
   selectedMarker?: string;
   onSelectMarker?: (marker: string) => void;
-  /** ── Flair extension ── When `onSelectFlair` is supplied, the popover
-   *  renders a flair section: ONE row of four cells (∅ / nyan / naruto /
-   *  onepiece, from FLAIR_STATES) below the color grid, separated by a
-   *  horizontal hairline. Each non-∅ cell is a miniature live row preview
-   *  carrying its always-on animated flair overlay (rk-flair-*), mirroring
-   *  the marker column's live-preview pattern (tint.base background like the
-   *  marker previews; the overlay animates exactly as it does on real rows).
-   *  Selection calls `onSelectFlair` DIRECTLY with the exact state — `""`
-   *  clears, no cycling. Keyboard nav reaches the cells as an extra grid row
-   *  (FLAIR_ROW) under the color grid: ArrowDown from the bottom color row
-   *  enters it, ArrowLeft/Right walk it. Available on every flair-capable
-   *  caller — window rows (beside the marker column) and session rows; NOT
-   *  server group headers, which mirror the SERVER-pane tiles. When
-   *  `onSelectFlair` is ABSENT no flair row renders. */
+  /** When `onSelectFlair` is supplied, a flair row (∅ / nyan / naruto /
+   *  onepiece) renders below the color grid behind a horizontal hairline —
+   *  live row previews like the marker column, each carrying its always-on
+   *  rk-flair-* overlay. Selection calls `onSelectFlair` DIRECTLY — `""`
+   *  clears, no cycling. ArrowDown from the bottom color row enters it as an
+   *  extra grid row (FLAIR_ROW). Offered on window and session rows; NOT
+   *  server group headers. */
   selectedFlair?: string;
   onSelectFlair?: (flair: string) => void;
 };
 
-/** Colors per row in the color grid. The layout is a conceptual 5-column grid:
- *  marker column (col 0, when shown) + 4 color columns (cols 1–4), 6 rows
- *  (removal row + 5 color rows). The 4-wide layout renders each family's two
- *  shades ADJACENT (row 1: red, red-dark, orange, orange-dark; …) because
- *  PICKER_COLOR_VALUES is in paired order. */
+/** Colors per row. The layout is a conceptual 5-column grid: marker column
+ *  (col 0, when shown) + 4 color columns (cols 1–4), 6 rows (removal row + 5
+ *  color rows). The 4-wide layout renders each family's two shades ADJACENT
+ *  because PICKER_COLOR_VALUES is in paired order. */
 const COLOR_COLS = 4;
 
-/** The marker-cell order shown in the picker column: none / dotted / dashed /
- *  solid / double / thick. Mirrors MARKER_STATES, with `∅` in row 0 (the
- *  removal row) and the five non-empty states beside the five color rows.
- *
- *  DELIBERATE 1:1 PAIRING (supersedes the former "load-bearing coincidence"):
- *  the marker column and the color grid are sized to pair row-for-row —
- *  6 marker cells ↔ 6 grid rows (Clear + 20 colors laid out 4-wide). The
- *  invariant GRID_ROWS === MARKER_CELLS.length is part of the design (and
- *  asserted in swatch-popover.test.tsx): extend MARKER_STATES and
+/** DELIBERATE 1:1 PAIRING: the marker column and the color grid pair
+ *  row-for-row — the invariant GRID_ROWS === MARKER_CELLS.length is part of
+ *  the design (asserted in swatch-popover.test.tsx). Extend MARKER_STATES and
  *  PICKER_COLOR_VALUES together so it holds. */
 const MARKER_CELLS = MARKER_STATES;
 
 /** Number of grid rows: the removal row + 20 / 4 = 5 color rows. */
 const GRID_ROWS = 1 + Math.ceil(PICKER_COLOR_VALUES.length / COLOR_COLS); // 6
 
-/** The flair row index (flair-enabled callers only): ONE row directly below
- *  the color grid, its four cells (∅ / nyan / naruto / onepiece) occupying
- *  cols 1–4 of the conceptual grid. The marker column does NOT extend into
- *  it — ArrowLeft from the flair row's first cell is a no-op. */
+/** The flair row index: one row below the color grid, cells at cols 1–4. The
+ *  marker column does NOT extend into it — ArrowLeft from its first cell is a
+ *  no-op. */
 const FLAIR_ROW = GRID_ROWS;
 
-/** Keyboard focus position on the conceptual 5-column grid.
- *  - `row`: 0 = removal row (∅ | Clear | ✕), 1–5 = color rows, FLAIR_ROW (6)
- *    = the flair row (only valid when the flair section is shown).
- *  - `col`: 0 = marker column (only valid when markers shown); 1–4 = color
- *    columns. On row 0 the `Clear` button spans cols 1–3 as a SINGLE focus
- *    target canonicalized to col 1, and the ✕ close cell sits at col 4. */
+/** Keyboard focus position on the conceptual grid. row 0 = removal row
+ *  (∅ | Clear | ✕), 1–5 = color rows, FLAIR_ROW = flair row; col 0 = marker
+ *  column, 1–4 = color columns. On row 0 the Clear button spans cols 1–3 as a
+ *  SINGLE focus target canonicalized to col 1; the ✕ cell sits at col 4. */
 type GridPos = { row: number; col: number };
 
 /** Color-array index for a grid position (rows 1–5, cols 1–4). */
@@ -119,9 +87,9 @@ function colorIndexAt(row: number, col: number): number {
   return (row - 1) * COLOR_COLS + (col - 1);
 }
 
-/** Last valid color column in a color row. With 20 colors filling 5×4 exactly
- *  there are no dead cells any more — every color row's last column is 4 — but
- *  the clamp is kept generic so a future vocabulary change degrades safely. */
+/** Last valid color column in a color row. 20 colors fill the 5×4 grid
+ *  exactly, but the clamp is kept generic so a future vocabulary change
+ *  degrades safely. */
 function maxColorCol(row: number): number {
   const rowStart = (row - 1) * COLOR_COLS;
   const inRow = Math.min(PICKER_COLOR_VALUES.length - rowStart, COLOR_COLS);
@@ -144,28 +112,20 @@ export function SwatchPopover({
     [theme.palette, theme.category],
   );
 
-  // The marker section is rendered only when a marker write callback is
-  // present. Color-only callers omit it and get the pure color grid (same
-  // square style, no marker column).
   const showMarkers = !!onSelectMarker;
-
-  // The flair section (a row below the color grid) renders only when a flair
-  // write callback is present. Color-only callers omit it.
   const showFlair = !!onSelectFlair;
 
-  // Normalize the incoming selection to its canonical display value
-  // ("orange" / "orange-dark") so a legacy-stored value ("1+3") highlights the
-  // same swatch as its family, and a dark-stored value highlights the DARK
-  // swatch (not its normal sibling). Undefined when uncolored or unrecognized.
+  // Normalize the selection to its canonical display value so a legacy-stored
+  // value ("1+3") highlights its family swatch and a dark-stored value
+  // highlights the DARK swatch (not its normal sibling).
   const parsedSelected = parseColorValue(selectedColor);
   const selectedValue = parsedSelected ? formatColorValue(parsedSelected) : undefined;
 
-  // Live preview color for the marker row previews. Derived from the selection
-  // prop, but a swatch pick ALSO updates this local override so the marker
-  // column repaints immediately regardless of whether (or how fast) the caller
-  // echoes the selection back through props — the popover stays open on pick,
-  // and the preview must not lag the click. `undefined` = no override;
-  // `null` = cleared (gray sentinel).
+  // Preview color for the marker/flair cells. A swatch pick updates this
+  // local override so the previews repaint immediately regardless of whether
+  // (or how fast) the caller echoes the selection back through props — the
+  // popover stays open on pick, and the preview must not lag the click.
+  // `undefined` = no override; `null` = cleared (gray sentinel).
   const [previewOverride, setPreviewOverride] = useState<string | null | undefined>(undefined);
   const previewValue = previewOverride === undefined ? selectedValue : previewOverride ?? undefined;
   const previewTint =
@@ -176,11 +136,8 @@ export function SwatchPopover({
     rowBorders.get(UNCOLORED_SELECTED_KEY) ??
     theme.palette.foreground;
 
-  // The single write seam: map a picked NORMAL-shade family name ("orange") to
-  // its legacy descriptor ("1+3") before handing it to the caller's onSelect,
-  // so pre-existing stored color values stay in the legacy vocabulary. Dark
-  // picks ("orange-dark") and `null` (Clear) pass through untouched. Also
-  // repaints the marker row previews (local override above).
+  // The write seam: legacy mapping per the onSelect prop doc, plus the
+  // immediate preview repaint (local override above).
   const emit = useCallback(
     (value: string | null) => {
       setPreviewOverride(value);
@@ -189,44 +146,32 @@ export function SwatchPopover({
     [onSelect],
   );
 
-  // Normalize the current marker to one of the known cells ("" when unset).
   const currentMarker = selectedMarker ?? "";
-
-  // Normalize the current flair the same way ("" when unset).
   const currentFlair = selectedFlair ?? "";
 
-  // Initial focus FOLLOWS SELECTION: the selected color swatch, or the Clear
-  // color cell (row 0 — already aria-selected in that state) when uncolored.
-  // Never an arbitrary swatch — a focus ring on an unselected color reads as a
-  // phantom selection. The marker column is reached via ArrowLeft.
+  // Initial focus FOLLOWS SELECTION: the selected swatch, or the Clear cell
+  // when uncolored — never an arbitrary swatch, whose focus ring would read
+  // as a phantom selection.
   const [focus, setFocus] = useState<GridPos>(() => {
     const idx = selectedValue != null ? PICKER_COLOR_VALUES.indexOf(selectedValue) : -1;
     if (idx < 0) return { row: 0, col: 1 };
     return { row: Math.floor(idx / COLOR_COLS) + 1, col: (idx % COLOR_COLS) + 1 };
   });
-  // Focus-visible semantics: the focus ring renders only after the keyboard
-  // has actually been used (first arrow key). The listbox autofocuses on
-  // mount, so an always-on ring would show mouse users a phantom highlight
-  // they never asked for.
+  // The focus ring renders only after the first arrow key: the listbox
+  // autofocuses on mount, so an always-on ring would show mouse users a
+  // phantom highlight.
   const [keyboardActive, setKeyboardActive] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Activate the cell at a grid position (Enter/Space). The marker column maps
-  // to onSelectMarker; row 0's color side is Clear (cols 1–3) and the ✕ close
-  // cell (col 4); color cells map to onSelect.
+  // Activate the cell at a grid position (Enter/Space).
   const activate = useCallback(
     (pos: GridPos) => {
       if (pos.row === FLAIR_ROW) {
-        // Flair row: FLAIR_STATES[col - 1] — ∅ at col 1 (clears), then nyan /
-        // naruto / onepiece at cols 2–4. Direct pick, no cycling. The explicit
-        // undefined check mirrors the marker column's pairing guard.
         const flair = FLAIR_STATES[pos.col - 1];
         if (onSelectFlair && flair !== undefined) onSelectFlair(flair);
       } else if (pos.col === 0) {
-        // Marker column: MARKER_CELLS[row] — ∅ in row 0, the five non-empty
-        // states beside the five color rows (the deliberate 1:1 pairing
-        // above). The explicit undefined check guards against that pairing
-        // drifting (GRID_ROWS outgrowing MARKER_CELLS) — never emit undefined.
+        // The undefined check guards against the 1:1 pairing drifting
+        // (GRID_ROWS outgrowing MARKER_CELLS) — never emit undefined.
         const marker = MARKER_CELLS[pos.row];
         if (onSelectMarker && marker !== undefined) onSelectMarker(marker);
       } else if (pos.row === 0) {
@@ -253,10 +198,9 @@ export function SwatchPopover({
     return () => document.removeEventListener("keydown", handleKeyDown, true);
   }, [onClose]);
 
-  // Autofocus the listbox on mount so keyboard nav works immediately — the
-  // `Window: Label` palette action is the only keyboard path to the marker
-  // section, and arrow keys are dead until the listbox has focus. Mirrors
-  // pin-popover.tsx's mount-focus of its input.
+  // Autofocus the listbox on mount — the `Window: Label` palette action is
+  // the only keyboard path to the marker section, and arrow keys are dead
+  // until the listbox has focus.
   useEffect(() => {
     containerRef.current?.focus();
   }, []);
@@ -278,11 +222,9 @@ export function SwatchPopover({
     };
   }, [onClose]);
 
-  // Arrow-key movement on the conceptual grid. ArrowLeft/ArrowRight cross the
-  // vertical hairline (marker column ↔ color columns); ArrowUp/ArrowDown move
-  // within a column. Moves off a grid edge clamp to the nearest valid cell
-  // (no-op at hard edges) — 20 colors fill the 5×4 grid exactly, so there are
-  // no dead cells, but the clamp stays for safety.
+  // Arrow-key movement: ArrowLeft/Right cross the hairline (marker ↔ color),
+  // ArrowUp/Down move within a column; edge moves clamp to the nearest valid
+  // cell.
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key.startsWith("Arrow")) setKeyboardActive(true);
@@ -339,8 +281,8 @@ export function SwatchPopover({
   const focusOnClose = keyboardActive && focus.row === 0 && focus.col === COLOR_COLS;
 
   return (
-    // TipGroup: the marker cells are a warm-tip cluster (260722-73al) —
-    // sweeping down the tiny 18px cells names each marker instantly.
+    // TipGroup: the marker cells are a warm-tip cluster — sweeping down the
+    // tiny 18px cells names each marker instantly.
     <TipGroup>
     <div
       ref={containerRef}
@@ -352,16 +294,11 @@ export function SwatchPopover({
       style={{ boxShadow: "3px 3px 0 rgba(0,0,0,.35)" }}
     >
       <div className="flex">
-        {/* Marker column (col 0) + vertical hairline — Label-picker callers only.
-            Each 18px cell + 3px gap row-aligns 1:1 with the color grid beside it:
-            ∅ beside Clear color (the removal row), dotted/dashed/solid/double/
-            thick beside the five color rows. Non-∅ cells are LIVE ROW PREVIEWS
-            of the currently selected color: tint.base background (gray sentinel
-            when uncolored), guarded-color stripe with a 2px left inset, and the
-            paired row texture (scanline wash on double, hazard weave on thick,
-            data rain on dashed). Previews mirror the row's RESTING look — the
-            always-on rain animates, but never rk-scanlines-crawl (selected-
-            state motion) here. */}
+        {/* Marker column (col 0) + vertical hairline. Each 18px cell + 3px gap
+            row-aligns 1:1 with the color grid beside it. Non-∅ cells are LIVE
+            ROW PREVIEWS of the currently selected color: tint.base background
+            (gray sentinel when uncolored), guarded-color stripe, and the
+            paired row texture. */}
         {showMarkers && (
           <>
             <div className="flex flex-col gap-[3px]">
@@ -393,11 +330,11 @@ export function SwatchPopover({
                     }
                   >
                     {/* Paired row texture — the row's RESTING look: the dashed
-                        rain animates (always-on on real rows), but no crawl
-                        class ever, even when double is selected. The thick
-                        cell drops the hazard's left-wedge mask (preview
-                        modifier) — masked at 18px the weave fades out under
-                        the 6px stripe and is invisible. */}
+                        rain animates (always-on on real rows) but never the
+                        crawl (selected-state motion), even when double is
+                        selected. The thick cell drops the hazard's left-wedge
+                        mask — masked at 18px the weave is invisible under the
+                        6px stripe. */}
                     {state === "double" && (
                       <span aria-hidden="true" className="rk-scanlines absolute inset-0 pointer-events-none" />
                     )}
@@ -407,8 +344,7 @@ export function SwatchPopover({
                     {state === "thick" && (
                       <span aria-hidden="true" className="rk-hazard rk-hazard-preview absolute inset-0 pointer-events-none" />
                     )}
-                    {/* Mini-row stripe: guarded color, 2px inset off the cell's
-                        left edge so the marker doesn't kiss the boundary. */}
+                    {/* Stripe inset 2px so the marker doesn't kiss the edge. */}
                     {stripe && (
                       <span className="absolute inset-y-0 right-0" style={{ left: 2, ...stripe }} />
                     )}
@@ -425,10 +361,8 @@ export function SwatchPopover({
             <div className="w-px bg-border mx-1.5 self-stretch" aria-hidden="true" />
           </>
         )}
-        {/* Color section (cols 1–4): the removal row — Clear (cols 1–3) + the
-            ✕ close cell (col 4, the explicit dismiss; selection never closes) —
-            then the 20 family/shade swatches laid out 4-wide in PAIRED order —
-            each family's normal|dark shades adjacent (5 full rows). */}
+        {/* Color section (cols 1–4): the removal row (Clear + ✕), then the 20
+            family/shade swatches 4-wide in PAIRED order. */}
         <div className="grid grid-cols-4 gap-[3px]">
           <button
             role="option"
@@ -441,9 +375,7 @@ export function SwatchPopover({
             Clear
           </button>
           {/* ✕ — the explicit dismiss. role=option (never aria-selected) so
-              the listbox holds only ARIA-valid children — an option-as-command,
-              the same pattern Clear already uses. Escape and outside-click
-              remain the other two close paths. */}
+              the listbox holds only ARIA-valid children. */}
           <button
             role="option"
             aria-selected={false}
@@ -458,10 +390,9 @@ export function SwatchPopover({
           {PICKER_COLOR_VALUES.map((value, i) => {
             const tint = rowTints.get(value);
             const fallback = colorValueToHex(value, theme.palette) ?? theme.palette.foreground;
-            // Uniform SOLID square: one fill — the value's selected-tint blend
-            // (no more split base/selected halves). The bright selection ring +
-            // ✓ glyph keep the picked swatch unambiguous between adjacent
-            // same-family shades.
+            // One solid fill (the value's selected-tint blend); the ring + ✓
+            // keep the picked swatch unambiguous between adjacent same-family
+            // shades.
             const fill = tint?.selected ?? fallback;
             const isSelected = selectedValue === value;
             const isFocused =
@@ -488,14 +419,8 @@ export function SwatchPopover({
               </button>
             );
           })}
-          {/* Flair section (flair-enabled callers only): one row below the
-              color grid, behind a horizontal hairline — ∅ (clear) at col 1,
-              then nyan / naruto / onepiece at cols 2–4. Each non-∅ cell is a
-              miniature LIVE ROW PREVIEW following the marker column's pattern:
-              the selected color's tint.base background (gray sentinel when
-              uncolored) carrying its always-on animated rk-flair-* overlay,
-              exactly the row's resting look. Selection calls onSelectFlair
-              DIRECTLY — "" clears, no cycling. */}
+          {/* Flair row: live row previews of the selected color, each carrying
+              its always-on rk-flair-* overlay. */}
           {showFlair && (
             <>
               <div className="col-span-4 h-px bg-border self-center" aria-hidden="true" />
@@ -522,8 +447,6 @@ export function SwatchPopover({
                         : undefined
                     }
                   >
-                    {/* The flair overlay itself, running live (always-on on
-                        real rows, so the preview carries it too). */}
                     {isPreview && (
                       <span aria-hidden="true" className={`rk-flair-${state} absolute inset-0 pointer-events-none`} />
                     )}

--- a/app/frontend/src/globals.css
+++ b/app/frontend/src/globals.css
@@ -540,63 +540,41 @@ summary {
 }
 
 /* ── Flair overlays (decoration-only channel) ────────────────────────────────
-   A row carrying a flair value (`nyan` / `naruto` / `onepiece`) gets an
-   always-on, ambient, CSS-only animated overlay — pure decoration: no wiring
-   to @rk_agent_state or the status pyramid, and it animates in EVERY row
-   state (rest, hover, selected). Mounted on window rows and session rows (NOT
-   server group headers, which mirror the flair-free SERVER-pane tiles) as a
-   dedicated absolutely-positioned inner element
-   (inset-0, overflow-hidden, pointer-events-none, z-5) — the SAME overlay
-   discipline as .rk-scanlines: clipping lives on the overlay, NEVER the row
-   root (whose top-full popovers must stay unclipped).
+   Always-on CSS-only overlays for rows carrying a flair value (`nyan` /
+   `naruto` / `onepiece`) — pure decoration: no wiring to @rk_agent_state or
+   the status pyramid, and it animates in EVERY row state. Mounted on window
+   and session rows (NOT server group headers) as an absolutely-positioned
+   inner element (inset-0, overflow-hidden, pointer-events-none, z-5) — the
+   .rk-scanlines overlay discipline: clipping lives on the overlay, NEVER the
+   row root (whose top-full popovers must stay unclipped).
 
-   Sprites are ORIGINAL stylized pixel art embedded as inline SVG data URIs —
-   no external requests, no copyrighted assets. Traversal is
-   background-position only, NEVER transform (the drag-ghost rule — see
-   .rk-scanlines-crawl) and never `left` (no layout thrash).
-
-   FRAME ANIMATION (the sprite-sheet mechanism): each sprite is a VERTICAL
-   sheet of 22px-tall frames (frame n at y = -22n). The two
-   background-position LONGHANDS animate independently and compose without
-   clobbering (the same longhand-split the onepiece bob pioneered):
-   background-position-x carries the slow linear traversal, while
-   background-position-y steps through the sheet with `step-end` keyframes —
-   a run cycle, sail billow, flag flutter, and bob at classic low-fps sprite
-   cadence, all compositor-only. The pseudos are fixed 22px strips (static
-   top/margin centering, no animated layout), so the px frame offsets hold at
-   every row height (24px rows, 36px coarse rows, 18px picker preview cells).
-
-   Each sprite layer is no-repeat and slides from a fully-off-left negative
-   offset to a fully-off-right `calc(100% + Npx)` (the scanline-band trick: a
-   no-repeat background outside its area paints nothing), so any row width
-   traverses edge-to-edge. A trail layer rides the SAME keyframes as its
-   sprite on the same pseudo; the from/to constants are balanced per layer
-   (start offset − image width + end offset equal across layers) so both
-   layers displace by identical px and the trail stays glued to the sprite.
-   Ambient parallax layers (nyan's starfield, naruto's speed streaks, the
-   onepiece waves) live on ::before as repeat-x tiles drifting the OPPOSITE
-   way, displaced by exact tile multiples per loop (seamless). Trails and
-   ambience carry low alphas; the sprites themselves are near-opaque but
-   small, and row text paints above the z-5 overlay, so rows stay readable.
-
-   WebGL was CONSIDERED AND REJECTED for these: browsers cap live WebGL
-   contexts per page (~8–16), and every flaired row would need one — dozens
-   of rows would silently evict each other's contexts. Stepped sprite sheets
-   are the frame-true look at compositor cost.
+   Sprites are ORIGINAL pixel art as inline SVG data URIs — no external
+   requests, no copyrighted assets. Constraints the rules below rely on:
+   - Traversal is background-position only, NEVER transform (the drag-ghost
+     rule — see .rk-scanlines-crawl) and never `left` (layout thrash).
+   - Each sprite is a VERTICAL sheet of 22px frames (frame n at y = -22n).
+     The two background-position LONGHANDS animate independently without
+     clobbering: -x carries the linear traversal, -y steps frames (step-end).
+   - The pseudos are fixed 22px strips (static centering, no animated
+     layout), so px frame offsets hold at every row height (24px rows, 36px
+     coarse rows, 18px picker preview cells).
+   - Sprite layers are no-repeat, sliding off-left negative → off-right
+     calc(100% + Npx) so any row width traverses edge-to-edge; a trail layer
+     rides the SAME keyframes, its from/to constants balanced per layer
+     (start − image width + end equal) so the trail stays glued to the sprite.
+   - ::before ambience tiles drift the OPPOSITE way, displaced by exact tile
+     multiples per loop (seamless).
+   WebGL was rejected: browsers cap live contexts per page (~8–16) and every
+   flaired row would need one.
 
    ORDER MATTERS (same discipline as .rk-dash-rain): these base rules PRECEDE
    the prefers-reduced-motion block so its equal-specificity hidden overrides
-   win by source order — the flairs are motion-only decoration and hide
-   entirely there. */
+   win by source order — the flairs are motion-only and hide entirely there. */
 
-/* nyan: the pop-tart cat. ::after is a 22px strip with TWO layers — the cat
-   sheet (36×88: 4 frames — leg shuffle A/B, tail wag up/down, 1px body bob)
-   and a 140px rainbow comet-trail (6 full-saturation stripes, left edge
-   faded out through an SVG mask) glued to the cat's left edge. The frames
-   animation steps the sheet on layer 1 and jiggles the trail ±1px on layer 2
-   at the same ~6.7fps cadence (the original's stripe wave). ::before is a
-   parallax starfield: an 80px twinkling-star tile (2-frame sheet) drifting
-   the OPPOSITE way, exactly one tile per loop. ~9s traversal. */
+/* nyan: ::after layers the cat sheet (36×88, 4 frames) and a 140px rainbow
+   trail glued to its left edge, stepped together at ~6.7fps (the trail
+   jiggles ±1px); ::before is an 80px star tile (2-frame sheet) drifting the
+   opposite way, one tile per loop. ~9s traversal. */
 @keyframes rk-flair-nyan-x {
   from { background-position-x: -36px, -176px; }
   to { background-position-x: calc(100% + 40px), calc(100% + 4px); }
@@ -655,12 +633,9 @@ summary {
     rk-flair-nyan-y 0.6s step-end infinite;
 }
 
-/* naruto: an orange-clad runner in the arms-back naruto-run lean. ::after is
-   a 22px strip with the runner sheet (32×88: 4 frames — stride / tuck / mid
-   stride leg cycle, fluttering headband ribbon, 1px bob) plus a 120px trail
-   sheet (120×44, 2 frames: drifting leaves, dust puffs, speed lines) glued
-   behind, stepping at ~8fps. ::before is a faint full-width speed-streak
-   tile racing the OPPOSITE way. ~6s traversal (the dash). */
+/* naruto: ::after layers the runner sheet (32×88, 4 frames) and a 120×44
+   2-frame trail glued behind, stepping at ~8fps; ::before is a faint
+   speed-streak tile racing the opposite way. ~6s traversal. */
 @keyframes rk-flair-naruto-x {
   from { background-position-x: -32px, -152px; }
   to { background-position-x: calc(100% + 40px), calc(100% + 8px); }
@@ -712,13 +687,10 @@ summary {
     rk-flair-naruto-y 0.5s step-end infinite;
 }
 
-/* onepiece: a pirate ship under sail. ::after is a bottom-anchored 22px
-   strip with the ship sheet (34×88: 4 frames — sail billow A/B, fluttering
-   black flag with the straw-hat-over-skull emblem, ±1.4° hull roll, 1px
-   bob, wake dashes off the stern) stepping at a gentle ~2.5fps. ::before is
-   TWO scallop-wave tiles (16px and 24px periods) drifting the OPPOSITE way
-   at different speeds — parallax swell, displaced by exact tile multiples
-   per loop. ~14s traversal. */
+/* onepiece: ::after is a bottom-anchored strip with the ship sheet (34×88,
+   4 frames) stepping at ~2.5fps; ::before is TWO scallop-wave tiles (16px +
+   24px periods) drifting the opposite way at different speeds. ~14s
+   traversal. */
 @keyframes rk-flair-onepiece-x {
   from { background-position-x: -34px; }
   to { background-position-x: calc(100% + 34px); }

--- a/fab/changes/260814-z4x1-reduce-code-comment-density/.history.jsonl
+++ b/fab/changes/260814-z4x1-reduce-code-comment-density/.history.jsonl
@@ -7,3 +7,4 @@
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-08-14T19:32:41Z"}
 {"event":"review","result":"passed","ts":"2026-08-14T19:32:41Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-08-14T19:33:02Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-08-14T19:34:44Z"}

--- a/fab/changes/260814-z4x1-reduce-code-comment-density/.history.jsonl
+++ b/fab/changes/260814-z4x1-reduce-code-comment-density/.history.jsonl
@@ -8,3 +8,4 @@
 {"event":"review","result":"passed","ts":"2026-08-14T19:32:41Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-08-14T19:33:02Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-08-14T19:34:44Z"}
+{"event":"review","result":"passed","ts":"2026-08-14T19:39:15Z"}

--- a/fab/changes/260814-z4x1-reduce-code-comment-density/.history.jsonl
+++ b/fab/changes/260814-z4x1-reduce-code-comment-density/.history.jsonl
@@ -1,0 +1,9 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-08-14T19:13:43Z"}
+{"args":"Reduce code comment density: comments should state constraints the code can't show — not narrate the next line, mirror sibling code, or cite change IDs. Two parts: (1) add the rule to fab/project/code-quality.md anti-patterns; (2) one-time distillation sweep of the heaviest files","cmd":"fab-new","event":"command","ts":"2026-08-14T19:13:43Z"}
+{"delta":"+4.7","event":"confidence","score":4.7,"trigger":"calc-score","ts":"2026-08-14T19:15:22Z"}
+{"cmd":"fab-fff","event":"command","ts":"2026-08-14T19:18:19Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-08-14T19:18:32Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-08-14T19:27:43Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-08-14T19:32:41Z"}
+{"event":"review","result":"passed","ts":"2026-08-14T19:32:41Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-08-14T19:33:02Z"}

--- a/fab/changes/260814-z4x1-reduce-code-comment-density/.status.yaml
+++ b/fab/changes/260814-z4x1-reduce-code-comment-density/.status.yaml
@@ -10,7 +10,7 @@ progress:
     review: done
     hydrate: done
     ship: done
-    review-pr: active
+    review-pr: done
 plan:
     generated: true
     task_count: 5
@@ -34,7 +34,7 @@ stage_metrics:
     review: {started_at: "2026-08-14T19:27:43Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-14T19:32:41Z"}
     hydrate: {started_at: "2026-08-14T19:32:41Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-14T19:33:02Z"}
     ship: {started_at: "2026-08-14T19:33:02Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-14T19:34:44Z"}
-    review-pr: {started_at: "2026-08-14T19:34:44Z", driver: git-pr, iterations: 1}
+    review-pr: {started_at: "2026-08-14T19:34:44Z", driver: git-pr, iterations: 1, completed_at: "2026-08-14T19:39:15Z"}
 prs:
     - https://github.com/sahil87/run-kit/pull/613
 change_type_source: explicit
@@ -54,4 +54,4 @@ true_impact:
     computed_at_stage: ship
 summary: Added the comment-narration anti-pattern rule to code-quality.md and distilled comments in globals.css (flair block), api/sessions.go, api/settings.go, and swatch-popover.tsx — comment-only, net -119 lines
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-08-14T19:34:44Z
+last_updated: 2026-08-14T19:39:15Z

--- a/fab/changes/260814-z4x1-reduce-code-comment-density/.status.yaml
+++ b/fab/changes/260814-z4x1-reduce-code-comment-density/.status.yaml
@@ -9,8 +9,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 plan:
     generated: true
     task_count: 5
@@ -33,23 +33,25 @@ stage_metrics:
     apply: {started_at: "2026-08-14T19:18:32Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-14T19:27:43Z"}
     review: {started_at: "2026-08-14T19:27:43Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-14T19:32:41Z"}
     hydrate: {started_at: "2026-08-14T19:32:41Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-14T19:33:02Z"}
-    ship: {started_at: "2026-08-14T19:33:02Z", driver: fab-fff, iterations: 1}
-prs: []
+    ship: {started_at: "2026-08-14T19:33:02Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-14T19:34:44Z"}
+    review-pr: {started_at: "2026-08-14T19:34:44Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/sahil87/run-kit/pull/613
 change_type_source: explicit
 true_impact:
-    added: 0
-    deleted: 0
-    net: 0
+    added: 393
+    deleted: 271
+    net: 122
     excluding:
-        added: 0
-        deleted: 0
-        net: 0
+        added: 151
+        deleted: 271
+        net: -120
     tests:
         added: 0
         deleted: 0
         net: 0
-    computed_at: "2026-08-14T19:33:02Z"
-    computed_at_stage: hydrate
+    computed_at: "2026-08-14T19:34:44Z"
+    computed_at_stage: ship
 summary: Added the comment-narration anti-pattern rule to code-quality.md and distilled comments in globals.css (flair block), api/sessions.go, api/settings.go, and swatch-popover.tsx — comment-only, net -119 lines
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-08-14T19:33:02Z
+last_updated: 2026-08-14T19:34:44Z

--- a/fab/changes/260814-z4x1-reduce-code-comment-density/.status.yaml
+++ b/fab/changes/260814-z4x1-reduce-code-comment-density/.status.yaml
@@ -1,0 +1,55 @@
+id: z4x1
+name: 260814-z4x1-reduce-code-comment-density
+created: 2026-08-14T19:13:43Z
+created_by: sahil-noon
+change_type: refactor
+issues: []
+progress:
+    intake: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+plan:
+    generated: true
+    task_count: 5
+    acceptance_count: 8
+    acceptance_completed: 8
+confidence:
+    certain: 3
+    confident: 4
+    tentative: 0
+    unresolved: 0
+    score: 4.7
+    fuzzy: true
+    dimensions:
+        signal: 78.6
+        reversibility: 85.0
+        competence: 83.6
+        disambiguation: 78.6
+stage_metrics:
+    intake: {started_at: "2026-08-14T19:13:43Z", driver: fab-new, iterations: 1, completed_at: "2026-08-14T19:18:32Z"}
+    apply: {started_at: "2026-08-14T19:18:32Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-14T19:27:43Z"}
+    review: {started_at: "2026-08-14T19:27:43Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-14T19:32:41Z"}
+    hydrate: {started_at: "2026-08-14T19:32:41Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-14T19:33:02Z"}
+    ship: {started_at: "2026-08-14T19:33:02Z", driver: fab-fff, iterations: 1}
+prs: []
+change_type_source: explicit
+true_impact:
+    added: 0
+    deleted: 0
+    net: 0
+    excluding:
+        added: 0
+        deleted: 0
+        net: 0
+    tests:
+        added: 0
+        deleted: 0
+        net: 0
+    computed_at: "2026-08-14T19:33:02Z"
+    computed_at_stage: hydrate
+summary: Added the comment-narration anti-pattern rule to code-quality.md and distilled comments in globals.css (flair block), api/sessions.go, api/settings.go, and swatch-popover.tsx — comment-only, net -119 lines
+# true_impact: lazily created on first stage-finish that computes it (no placeholder here).
+last_updated: 2026-08-14T19:33:02Z

--- a/fab/changes/260814-z4x1-reduce-code-comment-density/intake.md
+++ b/fab/changes/260814-z4x1-reduce-code-comment-density/intake.md
@@ -1,0 +1,72 @@
+# Intake: Reduce Code Comment Density
+
+**Change**: 260814-z4x1-reduce-code-comment-density
+**Created**: 2026-08-15
+
+## Origin
+
+Backlog item `[z4x1]` (2026-08-14), invoked via `/fab-new z4x1` (one-shot, no prior conversation):
+
+> Reduce code comment density: comments should state constraints the code can't show — not narrate the next line, mirror sibling code, or cite change IDs. Two parts: (1) add the rule to fab/project/code-quality.md anti-patterns so apply/review stop generating mirror-prose; (2) one-time distillation sweep of the heaviest files (flair CSS block in globals.css, api/sessions.go+settings.go channel handlers, swatch-popover.tsx) — ~22% of PR 605's impl lines were comments.
+
+## Why
+
+1. **The pain point**: Pipeline-generated code carries heavy mirror-prose commenting — comments that restate what the next line does, describe sibling code, or cite the change/PR that introduced them. Measured in this repo today: `swatch-popover.tsx` is 147 comment lines out of 546 (~27%), `api/sessions.go` 43/262 (~16%), `api/settings.go` 32/249 (~13%), and the flair block in `globals.css` opens with a ~60-line rationale banner. The backlog cites ~22% of PR #605's implementation lines being comments.
+2. **The consequence if unfixed**: Every future apply stage keeps generating the same density (nothing in `code-quality.md` discourages it), review never flags it, and readers must wade through narration to find the few comments that carry real constraints. Provenance citations (change IDs, PR numbers) also rot — git history already records provenance.
+3. **Why this approach**: A rule in `fab/project/code-quality.md § Anti-Patterns` is the systemic fix — plan generation lifts anti-patterns into review acceptance items automatically, so both apply (generation-time) and review (enforcement-time) inherit it with one edit. The sweep is a one-time cleanup of the worst existing offenders so the new rule isn't contradicted by the codebase it points at. A repo-wide sweep is deliberately out of scope — the named files are the measured heavy hitters; the rule prevents new accumulation elsewhere.
+
+## What Changes
+
+### Part 1: Anti-pattern rule in `fab/project/code-quality.md`
+
+Add one bullet to the `## Anti-Patterns` section (which currently ends at "Adding routes without explicit spec justification"):
+
+```markdown
+- Comment narration — comments must state constraints the code can't show (invariants, cross-file contracts, non-obvious "why"); never narrate the next line, mirror sibling code, restate what the diff/reviewer needs ("this preserves X"), or cite change IDs / PR numbers (git history owns provenance)
+```
+
+Exact wording may be lightly edited for fit, but all four prohibited forms (narrate next line, mirror sibling code, reviewer-directed prose, change-ID citations) and the positive criterion (constraints the code can't show) MUST survive. No change to `code-review.md` — anti-patterns already flow into review acceptance via plan generation (`_generation.md` step 6: one acceptance item per relevant anti-pattern).
+
+### Part 2: One-time distillation sweep (comment-only edits, four targets)
+
+For each target, walk every comment and apply the keeper criterion: **keep (possibly condensed) any comment stating a constraint the code can't show** — validation asymmetries, ordering/stacking tradeoffs, cross-file contracts, sentinel semantics; **delete or condense** narration, sibling-mirroring, and provenance citations. Zero executable-code changes.
+
+- **`app/frontend/src/globals.css` — the flair overlays block (~lines 542–600 banner + per-keyframe comments)**: the banner's keeper content is the real design constraint (why source-order/stacking-context wins over the alternative, the ~8–16 stacking contexts cost argument, motion-only decoration hides under reduced-motion); the value-enumeration and section-mirroring prose condenses. Section navigation banners (`── Flair overlays ──` style rules) stay — they are navigational structure, not narration.
+- **`app/backend/api/sessions.go` — channel handlers**: keepers include the permissive-vs-tightened validation asymmetry (rename SOURCE stays permissive so pre-existing spacey sessions can be renamed; new/renamed-TO names use the tightened rule) — condense, don't delete. The `sessionStringOption` descriptor doc comment keeps its contract ("adding a channel is a descriptor + route registration"); per-field narration ("decode extracts the value pointer…encoding/json semantics preserved exactly") condenses to the one non-obvious fact (unknown-key/case-fold behavior is deliberately preserved).
+- **`app/backend/api/settings.go` — channel handlers**: same treatment as sessions.go (the two files share the per-row channel seam from PR #608).
+- **`app/frontend/src/components/swatch-popover.tsx`** (~27% comment lines, the densest target): keepers include the legacy-value normalization contract ("1+3" highlights its family; dark-stored highlights the DARK swatch) and the `undefined` vs `null` sentinel semantics; the render-gating narration ("section renders only when callback present") deletes — the conditional JSX shows it.
+- **Functional comment markers are preserved everywhere**: `review-ignore` suppressions, lint/ts directives, the deliberate NUL-join note in `session-tiles.tsx` (not a sweep target, listed as the class of thing that must survive if encountered), and Go doc comments on exported identifiers (condense but keep — `go vet`/doc conventions expect them).
+
+### Verification
+
+Comment-only sweep still runs the standard gates: `go test ./...` (backend), `npx tsc --noEmit` (frontend), and the existing colocated unit tests (`swatch-popover.test.tsx`) — proving no executable line moved. No new tests: there is no behavior to test; the rule addition is config prose.
+
+## Affected Memory
+
+None — comment-only code edits plus a project-config (`fab/project/code-quality.md`) rule addition. No spec-level behavior changes, so no memory files are created, modified, or removed.
+
+## Impact
+
+- `fab/project/code-quality.md` — one anti-pattern bullet (systemic; affects every future apply/review)
+- `app/frontend/src/globals.css` — flair block comments only
+- `app/backend/api/sessions.go`, `app/backend/api/settings.go` — channel-handler comments only
+- `app/frontend/src/components/swatch-popover.tsx` — comments only
+- No API, route, dependency, or behavior changes; no test-file changes expected
+
+## Open Questions
+
+None — the backlog item names the rule, the target file for it, and the sweep targets explicitly.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Anti-pattern wording lifts the backlog's own criterion (constraints the code can't show; no next-line narration, sibling mirroring, reviewer-directed prose, or change-ID citations) | Backlog text states the rule near-verbatim; trivially editable later | S:90 R:95 A:90 D:90 |
+| 2 | Certain | Rule lands in `code-quality.md § Anti-Patterns` only; `code-review.md` untouched | Backlog names the file+section explicitly; plan generation already lifts anti-patterns into review acceptance | S:90 R:90 A:85 D:85 |
+| 3 | Certain | Sweep is comment-only — zero executable-code changes, verified by existing gates (go test, tsc, unit tests) | "Distillation sweep" of comments by definition; behavior preservation is the obvious safety contract | S:85 R:90 A:95 D:90 |
+| 4 | Confident | Sweep scope is exactly the four named files; no repo-wide sweep | Backlog names "the heaviest files" and lists them; the rule handles future accumulation elsewhere | S:80 R:70 A:75 D:70 |
+| 5 | Confident | Keeper criterion is qualitative (per-comment constraint test), no numeric density target | ~22% is cited as evidence, not a target; a numeric quota would incentivize deleting keeper comments | S:70 R:85 A:75 D:65 |
+| 6 | Confident | Functional/navigational comments survive: review-ignore markers, lint directives, Go exported-identifier doc comments (condensed), CSS section banners | These carry tooling or navigation function, not narration; standard convention | S:65 R:85 A:80 D:70 |
+| 7 | Confident | No memory updates (Affected Memory: none) | Template rule: implementation-only changes don't need memory updates; nothing spec-level changes | S:70 R:80 A:85 D:80 |
+
+7 assumptions (3 certain, 4 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260814-z4x1-reduce-code-comment-density/plan.md
+++ b/fab/changes/260814-z4x1-reduce-code-comment-density/plan.md
@@ -1,0 +1,105 @@
+# Plan: Reduce Code Comment Density
+
+**Change**: 260814-z4x1-reduce-code-comment-density
+**Intake**: `intake.md`
+
+## Requirements
+
+### Process: Comment anti-pattern rule
+
+#### R1: Anti-pattern rule in code-quality.md
+`fab/project/code-quality.md` `## Anti-Patterns` MUST gain a comment-narration bullet stating the positive criterion (comments state constraints the code can't show — invariants, cross-file contracts, non-obvious "why") and all four prohibited forms: narrating the next line, mirroring sibling code, reviewer-directed prose, and change-ID / PR-number citations. `code-review.md` SHALL NOT be edited — anti-patterns already flow into review acceptance via plan generation.
+
+- **GIVEN** a future apply or review stage loads `fab/project/code-quality.md`
+- **WHEN** it reads `## Anti-Patterns`
+- **THEN** the comment-narration rule is present as one bullet alongside the existing anti-patterns
+- **AND** no other file carries the rule
+
+### Cleanup: Comment distillation sweep
+
+#### R2: Distill the four named targets
+The sweep MUST walk every comment in `app/frontend/src/globals.css` (flair overlays block only), `app/backend/api/sessions.go`, `app/backend/api/settings.go`, and `app/frontend/src/components/swatch-popover.tsx`, keeping (condensed where possible) only comments that state constraints the code can't show, and deleting narration, sibling-mirroring, reviewer-directed prose, and change-ID/PR citations. Functional and navigational comments MUST survive: `review-ignore` suppressions, lint/ts directives, Go doc comments on exported identifiers (condensed but present), and CSS section banners (`── … ──`).
+
+- **GIVEN** the flair block's ~60-line banner in `globals.css`
+- **WHEN** the sweep distills it
+- **THEN** the stacking-context/source-order design constraint and reduced-motion note survive condensed, while value enumeration and section-mirroring prose are gone
+- **GIVEN** `sessions.go`'s rename handlers
+- **WHEN** the sweep distills them
+- **THEN** the permissive-SOURCE vs tightened-TARGET validation asymmetry remains documented (condensed), and per-field decode narration collapses to the one non-obvious fact (unknown-key/case-fold JSON semantics deliberately preserved)
+- **GIVEN** `swatch-popover.tsx`
+- **WHEN** the sweep distills it
+- **THEN** the legacy-value normalization contract and `undefined` vs `null` sentinel semantics remain, while render-gating narration ("renders only when callback present") is deleted
+
+#### R3: Behavior preservation
+The sweep MUST change zero executable lines — the diff in the four swept files touches only comments (and whitespace left by removed comment blocks). Verification gates MUST pass: `go test ./...` in `app/backend/`, `npx tsc --noEmit` in `app/frontend/`, and the colocated `swatch-popover.test.tsx` suite.
+
+- **GIVEN** the completed sweep
+- **WHEN** `git diff` is inspected for the four swept files
+- **THEN** every removed/changed line is a comment line (or blank line churn), and all three gates pass
+
+### Non-Goals
+
+- Repo-wide comment sweep — the rule prevents new accumulation; only the four measured heavy hitters are swept
+- Numeric density target — the keeper criterion is qualitative per comment; a quota would incentivize deleting keeper comments
+- Editing `fab/project/code-review.md` — anti-patterns already reach review via plan generation
+
+## Tasks
+
+### Phase 1: Setup
+
+- [x] T001 Add the comment-narration bullet to `fab/project/code-quality.md` `## Anti-Patterns` (positive criterion + four prohibited forms) <!-- R1 -->
+
+### Phase 2: Core Implementation
+
+- [x] T002 [P] Distill the flair overlays comment block in `app/frontend/src/globals.css` (banner ~lines 542–600 + per-keyframe comments); keep the stacking-context/source-order constraint and reduced-motion note, keep `── … ──` section banners <!-- R2 -->
+- [x] T003 [P] Distill channel-handler comments in `app/backend/api/sessions.go` and `app/backend/api/settings.go`; keep the rename-validation asymmetry and the descriptor contract, condense per-field decode narration, keep exported-identifier doc comments <!-- R2 -->
+- [x] T004 [P] Distill comments in `app/frontend/src/components/swatch-popover.tsx`; keep normalization contract + `undefined`/`null` sentinel semantics, delete render-gating narration <!-- R2 -->
+
+### Phase 3: Integration & Edge Cases
+
+- [x] T005 Verify behavior preservation: comment-only diff check on the four swept files, then `go test ./...` (app/backend), `npx tsc --noEmit` (app/frontend), and the `swatch-popover` unit suite <!-- R3 -->
+
+## Acceptance
+
+### Functional Completeness
+
+- [x] A-001 R1: `fab/project/code-quality.md` `## Anti-Patterns` contains the comment-narration bullet with the positive criterion and all four prohibited forms; no other file was edited for the rule
+- [x] A-002 R2: All four targets are distilled — remaining comments each state a constraint the code can't show; narration, sibling-mirroring, and change-ID/PR citations are gone
+
+### Behavioral Correctness
+
+- [x] A-003 R3: The diff in the four swept files contains no executable-line changes — comment and blank lines only (plus gofmt field-alignment whitespace on the `set`/`unset` struct fields in sessions.go, tokens identical)
+
+### Scenario Coverage
+
+- [x] A-004 R2: Spot-check keepers survived: rename-validation asymmetry (sessions.go), descriptor contract (sessions.go), stacking-context constraint + reduced-motion note (globals.css), normalization contract + sentinel semantics (swatch-popover.tsx)
+
+### Edge Cases & Error Handling
+
+- [x] A-005 R2: Functional markers preserved — no `review-ignore` / lint / ts directives existed in the swept ranges (grep-verified); Go doc comments on the handler identifiers still present (condensed); CSS `── Flair overlays ──` section banner intact
+
+### Code Quality
+
+- [x] A-006 Pattern consistency: Surviving comments match surrounding comment idiom (Go doc-comment form, CSS banner form)
+- [x] A-007 No unnecessary duplication: The rule text lives in exactly one place (`code-quality.md` — grep of fab/project/ confirms a single occurrence)
+- [x] A-008 Verification gates: `go test ./...`, `npx tsc --noEmit`, and the swatch-popover unit suite (47 tests) all pass; gofmt clean
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All acceptance items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] A-NNN **N/A**: {reason}`
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Confident | sessions.go + settings.go grouped as one task (T003) | Same channel-handler seam (PR #608), same treatment, small combined size — one focused session | S:75 R:90 A:85 D:80 |
+| 2 | Certain | Go doc comments on exported identifiers are kept (condensed), never deleted | Go documentation convention; golint/pkgsite expect them | S:85 R:90 A:95 D:90 |
+| 3 | Confident | Blank-line churn from removed comment blocks counts as comment-only for R3 | Removing a comment block naturally collapses surrounding blank lines; executable lines still untouched | S:70 R:85 A:85 D:80 |
+
+3 assumptions (1 certain, 2 confident, 0 tentative).
+
+## Deletion Candidates
+
+- None — comment-only distillation plus one config-rule bullet; no existing code, symbol, or config made redundant or unused.

--- a/fab/project/code-quality.md
+++ b/fab/project/code-quality.md
@@ -21,6 +21,7 @@
 - Polling from the client — use the SSE stream, not `setInterval` + fetch
 - Database/ORM/migration imports — this project has no database by constitution
 - Adding routes without explicit spec justification
+- Comment narration — comments must state constraints the code can't show (invariants, cross-file contracts, non-obvious "why"); never narrate the next line, mirror sibling code, address the reviewer ("this preserves X"), or cite change IDs / PR numbers (git history owns provenance)
 
 ## Verification
 


### PR DESCRIPTION
## Meta

| Change ID | Type | Confidence | Plan | Review |
|-----------|------|------------|------|--------|
| `z4x1` | refactor | 4.7/5.0 | 5/5 tasks, 8/8 acceptance ✓ | ✓ 1 cycle |

| Impact | +/− | Net |
|--------|----:|----:|
| raw | +393 / −271 | +122 |
| **true** | **+151 / −271** | **-120** |
| └ impl  (clamped from net -120) | +151 / −271 | +0 |
| └ tests | +0 / −0 | +0 |

<sub>excludes `fab/`, `docs/` · generated by fab-kit v2.20.1</sub>

**Pipeline:** [intake](https://github.com/sahil87/run-kit/blob/260814-z4x1-reduce-code-comment-density/fab/changes/260814-z4x1-reduce-code-comment-density/intake.md) ✓ → [apply](https://github.com/sahil87/run-kit/blob/260814-z4x1-reduce-code-comment-density/fab/changes/260814-z4x1-reduce-code-comment-density/plan.md) ✓ → review ✓ → hydrate ✓ → ship → review-pr

## Summary

Pipeline-generated code carries heavy mirror-prose commenting — comments narrating the next line, mirroring sibling code, or citing change IDs (~27% of swatch-popover.tsx's lines; ~22% of PR #605's impl lines). This adds a comment-narration anti-pattern rule to `fab/project/code-quality.md` so future apply/review stages stop generating it, and distills the four heaviest files down to constraint-bearing comments only — comment-only edits, no executable-line changes.

## Changes

- **Anti-pattern rule in `fab/project/code-quality.md`** — comments must state constraints the code can't show; never narrate the next line, mirror sibling code, address the reviewer, or cite change IDs/PR numbers
- **One-time distillation sweep (comment-only)** — `globals.css` flair block, `api/sessions.go` + `api/settings.go` channel handlers, `swatch-popover.tsx`
- **Verification** — `go test ./...`, `tsc --noEmit`, swatch-popover suite 47/47; diff verified comment/whitespace-only