### PR TITLE
chore: upgrade CI/release to pnpm 10, pin via packageManager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
-          version: 9
+          package_json_file: app/frontend/package.json
 
       - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
 
@@ -95,7 +95,7 @@ jobs:
       # resolve the store path.
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
-          version: 9
+          package_json_file: app/frontend/package.json
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
-          version: 9
+          package_json_file: app/frontend/package.json
 
       - name: Install frontend dependencies
         run: cd app/frontend && pnpm install --frozen-lockfile
@@ -174,7 +174,7 @@ jobs:
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
-          version: 9
+          package_json_file: app/desktop/package.json
 
       - name: Install desktop dependencies
         run: cd app/desktop && pnpm install --frozen-lockfile
@@ -216,7 +216,7 @@ jobs:
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
-          version: 9
+          package_json_file: app/desktop/package.json
 
       - name: Install desktop dependencies
         run: cd app/desktop && pnpm install --frozen-lockfile
@@ -257,7 +257,7 @@ jobs:
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
-          version: 9
+          package_json_file: app/desktop/package.json
 
       - name: Install desktop dependencies
         run: cd app/desktop && pnpm install --frozen-lockfile

--- a/app/desktop/package.json
+++ b/app/desktop/package.json
@@ -8,6 +8,7 @@
   "engines": {
     "node": ">=22.12.0"
   },
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "compile": "tsc && node -e \"fs.mkdirSync('dist/welcome',{recursive:true});fs.copyFileSync('src/welcome/welcome.html','dist/welcome/welcome.html')\"",
     "test": "node --test \"dist/**/*.test.js\"",
@@ -15,7 +16,8 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "electron"
+      "electron",
+      "electron-winstaller"
     ]
   },
   "devDependencies": {

--- a/app/desktop/pnpm-workspace.yaml
+++ b/app/desktop/pnpm-workspace.yaml
@@ -1,10 +1,6 @@
-# `packages` is required by pnpm 9 (release.yml pins version 9 — a
-# settings-only workspace file errors with "packages field missing or
-# empty"); pnpm 10+ would accept the file without it. `.` = this directory is
-# the sole package, which matches the existing non-workspace lockfile exactly.
+# Declares this directory as a single-package workspace. Build-script
+# approvals live in package.json `pnpm.onlyBuiltDependencies` — do not add
+# settings here that pnpm reads from package.json, and keep `packages` present
+# (it matches the existing non-workspace lockfile exactly).
 packages:
   - '.'
-
-allowBuilds:
-  electron: true
-  electron-winstaller: true

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "run-kit-frontend",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.33.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -49,6 +50,7 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild",
+      "msw",
       "sharp"
     ]
   }

--- a/app/frontend/pnpm-workspace.yaml
+++ b/app/frontend/pnpm-workspace.yaml
@@ -1,10 +1,6 @@
-# `packages` is required by pnpm 9 (CI pins version 9 in ci.yml/release.yml —
-# a settings-only workspace file errors with "packages field missing or
-# empty"); pnpm 10+ would accept the file without it. `.` = this directory is
-# the sole package, which matches the existing non-workspace lockfile exactly.
+# Declares this directory as a single-package workspace. Build-script
+# approvals live in package.json `pnpm.onlyBuiltDependencies` — do not add
+# settings here that pnpm reads from package.json, and keep `packages` present
+# (it matches the existing non-workspace lockfile exactly).
 packages:
   - '.'
-
-allowBuilds:
-  esbuild: true
-  msw: true


### PR DESCRIPTION
## Why

Local dev runs pnpm 10.33 while CI/release pinned pnpm 9 — that skew is what broke the last release (#671 fixed the symptom). pnpm 9 also no longer receives fixes.

## Changes

1. **Workflows** — all six `pnpm/action-setup` blocks (ci.yml ×2, release.yml ×4) now read the pnpm version from the relevant app's `packageManager` field via `package_json_file` instead of a hardcoded `version: 9`. Single source of truth per package.
2. **Build-script approvals** — pnpm 10 skips dependency install scripts unless approved. Added `msw` (frontend) and `electron-winstaller` (desktop) to `pnpm.onlyBuiltDependencies`; the `allowBuilds:` blocks in both pnpm-workspace.yaml files were dead config (pnpm 10.33 still reported those scripts as ignored) and are removed. `electron-winstaller`'s install script is load-bearing for the `desktop-windows` job (selects 7-Zip / Squirrel tooling).
3. **Version pinning** — `"packageManager": "pnpm@10.33.0"` added to both package.jsons; pnpm 10 self-manages to the pinned version, preventing future dev/CI skew.

## Verification

- `pnpm install --frozen-lockfile` passes in both `app/frontend` and `app/desktop` under pnpm 10.33, with all approved build scripts running and no "Ignored build scripts" warning.
- Lockfiles unchanged — format 9.0 is shared by pnpm 9 and 10, no regeneration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)