### PR TITLE
chore: remove padding above first session row in server group

### DIFF
--- a/app/frontend/src/components/sidebar/index.tsx
+++ b/app/frontend/src/components/sidebar/index.tsx
@@ -2440,11 +2440,11 @@ function ServerGroupInner(props: ServerGroupProps) {
               Placement is the ONLY difference — no badge, frame, or divider.
               Not draggable (it does not participate in window drag-reorder);
               it still joins the roving-tabindex tree via rowKey/tabIndex.
-              It sits OUTSIDE the pt-1 session-list container: its full-width
-              tinted slab (scanlines) must share an edge with the tinted group
-              header above — the 4px padding reads as a bare-background slice
-              between two colored bands there, while below the slab it reads as
-              intentional breathing room before the first session group. */}
+              It sits OUTSIDE the session-list container so its full-width
+              tinted slab (scanlines) shares an edge with the tinted group
+              header above and with the first session row below — rows sit
+              flush with no gaps (the container keeps only pb-1, separating
+              this group from the next server's header). */}
           {operatorEntry && (
             <WindowRow
               win={operatorEntry.win}
@@ -2489,7 +2489,7 @@ function ServerGroupInner(props: ServerGroupProps) {
               onForkWindow={onForkWindow}
             />
           )}
-          <div className="pt-1 pb-1">
+          <div className="pb-1">
           {sessions.length === 0 ? (
             <button
               onClick={() => onCreateSession(server)}


### PR DESCRIPTION
## Summary

Follow-up to #614: the session-list container's `pt-1` (4px top padding) still left a gap between the pinned operator row (or the server group header) and the first session row. This removes it so session rows sit flush there too; the container keeps `pb-1`, which separates a server group from the next server's header rather than from a session row. Verified in-browser: gap above every session row is 0px, all rows uniformly 24px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)