### PR TITLE
chore: declare tmux dependency in formula template

### DIFF
--- a/.github/formula-template.rb
+++ b/.github/formula-template.rb
@@ -4,14 +4,20 @@ class RunKit < Formula
   version "VERSION_PLACEHOLDER"
   license "MIT"
 
+  # tmux is a hard runtime dependency — every rk feature drives a tmux
+  # server. Declaring it pulls a current tmux onto hosts that lack one and
+  # keeps brew-managed tmux current via `brew upgrade`. It cannot upgrade a
+  # stale already-installed keg (Homebrew deps carry no version floor) —
+  # rk's daemon-start version check owns that (change 260819-vtd1).
+  depends_on "tmux"
+
   # code-server backs the `code` lens (change 260811-k3vp) — the dashboard
   # embeds it via /proxy on the deterministic RK_PORT+2 port and treats it
   # as always installed. rk manages the install itself (a digest-verified
   # standalone tarball under ~/.rk/code-server-bin, acquired on first daemon
   # start or via `rk code-server install`), so there is deliberately NO
   # depends_on — Homebrew's code-server formula is deprecated/pinned and
-  # would make this formula uninstallable when disabled. (tmux is likewise
-  # NOT declared — long-standing assumption that the host provides it.)
+  # would make this formula uninstallable when disabled.
 
   on_macos do
     on_arm do


### PR DESCRIPTION
Completes W3 of the tmux version floor plan (follow-up to #658/#664).

## What
Adds `depends_on "tmux"` to `.github/formula-template.rb` — the canonical source the release workflow regenerates the tap's `Formula/run-kit.rb` from — and retires the stale "tmux is NOT declared" comment.

## Why
- Pulls a current tmux onto hosts that lack one; brew-managed tmux then rides `brew upgrade`.
- A stale already-installed keg is out of Homebrew's reach (deps carry no version floor) — the daemon-start version check from 260819-vtd1 (#658) owns that case.
- Landing it in the template (not just the tap) means release version bumps preserve the line.

The tap's live copy was updated in lockstep: sahil87/homebrew-tap@16485c1.

Not a fab change by design — single-spot packaging edit, no memory/spec impact (plan § packaging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)