### PR TITLE
test: Named Subtests in TestParseVersionToken

### DIFF
--- a/app/backend/internal/tmux/version_test.go
+++ b/app/backend/internal/tmux/version_test.go
@@ -54,23 +54,24 @@ func TestParseVersion(t *testing.T) {
 // `#{version}` server probe — no `tmux ` prefix, same unknown semantics.
 func TestParseVersionToken(t *testing.T) {
 	cases := []struct {
+		name      string
 		token     string
 		wantOK    bool
 		wantMajor int
 		wantMinor int
 		wantRaw   string
 	}{
-		{"3.2a", true, 3, 2, "3.2a"},
-		{"3.4", true, 3, 4, "3.4"},
-		{"4.0", true, 4, 0, "4.0"},
-		{"3.4\n", true, 3, 4, "3.4"},
-		{"next-3.7", false, 0, 0, ""},
-		{"3.2a-3ubuntu1", false, 0, 0, ""},
-		{"tmux 3.4", false, 0, 0, ""},
-		{"", false, 0, 0, ""},
+		{"release with suffix", "3.2a", true, 3, 2, "3.2a"},
+		{"plain release", "3.4", true, 3, 4, "3.4"},
+		{"major bump", "4.0", true, 4, 0, "4.0"},
+		{"trailing newline", "3.4\n", true, 3, 4, "3.4"},
+		{"snapshot", "next-3.7", false, 0, 0, ""},
+		{"vendor suffix", "3.2a-3ubuntu1", false, 0, 0, ""},
+		{"client -V shape", "tmux 3.4", false, 0, 0, ""},
+		{"empty", "", false, 0, 0, ""},
 	}
 	for _, tc := range cases {
-		t.Run(tc.token, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			v, ok := parseVersionToken(tc.token)
 			if ok != tc.wantOK {
 				t.Fatalf("parseVersionToken(%q) ok = %v, want %v", tc.token, ok, tc.wantOK)

--- a/fab/changes/260819-a8bf-doctor-tmux-drift-note/.history.jsonl
+++ b/fab/changes/260819-a8bf-doctor-tmux-drift-note/.history.jsonl
@@ -9,3 +9,4 @@
 {"event":"review","result":"passed","ts":"2026-08-19T17:51:53Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-08-19T17:54:00Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-08-19T17:56:56Z"}
+{"event":"review","result":"passed","ts":"2026-08-19T18:19:38Z"}

--- a/fab/changes/260819-a8bf-doctor-tmux-drift-note/.status.yaml
+++ b/fab/changes/260819-a8bf-doctor-tmux-drift-note/.status.yaml
@@ -10,7 +10,7 @@ progress:
     review: done
     hydrate: done
     ship: done
-    review-pr: active
+    review-pr: done
 plan:
     generated: true
     task_count: 4
@@ -34,7 +34,7 @@ stage_metrics:
     review: {started_at: "2026-08-19T17:44:33Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-19T17:51:53Z"}
     hydrate: {started_at: "2026-08-19T17:51:53Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-19T17:54:00Z"}
     ship: {started_at: "2026-08-19T17:54:00Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-19T17:56:56Z"}
-    review-pr: {started_at: "2026-08-19T17:56:56Z", driver: git-pr, iterations: 1}
+    review-pr: {started_at: "2026-08-19T17:56:56Z", driver: git-pr, iterations: 1, completed_at: "2026-08-19T18:19:38Z"}
 prs:
     - https://github.com/sahil87/run-kit/pull/664
 true_impact:
@@ -53,4 +53,4 @@ true_impact:
     computed_at_stage: ship
 summary: doctor's tmux row gains a per-server drift note (binary newer than running server → named-socket restart hint); internal/tmux gains parseVersionToken, Version.OlderThan, and the fail-soft ServerVersion probe
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-08-19T17:56:56Z
+last_updated: 2026-08-19T18:19:38Z


### PR DESCRIPTION
## Summary

Follow-up to #664 (merged mid-review): Copilot's review landed after the merge, so its one fix rides this fresh PR instead of the merged branch. `TestParseVersionToken` subtests now carry explicit `name` fields — the raw `"3.4\n"` token no longer forms a subtest name containing a newline, keeping `go test` output readable/filterable.

Also carries the a8bf review-pr stage-completion bookkeeping (`.status.yaml`, `.history.jsonl`).

## Changes

- `app/backend/internal/tmux/version_test.go`: explicit subtest names in `TestParseVersionToken` (tokens unchanged)