### PR TITLE
fix: add packages field to desktop pnpm-workspace.yaml for pnpm 9

### DIFF
--- a/app/desktop/pnpm-workspace.yaml
+++ b/app/desktop/pnpm-workspace.yaml
@@ -1,3 +1,10 @@
+# `packages` is required by pnpm 9 (release.yml pins version 9 — a
+# settings-only workspace file errors with "packages field missing or
+# empty"); pnpm 10+ would accept the file without it. `.` = this directory is
+# the sole package, which matches the existing non-workspace lockfile exactly.
+packages:
+  - '.'
+
 allowBuilds:
   electron: true
   electron-winstaller: true


### PR DESCRIPTION
## Problem

Release builds fail at **Install desktop dependencies** with:

```
ERROR  packages field missing or empty
```

PR #653 added `app/desktop/pnpm-workspace.yaml` with only an `allowBuilds:` map. The release workflow's desktop jobs pin **pnpm 9**, which hard-errors on a settings-only workspace file; pnpm 10 (used locally) accepts it, so it passed unnoticed — the desktop jobs only run in `release.yml`, not PR CI.

## Fix

Add `packages: ['.']`, mirroring the identical fix (and comment) already in `app/frontend/pnpm-workspace.yaml`. `.` = this directory is the sole package, matching the existing non-workspace lockfile, so `--frozen-lockfile` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)