### PR TITLE
docs: Code Bridge — record follow-on work in spec and plan

### DIFF
--- a/docs/specs/code-bridge.md
+++ b/docs/specs/code-bridge.md
@@ -184,6 +184,27 @@ mile — refresh, focus, open the diffs the reviewer should start with — not t
 | P2 | `rk code exec / hosts / commands`; host resolution; embed + install step; `rk doctor` line | Distribution and version-skew story |
 | P3 | `rk skill code` topic page; `rk code open` once `@rk_code_folder` exists | Agent-facing ergonomics |
 
+## Follow-on work (after this change ships)
+
+The bridge is a capability; nothing invokes it until the agent side is wired. In order:
+
+1. **Agent discovery — `rk skill code` + consumer skills.** P3's topic page covers the rk side. Each
+   consuming repo's toolkit skill (e.g. loom's `.claude/skills/shll-toolkit`) needs a matching pointer
+   so an agent asked to "prep PR #N" reaches for `rk code exec` instead of describing clicks.
+2. **A "prepare PR for review" recipe as a consumer-side skill** (e.g. `/review-prep <pr>`): worktree +
+   `gh pr checkout`, wait for the host to register (`rk code hosts`), then `pr.refreshList`, focus the
+   PR sidebar, open the first diffs, `rk notify`. This is the motivating use case — without it the bridge
+   is unused.
+3. **Close the latch gap — `@rk_code_folder` + `rk code open`.** The recipe above keeps one human step
+   (open the code surface once so the folder latches). Landing the deferred `@rk_code_folder`
+   tmux-option store from `right-panel.md` and wrapping it as `rk code open <folder>` removes the only
+   manual step in the loop. Own run-kit change, not this one.
+4. **Fold into existing review skills.** Consumer `git-pr-review`-style skills that review via `gh` in
+   the terminal can additionally stage the review visually in the code tile — an amendment, not a new
+   skill.
+
+Item 2 is the one that makes the feature visible day to day; 1 is its prerequisite, 3 its polish.
+
 ## Open questions
 
 1. **Command group name**: `rk code exec` (lean — `code-server` is install management, `code` is the

--- a/fab/changes/260826-83jz-code-bridge-extension/plan.md
+++ b/fab/changes/260826-83jz-code-bridge-extension/plan.md
@@ -333,6 +333,24 @@ plain `node --test` over a real Unix socket (the intake's smoke-test requirement
 - All acceptance items must pass before `/fab-continue` (hydrate)
 - If an item is not applicable, mark checked and prefix with **N/A**: `- [x] A-NNN **N/A**: {reason}`
 
+## Follow-on Work
+
+Not part of this change (see § Non-Goals). What turns the shipped capability into something agents
+actually use, in order — mirrored in `docs/specs/code-bridge.md` § Follow-on work:
+
+1. **Agent discovery.** `rk skill code` covers the rk side; each consuming repo's toolkit skill (e.g.
+   loom's `.claude/skills/shll-toolkit`) needs a pointer so an agent asked to "prep PR #N" reaches for
+   `rk code exec` instead of describing clicks. *Consumer repos.*
+2. **`/review-prep <pr>` recipe.** Worktree + `gh pr checkout`, wait for `rk code hosts` to show the
+   folder, then `pr.refreshList`, focus the PR sidebar, open the first diffs, `rk notify`. The motivating
+   use case — the item that makes the bridge visible day to day. *Consumer repos.*
+3. **Latch gap — `@rk_code_folder` + `rk code open <folder>`.** The recipe keeps one human step (open
+   the code surface once so the folder latches). Landing the deferred `@rk_code_folder` tmux-option store
+   from `right-panel.md` and wrapping it as `rk code open` removes it. *Own run-kit change.*
+4. **Fold into existing review skills.** `git-pr-review`-style skills that review via `gh` in the
+   terminal can additionally stage the review in the code tile — an amendment, not a new skill.
+   *Consumer repos.*
+
 ## Deletion Candidates
 
 - None — this change adds new functionality without making existing code redundant. The only relocated symbol, `codeServerExtensionsDir` (`internal/daemon/codeserver.go` → exported `codeserver.ExtensionsDir` in `internal/codeserver/extension.go`), was moved with its sole daemon call site updated in the same diff; no orphan remains.


### PR DESCRIPTION
## Summary

#743 (spec + intake) and #745 (implementation) shipped the code bridge. This records what comes next so the capability actually gets used: agent discovery in consumer toolkit skills, a `/review-prep <pr>` recipe (the motivating use case), the `@rk_code_folder` + `rk code open` latch upgrade as its own run-kit change, and folding visual staging into existing review skills.

## Changes

- `docs/specs/code-bridge.md` — new § Follow-on work (four ordered items, with which repo owns each)
- `fab/changes/260826-83jz-code-bridge-extension/plan.md` — matching § Follow-on Work before Deletion Candidates; explicitly out of scope for the completed change

🤖 Generated with [Claude Code](https://claude.com/claude-code)