### PR TITLE
ci: increase e2e shard count from 3 to 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         run: just test-frontend
 
   e2e:
-    name: E2E (shard ${{ matrix.shard }}/3)
+    name: E2E (shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
     # Blocking gate (since 260602-a1wo). The e2e suite is SSE-driven and shares
     # one dev + tmux server per shard; under a 2-vCPU runner's contention a
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -143,8 +143,8 @@ jobs:
       - name: Set up project (deps, playwright chromium, .env.local)
         run: just setup
 
-      - name: Run e2e tests (shard ${{ matrix.shard }}/3)
-        run: just test-e2e --shard=${{ matrix.shard }}/3
+      - name: Run e2e tests (shard ${{ matrix.shard }}/4)
+        run: just test-e2e --shard=${{ matrix.shard }}/4
 
       - name: Upload Playwright report on failure
         if: failure()
@@ -158,7 +158,7 @@ jobs:
 
   # Single stable-named aggregate gate for branch-protection / rulesets to
   # require. The individual jobs above have names that are fine to require
-  # directly EXCEPT the e2e matrix, whose names (`E2E (shard N/3)`) are coupled
+  # directly EXCEPT the e2e matrix, whose names (`E2E (shard N/4)`) are coupled
   # to the shard count — requiring those by name would silently break the gate
   # if the matrix ever changes. Requiring this one job instead decouples the
   # ruleset from the job topology: changing the shard count needs no ruleset


### PR DESCRIPTION
## Summary

E2E is CI's critical path (shards at ~4–5.5 min vs backend 1:13 / frontend 2:07), while fixed per-shard setup is only ~52s. A 4th shard cuts expected e2e wall time to roughly 4 minutes. The `CI gate` aggregate job decouples the required check from the matrix, so no ruleset change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)