### PR TITLE
fix: Host-menu drag grip is a real drag handle

### DIFF
--- a/app/frontend/src/components/shell-titlebar-strip.test.tsx
+++ b/app/frontend/src/components/shell-titlebar-strip.test.tsx
@@ -734,6 +734,44 @@ describe("ShellTitlebarStrip host menu — accent bars, waiting counts, reorder 
     expect(reordered[1].textContent).toContain("alpha");
   });
 
+  it("a drag started from the ⋮⋮ grip itself commits the reorder (the grip is a real handle)", async () => {
+    const four = [
+      { id: "a", name: "alpha", url: "http://a:3000", active: true },
+      { id: "b", name: "beta", url: "http://b:3000", active: false },
+      { id: "c", name: "gamma", url: "http://c:3000", active: false },
+      { id: "d", name: "delta", url: "http://d:3000", active: false },
+    ];
+    const bridge = await renderInteractive(four, "darwin", false, true);
+    fireEvent.click(screen.getByRole("button", { name: "Switch host" }));
+    const grips = screen.getAllByTestId("shell-host-grip");
+    expect(grips).toHaveLength(4);
+    // The grip must be draggable itself and must NOT swallow pointer events:
+    // it sits on the cluster (a sibling of the row button), so a
+    // pointer-events-none grip has no draggable ancestor and can never
+    // start a drag.
+    for (const grip of grips) {
+      expect(grip).toHaveAttribute("draggable", "true");
+      expect(grip.className).not.toContain("pointer-events-none");
+    }
+    const dataTransfer = {
+      setData: vi.fn(),
+      types: ["application/x-shell-host-reorder"],
+      effectAllowed: "",
+      dropEffect: "",
+    };
+    // Drag row 4 (delta) BY ITS GRIP onto row 1 (alpha) — the dragstart
+    // bubbles from the grip to the row wrapper's shared handler.
+    fireEvent.dragStart(grips[3], { dataTransfer });
+    expect(dataTransfer.setData).toHaveBeenCalledWith("application/x-shell-host-reorder", "d");
+    const rows = screen.getAllByRole("menuitemradio");
+    fireEvent.dragOver(rows[0], { dataTransfer });
+    fireEvent.drop(rows[0], { dataTransfer });
+    fireEvent.dragEnd(grips[3], { dataTransfer });
+    expect(bridge.reorder).toHaveBeenCalledTimes(1);
+    expect(bridge.reorder).toHaveBeenCalledWith("d", 0);
+    expect(screen.getAllByRole("menuitemradio")[0].textContent).toContain("delta");
+  });
+
   it("a denied drag-drop reorder surfaces the error toast and refetches the list", async () => {
     const bridge = await renderInteractive(hosts, "darwin", false, true);
     bridge.reorder.mockResolvedValue({ ok: false });

--- a/app/frontend/src/components/shell-titlebar-strip.tsx
+++ b/app/frontend/src/components/shell-titlebar-strip.tsx
@@ -419,6 +419,15 @@ export function ShellTitlebarStrip() {
     dragIdRef.current = id;
     e.dataTransfer.setData(HOST_REORDER_MIME, id);
     e.dataTransfer.effectAllowed = "move";
+    // A grip-initiated drag would default to the tiny dots as its drag
+    // image; the row (the handler's wrapper) is what moves. Optional call:
+    // jsdom/test DataTransfer mocks carry no setDragImage.
+    const rect = e.currentTarget.getBoundingClientRect();
+    e.dataTransfer.setDragImage?.(
+      e.currentTarget,
+      e.clientX - rect.left,
+      e.clientY - rect.top,
+    );
   }, []);
 
   const onRowDragOver = useCallback((e: React.DragEvent, targetId: string) => {
@@ -829,11 +838,19 @@ export function ShellTitlebarStrip() {
                           </button>
                         </Tip>
                       )}
-                      {/* Drag grip — visual only; the row is the draggable. */}
+                      {/* Drag grip — a REAL handle, not decoration: the
+                          cluster is a SIBLING of the draggable row button, so
+                          a pointer-events-none grip would drop presses on the
+                          non-draggable cluster div and no drag could ever
+                          start from the dots. Its dragstart bubbles to the
+                          wrapper's shared handler; clicks on it stay inert
+                          (a grip never selects the host). */}
                       {canReorder && (
                         <span
                           aria-hidden="true"
-                          className="pointer-events-none text-[10px] leading-none tracking-[-2px] text-text-secondary opacity-60"
+                          draggable
+                          data-testid="shell-host-grip"
+                          className="cursor-grab text-[10px] leading-none tracking-[-2px] text-text-secondary opacity-60"
                         >
                           ⋮⋮
                         </span>


### PR DESCRIPTION
## Summary

Dragging a host row in the desktop-shell host dropdown by its ⋮⋮ grip did nothing — the grip sat on the hover action cluster, a **sibling** of the draggable row button, and was `pointer-events-none`, so presses fell onto the non-draggable cluster div where no drag can start. Dragging only worked from the few uncovered pixels at the row's extreme right, making the hover affordance misleading.

## Changes

- The grip is now `draggable` itself (its `dragstart` bubbles to the row wrapper's shared handler), with `cursor-grab` and pointer events restored — clicks on it remain inert
- `onRowDragStart` sets the drag image to the row wrapper (optional call — grip-initiated drags would otherwise show the tiny dots as the drag image)
- Regression test: a drag started from the grip commits the reorder; grips assert `draggable` and no `pointer-events-none`