### PR TITLE
fix(sidebar): widen session collapse chevron into the marker gutter

### DIFF
--- a/app/frontend/src/components/sidebar/session-row.tsx
+++ b/app/frontend/src/components/sidebar/session-row.tsx
@@ -309,7 +309,10 @@ function SessionRowInner({
       // STATUS_RAIL_WIDTH_PX — Tailwind scans literal classes only). On fine
       // pointers the hover cluster owns the right edge and no reserve exists;
       // ghost rows have no rail and no reserve.
-      className={`flex items-center justify-between group pl-1.5 sm:pl-2${ghost ? "" : " coarse:pr-[56px]"} relative${tint ? "" : " hover:bg-bg-card/50"} transition-colors${isDragSource ? " opacity-50" : ""}`}
+      // The row carries NO left padding: the collapse chevron is the gutter,
+      // occupying the same left column as the window row's marker well (see
+      // the chevron below).
+      className={`flex items-center justify-between group${ghost ? "" : " coarse:pr-[56px]"} relative${tint ? "" : " hover:bg-bg-card/50"} transition-colors${isDragSource ? " opacity-50" : ""}`}
       draggable={draggable}
       onDragStart={
         onDragStart
@@ -357,10 +360,20 @@ function SessionRowInner({
           overlays) and while this row is the drag source (cube/warp animate
           transforms on child spans — the drag ghost rule). */}
       <FlairOverlay flair={session.flair} hidden={isDragSource} color={flairColor} />
-      <div className="flex items-center gap-1.5 min-w-0 flex-1">
+      {/* `gap-2` is the 8px well→content gap the window row holds between its
+          marker well and its label; matching it here lands the session name on
+          the same content-start column as its own window rows. */}
+      <div className="flex items-center gap-2 min-w-0 flex-1">
+        {/* The chevron IS the left gutter. Its width literals track
+            MARKER_WELL_WIDTH (window-row.tsx) at both pointer classes —
+            22px fine, 36px coarse — so the chevron square and the marker
+            squares below it share one column, and the name columns align.
+            Tailwind scans literal classes only, hence no shared constant.
+            Width is load-bearing for touch: without a floor the button is
+            only as wide as the ▼ glyph (~7px). */}
         <button
           onClick={() => onToggleCollapse(server, name)}
-          className="text-xs text-text-secondary hover:text-text-primary transition-colors shrink-0 min-h-[24px] coarse:min-h-[36px] flex items-center justify-center"
+          className="text-xs text-text-secondary hover:text-text-primary transition-colors shrink-0 min-w-[22px] min-h-[24px] coarse:min-w-[36px] coarse:min-h-[36px] flex items-center justify-center"
           aria-expanded={!isCollapsed}
           aria-label={`${isCollapsed ? "Expand" : "Collapse"} ${session.name}`}
         >


### PR DESCRIPTION
## Problem

The session-row collapse chevron carried a height floor but **no width floor and no padding**, so its hit target was only as wide as the `▼` glyph — about **7px**. On touch, `coarse:min-h-[36px]` stretched it taller while leaving it glyph-narrow, making it a 36×7 sliver. Reported from a phone: *"I am barely able to press the expand / collapse button on a session row."*

It was the only button in `session-row.tsx` without the project's `min-w-[24px]` token, and the sole toggle path — there is no coarse-pointer alternative gesture.

## Change

Size the chevron to `MARKER_WELL_WIDTH` at both pointer classes (22px fine, 36px coarse) and let it own the row's left edge, with the window row's 8px well→content gap after it.

1. Row root — dropped `pl-1.5 sm:pl-2`; the chevron is now the gutter.
2. `row-left` — `gap-1.5` → `gap-2`, matching the well→content gap.
3. Chevron — added `min-w-[22px] coarse:min-w-[36px]`.

The chevron square now occupies the same column as the window rows' marker wells, and the session name lands on the same content-start column as its own windows.

## Why it depends on #775

A plain `min-w` bump would have **inverted the tree**. #775 moved window content start to `coarse:pl-[44px]`; the naive fix lands the session name at 48px against window text at 44px — the parent row sitting right of its own children (and 36px vs 30px on fine). Sizing to the well width instead lands both flush.

This is why the branch was held until #775 merged. #775 does not touch `session-row.tsx`, so nothing would have flagged the conflict — only the visual column silently desyncs.

## Trade-off

The session name is now **flush** with its window children rather than indented 10–24px left of them. Hierarchy rests on `font-medium` plus the chevron-vs-marker distinction in the shared gutter. Deliberate, and confirmed with the author.

Cost on a 375px phone: ~27px of the session name's truncation budget. The name is `truncate flex-1`, so it ellipsises earlier and nothing clips.

## Verification

Measured against the running app with a throwaway Playwright probe (removed before commit):

| pointer | chevron | session name x | window text x | |
|---|---|---|---|---|
| fine | **22 × 24** (was ~7×24) | 30px | 30px | flush |
| coarse | **36 × 36** (was ~7×36) | 44px | 44px | flush |

- `just check` — clean
- Frontend unit — 177 files / 3623 tests passed
- e2e `session-tiles`, `sidebar-multiselect`, `sidebar-keyboard-nav`, `row-flyout` — 30 passed

Note: 36px is still under the 44px HIG/WCAG ideal, but the coarse row is only 36px tall — matching row height is the ceiling without redesigning row geometry.

No new tests: the change is pure layout geometry on an existing control, and the specs that drive this chevron address it by `aria-label`, which is unchanged.
