### PR TITLE
docs: UI State spec + implementation plan (tmux options as the single UI store)

### DIFF
--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -34,6 +34,7 @@
 | [Status Pyramid](status-pyramid.md) | Precedence model for status signals — tier ladder (PR > fab > agent > tmux), channel model (hue/shape/animation), attention overlay, decision table, rollups |
 | [Surface Layout](surface-layout.md) | The center as a layout of surfaces — preset shapes × ordered surfaces × ratios, the `?layout=` state ladder, tile verbs, rail toggles, and the `@rk_win_lens`/view-switcher retirement map |
 | [Themes](themes.md) | Theme system architecture: ANSI palettes, derivation, tmux integration, import script |
+| [UI State](ui-state.md) | Every addressable UI thing is a tmux option — the `@N/<surface>/<n>` addressing grammar, the `@rk_win_*` inventory (layout, indexed web tabs, code root), tab state vs viewer preferences, `rk tab` CLI, absorption of `rk present` and the `?layout=` ladder |
 | [Window Views](window-views.md) | Rows are substrates, views are lenses — the parallel-view model (tty/web/chat/desktop): derived availability vs per-viewer choice, the shared switcher contract, two-species taxonomy, migration map for iframe / desktop (PR #71) / chat |
 
 ## Wiki

--- a/docs/specs/right-panel.md
+++ b/docs/specs/right-panel.md
@@ -1,5 +1,10 @@
 # Right Panel — A Second Slot Beside the Terminal
 
+> **Amended by [`ui-state.md`](ui-state.md) (2026-08-28, draft):** P1 (per-viewer, URL-addressable panel choice) is superseded by shared
+> `@rk_win_layout`; § Companion Windows is unshipped and tracked there as an open question.
+> Read this file's rules through that lens until the in-place amendment lands
+> with implementation.
+
 > A collapsible right-side panel on the terminal route that renders a **second
 > (substrate, lens) pair** beside the tty, behind an icon rail rendered on
 > every desktop terminal route and collapsible from the top bar

--- a/docs/specs/surface-layout.md
+++ b/docs/specs/surface-layout.md
@@ -1,5 +1,11 @@
 # Surface Layout — The Center Is a Layout of Surfaces
 
+> **Amended by [`ui-state.md`](ui-state.md) (2026-08-28, draft):** § State — the resolution ladder (L1–L4) retires; shape+order live in
+> `@rk_win_layout`, `?layout=` dies after one release, ratios and zoom stay per-viewer.
+> Shapes and verbs are unchanged.
+> Read this file's rules through that lens until the in-place amendment lands
+> with implementation.
+
 > The terminal route's center becomes a **layout manager**: one to three tiles,
 > each rendering a **surface** (a (substrate, lens) pair per
 > [`right-panel.md`](right-panel.md)), arranged by a **preset shape** with a

--- a/docs/specs/ui-state.md
+++ b/docs/specs/ui-state.md
@@ -1,0 +1,432 @@
+# UI State — Every Addressable Thing Is a tmux Option
+
+> **Status**: DRAFT v0.2 (2026-08-28) — discussion artifact, iterating. Decided
+> 2026-08-28: zoom is per-viewer (not tmux); navigation is not tmux state in
+> v1; `?layout=` dies after one release of link translation. Assumes
+> `fab/plans/sahil/26-08-28-tmux-option-scope-naming.md` has shipped: every
+> option below uses the `@rk_<scope>_<name>` scheme and the plan's target map
+> is the starting inventory.
+>
+> **Supersedes / amends**: [`window-views.md`](window-views.md) R2 + R7 (choice
+> is no longer per-viewer), [`surface-layout.md`](surface-layout.md) § State —
+> the resolution ladder (L1–L4 retire), [`right-panel.md`](right-panel.md)
+> § Companion Windows (unshipped; folded into § Open Questions). Banners on those three files point here;
+> in-place amendments land with implementation. Terminology
+> stays: rows are substrates, views are lenses.
+
+## Contents
+
+- Goal
+- The Layer Stack
+- The One Rule — Tab State vs Viewer Preferences
+- Addressing Grammar
+- The Option Inventory
+- Layout in tmux
+- Web Tabs
+- Code Surface + Code Bridge
+- Viewer Behaviour — What Follows, What Doesn't
+- `rk tab` — The CLI Surface
+- What Dies, What Stays
+- Migration
+- Open Questions
+
+---
+
+## Goal
+
+An agent (or the operator at a shell) can **fully address and drive the
+run-kit UI with tmux commands alone** — open a tab, choose its layout, add a
+web tab, point the code surface at a folder, collapse it to one surface — and every
+viewer looking at that tab sees the result. run-kit's frontend becomes a
+faithful *renderer of tmux state*, not a second store that must be nudged.
+
+Corollary: `rk present`, the layout verbs, the surface toggles, the code
+bridge's host resolution, and the `?layout=` deep links all become **sugar
+over `set-option`**.
+
+---
+
+## The Layer Stack
+
+Two axes. The first is tmux's and needs nothing new; the second is run-kit's
+and this spec defines it.
+
+```
+axis 1 — tmux substrate                     axis 2 — run-kit lenses over a tab
+host ─ server (-L) ─ session ─ window ─ pane         tab ─ surface ─ [web tab]
+                              └─ "tab" ─────────────► @N
+```
+
+| Noun | Is | Address | Notes |
+|---|---|---|---|
+| **host** | a machine running `rk serve` | implicit (local daemon / `$TMUX` socket) | cross-host goes through `rk remote` tunnels; **not** in the address string (v1) |
+| **server** | a tmux server | `-L <name>` | as `rk mux` today |
+| **session** | tmux session | `=<name>:` | exact-match form, never fuzzy |
+| **tab** | a tmux **window** | `@N` | immutable id; window *name* belongs to the user and is never parsed |
+| **pane** | tmux pane | `%N` | substrate only — lenses render over the tab, not a pane |
+| **surface** | a lens kind over the tab | `@N/<surface>` | `tty` · `web` · `code` · `chat` · `desktop` · `agents` (open registry, window-views.md) |
+| **web tab** | one page inside the `web` surface | `@N/web/<n>` | 1-based index; the only surface with sub-addresses (v1) |
+
+The **tab is not the terminal**. `tty` is a lens over the window's panes and
+is the one surface that can never be closed (R3), but it is a surface like
+the others. `rk tab …` never means "the tty".
+
+---
+
+## The One Rule — Tab State vs Viewer Preferences
+
+> **Anything addressable as `@N/…` is a tmux option. Anything about the
+> viewer's device is not.**
+
+| Class | Lives in | Agent-writable? | Examples |
+|---|---|---|---|
+| **Tab state** — what the tab shows | tmux window options `@rk_win_*` | **yes** | layout shape+order, web tab set + active, code folder, note, color, marker |
+| **Substrate facts** — derived from processes | pane/window options written by hooks or derived by the daemon | by hooks | agent state, chat identity, git root, ports |
+| **Viewer preferences** — how this device renders | browser storage | no | theme, terminal font size, sidebar width/open, keybindings, macros, compose drafts, web zoom, **tile zoom / mobile single-tile choice**, divider ratios |
+| **Navigation** — which tab this viewer is on | the URL route | *by intent only* (§ Viewer Behaviour) | `/$server/@N` |
+
+Today's leak is class 1 living in class 3: `rk-layout:*`, `runkit-window-view:*`,
+`runkit-window-panel:*`, `runkit-code-folder:*` are all per-browser keys
+holding tab state (ratios and zoom stay local — they are reading postures). They move to `@rk_win_*` and the
+localStorage keys die.
+
+Why shared is *correct*, not a compromise: tmux already shares pane layout,
+active pane, and window order across every attached client. Two people
+attached to the same tmux window see the same panes. run-kit's per-viewer
+layout was the deviation from the substrate it renders; this spec removes
+the deviation. Mobile is handled by a **degradation rule**, not by separate
+state (§ Layout in tmux).
+
+---
+
+## Addressing Grammar
+
+One string, most-specific-wins, extending tmux's own:
+
+```
+[-L <server>] [=<session>:]@N[/<surface>[/<n>]]
+
+@12              the tab
+@12/web          the web surface of the tab
+@12/web/2        web tab 2 inside it
+@12/code         the code surface
+-L fabKit1 =fabKit:@3/web/1
+```
+
+Rules:
+
+- `@N` is mandatory when addressing a tab from outside it. Inside a pane,
+  every verb defaults to **the caller's own tab** (`$TMUX_PANE` → `@N`, the
+  `rk present` resolution) — the common agent case needs no address at all.
+- Session/server qualifiers are exactly `rk mux`'s grammar (strict `%N/@N/=session:`);
+  nothing fuzzy, no name-based window targets (a window name is a user label).
+- Surfaces are addressed by *kind*, not by tile position. Position is a
+  property of the layout (`@rk_win_layout`), so "slot A" is a layout
+  question, never an address.
+- Web tabs are **indexed, not named** — fewer round trips on the command line
+  (`rk tab web rm 2`, not `rk tab web rm --name docs`). Titles are derived
+  from the page and are display-only.
+
+---
+
+## The Option Inventory
+
+Starting point: the scope-naming plan's target map (22 options → 21 after
+`@rk_ctl_keepalive` deletes). This spec **adds** the rows marked *new*,
+**renames** two, and **retires** one.
+
+### Server (`@rk_srv_*`) — unchanged
+
+`@rk_srv_session_order` · `@rk_srv_rank` · `@rk_srv_origin` · `@rk_srv_managed` · `@rk_srv_ephemeral` · `@rk_srv_protected`
+
+### Session (`@rk_ses_*`) — unchanged
+
+`@rk_ses_color` · `@rk_ses_flair` · `@rk_ses_pin_board` · `@rk_ses_pin_home` · `@rk_ses_pin_order`
+
+### Window = tab (`@rk_win_*`)
+
+| Option | Value | Writer | Status |
+|---|---|---|---|
+| `@rk_win_color` | color token | UI, agents | plan |
+| `@rk_win_marker` / `@rk_win_flair` | marker/flair tokens | UI, agents | plan |
+| `@rk_win_note` | `<epoch>:<text>` | agents, operator | plan |
+| `@rk_win_role` | `operator` … | `rk role` | plan |
+| **`@rk_win_layout`** | `<shape>:<surface>[,<surface>…]` e.g. `main-left:tty,code,web` | UI verbs, `rk tab layout`, agents | **new** — replaces `rk-layout:*` localStorage, `?layout=`, `?view=`, `?panel=` |
+| **`@rk_win_web_<n>`** | URL (relative `/proxy/…`, `/present/…`, or absolute) | `rk tab web add`, UI address bar, `rk present` (sugar) | **new** — indexed set, `n ≥ 1`, dense (rm renumbers) |
+| **`@rk_win_web_<n>_root`** | absolute dir | `rk tab web add <file|dir>` | **new** — replaces `@rk_win_present_root`, now per web tab |
+| **`@rk_win_web_active`** | `n` | UI tab strip, `rk tab web select` | **new** |
+| **`@rk_win_code_root`** | absolute folder | first code-surface open (seed), code-server folder navigation, `rk tab code set` | **new** — replaces the `runkit-code-folder:*` localStorage latch |
+| `@rk_win_url` | — | — | **retired** → `@rk_win_web_1` (migration row) |
+| `@rk_win_present_root` | — | — | **retired** → `@rk_win_web_1_root` |
+| `@rk_win_lens` (ex `@rk_type`) | — | — | **retired** — the "default view hint" (R5) is subsumed by `@rk_win_layout`; `rk present --window` writes `@rk_win_layout=single:web` instead |
+
+### Pane (`@rk_pane_*`) — unchanged
+
+`@rk_pane_agent_state` · `@rk_pane_chat`
+
+### Option-value conventions
+
+- Absent and empty read alike as "unset" (the `hasWebUrl` trim rule, generalized).
+- Values are plain strings; **no JSON**. Multi-valued state is either an
+  indexed family (`_web_<n>`) or a `:`/`,`-delimited scalar with a fixed
+  grammar (`@rk_win_layout`). Every value must be writable by hand with one
+  `tmux set-option -w` and readable with one `#{@…}` format.
+- Every `@rk_win_*` row joins the **snapshot round-trip set** (`internal/snapshot`
+  capture + restore); indexed families are captured by enumeration.
+- Invalid values degrade, never error: an unknown shape or unavailable surface
+  in `@rk_win_layout` degrades tile-by-tile toward `single:tty` at render
+  time (the R2 fallback spirit) — the option is left as written so the author
+  can see their mistake with `show-options`.
+
+---
+
+## Layout in tmux
+
+`@rk_win_layout` carries exactly what `?layout=` carried: **shape** (one of
+the surface-layout presets — `single`, `split-h`, `split-v`, `row`, `col`,
+`main-left`, `main-right`, `main-top`) and **order** (surfaces filling slots,
+first = slot A). The preset set is unchanged and deliberately not a free
+tree (surface-layout.md § Shape presets).
+
+What moves into tmux, what does not:
+
+| Layout value | Home | Why |
+|---|---|---|
+| shape | `@rk_win_layout` | agent-controllable, viewport-independent |
+| order | `@rk_win_layout` | same |
+| **zoom** (full-center one tile) | **per-viewer, localStorage** (`rk-layout-zoom:{server}:{@N}`) | decided 2026-08-28: zoom is a *reading posture*, like ratios — a phone zooming `web` must not zoom the desktop. An agent wanting one surface writes `single:<surface>` to the layout instead |
+| **ratios** (divider positions) | **per-viewer, localStorage** (`rk-layout-ratios:*` stays) | viewport-dependent — a 40/60 split means different things at 1440px and 390px; tmux itself re-flows pane sizes per client width |
+
+Every existing verb (Promote, Swap, Cycle shape, Close, rail toggles) becomes
+a **write to `@rk_win_layout`** through `POST /api/windows/{id}/options`,
+exactly like color and note today. The frontend holds no layout state of its
+own; it renders the option and repaints on the SSE/`/ws/state` option tick.
+The row-color safety-poll latency lesson applies: the POST handler must wake
+the hub so a viewer's own click repaints immediately.
+
+**Default.** Unset `@rk_win_layout` renders `single:tty`. The bare URL is the
+deep link to the tab; there is nothing else to encode.
+
+**Mobile degradation rule.** A coarse-pointer/narrow viewer renders **one
+tile**: the viewer's local zoom if set, else slot A of the shared layout.
+The mobile "switch-to-tile" verb writes the local zoom key only — it never
+touches `@rk_win_layout`, so a phone user reading `web` leaves the desktop
+viewer's arrangement alone. The *set* of tiles available to switch among is
+the shared layout's order; adding a surface that is not in the layout goes
+through the shared `--add` mutation like everywhere else.
+
+**Deep links.** `?layout=` is **retired**. For one release the existing
+route-entry shim translates old `?view=`/`?panel=`/`?layout=` links into a
+one-shot write of `@rk_win_layout` (only when the option is unset; otherwise
+the param is dropped and the shared layout wins). After that release the
+param is ignored. The URL is always the bare route `/$server/@N`; "look at my
+arrangement" is expressed as `rk tab layout @N …`, not as a link.
+
+---
+
+## Web Tabs
+
+**One `web` surface per tab; N web tabs inside it.** Chosen over "N web
+surfaces per tab" because:
+
+1. surface-layout v1 fixed *one tile per surface kind* and named the reason
+   two web tiles were punted — distinct page addresses would have to become
+   per-viewer state. With the address set in tmux the objection is gone, but
+   the *layout encoding* still names kinds; web tabs keep it that way.
+2. Two webviews in one tab would need a second arrangement model nested
+   inside the first. Web tabs are a strip, not a layout.
+3. Boards (surface-layout phase 4) tile surfaces across tabs; `@N/web/2` is
+   addressable by a board tile for free.
+
+State: `@rk_win_web_<n>` (URL), `@rk_win_web_<n>_root` (present root, file/dir
+kinds only), `@rk_win_web_active`. **`n ≤ 8`** — the daemon reads window
+options through `ListWindows`' fixed tmux format string (one call per server
+per tick) and a format string cannot enumerate a family, so the URL slots are
+spelled out `#{@rk_win_web_1}`…`#{@rk_win_web_8}`; roots stay out of the tick
+(the `/present/{windowId}/{n}/*` handler reads `_<n>_root` at request time,
+as it reads `@rk_win_present_root` today). `web add` on a full strip exits 1.
+The set is **dense and 1-based**; removing
+tab 2 of 3 renumbers 3→2 and the daemon fixes up `_active`. Renumbering is
+acceptable because addresses are for commands, not for durable references —
+the same trade tmux makes with window indices.
+
+Rendering: the web tile grows a tab strip when `n ≥ 2` (hidden at `n = 1`,
+today's chrome unchanged). Each web tab keeps its own iframe mounted (P3 —
+hide, never unmount) so switching does not reload a dev server page.
+Address-bar edits write `@rk_win_web_<active>`. Same-origin in-page
+navigation updates the *display* only (as today) — the stored URL is the
+tab's home, not its current location.
+
+**Identity is the URL, not the index (decided 2026-08-28).** `web add` is
+idempotent on an identical resolved URL: it returns the existing index
+instead of appending, and for file/dir kinds bumps that entry's `?v=`
+cache-buster — which is exactly `rk present`'s re-present-is-refresh
+contract, now falling out of the add verb. An agent that needs "my" web tab
+back simply re-adds the same target; no durable ids, indices stay dense.
+
+**Declared only (decided 2026-08-28).** Every member of the family is written
+by someone. Ports detected on the tab's panes (`internal/ports`) are *not*
+auto-materialised as web tabs — a derived member coming and going would
+renumber declared ones under an agent's feet. Instead the strip offers a
+detected port as a one-click **"+ add as web tab"** affordance, which is an
+ordinary declared write.
+
+**`rk present` is absorbed.** Its five target kinds and the `ProbePort`
+step live on unchanged in `internal/present`; the verb becomes sugar:
+
+```
+rk present <target>               ≡  rk tab web add <target> --show
+rk present --window[=name] <t>    ≡  rk tab new [--name] && rk tab web add <t> --layout single:web
+```
+
+`--show` = ensure `web` is in `@rk_win_layout` (grow through the ordinary
+growth shapes) and set `_active` to the new index. The L3 "transient
+auto-open carve-out" dies — auto-open is now just the layout write every
+viewer renders.
+
+---
+
+## Code Surface + Code Bridge
+
+`@rk_win_code_root` replaces the per-browser latch. Seed rule unchanged:
+written once, the first time the code surface renders for the tab, from the
+derived git root; afterwards only code-server's own folder navigation (the
+`load`-event seam) or an explicit `rk tab code set <folder>` moves it. The
+terminal never moves it.
+
+The code bridge already keys hosts by `folder` in `cb/hosts/<hostId>.json`.
+With the folder in tmux, `rk code exec` gains a **tab-addressed form**:
+
+```
+rk code exec [--tab @N] <command> [args…]     # host = the one whose folder == @N's @rk_win_code_root
+```
+
+Default `--tab` is the caller's own tab, so an agent in a pane says
+`rk code exec workbench.action.files.openFile $uri` and hits *its* editor.
+Host resolution by cwd remains the fallback when the tab has no code root.
+The bridge is thus the code surface's command channel exactly as
+`set-option` is every other surface's — it is the one surface whose interior
+(open files, cursor) is not tmux state and never will be.
+
+---
+
+## Viewer Behaviour — What Follows, What Doesn't
+
+With tab state in tmux, "does the agent control the UI?" reduces to one
+question: **which tab is the viewer on?**
+
+| Agent action | Viewer on that tab | Viewer on another tab |
+|---|---|---|
+| any `@rk_win_*` write (layout, web add, code root, color…) | repaints on the next option tick | nothing visible beyond sidebar signals (color, marker, dot) |
+| `rk tab new` | — | new row appears in the sidebar |
+| "look at this" (`--notify`) | already looking | Web Push with a deep link, as `rk present --notify` today |
+
+Navigation is deliberately **not** tmux state in v1. tmux's own "active
+window" is per-session-per-client and run-kit's route is the analogue; an
+agent that could yank every viewer's route would make the dashboard
+unusable with two people or two agents. The nudge channel is push
+notification + sidebar attention (right-panel P4: hidden must never mean
+invisible-when-stuck).
+
+Opt-in **follow mode** — a viewer toggles "follow session X" and their route
+tracks the session's tmux active window (`select-window` from a pane then
+navigates the follower) — is the natural v2 and needs no new option: it
+reads a tmux fact that already exists.
+
+---
+
+## `rk tab` — The CLI Surface
+
+All verbs are thin: resolve address → one or two `set-option` (or
+`new-window`) calls → print the resulting address on stdout (data), diagnostics
+on stderr. They **work with `rk serve` down** (the `rk mux`/`rk present`
+pattern — tmux is the store, the daemon is a renderer).
+
+```
+rk tab new [--session =S] [--cwd DIR] [--name N] [--layout L]      → prints @N
+rk tab layout [@N] <shape>:<surface,…>                            # set
+rk tab layout [@N] --add <surface> | --rm <surface> | --promote <surface> | --cycle
+rk tab web add    [@N] <target> [--show]                           → prints @N/web/<n>
+rk tab web rm     [@N/web/<n>]
+rk tab web select [@N/web/<n>]
+rk tab web ls     [@N]
+rk tab code set   [@N] <folder>
+rk tab show       [@N]                                             # dump every @rk_win_* of the tab
+```
+
+`--add/--rm/--promote/--cycle` are the same three layout mutations the UI
+verbs perform (surface-layout § Verbs), so agent and human go through one
+growth/collapse table. Address arguments accept the full grammar; omitted
+`@N` means the caller's tab.
+
+Placement (cli-layering.md): `rk tab` is substrate — it manipulates tmux
+options and windows and knows nothing about pipelines. fab's `fab pane`
+migration map may route "open the worker's tab with code on the right"
+through it later.
+
+---
+
+## What Dies, What Stays
+
+| Dies | Replaced by |
+|---|---|
+| `rk-layout:{server}:{@N}` localStorage | `@rk_win_layout` |
+| `runkit-window-view:*`, `runkit-window-panel:*` (legacy of `?view=`/`?panel=`) | `@rk_win_layout` |
+| `runkit-code-folder:*` latch | `@rk_win_code_root` |
+| `?layout=`, `?view=`, `?panel=`; L1–L4 ladder | `@rk_win_layout`; one release of link translation, then bare routes only |
+| `@rk_win_lens` / R5 default-view hint | `@rk_win_layout` |
+| `@rk_win_url` + `@rk_win_present_root` | `@rk_win_web_1` + `@rk_win_web_1_root` |
+| L3 present auto-open carve-out | `--show` writes the layout |
+| `rk present` as a first-class verb | kept as sugar over `rk tab web add` |
+
+| Stays |
+|---|
+| `rk-layout-ratios:*` (viewport-dependent) + the new per-viewer zoom key |
+| every viewer preference key (theme, fonts, sidebar, keybindings, macros, drafts, web zoom) |
+| the preset shape set, the verb table, the rail-as-toggle semantics |
+| window-views R1 (availability derived), R3 (tty always reachable), R4 (one switcher), R6 (dot = current lens health) |
+
+---
+
+## Migration
+
+Rides the scope-naming plan's `MigrateLegacyOptions` table (managed-conf
+apply path, once per server per daemon lifetime, idempotent):
+
+- `@rk_win_url` → `@rk_win_web_1`; `@rk_win_present_root` → `@rk_win_web_1_root`; set `_active=1` when `_web_1` exists.
+- `@rk_win_lens=iframe` → `@rk_win_layout=single:web` (only when `_layout` unset), then unset `_lens`.
+- localStorage → tmux is **client-side, one-shot, on route entry**: if the tab has no `@rk_win_layout` and this browser holds `rk-layout:{server}:{@N}`, POST it once, then delete the key. Same for the code-folder latch. Last browser to arrive wins on a never-visited tab — acceptable; it is the viewer's own last layout either way.
+- Snapshot restore: the new rows enter the explicit option list; window ids remap as today.
+
+---
+
+## Open Questions
+
+**Decided (2026-08-28)** — recorded so the reasoning survives:
+
+- *Zoom is per-viewer.* Zoom and the mobile single-tile choice are reading
+  postures, not tab state; they live in localStorage beside ratios. An
+  agent that wants one surface writes `single:<surface>` to the layout.
+- *Navigation is not tmux state (v1).* Agents nudge (push + sidebar
+  attention), never move a viewer's route. Follow-mode is the v2 candidate.
+- *`?layout=` dies.* One release of translation into a one-shot option
+  write, then the URL is always the bare route.
+- *Web-tab identity is the URL.* `web add` is idempotent on an identical
+  URL (returns the index, bumps `?v=`); no ids (§ Web Tabs).
+- *Web tabs are declared, never derived.* Detected ports become a one-click
+  add affordance, not auto-members (§ Web Tabs).
+
+**OQ1 — Ratios in tmux?** Percent ratios *could* be shared (`@rk_win_ratios`)
+so an agent can say "code gets 70%". Deferred: viewport-dependence is real
+and tmux's own model re-flows per client. Revisit when an agent actually
+asks for it.
+
+**OQ2 — Companions (`@rk_owner`).** Never shipped (no code references at
+`67f4a553`). If revived it is one more `@rk_win_*` row (`@rk_win_owner`) and
+`rk tab` must decide whether `@N` of a companion is a valid target. Keep the
+right-panel.md section as a target note; nothing here depends on it.
+
+**OQ3 — Boards.** A board is a layout of surfaces across tabs. With tab
+state in tmux, does a board become `@rk_ses_pin_*` referencing `@N/<surface>`
+addresses? Likely yes, and it would retire settings.yaml boards — out of
+scope here, noted so nobody designs against it.

--- a/docs/specs/window-views.md
+++ b/docs/specs/window-views.md
@@ -1,5 +1,10 @@
 # Window Views — Rows Are Substrates, Views Are Lenses
 
+> **Amended by [`ui-state.md`](ui-state.md) (2026-08-28, draft):** R2 and R7 no longer hold — lens *choice* (layout) is shared tmux
+> state (`@rk_win_layout`), not per-viewer URL state; R1/R3/R4/R6 unchanged.
+> Read this file's rules through that lens until the in-place amendment lands
+> with implementation.
+
 > The model for every "parallel view" of a tmux window run-kit renders: what a
 > window row *is*, what a view *is*, how view availability is derived, and how
 > view choice is expressed. This spec unifies three features that grew up with

--- a/fab/plans/sahil/26-08-28-ui-state-tmux-options.md
+++ b/fab/plans/sahil/26-08-28-ui-state-tmux-options.md
@@ -1,0 +1,137 @@
+# UI State in tmux Options — `@rk_win_layout`, Web Tabs, `rk tab`
+
+**Drafted**: 2026-08-28 · against `67f4a553` · spec: [`docs/specs/ui-state.md`](../../../docs/specs/ui-state.md) (v0.2)
+**Shape**: 5 changes, run-kit only (fab-kit untouched — it reads one pane option and nothing here)
+**Prerequisite**: `26-08-28-tmux-option-scope-naming.md` shipped (Changes 1–3) — every name below is the `@rk_<scope>_<name>` form and `MigrateLegacyOptions` exists.
+
+## Diagnosis
+
+Tab state lives in the browser. `rk-layout:{server}:{@N}`, `runkit-window-view:*`, `runkit-window-panel:*` (surface-layout.ts:308-362), and the code-folder latch `runkit-code-folder:*` (code-folder-latch.ts) are per-browser keys deciding what a *tab* shows; `?layout=` is a second copy of the same state in the URL (the L1–L4 ladder, surface-layout.ts:286). Consequences: an agent cannot open a surface on a tab (`rk present` had to grow the `present-auto-expand.ts` render-time carve-out to fake it), two viewers of one tab disagree, and a snapshot restore orphans every key. The web surface holds exactly one URL (`@rk_win_url`, window-scoped, last-write-wins).
+
+Target: tab state is `@rk_win_*`; the frontend renders options and writes them back through the one `POST /api/windows/{id}/options` seam it already uses for color/marker/note; a `rk tab` verb family gives agents the same seam from a shell.
+
+### Facts that shape the plan (verified at `67f4a553`)
+
+- **Options reach the frontend via a fixed format string.** `ListWindows` reads `#{@rk_win_url}` as one positional field (tmux-sessions.md "field 10"); indexed families cannot be enumerated in a format → **cap web tabs at 8** and spell the slots out. Roots stay out of the tick: `api/present.go` already does `tmux.GetWindowOption` per request.
+- **One write seam already exists.** `api/windows.go:366-372` (`optKey*` allowlist) + `handleWindowOptions` (`:444`) partial-merge with `null`-clears; `api/client.ts:443 setWindowOptions`. New keys are allowlist rows, not new endpoints.
+- **Snapshots store struct fields**, not option names (`snapshot.go:62-63 RkType/RkURL`; `restore.go:335-341` maps at restore) → new fields on the struct, no on-disk migration.
+- **Layout logic is already pure.** `lib/surface-layout.ts` (506 lines, colocated tests) holds parse/serialize/degrade/promote/swap/close; only the *resolution + storage* half (`resolveLayout`, `read/writeStoredLayout`, `seedLayoutFromLegacy`, `translateLegacyParams`) dies. Ratios (`:380-426`) stay.
+- **`rk present` resolution is already tmux-free** (`internal/present.ParseTarget`, `Target.URL`, `ProbePort`) and will be reused verbatim by `rk tab web add`.
+- **`rk code exec` host resolution** (`cmd/rk/code.go:98,186`) is cwd/`--folder` based; adding a `--tab` arm is one more resolver ahead of it.
+- The `web-view-lens.spec.ts` :138/:295/:335 timeouts are pre-existing on main (memory) — baseline before touching that spec.
+
+---
+
+## Change 1 — Backend: options, payload, snapshot, migration (MEDIUM)
+
+Everything the frontend and CLI will read or write; ships alone so 2–4 build on a stable contract.
+
+### `internal/tmux`
+- Constants: `LayoutOption="@rk_win_layout"`, `WebTabOption(n)`, `WebTabRootOption(n)`, `WebActiveOption`, `CodeRootOption`, `MaxWebTabs=8`. Retire `URLOption`/`PresentRootOption`/`LensOption` constants (kept as `legacy*` for the migration table only).
+- `ListWindows` format: replace the `@rk_win_url`/`@rk_win_lens` fields with `layout`, `web_1..web_8`, `web_active`, `code_root` (field-count comment block updated; parser tolerant of empty slots). `Window` struct gains `Layout string`, `WebTabs []string` (dense, trailing empties trimmed), `WebActive int`, `CodeRoot string`; `RkURL`/`RkType` removed.
+- **Web-tab family ops** (pure over a `[]string` + tmux ops): `WebAdd(url) (index, existed)` — idempotent on identical URL, appends at `len+1`, refuses at 8; `WebRemove(n)` — shifts `n+1..len` down (URL *and* root), unsets the last slot, clamps/repoints `_active`; `WebSelect(n)`. Live in `internal/tmux/webtabs.go`, drive `SetWindowOptions` chained ops so each verb is one tmux round trip.
+- `MigrateLegacyOptions` rows: `@rk_win_url→@rk_win_web_1` (+ `_active=1`), `@rk_win_present_root→@rk_win_web_1_root`, `@rk_win_lens=iframe→@rk_win_layout=single:web` (only when `_layout` unset), then unset legacy. Table-driven like the existing rows.
+
+### `api`
+- `windows.go` allowlist: add `@rk_win_layout`, `@rk_win_web_1..8`, `@rk_win_web_active`, `@rk_win_code_root`; drop `@rk_win_url`/`@rk_win_lens`. Validation: `_layout` must parse (shape ∈ presets, surfaces ∈ registry, no repeats) — reject 400 rather than store garbage; `_web_n` must be a relative `/proxy|/present` path or absolute `http(s)`; `_active` ∈ 1..len. Handler wakes the hub after a successful write (row-color safety-poll lesson).
+- Window JSON: `layout`, `webTabs`, `webActive`, `codeRoot` replace `rkUrl`/`rkType` (SSE + `/ws/state` snapshots share the marshaller).
+- **New verb routes** (so the frontend strip and future callers get renumbering for free instead of re-implementing it): `POST /api/windows/{id}/web` `{target}` → `{index, existed}`; `DELETE /api/windows/{id}/web/{n}`; `POST /api/windows/{id}/web/{n}/select`. Thin wrappers over the `internal/tmux` family ops; `target` goes through `internal/present.ParseTarget` so the UI address bar and `rk tab web add` resolve identically.
+- `present.go` route: `/present/{windowId}/{n}/*` (n gated `^[1-8]$`), reads `_<n>_root`; the old `/present/{windowId}/*` form maps to `n=1` for one release.
+
+### `internal/snapshot`
+- `Window` fields `Layout`, `WebTabs`, `WebRoots`, `WebActive`, `CodeRoot` (drop `RkType`/`RkURL`); capture from the new `tmux.Window`; restore emits the family. Round-trip test asserts a 3-tab window restores dense with the same active index.
+
+### Tests
+- `webtabs_test.go` on a real test socket: add/idempotent/full, remove-middle renumbers URL+root and repoints active, select bounds.
+- `windows_test.go`: allowlist + validation matrix (bad shape, repeated surface, `_active` out of range, 9th tab).
+- Migration: legacy url+root+lens window → web_1 + root + `single:web`; second run no-op.
+- Snapshot round-trip.
+
+---
+
+## Change 2 — Frontend: layout + code root from tmux, ladder retired (LARGE)
+
+### `lib/surface-layout.ts`
+- Delete `resolveLayout`, `layoutStorageKey`, `read/writeStoredLayout`, `seedLayoutFromLegacy`, `hintLayout`. Keep `parseLayout`/`serializeLayout`/`degradeLayout`/verbs/ratios. New `effectiveLayout(win)`: `parseLayout(win.layout) ?? single:tty`, degraded tile-by-tile by `availableTiles(win)` (the option is never rewritten by degradation).
+- `translateLegacyParams` becomes **one-shot**: at route entry, if the URL carries `?view|?panel|?layout` and `win.layout` is empty, POST the translated layout once, then `replaceState` to the bare route. If `win.layout` is set, just drop the params. Both arms delete the matching `rk-layout:*`/`runkit-window-view:*`/`runkit-window-panel:*` keys (client-side one-shot migration, § Migration in the spec).
+- New per-viewer zoom key `rk-layout-zoom:{server}:{windowId}` (`read/writeStoredZoom`, same try/catch-noop pattern as ratios). Zoom verb writes it; mobile switch-to-tile writes it; cleared when the zoomed surface leaves the layout.
+
+### `app.tsx` / `components/surface-layout.tsx`
+- Layout state = `effectiveLayout(routeWindow)` — no `useState` copy. Every verb (promote / swap / cycle / close / rail toggle / `Tile:` palette rows / mobile persisting arm) → `setWindowOptions(server, id, {"@rk_win_layout": serializeLayout(next)})`. Optimistic render until the option tick confirms (the existing color-swatch pattern).
+- URL mirroring (`replaceState` of `?layout=`) removed; router-url.ts loses the param; history entries are bare routes.
+- `lib/present-auto-expand.ts` + its `SurfaceLayout` hook deleted (the layout write *is* the expand). `present-auto-expand.spec.ts` is rewritten as "present grows the shared layout" (Change 4 ships the write; until then the spec asserts the option-driven repaint using `tmux set-option -w @rk_win_layout` directly — the `_tmux.ts` pattern).
+- Focus-memory (`lib/focus-memory.ts`) keys unchanged — it is a viewer posture.
+
+### Code root
+- `lib/code-folder-latch.ts`: storage functions deleted; module keeps the pure seed/follow decision and exports `codeRootFor(win)` = `win.codeRoot || derived gitRoot`. Seed write (first render of the `code` tile with empty `win.codeRoot`) and follow write (`onCodeFolderNavigated`) both → `setWindowOptions({"@rk_win_code_root": folder})`. One-shot client migration of `runkit-code-folder:*` alongside the layout keys.
+
+### Tests
+- `surface-layout.test.ts`: drop ladder/storage cases; add `effectiveLayout` degradation + one-shot translation arms (mock `setWindowOptions`).
+- e2e: `surface-layout.spec`, `right-panel.spec`, `mobile-layout.spec`, `surface-focus-chords.spec`, `code-folder-latch.spec` re-pointed: assertions read `tmux show-option -wv @rk_win_layout` after a verb and reload-persistence goes through tmux, not localStorage. Add: two contexts on one tab see the same layout after one clicks Promote; zoom in one context does not appear in the other. `test-e2e` notes: run touched specs against clean main first (web-view-lens preexisting failures).
+
+### Docs (land with this change)
+- In-place amendments replacing the banners: `window-views.md` R2/R7 rewritten, R5 deleted; `surface-layout.md` § State replaced by a pointer + the ratios/zoom paragraph; `right-panel.md` P1 rewritten. `ui-state.md` status → `[current]` for §§ Layout, Code.
+
+---
+
+## Change 3 — Frontend: web tab strip (MEDIUM)
+
+### `components/iframe-window.tsx`
+- Renders `win.webTabs` as a strip above the address bar when `length ≥ 2` (hidden at 1 — today's chrome byte-identical). Each tab keeps its iframe mounted, `hidden` when inactive (P3), so switching never reloads.
+- Tab click → `POST …/web/{n}/select`; close glyph → `DELETE …/web/{n}`; `+` → `POST …/web` with the address-bar draft. Address-bar submit on the active tab → `setWindowOptions({"@rk_win_web_<active>": url})` (same-URL no-op; the `?v=` bump for `/present/` kinds happens server-side in `WebAdd`, so the bar routes through `POST …/web` when the draft is a file/dir-looking target — decided in review, default: always `POST …/web`).
+- Detected-port affordance: `win.ports` (already on the payload for the sidebar) not present in `webTabs` → a muted `+ :3000` chip at the strip's end; click = `POST …/web {target: ":3000"}`. Declared write, nothing derived.
+- Onboarding state unchanged (`webTabs.length === 0`).
+- `lib/web-url.ts` gains `webTabTitle(url)` (display: `localhost:3000/…`, basename for `/present/`, host for external) — pure, tested.
+
+### Tests
+- `iframe-window` unit: strip visibility threshold, active hiding, title derivation.
+- e2e `web-tabs.spec.ts` (+ `.spec.md`): seed three tabs with `tmux set-option -w`, assert strip, select, remove-middle renumbering visible in the DOM, second context sees the same active tab.
+
+---
+
+## Change 4 — CLI: `rk tab` family, `rk present` as sugar, `rk code exec --tab` (MEDIUM)
+
+### `internal/tabaddr` (new, pure)
+- `Parse(s) (Addr, error)` for `[@N][/surface[/n]]` + the surrounding `-L`/`=session:` handled by the existing `rk mux` flag/target plumbing; `Addr{WindowID, Surface, Index}`. Own-tab default resolved by the caller via `$TMUX_PANE` → `display-message -p '#{window_id}'` (the `present.go` code path, extracted to `cmd/rk/owntab.go`).
+
+### `cmd/rk/tab*.go`
+- `rk tab new [--session =S] [--cwd D] [--name N] [--layout L]` → `CreateWindowWithOptionsID` (+ `@rk_win_layout`), prints `@N`.
+- `rk tab layout [@N] <L>` | `--add S` | `--rm S` | `--promote S` | `--cycle` — Go port of the four pure mutations (`lib/surface-layout.ts` promote/swap/close + growth shapes) in `internal/layoutspec` so CLI and UI share one table; unit tests mirror the TS ones case-for-case.
+- `rk tab web add [@N] <target> [--show]` → `present.ParseTarget` + `ProbePort` + `tmux.WebAdd`; `--show` = layout `--add web` + `WebSelect`. Prints `@N/web/<n>`. Exit 1 when full.
+- `rk tab web rm|select [@N/web/<n>]`, `rk tab web ls [@N]` (index, url, active marker; `--json`).
+- `rk tab code set [@N] <folder>`; `rk tab show [@N]` (every `@rk_win_*`, `--json`).
+- All verbs tmux-only (work with `rk serve` down); stdout = data, stderr = diagnostics; toolkit exit codes.
+
+### `rk present`
+- Body becomes: `rk tab web add <target> --show` (+ `--notify` unchanged); `--window[=name]` = `rk tab new --layout single:web` then add. `internal/present` untouched. Help text says "alias of `rk tab web add --show`".
+
+### `rk code exec --tab [@N]`
+- New resolver ahead of `--folder`/cwd: `@rk_win_code_root` of the target tab (own tab by default when inside tmux); falls through when empty. `code.go:98` host-matching reused.
+
+### Tests + standards
+- `tab_*_test.go` on test sockets per verb; `present_test.go` asserts equivalence with `web add --show`; `code_test.go` `--tab` arm.
+- `help-dump` + toolkit-standards Principle 9 pass for the new family; `rk skill run-kit` bundle teaches `rk tab` and demotes `rk present` to alias.
+
+---
+
+## Change 5 — Cleanup after one release (SMALL)
+
+- Drop `?view|?panel|?layout` translation, the client-side localStorage migration, `/present/{windowId}/*` (n-less) route, and the `@rk_win_url`/`_present_root`/`_lens` migration rows → unset-only.
+- `rk doctor` row: windows still carrying legacy names (0 expected).
+- Hydrate: `tmux-sessions.md` registry (new rows + cap), `ui/lenses-and-layout.md`, `architecture.md` (`rk tab`, `present` alias), `code-bridge.md` (`--tab`), `layout-snapshots.md`.
+
+---
+
+## Sequencing
+
+```
+1 (backend contract)
+├── 2 (layout + code root)      ── docs amendments land here
+│    └── 3 (web strip)          ── needs 2's option-driven render
+└── 4 (rk tab)                  ── parallel with 2/3 after 1; present-auto-expand.spec rewrite lands in 2 using raw set-option, re-pointed to `rk present` in 4
+5 after 2–4 have been in a release
+```
+
+- One PR per change, each `/fab-new` → confidence gate → `/fab-fff`. Change types: 1 `feature`, 2 `refactor`, 3 `feature`, 4 `feature`, 5 `chore`.
+- Change 2 is the risky one (1844-line `surface-layout.tsx`, 5 e2e specs): baseline every touched spec on clean `origin/main` first; run `surface-layout`, `right-panel`, `mobile-layout`, `code-folder-latch`, `present-auto-expand`, `web-view-lens` together before ship (pane-worker green claims are scoped).
+- Constitution check per change: II (derived from tmux, cold-start equivalent), IV (no new routes beyond the three web verbs and the indexed present path; `?layout=` removed), V (palette/CLI are the mechanism; buttons mirror).

--- a/fab/plans/sahil/26-08-28-ui-state-tmux-options.md
+++ b/fab/plans/sahil/26-08-28-ui-state-tmux-options.md
@@ -1,8 +1,8 @@
 # UI State in tmux Options — `@rk_win_layout`, Web Tabs, `rk tab`
 
-**Drafted**: 2026-08-28 · against `67f4a553` · spec: [`docs/specs/ui-state.md`](../../../docs/specs/ui-state.md) (v0.2)
+**Drafted**: 2026-08-28 · against `7971264c` (rebased from `67f4a553`) · spec: [`docs/specs/ui-state.md`](../../../docs/specs/ui-state.md) (v0.2)
 **Shape**: 5 changes, run-kit only (fab-kit untouched — it reads one pane option and nothing here)
-**Prerequisite**: `26-08-28-tmux-option-scope-naming.md` shipped (Changes 1–3) — every name below is the `@rk_<scope>_<name>` form and `MigrateLegacyOptions` exists.
+**Prerequisite**: `26-08-28-tmux-option-scope-naming.md` Changes 1–3 — **shipped** (#752, #753, #755). Every name below is the `@rk_<scope>_<name>` form; `internal/tmux/legacy_options.go` holds the table-driven `MigrateLegacyOptions` / `MigrateLegacyOptionsOnce`. Its Change 4 (fab-kit) is not needed here.
 
 ## Diagnosis
 
@@ -10,11 +10,13 @@ Tab state lives in the browser. `rk-layout:{server}:{@N}`, `runkit-window-view:*
 
 Target: tab state is `@rk_win_*`; the frontend renders options and writes them back through the one `POST /api/windows/{id}/options` seam it already uses for color/marker/note; a `rk tab` verb family gives agents the same seam from a shell.
 
-### Facts that shape the plan (verified at `67f4a553`)
+### Facts that shape the plan (verified at `7971264c`)
 
 - **Options reach the frontend via a fixed format string.** `ListWindows` reads `#{@rk_win_url}` as one positional field (tmux-sessions.md "field 10"); indexed families cannot be enumerated in a format → **cap web tabs at 8** and spell the slots out. Roots stay out of the tick: `api/present.go` already does `tmux.GetWindowOption` per request.
 - **One write seam already exists.** `api/windows.go:366-372` (`optKey*` allowlist) + `handleWindowOptions` (`:444`) partial-merge with `null`-clears; `api/client.ts:443 setWindowOptions`. New keys are allowlist rows, not new endpoints.
-- **Snapshots store struct fields**, not option names (`snapshot.go:62-63 RkType/RkURL`; `restore.go:335-341` maps at restore) → new fields on the struct, no on-disk migration.
+- **Snapshots store struct fields**, not option names (`snapshot.go:62-63 RkType/RkURL`; `restore.go` maps to `tmux.*Option` constants at restore) → new fields on the struct, no on-disk migration.
+- **A second writer of `@rk_win_lens`/`@rk_win_url` exists**: `POST /api/windows` (`api/windows.go:94-97`, the sidebar's "Open in window" for a port, `client.ts createWindow(..., "iframe", url)`) creates iframe windows directly — it must be retargeted, not just the `/options` allowlist.
+- Constants already named: `tmux.URLOption`, `tmux.LensOption`, `tmux.PresentRootOption` (`tmux.go:115-124`), with `legacy*Option` twins in the migration table.
 - **Layout logic is already pure.** `lib/surface-layout.ts` (506 lines, colocated tests) holds parse/serialize/degrade/promote/swap/close; only the *resolution + storage* half (`resolveLayout`, `read/writeStoredLayout`, `seedLayoutFromLegacy`, `translateLegacyParams`) dies. Ratios (`:380-426`) stay.
 - **`rk present` resolution is already tmux-free** (`internal/present.ParseTarget`, `Target.URL`, `ProbePort`) and will be reused verbatim by `rk tab web add`.
 - **`rk code exec` host resolution** (`cmd/rk/code.go:98,186`) is cwd/`--folder` based; adding a `--tab` arm is one more resolver ahead of it.
@@ -30,7 +32,8 @@ Everything the frontend and CLI will read or write; ships alone so 2–4 build o
 - Constants: `LayoutOption="@rk_win_layout"`, `WebTabOption(n)`, `WebTabRootOption(n)`, `WebActiveOption`, `CodeRootOption`, `MaxWebTabs=8`. Retire `URLOption`/`PresentRootOption`/`LensOption` constants (kept as `legacy*` for the migration table only).
 - `ListWindows` format: replace the `@rk_win_url`/`@rk_win_lens` fields with `layout`, `web_1..web_8`, `web_active`, `code_root` (field-count comment block updated; parser tolerant of empty slots). `Window` struct gains `Layout string`, `WebTabs []string` (dense, trailing empties trimmed), `WebActive int`, `CodeRoot string`; `RkURL`/`RkType` removed.
 - **Web-tab family ops** (pure over a `[]string` + tmux ops): `WebAdd(url) (index, existed)` — idempotent on identical URL, appends at `len+1`, refuses at 8; `WebRemove(n)` — shifts `n+1..len` down (URL *and* root), unsets the last slot, clamps/repoints `_active`; `WebSelect(n)`. Live in `internal/tmux/webtabs.go`, drive `SetWindowOptions` chained ops so each verb is one tmux round trip.
-- `MigrateLegacyOptions` rows: `@rk_win_url→@rk_win_web_1` (+ `_active=1`), `@rk_win_present_root→@rk_win_web_1_root`, `@rk_win_lens=iframe→@rk_win_layout=single:web` (only when `_layout` unset), then unset legacy. Table-driven like the existing rows.
+- `POST /api/windows` (`windows.go:94-97`): `rkType="iframe"` + `rkUrl` → write `@rk_win_layout=single:web` + `@rk_win_web_1` (+ `_active=1`); `client.ts createWindow` signature loses the `rkType` arm in Change 2.
+- `MigrateLegacyOptions` rows (`legacy_options.go` table): `@rk_win_url→@rk_win_web_1` (+ `_active=1`), `@rk_win_present_root→@rk_win_web_1_root`, `@rk_win_lens=iframe→@rk_win_layout=single:web` (only when `_layout` unset), then unset legacy. Table-driven like the existing rows.
 
 ### `api`
 - `windows.go` allowlist: add `@rk_win_layout`, `@rk_win_web_1..8`, `@rk_win_web_active`, `@rk_win_code_root`; drop `@rk_win_url`/`@rk_win_lens`. Validation: `_layout` must parse (shape ∈ presets, surfaces ∈ registry, no repeats) — reject 400 rather than store garbage; `_web_n` must be a relative `/proxy|/present` path or absolute `http(s)`; `_active` ∈ 1..len. Handler wakes the hub after a successful write (row-color safety-poll lesson).


### PR DESCRIPTION
## Summary

Discussion output from a `/fab-discuss` session on run-kit's UI building blocks — no code changes.

- **New spec `docs/specs/ui-state.md`** (draft v0.2): every addressable UI thing is a tmux option. Defines the `[-L srv] [=ses:]@N[/<surface>[/<n>]]` addressing grammar, the tab-state-vs-viewer-preference rule, the `@rk_win_*` inventory (`_layout`, indexed `_web_1..8` + `_root` + `_active`, `_code_root`), web tabs (one web surface, N indexed web tabs, declared-only, URL-idempotent add), `rk tab` CLI surface, absorption of `rk present` and `rk code exec --tab`, and the retirement of the `?layout=` ladder.
- **Decisions recorded**: zoom + mobile single-tile stay per-viewer; navigation is not tmux state in v1; `?layout=` dies after one release of translation.
- **New plan `fab/plans/sahil/26-08-28-ui-state-tmux-options.md`**: 5 changes (backend contract → frontend layout/code-root → web tab strip ∥ `rk tab` family → cleanup), anchored at `7971264c`, prerequisite scope-naming Changes 1–3 already merged (#752/#753/#755).
- Amendment banners on `window-views.md`, `surface-layout.md`, `right-panel.md` pointing at the new spec (in-place amendments land with implementation, plan Change 2); index row added.

## Test plan

Docs only — no build or test impact.