### PR TITLE
fix: Snapshotter Ephemeral Test Clock Pin

### DIFF
--- a/app/backend/internal/snapshot/snapshotter_test.go
+++ b/app/backend/internal/snapshot/snapshotter_test.go
@@ -468,6 +468,14 @@ func TestSnapshotterEphemeralSkipsWritesAndRetires(t *testing.T) {
 	eph := newFakeEphemeral()
 	s.ephemeral = eph.fn
 
+	// Pin the clock BEFORE the first tick: bookkeeping (lastPass) must be
+	// stamped on the pinned timeline, or the later advance computes a
+	// negative elapsed against real wall time and the safety pass is never
+	// due (the fixed date sits in the past once the calendar passes it).
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	s.now = func() time.Time { return now }
+	s.safetyInterval = time.Minute
+
 	// First observation lands a latest before the mark is set.
 	s.tick(context.Background())
 	if cap.count() != 1 {
@@ -480,9 +488,6 @@ func TestSnapshotterEphemeralSkipsWritesAndRetires(t *testing.T) {
 	// Mark the server ephemeral; the next due pass (safety) must retire the
 	// lingering latest and capture nothing.
 	eph.mark("kit", true)
-	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
-	s.now = func() time.Time { return now }
-	s.safetyInterval = time.Minute
 	now = now.Add(2 * time.Minute)
 	s.tick(context.Background())
 


### PR DESCRIPTION
## Summary

`TestSnapshotterEphemeralSkipsWritesAndRetires` is a time-bomb: it runs its first `tick` on the REAL clock (stamping `lastPass` at wall time), then pins `s.now` to the hardcoded `2026-08-21 12:00 UTC`. While the wall clock was before that moment (the morning #700 was tested), elapsed was positive and the safety pass fired; once the calendar passed it, `now.Sub(lastPass)` went negative (snapshotter.go:174), the retire pass is never due, and the test fails deterministically — #700 PR CI green, every run after 2026-08-21 20:45 UTC red, including main and unrelated PRs (#704).

## Changes

- Pin the clock (and `safetyInterval`) BEFORE the first tick, matching every sibling test in the file (`TestSnapshotterUnmarkResumesCoverage`, the Aug-5 tests); the advance then computes on one pinned timeline
- Production code untouched — the snapshotter is correct; only the test ordering was wrong

Verified: `go test ./internal/snapshot/ -count=5` green, full backend suite green.