### PR TITLE
fix: Bound CI apt tmux install against mirror hangs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,16 @@ jobs:
       # internal/sessions integration tests shell out to fab + tmux. fab is not
       # available on the runner, so those cases t.Skip — the rest still run.
       - name: Install tmux
-        run: sudo apt-get update && sudo apt-get install -y tmux
+        # apt has no network timeout by default — a stalled mirror connection
+        # (the recurring azure.archive.ubuntu.com flake) hangs this step until
+        # the 360-minute job timeout. Bound the step and give apt explicit
+        # fetch timeouts + retries so a mirror stall fails in minutes and a
+        # re-run recovers.
+        timeout-minutes: 5
+        run: |
+          APT_OPTS="-o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20"
+          sudo apt-get $APT_OPTS update
+          sudo apt-get $APT_OPTS install -y tmux
 
       - name: Run backend tests
         run: just test-backend
@@ -102,7 +111,16 @@ jobs:
       # rk-test-e2e server is naturally isolated between shards — that is what
       # makes sharding (rather than in-process workers) the safe parallelism.
       - name: Install tmux
-        run: sudo apt-get update && sudo apt-get install -y tmux
+        # apt has no network timeout by default — a stalled mirror connection
+        # (the recurring azure.archive.ubuntu.com flake) hangs this step until
+        # the 360-minute job timeout. Bound the step and give apt explicit
+        # fetch timeouts + retries so a mirror stall fails in minutes and a
+        # re-run recovers.
+        timeout-minutes: 5
+        run: |
+          APT_OPTS="-o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20"
+          sudo apt-get $APT_OPTS update
+          sudo apt-get $APT_OPTS install -y tmux
 
       # The air binary only changes when its pinned version does — cache it to
       # skip the ~17s source build. Bump the key together with the version in


### PR DESCRIPTION
## Problem

CI jobs intermittently hang forever on the `Install tmux` step (`sudo apt-get update && sudo apt-get install -y tmux`). Seen this morning on runs 32224945605 and 32228833903: 3–4 jobs per run stuck at that step for 10+ minutes while sibling jobs on the same commit ran the identical step in seconds — the classic Azure Ubuntu mirror stall. apt has **no default network timeout**, so a stalled fetch hangs until the 360-minute job timeout, and the stuck jobs starve runner slots for later PRs (run 32219239771 sat fully queued behind them).

## Fix

Both `Install tmux` steps (backend + e2e):

1. `timeout-minutes: 5` on the step — a hang now fails in minutes, not 6 hours.
2. Explicit apt fetch bounds — `Acquire::Retries=3`, `Acquire::http::Timeout=20`, `Acquire::https::Timeout=20` — so a stalled connection times out and retries instead of blocking indefinitely.

A mirror flake now surfaces as a fast, re-runnable step failure instead of a silent multi-hour hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)