### PR TITLE
chore: remove gap between sidebar session groups

### DIFF
--- a/app/frontend/src/components/sidebar/index.tsx
+++ b/app/frontend/src/components/sidebar/index.tsx
@@ -2522,7 +2522,7 @@ function ServerGroupInner(props: ServerGroupProps) {
                   // sync-latency scopes window-row counts to one session) —
                   // don't couple selectors to the spacing utility classes.
                   data-session-group={session.name}
-                  className={`mb-1${isGhostSession ? " opacity-50 animate-pulse" : ""}`}
+                  className={isGhostSession ? "opacity-50 animate-pulse" : undefined}
                 >
                   <SessionRow
                     server={server}


### PR DESCRIPTION
## Summary

Each sidebar session group carried a `mb-1` (4px margin-bottom) on its wrapper, leaving a visible gap between the last window row of one session and the next session's row. This removes the margin so session rows sit flush with the row above; session and window rows both render at exactly 24px (verified in-browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)