### PR TITLE
fix: close the marker pad on a second strip click

### DIFF
--- a/app/frontend/src/components/sidebar/window-row.test.tsx
+++ b/app/frontend/src/components/sidebar/window-row.test.tsx
@@ -1090,6 +1090,33 @@ describe("WindowRow", () => {
       expect(screen.getByTestId("marker-pad")).toBeInTheDocument();
     });
 
+    it("closes the pad on a second no-move strip click", () => {
+      const onMarkerChange = vi.fn();
+      renderAxis(makeWindow({ marker: "manual:1" }), { onMarkerChange });
+      const strip = screen.getByTestId("marker-strip");
+      fireEvent.pointerDown(strip, { pointerId: 1, clientX: 4, clientY: 10 });
+      fireEvent.pointerUp(strip, { pointerId: 1, clientX: 4, clientY: 10 });
+      expect(screen.getByTestId("marker-pad")).toBeInTheDocument();
+      fireEvent.pointerDown(strip, { pointerId: 2, clientX: 4, clientY: 10 });
+      fireEvent.pointerUp(strip, { pointerId: 2, clientX: 4, clientY: 10 });
+      expect(screen.queryByTestId("marker-pad")).toBeNull();
+      expect(onMarkerChange).not.toHaveBeenCalled();
+    });
+
+    it("still commits a drag that starts from an already-open pad", () => {
+      const onMarkerChange = vi.fn();
+      renderAxis(makeWindow({ marker: "manual:1" }), { onMarkerChange });
+      const strip = screen.getByTestId("marker-strip");
+      fireEvent.pointerDown(strip, { pointerId: 1, clientX: 4, clientY: 10 });
+      fireEvent.pointerUp(strip, { pointerId: 1, clientX: 4, clientY: 10 });
+      expect(screen.getByTestId("marker-pad")).toBeInTheDocument();
+      fireEvent.pointerDown(strip, { pointerId: 2, clientX: 4, clientY: 10 });
+      fireEvent.pointerMove(strip, { pointerId: 2, clientX: 30, clientY: 10 });
+      fireEvent.pointerUp(strip, { pointerId: 2, clientX: 30, clientY: 10 });
+      expect(onMarkerChange).toHaveBeenCalledWith("srv", "alpha", "@0", "manual:2");
+      expect(screen.queryByTestId("marker-pad")).toBeNull();
+    });
+
     it("keeps strip presses out of row selection and HTML drag", () => {
       const onSelectWindow = vi.fn();
       const onDragStart = vi.fn();
@@ -1704,6 +1731,27 @@ describe("coarse pointer: rest glyph, rail target, and plain status dot", () => 
       const svg = fill.querySelector("svg")!;
       expect(Number(svg.getAttribute("width"))).toBeGreaterThan(22);
       expect(fill.querySelectorAll("path")).toHaveLength(3);
+    });
+
+    it("closes the pad on a second coarse tap", () => {
+      const onMarkerChange = vi.fn();
+      renderCoarseAxis(makeWindow({ marker: "manual:1" }), { onMarkerChange });
+      const strip = screen.getByTestId("marker-strip");
+      fireEvent.pointerDown(strip, {
+        pointerId: 1,
+        pointerType: "touch",
+        clientX: 4,
+        clientY: 10,
+      });
+      expect(screen.getByTestId("marker-pad")).toBeInTheDocument();
+      fireEvent.pointerDown(strip, {
+        pointerId: 2,
+        pointerType: "touch",
+        clientX: 4,
+        clientY: 10,
+      });
+      expect(screen.queryByTestId("marker-pad")).toBeNull();
+      expect(onMarkerChange).not.toHaveBeenCalled();
     });
 
     it("opens click-menu mode on coarse without capture or drag preview", () => {

--- a/app/frontend/src/components/sidebar/window-row.tsx
+++ b/app/frontend/src/components/sidebar/window-row.tsx
@@ -269,6 +269,10 @@ function WindowRowInner({
     originX: number;
     originY: number;
     start: Marker | null;
+    // Whether this row's pad was already open when the press landed. A no-move
+    // release closes it in that case, which is what makes a second click on the
+    // strip a toggle rather than a no-op.
+    wasOpen: boolean;
   } | null>(null);
   const [padPosition, setPadPosition] = useState({ left: MARKER_WELL_WIDTH_FINE, top: 0 });
   const [padLayout, setPadLayout] = useState(() =>
@@ -438,6 +442,16 @@ function WindowRowInner({
 
   const onStripDown = (event: React.PointerEvent<HTMLDivElement>) => {
     event.stopPropagation();
+    // Click-to-toggle. The document dismissal listener deliberately ignores
+    // presses on this row's own strip, so without this the strip could only
+    // ever open. Coarse resolves the toggle here because its tap has no
+    // release path (the drag gesture is fine-only); fine defers to the release
+    // so a drag starting from an already-open pad still commits a cell.
+    if (coarse && showMarkerPad) {
+      padClose();
+      return;
+    }
+    const wasOpen = showMarkerPad;
     const sidebarCandidate = event.currentTarget.closest("[data-sidebar-scroll]");
     if (sidebarCandidate instanceof HTMLElement) {
       const nextLayout = markerPadPopoverLayout(
@@ -452,6 +466,7 @@ function WindowRowInner({
       originX: event.clientX,
       originY: event.clientY,
       start: displayMarker,
+      wasOpen,
     };
     event.currentTarget.setPointerCapture?.(event.pointerId);
   };
@@ -481,8 +496,12 @@ function WindowRowInner({
       event.clientY - press.originY,
       padPitchRef.current,
     );
-    if (sameCell(cell, press.start)) setMarkerPreview(undefined);
-    else padCommit(cell);
+    // A no-move release on a pad this press already found open closes it; on a
+    // pad this press opened it leaves the click menu up.
+    if (sameCell(cell, press.start)) {
+      if (press.wasOpen) padClose();
+      else setMarkerPreview(undefined);
+    } else padCommit(cell);
     if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
       event.currentTarget.releasePointerCapture(event.pointerId);
     }


### PR DESCRIPTION
## What

Clicking the marker strip opened the pad; clicking it again did nothing. It now toggles shut.

## Why

The pad's document-level dismissal listener deliberately **ignores presses on the row's own strip**. That exemption exists so a press-drag gesture can start from an already-open pad without the pad closing under the finger — but it also meant the strip was the one target in the UI that could never dismiss the pad it had opened.

## How

- **Coarse** resolves the toggle at `pointerdown`, because a tap there has no release path (the drag gesture is fine-pointer-only).
- **Fine** defers to the release and only toggles when the pointer did not move, so a drag that starts from an open pad still commits its cell rather than closing.

The press now records whether it found the pad already open (`wasOpen`), which is what separates "this click opened it, leave the click menu up" from "this click found it open, close it".

## Tests

Three cases added to `window-row.test.tsx`:

- a second no-move strip click closes the pad and writes nothing
- a drag starting from an already-open pad still commits (`manual:1` → `manual:2`)
- a second coarse tap closes the pad

## Verification

`tsc --noEmit` clean · 3626 frontend unit tests pass · `just test-e2e "window-marker-gutter"` 3/3 pass.

Follow-up to #775. No fab pipeline — small single-behavior fix, as requested.