### PR TITLE
chore: draft intakes for host-switcher UX (nv0o, d99v, sywl)

### DIFF
--- a/fab/changes/260820-d99v-spa-host-form-dialog/.history.jsonl
+++ b/fab/changes/260820-d99v-spa-host-form-dialog/.history.jsonl
@@ -1,0 +1,3 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-08-20T10:23:52Z"}
+{"args":"shared SPA HostFormDialog for Add/Edit Host with servers:add-direct invoker, replacing the welcome-page swap for add when the SPA is live","cmd":"fab-new","event":"command","ts":"2026-08-20T10:23:52Z"}
+{"delta":"+4.8","event":"confidence","score":4.8,"trigger":"calc-score","ts":"2026-08-20T10:26:53Z"}

--- a/fab/changes/260820-d99v-spa-host-form-dialog/.status.yaml
+++ b/fab/changes/260820-d99v-spa-host-form-dialog/.status.yaml
@@ -1,0 +1,36 @@
+id: d99v
+name: 260820-d99v-spa-host-form-dialog
+created: 2026-08-20T10:23:52Z
+created_by: Sahil Ahuja
+change_type: feat
+issues: []
+progress:
+    intake: ready
+    apply: pending
+    review: pending
+    hydrate: pending
+    ship: pending
+    review-pr: pending
+plan:
+    generated: false
+    task_count: 0
+    acceptance_count: 0
+    acceptance_completed: 0
+confidence:
+    certain: 2
+    confident: 3
+    tentative: 0
+    unresolved: 0
+    score: 4.8
+    fuzzy: true
+    dimensions:
+        signal: 73.0
+        reversibility: 83.0
+        competence: 85.0
+        disambiguation: 78.0
+stage_metrics:
+    intake: {started_at: "2026-08-20T10:23:52Z", driver: fab-new, iterations: 1}
+prs: []
+change_type_source: explicit
+# true_impact: lazily created on first stage-finish that computes it (no placeholder here).
+last_updated: 2026-08-20T10:27:00Z

--- a/fab/changes/260820-d99v-spa-host-form-dialog/intake.md
+++ b/fab/changes/260820-d99v-spa-host-form-dialog/intake.md
@@ -1,0 +1,75 @@
+# Intake: SPA Host Form Dialog
+
+**Change**: 260820-d99v-spa-host-form-dialog
+**Created**: 2026-08-20
+
+## Origin
+
+Conversational (`/fab-discuss` session on the desktop-shell host switcher UX). User raised:
+
+> Issue 1: Why completely different design language between the two [Add Host and Edit Host dialogs]
+> Issue 2: Why even have two different dialog boxes for these — can edit / add be the same components?
+
+Analysis: Add Host is the Electron shell's welcome page (`app/desktop/src/welcome/`, standalone hand-styled dark-only HTML — the strip's `+ Add Host…` does a full page swap to `welcome?mode=add`); Edit Host is a themed React dialog inside the SPA (`shell-titlebar-strip.tsx`). The welcome page cannot be deleted (it is the zero-hosts / all-hosts-down bootstrap surface, and on win32 the only path to host #1), so full unification is impossible — but the user accepted the two-surface model with the requirement that both follow **the same design language and a consistent form contract**. This change delivers the SPA half: a shared Add/Edit dialog so the everyday add flow stops page-swapping. The welcome-page half is 260820-sywl-welcome-host-hub.
+
+## Why
+
+1. **Pain point**: adding a host while fully connected kicks the user out of the SPA into a full-page context switch (`welcome?mode=add`) for what is a two-field form — and that form looks nothing like the themed Edit Host dialog, though both edit the same entity with the same fields.
+2. **If unfixed**: the most common add path (user already connected, adding a second host) stays jarring, and the Add/Edit inconsistency reads as two different products.
+3. **Approach**: one shared `HostFormDialog` React component in add/edit modes, plus a new capability-gated shell invoker `servers:add-direct` that performs ping + persist over IPC. Older shells without the invoker keep today's page-swap path — the strip's established capability-degradation idiom.
+
+## What Changes
+
+### 1. Shared `HostFormDialog` component (SPA)
+
+Extract the Edit Host dialog currently inlined in `app/frontend/src/components/shell-titlebar-strip.tsx` (state at lines ~243–321, JSX near the confirm dialog) into a shared component following the project dialog conventions (see `run-kit/ui/dialogs-and-state` memory), with two modes:
+
+- **Fields (both modes)**: Name (optional) + URL — same labels, same validation copy (`Enter a full http(s) URL, e.g. http://host:3000`), same layout.
+- **Edit mode** (existing behavior preserved): prefilled from the row; name saves via `servers:rename`; URL via additive `servers:set-url` (URL field enabled only when the shell exposes `setUrl` — existing gating). No connectivity ping on save (a temporarily-down host must stay editable).
+- **Add mode** (new): empty form; on submit, calls the new `servers:add-direct` invoker which pings the URL first (the welcome flow's `welcome:test-host` semantics) and persists on success; a blank Name auto-derives from the ping's returned hostname — byte-for-byte the welcome add form's behavior. Ping/validation errors render inline in the dialog (same error slot as edit mode).
+
+### 2. New shell invoker `servers:add-direct` (desktop)
+
+In `app/desktop/src` (preload bridge + main): a `servers` group invoker that accepts `(name, url)`, reuses the existing main-side test-host + add-host path (`welcome:test-host` / `welcome:add-host` handlers in `main.ts` / `hosts.ts` — same validation, same persist, same set-active-and-switch tail), and returns structured success/error so the dialog can render ping failures inline. Additive and capability-projected like `setUrl`/`removeConfirmed` — the SPA feature-detects it.
+
+Decision point: whether add-direct switches to the new host on success. The welcome add flow persists + sets active; the dialog SHOULD match (persist + switch) for consistency — one behavior for "adding a host" everywhere.
+
+### 3. Strip wiring
+
+- The strip menu's `+ Add Host…` footer opens `HostFormDialog` in add mode **when `servers:add-direct` exists**; otherwise it keeps today's `servers:add` welcome-page swap. The footer renders if either invoker is present.
+- The Edit pencil / F2 path switches to the shared component (behavior unchanged).
+- The native `Hosts → Add Host…` menu item is NOT changed in this change — it keeps opening the welcome page in add mode (main-process code opening an SPA dialog would need reverse IPC into the page; out of scope).
+
+### Non-goals
+
+- No welcome-page changes (260820-sywl-welcome-host-hub owns restyle + host list + parity copy).
+- No removal of `servers:add` / the welcome add mode — it remains the bootstrap and old-shell fallback.
+
+## Affected Memory
+
+- `run-kit/ui/top-bar`: (modify) strip host menu — Add Host opens the shared dialog when `servers:add-direct` exists; Edit uses the same component
+- `run-kit/ui/dialogs-and-state`: (modify) new shared HostFormDialog (add/edit modes, field contract)
+- `run-kit/desktop-shell`: (modify) `servers:add-direct` invoker — ping + persist + switch, capability projection
+
+## Impact
+
+- `app/frontend/src/components/shell-titlebar-strip.tsx` + new `host-form-dialog.tsx` (+ tests)
+- `app/frontend/src/lib/shell.ts` — bridge narrowing for the new invoker
+- `app/desktop/src/preload.ts`, `main.ts`, `hosts.ts` (+ node-test siblings) — invoker + capability projection
+- Version-skew matrix to keep green: new SPA + old shell (footer falls back to page swap), old SPA + new shell (invoker unused)
+
+## Open Questions
+
+- (none — surface split, form contract, and fallback behavior were decided in the discussion)
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | One shared HostFormDialog with add/edit modes; fields Name (optional) + URL with identical validation copy | Discussed — the user's explicit consistency requirement | S:95 R:85 A:90 D:90 |
+| 2 | Certain | New additive capability-gated invoker `servers:add-direct` (ping + persist); old shells keep the welcome page swap | Discussed — option 2 accepted; matches the strip's established degradation idiom | S:90 R:80 A:90 D:85 |
+| 3 | Confident | Add mode pings + auto-derives blank name from hostname; edit mode keeps no-ping saves | Parity with the welcome add flow on add; editing a down host must not be blocked — inferred, not explicitly discussed | S:65 R:80 A:85 D:75 |
+| 4 | Confident | add-direct persists AND switches to the new host (welcome-flow parity) | One consistent "add" behavior everywhere; easily flipped if unwanted | S:60 R:85 A:80 D:70 |
+| 5 | Confident | Native `Hosts → Add Host…` menu item unchanged (still welcome page) | Reverse IPC from main into the SPA is out of scope; menu-bar adds are rare; revisitable | S:55 R:85 A:80 D:70 |
+
+5 assumptions (2 certain, 3 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260820-nv0o-host-menu-shortcut-digit-select/.history.jsonl
+++ b/fab/changes/260820-nv0o-host-menu-shortcut-digit-select/.history.jsonl
@@ -1,0 +1,3 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-08-20T10:23:22Z"}
+{"args":"host-switcher shortcut: SPA-bound Shift+Cmd+M opens the titlebar-strip hosts menu with digit-select, plus focus-visible fix for the row action cluster","cmd":"fab-new","event":"command","ts":"2026-08-20T10:23:22Z"}
+{"delta":"+5.0","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-08-20T10:26:53Z"}

--- a/fab/changes/260820-nv0o-host-menu-shortcut-digit-select/.status.yaml
+++ b/fab/changes/260820-nv0o-host-menu-shortcut-digit-select/.status.yaml
@@ -1,0 +1,36 @@
+id: nv0o
+name: 260820-nv0o-host-menu-shortcut-digit-select
+created: 2026-08-20T10:23:22Z
+created_by: Sahil Ahuja
+change_type: feat
+issues: []
+progress:
+    intake: ready
+    apply: pending
+    review: pending
+    hydrate: pending
+    ship: pending
+    review-pr: pending
+plan:
+    generated: false
+    task_count: 0
+    acceptance_count: 0
+    acceptance_completed: 0
+confidence:
+    certain: 4
+    confident: 2
+    tentative: 0
+    unresolved: 0
+    score: 5.0
+    fuzzy: true
+    dimensions:
+        signal: 81.7
+        reversibility: 87.5
+        competence: 88.3
+        disambiguation: 82.5
+stage_metrics:
+    intake: {started_at: "2026-08-20T10:23:22Z", driver: fab-new, iterations: 1}
+prs: []
+change_type_source: explicit
+# true_impact: lazily created on first stage-finish that computes it (no placeholder here).
+last_updated: 2026-08-20T10:27:00Z

--- a/fab/changes/260820-nv0o-host-menu-shortcut-digit-select/intake.md
+++ b/fab/changes/260820-nv0o-host-menu-shortcut-digit-select/intake.md
@@ -1,0 +1,81 @@
+# Intake: Host Menu Shortcut + Digit Select
+
+**Change**: 260820-nv0o-host-menu-shortcut-digit-select
+**Created**: 2026-08-20
+
+## Origin
+
+Conversational (`/fab-discuss` session on the desktop-shell host switcher UX). User raised two issues against the titlebar-strip hosts menu:
+
+> Issue 3: on the first line, the edit and delete icons are visible even without a hover. These should be visible only on a hover.
+> Issue 4: The shortcut is tough to reach. Do an analysis if Shift+Cmd+Number is available for these shortcuts (as opposed to Cmd+Alt)
+
+The ⇧⌘digit analysis concluded it is unavailable (⇧⌘3/4/5 are macOS system screenshot claims — `menu.ts:26-29` records the actual failure; the layer is also reserved for future positional tile jumps, `keybindings.ts:170-172`). The agreed replacement: a single easy chord that **opens** the hosts menu, with plain digits selecting a host while it is open. User explored shell-side bindings (⌘P, ⌘H, ⌘E, a menu accelerator) and, after discussion of the keystroke path (Electron is veto-not-relay; menu accelerators confiscate keys and create version-skew dead keys), approved: **SPA-registry binding on ⇧⌘M**, shell accelerators untouched.
+
+## Why
+
+1. **Pain point**: switching hosts by keyboard requires ⌥⌘1–9 — an awkward two-modifier stretch — and the mouse path needs a small click target. Separately, the menu's row action cluster (edit/remove/grip) is visible on the focused row even when the menu was opened by mouse, reading as visual noise (the active row receives programmatic focus on open, and the cluster reveals on `group-focus-within`).
+2. **If unfixed**: host switching — a core multi-host workflow — stays keyboard-hostile for the common case, and the menu looks broken-by-default on open.
+3. **Approach**: `⇧⌘M, <digit>` is two easy chords instead of one contorted one. Binding in the SPA registry (not a shell accelerator) ships on server-deploy cadence, is rebindable, appears in the cheatsheet/palette, and avoids the shell-accelerator failure mode (old SPA + new shell = swallowed dead key). ⌥⌘1–9 direct switching is untouched.
+
+## What Changes
+
+### 1. New SPA keybinding `host-menu-open` (⇧⌘M / ⇧Ctrl+M)
+
+In `app/frontend/src/lib/keybindings.ts` `DEFAULT_BINDINGS`, add:
+
+- `actionId: "host-menu-open"`, `code: "KeyM"`, `tier: "shifted"`, `scope: "global"`, `kind: "builtin"`, label like `"Host switcher"`, description like `"open the hosts menu"`, mapLabel `"hosts"`.
+- No `macTier` demotion (⌘M is the shell's minimize claim — `MAC_SHELL_CMD_CLAIMS`), no `macCode`. ⇧⌘M mac / ⇧Ctrl+M win-linux. `KeyM` is verified free on the shifted tier in every claim set (shell, browser, system, win/linux).
+- Handler mounts only where the shell titlebar strip renders (`ShellTitlebarStrip`) — the existing handler-presence gating pattern. In a browser host or on non-shell surfaces the binding resolves to no handler (palette/cheatsheet presentation follows the existing pattern for handler-gated actions).
+- Handler behavior: open the strip's host dropdown (`setOpen(true)` + the existing open-time focus placement on the active row). If already open, close (toggle), matching the stateful-chord family convention.
+
+### 2. Digit-select while the menu is open
+
+In `app/frontend/src/components/shell-titlebar-strip.tsx`, extend the open-menu keydown handling (the existing roving-focus block around lines 425–507): plain digits `1`–`9` (no modifiers) select the corresponding host row — same order as the rendered list, which IS the ⌥⌘1–9 accelerator order — and trigger the same switch path as click/Enter (`switchToHost` seam). Digit N beyond the row count is a no-op. This must not fire while the Edit dialog or remove confirm is open (the existing `dialogOpen` guard).
+
+### 3. Action cluster reveals on hover + keyboard focus only (issue 3 fix)
+
+In `shell-titlebar-strip.tsx` (~line 695), the cluster currently uses `invisible … group-hover:visible group-focus-within:visible`. Programmatic focus on menu open makes the active row show pencil/minus/grip at rest. Replace `group-focus-within:visible` with a `:focus-visible`-based reveal (`group-has-[:focus-visible]:visible`, Tailwind 4 `has` variant) so:
+
+- Mouse-opened menu: no cluster on the focused row (programmatic focus after pointer interaction does not match `:focus-visible` in Chromium).
+- Keyboard navigation (arrows/Tab): cluster reveals on the focused row — Delete/F2/⌥↑↓ affordances stay discoverable.
+- Tabbing into the cluster's own buttons keeps it visible (`has` covers descendants).
+- The mirrored `group-hover:invisible group-focus-within:invisible` classes on the ⌥⌘n hint zone (lines ~668, ~682) must be updated in lockstep so the hint yields the zone under exactly the same conditions the cluster shows.
+
+### 4. Palette registration
+
+Register the action in the command palette (project review rule: new keyboard shortcuts must be documented in the palette registration) — e.g. `Host: Switcher` opening the same dropdown.
+
+### Non-goals
+
+- No shell/Electron changes at all — no menu accelerator, no IPC. ⌥⌘1–9 and the native Hosts menu are untouched.
+- No welcome-page handling (that page has no strip; covered by change 260820-sywl-welcome-host-hub).
+
+## Affected Memory
+
+- `run-kit/ui/keyboard-and-palette`: (modify) new `host-menu-open` shifted-tier binding, its handler-presence gating, digit-select-while-open behavior
+- `run-kit/ui/top-bar`: (modify) host switcher menu — digit selection, cluster reveal semantics (hover + focus-visible, not focus-within)
+
+## Impact
+
+- `app/frontend/src/lib/keybindings.ts` — one binding entry (+ its unit tests / conflict checks)
+- `app/frontend/src/components/shell-titlebar-strip.tsx` — open handler wiring, digit-select in the menu keydown block, cluster visibility classes (+ `shell-titlebar-strip.test.tsx`)
+- Palette registry — one action
+- No backend, no desktop-shell changes
+
+## Open Questions
+
+- (none — chord, tier, ownership, and reveal semantics were all decided in the discussion)
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Chord is ⇧⌘M (mac) / ⇧Ctrl+M (win-linux), code `KeyM`, shifted tier, no mac demotion | Discussed — user approved ⇧⌘M explicitly; KeyM verified free in every claim set; rebindable later so low stakes | S:95 R:90 A:95 D:90 |
+| 2 | Certain | SPA-registry binding, NOT a shell menu accelerator | Discussed at length — user initially pushed shell-side; corrected on keystroke mechanics (veto-not-relay) and accepted SPA ownership | S:95 R:75 A:90 D:90 |
+| 3 | Certain | Digits 1–9 select hosts while the menu is open, in rendered-list order (= ⌥⌘n order) | Discussed — explicit part of the accepted design ("⇧⌘M, 3") | S:90 R:90 A:90 D:85 |
+| 4 | Confident | ⇧⌘M toggles (closes an already-open menu) | Matches the stateful-chord family convention (⌘B/⌘I); not explicitly discussed | S:60 R:90 A:85 D:75 |
+| 5 | Confident | Cluster reveal via `group-has-[:focus-visible]:visible`, replacing `group-focus-within:visible`; hint-zone mirror classes updated in lockstep | Mechanism verified in code; exact Tailwind variant is implementation's choice, easily adjusted | S:80 R:85 A:80 D:70 |
+| 6 | Confident | Palette action registered for the new shortcut | Project review rule requires it | S:70 R:95 A:90 D:85 |
+
+6 assumptions (3 certain, 3 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260820-sywl-welcome-host-hub/.history.jsonl
+++ b/fab/changes/260820-sywl-welcome-host-hub/.history.jsonl
@@ -1,0 +1,3 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-08-20T10:23:52Z"}
+{"args":"welcome page becomes the Host Hub: SPA design tokens, system theme, Your Hosts list with shared row anatomy, local Shift+Cmd+M handler","cmd":"fab-new","event":"command","ts":"2026-08-20T10:23:52Z"}
+{"delta":"+5.0","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-08-20T10:26:53Z"}

--- a/fab/changes/260820-sywl-welcome-host-hub/.status.yaml
+++ b/fab/changes/260820-sywl-welcome-host-hub/.status.yaml
@@ -1,0 +1,36 @@
+id: sywl
+name: 260820-sywl-welcome-host-hub
+created: 2026-08-20T10:23:52Z
+created_by: sahil-noon
+change_type: feat
+issues: []
+progress:
+    intake: ready
+    apply: pending
+    review: pending
+    hydrate: pending
+    ship: pending
+    review-pr: pending
+plan:
+    generated: false
+    task_count: 0
+    acceptance_count: 0
+    acceptance_completed: 0
+confidence:
+    certain: 5
+    confident: 0
+    tentative: 0
+    unresolved: 0
+    score: 5.0
+    fuzzy: true
+    dimensions:
+        signal: 82.0
+        reversibility: 85.0
+        competence: 86.0
+        disambiguation: 83.0
+stage_metrics:
+    intake: {started_at: "2026-08-20T10:23:52Z", driver: fab-new, iterations: 1}
+prs: []
+change_type_source: explicit
+# true_impact: lazily created on first stage-finish that computes it (no placeholder here).
+last_updated: 2026-08-20T10:27:00Z

--- a/fab/changes/260820-sywl-welcome-host-hub/intake.md
+++ b/fab/changes/260820-sywl-welcome-host-hub/intake.md
@@ -1,0 +1,67 @@
+# Intake: Welcome Host Hub
+
+**Change**: 260820-sywl-welcome-host-hub
+**Created**: 2026-08-20
+
+## Origin
+
+Conversational (`/fab-discuss` session on the desktop-shell host switcher UX). The user asked for a UX that works in **all three states** — no host registered, hosts registered but none open, a host open — ideally the same solution everywhere. Agreed model: one mental model, one chord, rendered by whichever surface owns the screen. The SPA surface is covered by 260820-nv0o (⇧⌘M opens the strip dropdown) and 260820-d99v (shared HostFormDialog). This change delivers the shell-owned surface: the welcome page is promoted to a **Host Hub** — restyled to the SPA design language, showing registered hosts, and handling ⇧⌘M locally. The user's design-language complaint (issue 1) applies here directly: the current `welcome.html` is a hand-styled dark-only approximation of the SPA that has drifted.
+
+## Why
+
+1. **Pain point**: in the "hosts registered but none open" state (active host failed its load gate, or user is on the welcome page), registered hosts are invisible — the page shows only an add form and the This Mac section; the menu bar is the only path to existing hosts. And the page's look diverges from the SPA (hardcoded dark palette, no theme response), so the first-run and failure experiences read as a different product.
+2. **If unfixed**: the two shell-owned states of the universal host UX stay broken/inconsistent, undermining the ⇧⌘M-means-hosts mental model established by the SPA changes.
+3. **Approach**: the welcome page is shell-owned, fully self-contained (strict CSP, inline CSS, no network) and must stay so — it is the zero-hosts bootstrap and the all-hosts-down fallback (on win32 the *only* path to host #1). So the fix is in-place: restyle to SPA tokens, add a Your Hosts list with the SPA dropdown's row anatomy, and bind ⇧⌘M in a local keydown handler. Each surface handles its own keys — no IPC, no accelerators.
+
+## What Changes
+
+### 1. Restyle `welcome.html` to the SPA design language
+
+- Replace the current approximated palette in `app/desktop/src/welcome/welcome.html`'s inline CSS with the SPA's actual design-token values (background, card, border, text-primary/secondary, accent) copied from the frontend theme (`globals.css` token values), keeping the page fully self-contained (values are copied, not imported — CSP forbids external fetches).
+- Support light/dark via `prefers-color-scheme` (system rung of the SPA's three-mode theme; the page currently hardcodes `color-scheme: dark`). No manual theme toggle on this page.
+- Typography/spacing aligned with the SPA (monospace stack already matches; heading sizes, label treatment, input/button styles brought to token values).
+- The add form keeps field parity with the shared form contract (Name optional + URL, same labels and validation copy as `HostFormDialog` from 260820-d99v).
+
+### 2. "Your Hosts" section (the state-B fix)
+
+- New section listing registered hosts, rendered above the add form. Row anatomy mirrors the SPA strip dropdown: ~3px accent bar in the host's persisted color, name, dimmed origin, right-aligned ⌥⌘n hint (matching the list order the shell menu uses). Click/Enter on a row switches to that host via the existing main-side switch path.
+- Empty state (no hosts registered): the section is hidden entirely and the add form is the hero — first-launch flow unchanged.
+- Bridge additions in `preload.ts` (welcome bridge): a host-list read (name, origin/url, accent color, active flag, order) and a switch-to-host invoker, both backed by existing `hosts.ts` / main-side seams. Structural narrowing in `welcome.ts` per the page's existing bridge pattern; the page degrades gracefully (no list section) under an older preload.
+
+### 3. Local ⇧⌘M handler
+
+- `welcome.ts` binds a document keydown for ⇧⌘M (mac) / ⇧Ctrl+M (win/linux): focuses the Your Hosts list (roving focus, arrows + Enter, plain digits 1–9 select — the same interaction grammar as the SPA dropdown). With no hosts registered it focuses the add form's URL field.
+- Shell-owned and shipped with the shell — no coordination with the SPA binding (each surface owns its screen's keys; the chords never coexist).
+
+### Non-goals
+
+- No removal or relocation of the add form or This Mac local-daemon section (states and flows preserved; This Mac gets the token restyle only).
+- No SPA changes (owned by 260820-nv0o / 260820-d99v).
+- No native-menu changes; ⌥⌘1–9 continue to work on this page as native accelerators.
+
+## Affected Memory
+
+- `run-kit/desktop-shell`: (modify) welcome page — Host Hub sections (Your Hosts list, row anatomy, ⇧⌘M/digit handler), SPA-token styling + prefers-color-scheme, new welcome-bridge surfaces (host list, switch)
+
+## Impact
+
+- `app/desktop/src/welcome/welcome.html` (styles + markup), `welcome.ts` (list rendering, keydown, bridge narrowing)
+- `app/desktop/src/preload.ts`, `main.ts`, `hosts.ts` — welcome-bridge list/switch surfaces (+ node-test siblings where logic is electron-free)
+- Design reference: the SPA strip dropdown rows (`shell-titlebar-strip.tsx`) and frontend theme tokens
+- Sequencing: depends on 260820-d99v only for the form-contract *copy* (labels/validation text); no code dependency — can build against the agreed contract if d99v is in flight
+
+## Open Questions
+
+- (none — the three-state model, row anatomy, and key ownership were decided in the discussion)
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Welcome page stays the bootstrap/fallback surface and keeps its add form; it is restyled in place, never replaced | Discussed — user confirmed the two-surface model ("we just need both to follow the same design language") | S:95 R:85 A:90 D:90 |
+| 2 | Certain | Your Hosts list with SPA row anatomy (accent bar, name, origin, ⌥⌘n hint); click/Enter switches | Discussed — explicit part of the accepted three-state UX | S:90 R:85 A:85 D:85 |
+| 3 | Certain | ⇧⌘M handled locally in welcome.ts (focus list; empty list → focus URL field), digits select | Discussed — the per-surface key-ownership principle the user accepted | S:90 R:85 A:85 D:85 |
+| 4 | Confident | Token values are copied into the inline CSS (not imported); page follows prefers-color-scheme only | CSP/self-containment forces copying; system-theme-only is the minimal faithful rung — a manual toggle would add chrome the page doesn't need | S:70 R:85 A:85 D:75 |
+| 5 | Confident | Welcome bridge gains list + switch surfaces with graceful degradation under an older preload | Follows the page's existing structural-narrowing pattern; shell + page ship together so skew is rare | S:65 R:85 A:85 D:80 |
+
+5 assumptions (3 certain, 2 confident, 0 tentative, 0 unresolved).


### PR DESCRIPTION
Three ready intakes from the host-switcher UX discussion (add/edit dialog design language, host-menu shortcut reachability, welcome-page host hub):

1. **260820-nv0o-host-menu-shortcut-digit-select** — SPA-bound ⇧⌘M opens the titlebar-strip hosts menu, plain digits 1–9 select while open, and the row action cluster reveals on hover + :focus-visible only (fixes the icons-visible-at-rest issue).
2. **260820-d99v-spa-host-form-dialog** — shared Add/Edit `HostFormDialog` + capability-gated `servers:add-direct` invoker (ping + persist + switch); older shells keep the welcome-page swap.
3. **260820-sywl-welcome-host-hub** — welcome page restyled to SPA design tokens with prefers-color-scheme support, a Your Hosts list (SPA row anatomy), and a local ⇧⌘M handler.

Intakes only — implementation runs through the fab pipeline per change, executed in the order above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)