### PR TITLE
chore: close review-pr status for 260820-nv0o (post-merge bookkeeping)

### DIFF
--- a/fab/changes/260820-nv0o-host-menu-shortcut-digit-select/.history.jsonl
+++ b/fab/changes/260820-nv0o-host-menu-shortcut-digit-select/.history.jsonl
@@ -8,3 +8,4 @@
 {"event":"review","result":"passed","ts":"2026-08-20T10:49:24Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-08-20T10:53:13Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-08-20T10:54:57Z"}
+{"event":"review","result":"passed","ts":"2026-08-20T12:00:17Z"}

--- a/fab/changes/260820-nv0o-host-menu-shortcut-digit-select/.status.yaml
+++ b/fab/changes/260820-nv0o-host-menu-shortcut-digit-select/.status.yaml
@@ -10,7 +10,7 @@ progress:
     review: done
     hydrate: done
     ship: done
-    review-pr: active
+    review-pr: done
 plan:
     generated: true
     task_count: 4
@@ -34,7 +34,7 @@ stage_metrics:
     review: {started_at: "2026-08-20T10:44:33Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-20T10:49:24Z"}
     hydrate: {started_at: "2026-08-20T10:49:24Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-20T10:53:13Z"}
     ship: {started_at: "2026-08-20T10:53:13Z", driver: fab-fff, iterations: 1, completed_at: "2026-08-20T10:54:57Z"}
-    review-pr: {started_at: "2026-08-20T10:54:57Z", driver: git-pr, iterations: 1}
+    review-pr: {started_at: "2026-08-20T10:54:57Z", driver: git-pr, iterations: 1, completed_at: "2026-08-20T12:00:17Z"}
 prs:
     - https://github.com/sahil87/run-kit/pull/681
 change_type_source: explicit
@@ -54,4 +54,4 @@ true_impact:
     computed_at_stage: ship
 summary: 'Added ⇧⌘M/⇧Ctrl+M host-menu-open chord (strip-local toggle) with plain-digit host select while the menu is open, Host: Switcher palette entry via the HOST_MENU_OPEN_EVENT seam, and swapped the row action cluster reveal to hover + :focus-visible'
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-08-20T10:54:57Z
+last_updated: 2026-08-20T12:00:17Z


### PR DESCRIPTION
## Summary

PR #681 (Host Menu Shortcut + Digit Select) was squash-merged while its Copilot review request was still pending (GitHub silently dropped the request — 201 Created, no timeline event). Per the standing timeout policy the review-pr stage is closed as a no-review finish; this PR lands the 2-file fab status bookkeeping (.status.yaml review-pr → done, .history.jsonl event) that was stranded when the merged PR's branch auto-deleted.

## Changes

- fab/changes/260820-nv0o-host-menu-shortcut-digit-select/.status.yaml — review-pr active → done
- fab/changes/260820-nv0o-host-menu-shortcut-digit-select/.history.jsonl — review event appended