### PR TITLE
fix: Align Chrome Rules, Crumb Heights, and Surface-Toggle Order

### DIFF
--- a/app/frontend/src/app.tsx
+++ b/app/frontend/src/app.tsx
@@ -926,9 +926,9 @@ function AppShell() {
     [renderLayout, applyLayout],
   );
 
-  // The surfaces the current window can tile (`tty` first — R8's shared
-  // registry), consumed by the top-bar surface-toggle group and the palette
-  // gating.
+  // The surfaces the current window can tile (shortcut order, tty/code/web —
+  // R8's shared registry), consumed by the top-bar surface-toggle group and
+  // the palette gating.
   const panelSurfaces = useMemo(
     () => availableSurfaces(effectiveWindow),
     [effectiveWindow],
@@ -3948,7 +3948,7 @@ function AppShell() {
       onCreateWindow: handleCreateWindow,
       onSpawnAgent: handleSlotSpawnAgent,
       // Top-bar surface-toggle group: the tile surfaces the current window
-      // offers (`tty` first) plus the mode discriminant — desktop registers
+      // offers (shortcut order) plus the mode discriminant — desktop registers
       // TOGGLE mode (the open tiles + the shared toggle mutation); mobile
       // registers SWITCH mode (the visible tile + the switch-to-tile verb),
       // gated on ≥2 surfaces surviving the SURFACE_RAIL_HIDDEN render filter

--- a/app/frontend/src/components/surface-layout.test.tsx
+++ b/app/frontend/src/components/surface-layout.test.tsx
@@ -549,11 +549,11 @@ describe("SurfaceLayout focused tile (260812-wfic R2)", () => {
 });
 
 describe("SurfaceLayout header chrome (260812-wfic R3)", () => {
-  it("renders the kind glyph, a 30px bg-bg-card header, and the meta as an inset chip", () => {
+  it("renders the kind glyph, a 35px bg-bg-card header, and the meta as an inset chip", () => {
     renderLayout({ layout: { shape: "split-h", order: ["code", "web"] } });
     const codeTile = screen.getByTestId("surface-tile-code");
     const header = codeTile.firstElementChild!;
-    expect(header.className).toContain("h-[32px]");
+    expect(header.className).toContain("h-[35px]");
     expect(header.className).toContain("bg-bg-card");
     expect(header.className).toContain("text-[11px]");
     // The SURFACE_GLYPH kind glyph precedes the label.

--- a/app/frontend/src/components/surface-layout.tsx
+++ b/app/frontend/src/components/surface-layout.tsx
@@ -86,7 +86,8 @@ import {
  *   `bg-bg-inset` ground itself are provided by the Shell STAGE
  *   (260814-ldbs) — this grid ceded its own `p-[6px]`/`bg-bg-inset` so the
  *   tiles and the rail card share ONE continuous ground. Each tile carries a
- *   32px `bg-bg-card` header —
+ *   35px `bg-bg-card` header (32px content + 3px bottom rule, aligned with
+ *   the sidebar rail's `border-t-[3px]` seam) —
  *   kind glyph (`SURFACE_GLYPH`) + surface name + the small meta as an inset
  *   chip (git-root basename for code, `@rk_url` host for web) — with
  *   rest-visible boxed verb buttons (24×24, 26×26 coarse; 14px SVG glyphs
@@ -1378,9 +1379,14 @@ export function SurfaceLayout({
       >
         {/* Header px-1.5: the rail divider is a MINOR seam with ~6px air on
             both sides (the rail's chips hug it at the same distance on their
-            side) — only the window edge carries the 12px major-seam inset. */}
+            side) — only the window edge carries the 12px major-seam inset.
+            h-[35px] = 32px content + the 3px bottom rule: the sidebar's icon
+            rail is 32px tall and the panel below it opens with border-t-[3px],
+            so both horizontal rules start 32px below the card top at the same
+            chrome-rule weight (top bar, bottom bar, and sidebar panels all use
+            3px rules). */}
         {!mobile && (
-          <div className="flex items-center gap-1.5 px-1.5 h-[32px] shrink-0 border-b border-border bg-bg-card font-mono text-[11px] text-text-secondary select-none">
+          <div className="flex items-center gap-1.5 px-1.5 h-[35px] shrink-0 border-b-[3px] border-border bg-bg-card font-mono text-[11px] text-text-secondary select-none">
             {kind === "tty" && statusWindow && <StatusDot win={statusWindow} />}
             {kind === "tty" && ttyChip && (
               <span

--- a/app/frontend/src/components/top-bar.test.tsx
+++ b/app/frontend/src/components/top-bar.test.tsx
@@ -723,9 +723,12 @@ describe("TopBar", () => {
     // The session BreadcrumbDropdown (switcher + "+ New Session") is gone:
     // session switching lives in the sidebar rows and the palette, creation in
     // the palette / sidebar server-header `+`. The crumb is a static chip.
-    const chip = screen.getByText("run-kit");
-    // Boxed chip styling (CRUMB_BOX_CLASS), matching the sibling crumbs' box.
-    expect(chip).toHaveClass("rounded", "border", "border-border");
+    // The chip is the box around the truncating name span (CRUMB_BOX_CLASS).
+    const chip = screen.getByText("run-kit").parentElement!;
+    // Boxed chip styling (CRUMB_BOX_CLASS), matching the sibling crumbs' box —
+    // including the shared control min-height that keeps every crumb on the
+    // buttons' horizontal axis.
+    expect(chip).toHaveClass("rounded", "border", "border-border", "min-h-[28px]");
     // Non-interactive: a plain span — not a button, not a link, no ▾ caret.
     expect(chip.tagName).toBe("SPAN");
     expect(chip.closest("button, a")).toBeNull();

--- a/app/frontend/src/components/top-bar.tsx
+++ b/app/frontend/src/components/top-bar.tsx
@@ -361,7 +361,8 @@ type SurfaceTogglesToggle = Extract<SurfaceToggles, { mode: "toggle" }>;
  * into the right cluster as ONE bordered sub-group (with a trailing divider),
  * terminal route only. Two modes share the button grammar — one Tip-wrapped
  * button per available surface not in `SURFACE_RAIL_HIDDEN` (chat renders no
- * toggle), `tty` first, glyphs from `SURFACE_GLYPH`, LIT (`aria-pressed`,
+ * toggle), in `availableTiles`' shortcut order (⌘1 tty / ⌘2 code / ⌘3 web),
+ * glyphs from `SURFACE_GLYPH`, LIT (`aria-pressed`,
  * accent-green border/text on a 10% wash), the corner dot driven by the
  * caller's per-surface `showDot` predicate (web = has-content; others
  * always-on):

--- a/app/frontend/src/components/top-bar.tsx
+++ b/app/frontend/src/components/top-bar.tsx
@@ -267,9 +267,17 @@ function BreadcrumbSeparator() {
  * (LINK_CRUMB_CLASS), while the session crumb (260813-kvk7) is a static chip —
  * a session has no route of its own, so it carries the box with NO hover
  * affordance, no pointer cursor, and no ▾.
+ *
+ * min-h normalizes every crumb to the shared control height (28px fine /
+ * 30px coarse — the same box as the toggle + HistoryNav arrows) so the left
+ * cluster sits on one horizontal axis; a content-height crumb is ~1px shorter
+ * and centers 1px high of the fixed-height buttons. inline-flex makes the
+ * min-h bite (height is inert on inline elements) — crumbs that truncate put
+ * `truncate max-w-[16ch]` on an inner span, since text-overflow does not
+ * apply to a flex container's anonymous text item.
  */
 const CRUMB_BOX_CLASS =
-  "rounded border border-border px-1.5 py-0.5 text-text-secondary";
+  "inline-flex items-center min-h-[28px] coarse:min-h-[30px] rounded border border-border px-1.5 py-0.5 text-text-secondary";
 
 /**
  * Link-crumb affordance — the box plus the always-visible "this navigates"
@@ -1020,11 +1028,7 @@ export function TopBar({
             <a
               href="/"
               aria-label="RunKit home"
-              // min-h normalizes the crumb to the shared control height so the
-              // left cluster sits on one horizontal axis (28px fine / 30px
-              // coarse — the same box as the toggle + HistoryNav arrows,
-              // 260731-oiho).
-              className={`flex items-center gap-2 shrink-0 rk-brand-glitch min-h-[28px] coarse:min-h-[30px] ${LINK_CRUMB_CLASS}`}
+              className={`gap-2 shrink-0 rk-brand-glitch ${LINK_CRUMB_CLASS}`}
               onMouseEnter={brandSweep.onMouseEnter}
             >
               {/* Inline SVG (LogoSpinner at rest), not the /icon.svg img — the
@@ -1069,9 +1073,11 @@ export function TopBar({
                     <Tip label="tmux Server">
                       <a
                         href={serverHref}
-                        className={`rk-glint truncate max-w-[16ch] ${LINK_CRUMB_CLASS}`}
+                        className={`rk-glint ${LINK_CRUMB_CLASS}`}
                       >
-                        {server}
+                        <span className="truncate max-w-[16ch] [text-decoration:inherit]">
+                          {server}
+                        </span>
                       </a>
                     </Tip>
                   </span>
@@ -1090,8 +1096,8 @@ export function TopBar({
                   // the siblings' box styling with no hover affordance or caret.
                   <span className="hidden sm:flex items-center gap-1.5 min-w-0">
                     <BreadcrumbSeparator />
-                    <span className={`truncate max-w-[16ch] ${CRUMB_BOX_CLASS}`}>
-                      {sessionName}
+                    <span className={CRUMB_BOX_CLASS}>
+                      <span className="truncate max-w-[16ch]">{sessionName}</span>
                     </span>
                   </span>
                 )}

--- a/app/frontend/src/lib/right-panel.test.ts
+++ b/app/frontend/src/lib/right-panel.test.ts
@@ -36,9 +36,9 @@ describe("availableSurfaces", () => {
   // Registry order is tty, web, chat, code (surface-layout R8).
   it("offers code exactly when gitRoot is set", () => {
     const codeWin: ViewWindow = { gitRoot: "/repo" };
-    expect(availableSurfaces(codeWin)).toEqual(["tty", "web", "code"]);
+    expect(availableSurfaces(codeWin)).toEqual(["tty", "code", "web"]);
     expect(availableSurfaces({ rkUrl: "http://localhost:8080", chatProvider: "claude", gitRoot: "/repo" }))
-      .toEqual(["tty", "web", "chat", "code"]);
+      .toEqual(["tty", "code", "web", "chat"]);
   });
 
   it("gates code off without a gitRoot", () => {

--- a/app/frontend/src/lib/right-panel.ts
+++ b/app/frontend/src/lib/right-panel.ts
@@ -29,8 +29,9 @@ import { availableTiles, type SurfaceKind } from "./surface-layout";
 export type SurfaceName = SurfaceKind;
 
 /**
- * The surfaces a window offers, `tty` FIRST then `web`/`chat`/`code` per
- * capability (260812-ab5v R8). Delegates to `surface-layout.ts`'s
+ * The surfaces a window offers, in shortcut order — `tty`/`code`/`web` (the
+ * ⌘1/⌘2/⌘3 positional digits), `chat` last — per capability (260812-ab5v R8).
+ * Delegates to `surface-layout.ts`'s
  * `availableTiles` — the ONE registry rail + layout + switcher share — which
  * in turn keys off `window-view.ts`'s capability helpers (`hasWebUrl` for
  * `web`, `hasChat` for `chat`, `hasCode` for `code` — gitRoot-derived since

--- a/app/frontend/src/lib/surface-layout.test.ts
+++ b/app/frontend/src/lib/surface-layout.test.ts
@@ -94,7 +94,7 @@ describe("availableTiles", () => {
   it("always lists tty + web, then chat/code per capability — web availability is unconditional", () => {
     expect(availableTiles(plain)).toEqual(["tty", "web"]);
     expect(availableTiles(webWin)).toEqual(["tty", "web"]);
-    expect(availableTiles(fullWin)).toEqual(["tty", "web", "chat", "code"]);
+    expect(availableTiles(fullWin)).toEqual(["tty", "code", "web", "chat"]);
     expect(availableTiles(null)).toEqual(["tty", "web"]);
   });
 

--- a/app/frontend/src/lib/surface-layout.ts
+++ b/app/frontend/src/lib/surface-layout.ts
@@ -194,18 +194,22 @@ export function serializeLayout(layout: Layout): string {
 }
 
 /**
- * The surfaces a window can tile, `tty` FIRST (R8 — the shared registry the
- * rail, layout, and switcher all key off), then `web`/`chat`/`code` per
- * capability. Availability reuses the window-view helpers as the single
- * source of truth; reachability is NOT part of availability (it governs a
- * surface's content, not its presence). `web` is unconditional — the lens
- * always exists; `hasWebUrl` selects its content (onboarding vs live iframe),
- * so the degradation ladder never drops a web tile.
+ * The surfaces a window can tile (R8 — the shared registry the rail, layout,
+ * and switcher all key off). The order is the positional surface digits'
+ * order — ⌘1 tty, ⌘2 code, ⌘3 web (`lib/keybindings.ts`) — so the toggle
+ * group, switch group, and palette lists always render in shortcut order;
+ * `chat` (rail-hidden, no digit) comes last. Availability reuses the
+ * window-view helpers as the single source of truth; reachability is NOT part
+ * of availability (it governs a surface's content, not its presence). `web`
+ * is unconditional — the lens always exists; `hasWebUrl` selects its content
+ * (onboarding vs live iframe), so the degradation ladder never drops a web
+ * tile.
  */
 export function availableTiles(win: ViewWindow | null | undefined): SurfaceKind[] {
-  const tiles: SurfaceKind[] = ["tty", "web"];
-  if (hasChat(win)) tiles.push("chat");
+  const tiles: SurfaceKind[] = ["tty"];
   if (hasCode(win)) tiles.push("code");
+  tiles.push("web");
+  if (hasChat(win)) tiles.push("chat");
   return tiles;
 }
 


### PR DESCRIPTION
## Summary

Three small top-bar/chrome consistency fixes, the first two measured pixel-exact from a 2× screenshot. (1) The surface tile header (`h-[32px]` + 1px `border-b`) put its bottom rule at 31px while the adjacent sidebar rail's seam (32px rail + `border-t-[3px]` on the panel below) starts at 32px — the header is now `h-[35px] border-b-[3px]` (32px content + 3px rule), joining the top bar / bottom bar / sidebar 3px chrome-rule vocabulary. (2) The server and session breadcrumb crumbs were content-height (~27px) and centered 1px high of the fixed-height controls; `CRUMB_BOX_CLASS` now carries the shared control min-height (`28px` fine / `30px` coarse, the brand crumb's existing treatment), with `truncate max-w-[16ch]` moved to an inner span since text-overflow doesn't apply inside a flex container. (3) The surface-toggle group rendered tty/web/code while the positional digits are ⌘1 tty / ⌘2 code / ⌘3 web — `availableTiles` now returns shortcut order (`tty`, `code`, `web`, rail-hidden `chat` last), which the toggle group, mobile switch group, and palette lists all inherit.

## Changes

- `surface-layout.tsx` — tile header `h-[32px] border-b` → `h-[35px] border-b-[3px]`, aligning its bottom rule with the sidebar rail seam
- `top-bar.tsx` — `CRUMB_BOX_CLASS` gains `inline-flex items-center min-h-[28px] coarse:min-h-[30px]`; brand crumb drops its now-duplicate min-h; server/session crumbs truncate via an inner span
- `lib/surface-layout.ts` — `availableTiles` returns `tty`/`code`/`web`/`chat` (⌘1/⌘2/⌘3 shortcut order); comment touch-ups in `right-panel.ts`, `top-bar.tsx`, `app.tsx`
- Tests updated: header-height assertion, session-chip lookup, and `availableTiles`/`availableSurfaces` order expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)