### PR TITLE
docs: Code Bridge — spec + draft intake for `rk code exec` and the rk-code-bridge extension

### DIFF
--- a/docs/specs/code-bridge.md
+++ b/docs/specs/code-bridge.md
@@ -1,0 +1,194 @@
+# Code Bridge — run VS Code commands in the `code` lens from the shell
+
+> Design record for `rk code exec` and the `rk-code-bridge` code-server extension. Baseline: run-kit
+> v3.18.1, code-server 4.112. Companion to [`right-panel.md`](right-panel.md) § The `code` lens, which
+> owns the code-server topology (`/code/` route, `RK_PORT+2`, the per-window folder latch); this spec
+> adds the one thing that lens lacks — a channel *into* the extension host.
+
+## Problem
+
+Agents in run-kit panes can open windows, present web content (`rk present`), and the `code` lens
+renders code-server on a latched folder. But nothing can act *inside* the editor: code-server exposes no
+command channel — its CLI only opens files, the URL `payload=` parameter only supports `openFile`, and
+the GitHub Pull Requests extension's URI handler is for auth callbacks. That extension's 171 `pr.*`
+commands — and every other palette command — are reachable only from inside the extension host.
+
+Motivating case: "prepare PR #N for review". The agent can `gh pr checkout`, and the `code` lens shows
+the folder, but it cannot refresh the PR view, focus the PR sidebar, or open the diffs the reviewer
+should start with. The last mile stays manual.
+
+The gap is exactly one thing: a process inside the extension host that calls
+`vscode.commands.executeCommand()` on behalf of a same-user shell.
+
+## Shape
+
+```
+agent shell / tmux pane          unix socket (0600)                      code-server extension host
+rk code exec pr.refreshList ──▶ $XDG_STATE_HOME/run-kit/cb/<hostId>.sock ──▶ rk-code-bridge extension
+        │                                                                     net.createServer → executeCommand
+        │  looks up host by folder                                            one per open folder/window
+        └──────────────▶ $XDG_STATE_HOME/run-kit/cb/hosts/<hostId>.json ◀─── registers on activate
+                         {hostId, folder, pid, sock, extVersion, startedAt}
+```
+
+Two pieces, one contract:
+
+1. **`rk-code-bridge`** — a ~60-line VS Code extension (TypeScript; deps: `vscode` API + Node `net`),
+   source at `app/code-bridge/`. On activate it opens a Unix socket, writes a host record, and serves
+   `executeCommand` requests. On deactivate it removes both.
+2. **`rk code`** — a new cobra command group. `exec` resolves the right host, sends the request, prints
+   the result. `hosts` lists live hosts. The VSIX is `go:embed`ded and installed by the existing
+   `rk code-server install` / `update`.
+
+The daemon is not involved. The bridge is peer-to-peer between a shell and an extension host; the
+`/code/` route, the latch, and reachability handling in `right-panel.md` are untouched.
+
+## Protocol
+
+Newline-delimited JSON over the socket. One request per connection (keeps the extension stateless).
+
+```jsonc
+→ {"id":"k3f9","command":"pr.checkoutByNumber","args":[2908],"timeoutMs":30000}
+← {"id":"k3f9","ok":true,"result":null,"ms":812}
+
+→ {"id":"q1","command":"nope.doesNotExist","args":[]}
+← {"id":"q1","ok":false,"error":{"kind":"unknown-command","message":"command 'nope.doesNotExist' not found"}}
+
+→ {"id":"p2","command":"__ping"}
+← {"id":"p2","ok":true,"result":{"folder":"/Users/sahil/code/sahil87/run-kit","pid":81784,"version":"0.1.0"}}
+```
+
+| Field | Notes |
+|-------|-------|
+| `command` | Any registered command id. `__ping` and `__commands` (returns `vscode.commands.getCommands(true)`) are bridge-internal. |
+| `args` | JSON array, passed positionally. Path-like strings are **not** auto-converted; the one piece of sugar is the `{"$uri":"file:///…"}` marker, rewritten to `vscode.Uri.parse` — `vscode.open` / `vscode.diff` want Uris. |
+| `result` | Serialised via `JSON.stringify`; non-serialisable results become `{"$nonSerializable":true,"type":"…"}`. Never throws on serialisation. |
+| `error.kind` | `unknown-command` · `threw` · `timeout` · `bad-request`. Maps to CLI exit codes below. |
+
+## CLI surface
+
+```
+rk code exec <command> [json-arg…]      # run a command; args are JSON literals (bare words → strings)
+      --folder <path>                     # target host by workspace folder (default: git toplevel of cwd)
+      --host <id>                         # target by host id from `rk code hosts`
+      --all                               # fan out to every live host
+      --timeout 30s
+      --json                              # raw response envelope on stdout (default prints result only)
+rk code hosts [--json]                    # live hosts: id, folder, pid, age; prunes records whose pid is dead
+rk code commands [--folder]               # `__commands` — grep-able list of what the palette can do
+```
+
+Output contract follows the toolkit standard (`toolkit-standards`): stdout is data (the result JSON),
+stderr is diagnostics; exit `0` ok, `1` operational (no host, timeout, command threw), `2` usage (bad
+JSON arg, unknown flag). `unknown-command` exits 1 with the closest matches on stderr. `--quiet`
+suppresses chatter only (Principle 9).
+
+### Host resolution
+
+1. `--host` wins.
+2. `--folder` (default: git toplevel of cwd) is matched against each record's `folder` — exact first,
+   then longest-prefix (a worktree under a multi-root workspace still resolves).
+3. No match and exactly one live host → use it, with a stderr note. Several → exit 1 listing them.
+   None → exit 1 with the hint to open the `code` lens on that folder.
+
+### No `rk code open` (yet)
+
+An earlier draft had `rk code open <folder>` as sugar over `rk present`. That is wrong for run-kit: the
+`code` lens's folder is a **per-viewer latch** in localStorage (`right-panel.md`), seeded once from the
+active pane's git root and moved only by the editor's own navigation. A CLI cannot set it today. The
+right hook is the deferred `@rk_code_folder` tmux-option upgrade path named in `right-panel.md`; when
+that lands, `rk code open` becomes a one-line wrapper over it. Until then the agent's recipe is: be in
+the repo when the user first opens the code surface, or ask the user to File > Open Folder.
+
+## Extension lifecycle
+
+- `activationEvents: ["*"]` — deliberately eager; being reachable before any user action is the point,
+  and it costs one socket. Fallback to `onStartupFinished` if startup cost ever shows.
+- `hostId` = short hash of (workspace folder, machine id). Deterministic, so a reloaded window reuses
+  its record and socket path instead of leaking one per reload.
+- Socket at `$XDG_STATE_HOME/run-kit/cb/<hostId>.sock` (default `~/.local/state/run-kit/cb/`) — the
+  same state root `layout-snapshots` uses. Not `~/.config/run-kit` (config is user-authored; this is
+  runtime state) and not the legacy `~/.rk`. ~50 bytes, under the 104-byte macOS `sun_path` cap.
+  Stale socket files are unlinked on activate.
+- Registry record `$XDG_STATE_HOME/run-kit/cb/hosts/<hostId>.json`:
+  `{hostId, folder, pid, sock, extVersion, startedAt}`. The CLI treats a record as live only if
+  `kill -0 pid` succeeds **and** `__ping` answers; otherwise it removes it.
+- VS Code setting `rk.bridge.enabled` (default `true`) as the off switch, written into the managed
+  profile's `settings.json` alongside the existing `chat.disableAIFeatures` etc. No allowlist in v1
+  (see Security).
+
+## Security
+
+This is a same-user, local-only RCE into the editor. That is the feature; the design keeps it at exactly
+that privilege level and no wider.
+
+- **Unix socket, not TCP.** A localhost port is reachable by any page in the user's browser (a form POST
+  to `127.0.0.1:port` is not blocked by CORS). A filesystem socket is reachable only by processes that
+  can open a path under the user's state dir.
+- `cb/` is 0700, sockets 0600. The extension refuses to start if the dir has looser permissions.
+- No privilege gained: anything a caller can do through the bridge it could already do as the same user
+  (edit the extensions dir, edit settings, kill the process). An allowlist would be theatre against a
+  threat already inside the account. Revisit if code-server is ever bound beyond loopback or run as a
+  different user — the `rk remote` path keeps it loopback + SSH, so that holds there too.
+- The bridge never spawns processes itself. `workbench.action.terminal.sendSequence` is reachable
+  through it — equivalent to typing in the user's terminal, which the shell already can.
+
+## Distribution
+
+1. Extension source at `app/code-bridge/` (package.json, `src/extension.ts`, esbuild bundle), built
+   with `vsce package` in the release workflow → `rk-code-bridge-<v>.vsix`. Version pinned to the rk
+   release version.
+2. Go side `//go:embed`s the VSIX (`internal/installers`, next to the code-server installer).
+   `rk code-server install` / `update` gain a step:
+   `code-server --install-extension <tmp.vsix> --extensions-dir ~/.local/share/code-server/extensions`
+   when installed ≠ embedded version. The daemon's `rk-code-server` sibling session is restarted on
+   update as today.
+3. Version skew: the record carries `extVersion`; the CLI warns on stderr when it is older than its
+   embedded version and suggests `rk code-server update`. Protocol is additive-only, so mismatch
+   degrades, never breaks.
+4. `rk doctor` gains a line: bridge installed / live hosts.
+5. `rk skill code` topic page so agents discover the surface; `rk help-dump` picks up the group
+   automatically (toolkit-standards new-surface check).
+
+## Motivating use case, end to end
+
+```sh
+# prepare PR #2908 for review in its own worktree + editor tile
+rk riff pr-2908 …                                          # worktree + window (or wt create + new-window)
+gh pr checkout 2908
+# user opens the code surface once → latch seeds to this worktree; bridge host registers within ~1s
+rk code exec pr.refreshList                                # GitHub PR extension picks up the branch's PR
+rk code exec vscode.diff '{"$uri":"…/a.ts"}' '{"$uri":"…/b.ts"}' "review: a.ts"
+rk code exec workbench.view.extension.github-pull-requests # focus the PR sidebar
+rk notify "PR 2908 ready in the code tile" --title review
+```
+
+The PR extension already detects the PR of the checked-out branch, so the bridge's job is the last
+mile — refresh, focus, open the diffs the reviewer should start with — not the checkout itself.
+
+## Alternatives considered
+
+| Option | Why not |
+|--------|---------|
+| File spool (drop `.json`, extension `fs.watch`es) | No response channel without a second file; ordering is racy; macOS `fs.watch` coalesces events. A socket is barely more code and gives request/response for free. |
+| HTTP on a localhost port | Reachable from browser JS (see Security); port allocation; would need a token. Strictly worse than a socket for a same-machine caller. |
+| Route through the daemon (`/api/code/exec`) | Adds a hop and puts editor RCE behind the web server's auth surface. Nothing in the daemon needs to know; keep it peer-to-peer. A thin proxy can be added later if `rk remote` hosts need cross-machine exec. |
+| Keystroke injection into the browser / code-server `payload=` | Neither can express "execute command X with args". |
+| Fork code-server to add a CLI | Maintenance burden for a 60-line problem. |
+
+## Phasing
+
+| Phase | Deliverable | Proves |
+|-------|-------------|--------|
+| P1 (spike, ~½ day) | Extension + hand-installed VSIX; throwaway `nc -U` script | Socket path length, eager activation, that `executeCommand` from a socket callback behaves on the ext-host event loop |
+| P2 | `rk code exec / hosts / commands`; host resolution; embed + install step; `rk doctor` line | Distribution and version-skew story |
+| P3 | `rk skill code` topic page; `rk code open` once `@rk_code_folder` exists | Agent-facing ergonomics |
+
+## Open questions
+
+1. **Command group name**: `rk code exec` (lean — `code-server` is install management, `code` is the
+   running editor) vs folding into the existing `rk code-server` group.
+2. **Remote hosts**: should P2 make exec reachable over `rk remote` tunnels (needs the daemon proxy),
+   or stay local-only? Lean: defer.
+3. **Deny-list**: ship a `rk.bridge.deny` setting anyway as belt-and-braces? Lean: no (see Security).
+4. **Does P3's `rk code open` pull the `@rk_code_folder` upgrade forward**, or wait for its own change?

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -25,6 +25,7 @@
 | [Agent State](agent-state.md) | The `@rk_agent_state` pane-option convention — two-tier ownership, value schema, writer/reader rules, shell reconciler, and the `rk agent setup` per-agent hook registry (cross-repo contract with fab-kit) |
 | [API](api.md) | HTTP, SSE, and WebSocket endpoint specification — the target API surface |
 | [Architecture](architecture.md) | System architecture, repository structure, data flow, build & deploy |
+| [Code Bridge](code-bridge.md) | `rk code exec` + the `rk-code-bridge` code-server extension — run VS Code palette commands in the `code` lens from a shell over a same-user Unix socket under `$XDG_STATE_HOME/run-kit/cb/`; protocol, host resolution, security stance, distribution via `rk code-server install`, phasing |
 | [CLI Layering](cli-layering.md) | Two-tool model — rk owns the tmux/agent substrate, fab owns pipeline choreography: delegation rules, the `rk mux`/`rk agent` grouping plan, hidden plumbing, the `fab pane` migration map, and the 8-part phased execution plan |
 | [Project Plan](project-plan.md) | 4-phase reimplementation plan: scaffold → backend → frontend → cleanup |
 | [Right Panel](right-panel.md) | Collapsible right panel on the terminal route — a second (substrate, lens) slot behind an icon rail: surface registry (web/code/agents), the `code` lens (code-server embed, git-root keyed), the `@rk_owner` companion-window convention, mobile sheet degradation, phasing |

--- a/fab/changes/260826-83jz-code-bridge-extension/.history.jsonl
+++ b/fab/changes/260826-83jz-code-bridge-extension/.history.jsonl
@@ -1,0 +1,3 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-08-26T07:26:16Z"}
+{"args":"rk code bridge: VS Code extension + rk code CLI to run command-palette commands inside the code-server tile over a unix socket","cmd":"fab-new","event":"command","ts":"2026-08-26T07:26:16Z"}
+{"delta":"+3.7","event":"confidence","score":3.7,"trigger":"calc-score","ts":"2026-08-26T07:28:52Z"}

--- a/fab/changes/260826-83jz-code-bridge-extension/.status.yaml
+++ b/fab/changes/260826-83jz-code-bridge-extension/.status.yaml
@@ -1,0 +1,36 @@
+id: 83jz
+name: 260826-83jz-code-bridge-extension
+created: 2026-08-26T07:26:16Z
+created_by: sahil-noon
+change_type: feat
+issues: []
+progress:
+    intake: ready
+    apply: pending
+    review: pending
+    hydrate: pending
+    ship: pending
+    review-pr: pending
+plan:
+    generated: false
+    task_count: 0
+    acceptance_count: 0
+    acceptance_completed: 0
+confidence:
+    certain: 3
+    confident: 6
+    tentative: 0
+    unresolved: 0
+    score: 3.7
+    fuzzy: true
+    dimensions:
+        signal: 65.0
+        reversibility: 85.6
+        competence: 71.7
+        disambiguation: 65.0
+stage_metrics:
+    intake: {started_at: "2026-08-26T07:26:16Z", driver: fab-new, iterations: 1}
+prs: []
+change_type_source: explicit
+# true_impact: lazily created on first stage-finish that computes it (no placeholder here).
+last_updated: 2026-08-26T07:28:52Z

--- a/fab/changes/260826-83jz-code-bridge-extension/intake.md
+++ b/fab/changes/260826-83jz-code-bridge-extension/intake.md
@@ -1,0 +1,137 @@
+# Intake: Code Bridge — `rk code exec` + the `rk-code-bridge` code-server extension
+
+**Change**: 260826-83jz-code-bridge-extension
+**Created**: 2026-08-26
+
+## Origin
+
+Conversational. Started in a loom `/fab-discuss` session (2026-08-26) where the user asked how far an
+agent can control the run-kit environment — open tabs, web/terminal tiles, the code-server tile — and
+specifically whether an agent can run VS Code command-palette commands (the GitHub Pull Requests
+extension's `pr.*` commands) inside the code tile to prepare a PR for review. Investigation against the
+live install (rk v3.18.1, code-server 4.112 on `127.0.0.1:3002`, PR extension 0.144.0) showed everything
+up to the extension host is controllable, but no external channel into the extension host exists. The
+user asked for a design, agreed to it, corrected the directory layout (XDG, not the legacy `~/.rk`), and
+redirected the work here:
+
+> I agree. Lets build a bridge extension. […] Save this design in the specs. And create an intake to take
+> this forward using another agent (dont execute it). […] This needs to happen in the run-kit repo.
+
+The design is saved as [`docs/specs/code-bridge.md`](../../../docs/specs/code-bridge.md). **That spec
+is the authoritative design; this intake summarises it and records the decisions.** While porting it
+here, one correction was made against run-kit's own specs: the draft's `rk code open` sugar (over
+`rk present :3002`) is wrong because the `code` lens folder is a per-viewer latch
+([`right-panel.md`](../../../docs/specs/right-panel.md) § The `code` lens); it is deferred to the
+`@rk_code_folder` upgrade path.
+
+## Why
+
+1. **Pain point.** Agents can put content in front of the user (`rk present`) and the `code` lens shows
+   the repo, but nothing can act *inside* the editor. For "prepare PR #N for review" the agent checks the
+   branch out and stops — refreshing the PR view, focusing the PR sidebar, opening the first diffs are all
+   human clicks.
+2. **Consequence.** The "agent prepares, human reviews" loop run-kit exists for breaks at the editor
+   boundary; agents fall back to describing what to click.
+3. **Why this approach.** code-server has no command channel (CLI opens files only; URL `payload=`
+   supports only `openFile`; the PR extension's URI handler is auth-only). The only place
+   `vscode.commands.executeCommand()` is callable is inside the extension host, so the minimal correct
+   fix is a tiny extension exposing it over a same-user Unix socket, plus an `rk` subcommand that speaks
+   to it. File spool, localhost HTTP, a daemon proxy, keystroke injection, and forking code-server were
+   considered and rejected (spec § Alternatives considered).
+
+## What Changes
+
+### 1. `rk-code-bridge` extension — `app/code-bridge/`
+
+- TypeScript; deps `vscode` API + Node `net`; esbuild bundle; `vsce package` → `rk-code-bridge-<v>.vsix`,
+  version = rk release version. `activationEvents: ["*"]`.
+- Activate: ensure `$XDG_STATE_HOME/run-kit/cb/` (default `~/.local/state/run-kit/cb/`) exists 0700 —
+  refuse to start if looser; `hostId` = short hash(workspace folder, machine id); unlink stale
+  `cb/<hostId>.sock`; `net.createServer` on it, chmod 0600; write `cb/hosts/<hostId>.json` =
+  `{hostId, folder, pid, sock, extVersion, startedAt}`. Deactivate: remove socket + record.
+- NDJSON, one request per connection: `{"id","command","args":[…],"timeoutMs"}` →
+  `{"id","ok":true,"result","ms"}` | `{"id","ok":false,"error":{"kind","message"}}`,
+  `kind ∈ unknown-command | threw | timeout | bad-request`.
+- Internals: `__ping` → `{folder, pid, version}`; `__commands` → `vscode.commands.getCommands(true)`.
+- Arg sugar: `{"$uri":"file:///…"}` → `vscode.Uri.parse`. No other coercion. Results via
+  `JSON.stringify`; non-serialisable → `{"$nonSerializable":true,"type"}`.
+- Setting `rk.bridge.enabled` (default `true`), declared in `contributes.configuration`.
+
+### 2. `rk code` command group — `app/backend/cmd/…`, `internal/codebridge`
+
+```
+rk code exec <command> [json-arg…]  [--folder <path>] [--host <id>] [--all] [--timeout 30s] [--json]
+rk code hosts [--json]
+rk code commands [--folder]
+```
+
+- Args are JSON literals; bare words become strings.
+- Host resolution: `--host` → `--folder` (default git toplevel of cwd; exact, then longest-prefix on record
+  `folder`) → single live host with stderr note → else exit 1 listing hosts.
+- Liveness: `kill -0 pid` **and** `__ping` answers; otherwise prune the record.
+- Toolkit contract: stdout data / stderr diagnostics; exit `0`/`1`/`2`; `--quiet` (Principle 9);
+  `unknown-command` → exit 1 + closest matches on stderr.
+
+### 3. Distribution
+
+- `//go:embed` the VSIX in `internal/installers`; `rk code-server install` / `update` run
+  `code-server --install-extension <tmp.vsix> --extensions-dir ~/.local/share/code-server/extensions`
+  when installed ≠ embedded version; restart the `rk-code-server` sibling session as today.
+- CLI warns on stderr when a host's `extVersion` < embedded; protocol additive-only.
+- `rk doctor`: "code bridge" line (installed / live hosts).
+- `rk skill code` topic page; `rk help-dump` new-surface check (toolkit-standards).
+- Release workflow: build the VSIX before the Go build.
+- `fab/project/config.yaml` `source_paths`: add `app/code-bridge/`.
+
+### 4. Phasing
+
+| Phase | Deliverable |
+|-------|-------------|
+| P1 spike | Extension + hand-installed VSIX + `nc -U` script; proves socket path, eager activation, `executeCommand` from a socket callback |
+| P2 | `rk code exec / hosts / commands`; resolution; embed + install; `rk doctor` line |
+| P3 | `rk skill code`; `rk code open` only once `@rk_code_folder` exists |
+
+## Affected Memory
+
+- `run-kit/code-bridge`: (new) the bridge — socket + registry contract, protocol, `rk code` family,
+  host resolution, install/version-skew story, security stance
+- `run-kit/architecture`: (modify) add `internal/codebridge`, the embedded VSIX in `internal/installers`,
+  and the `rk code` CLI group
+- `run-kit/configuration`: (modify) new state-dir tenant `$XDG_STATE_HOME/run-kit/cb/` next to
+  `snapshots/`; `rk.bridge.enabled` lives in the managed code-server profile, not `config.yaml`
+- `run-kit/toolkit-standards`: (modify) new-surface check covers `rk code`
+
+## Impact
+
+- **New**: `app/code-bridge/` (extension), `app/backend/internal/codebridge/` (client + resolver),
+  `rk code` cobra group.
+- **Modified**: `internal/installers` (embed + install step), `rk doctor`, `rk skill` bundle
+  (+ `code` topic), release workflow (VSIX build), `fab/project/config.yaml` source_paths.
+- **Runtime footprint**: `$XDG_STATE_HOME/run-kit/cb/`. Nothing under `~/.config/run-kit`; daemon
+  untouched; `/code/` route and latch untouched.
+- **Dependencies**: `@types/vscode`, `esbuild`, `@vscode/vsce` (dev-only) in the extension; no new Go deps.
+- **Tests**: Go unit tests for arg parsing, host resolution, liveness pruning, protocol envelope; an
+  extension smoke test over a real socket (Node, no VS Code host) for the request/response codec.
+
+## Open Questions
+
+- Command group name: `rk code exec` (recommended) or fold into `rk code-server`?
+- Should P2 make exec reachable over `rk remote` tunnels (needs a daemon proxy), or stay local-only (recommended)?
+- Ship a `rk.bridge.deny` setting as belt-and-braces despite the spec's argument against it (recommended: no)?
+- Does P3's `rk code open` pull the `@rk_code_folder` tmux-option upgrade forward, or wait for its own change?
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Transport is a Unix socket under `$XDG_STATE_HOME/run-kit/cb/`, not TCP/HTTP or a file spool | Discussed — user agreed; state root matches `layout-snapshots`; security argument in spec | S:90 R:70 A:90 D:90 |
+| 2 | Certain | NDJSON protocol, one request per connection, `__ping`/`__commands`, `$uri` marker | Presented in the design the user accepted; fully specified in the spec | S:90 R:85 A:90 D:85 |
+| 3 | Certain | No `rk code open` in v1 — deferred to `@rk_code_folder` | `right-panel.md` makes the latch per-viewer localStorage; a CLI cannot set it today | S:80 R:90 A:90 D:85 |
+| 4 | Confident | VSIX `go:embed`ded and installed by `rk code-server install/update` | Those commands already own the extensions dir and the `rk-code-server` restart | S:65 R:80 A:80 D:75 |
+| 5 | Confident | Extension source at `app/code-bridge/`, client at `internal/codebridge` | Mirrors `app/{backend,desktop,frontend}` and the `internal/*` library split in `architecture` | S:60 R:85 A:75 D:70 |
+| 6 | Confident | Command group is `rk code`, not `rk code-server` | Lean in spec; user has not chosen; trivially renamed before merge | S:50 R:90 A:45 D:40 |
+| 7 | Confident | Local-only in P2; `rk remote` deferred | Spec recommends defer; additive later | S:45 R:85 A:50 D:45 |
+| 8 | Confident | No `rk.bridge.deny` in v1 | Same-user privilege argument; ten-line addition if wanted | S:50 R:95 A:60 D:45 |
+| 9 | Confident | Eager activation (`activationEvents: ["*"]`) | Reachability before any user action is the point; `onStartupFinished` is the fallback | S:55 R:90 A:65 D:50 |
+
+9 assumptions (3 certain, 6 confident, 0 tentative, 0 unresolved).


### PR DESCRIPTION
## Summary

Agents can present content and the `code` lens shows a repo, but nothing can act *inside* the editor — code-server exposes no command channel, so the GitHub Pull Requests extension's `pr.*` commands (and every other palette command) are unreachable from a shell. This PR records the agreed design for closing that gap: a ~60-line `rk-code-bridge` extension serving `vscode.commands.executeCommand()` over a same-user Unix socket under `$XDG_STATE_HOME/run-kit/cb/`, plus an `rk code exec / hosts / commands` CLI group. No daemon involvement; the `/code/` route and folder latch from `right-panel.md` are untouched.

Design + intake only — no implementation. The intake is a draft (not activated) for another agent to pick up via `/fab-switch 260826-83jz-code-bridge-extension`.

## Changes

- `docs/specs/code-bridge.md` — problem, shape, NDJSON protocol, CLI surface + host resolution, why there is no `rk code open` yet (per-viewer latch → deferred to `@rk_code_folder`), extension lifecycle, security stance (socket not TCP; no allowlist rationale), distribution via `go:embed` + `rk code-server install/update`, alternatives, phasing, open questions
- `docs/specs/index.md` — index row
- `fab/changes/260826-83jz-code-bridge-extension/` — draft intake at `ready`, type `feat`; four open questions recorded as graded assumptions with recommendations

🤖 Generated with [Claude Code](https://claude.com/claude-code)