### PR TITLE
feat: rk skill Topic Discovery Conformance

### DIFF
--- a/app/backend/cmd/rk/skill.go
+++ b/app/backend/cmd/rk/skill.go
@@ -68,8 +68,16 @@ var skillTopics = map[string][]byte{
 	tutorialTopicName: skillTutorialTopic,
 }
 
+// reservedTopicsName is the toolkit-standard reserved topic: `rk skill topics`
+// enumerates the content-topic names machine-readably (one per line, stdout,
+// exit 0). It is a machine affordance, not a topic page — it has no canonical
+// docs/site file, must never become a skillTopics key, and stays out of the
+// Topics: help line and the core bundle's topic index.
+const reservedTopicsName = "topics"
+
 // skillTopicNames returns the sorted list of valid topic names, for the
-// unknown-topic error message (deterministic ordering).
+// unknown-topic error message, the Topics: help line, and the reserved
+// `topics` enumeration (deterministic ordering).
 func skillTopicNames() []string {
 	names := make([]string, 0, len(skillTopics))
 	for name := range skillTopics {
@@ -95,15 +103,21 @@ var skillCmd = &cobra.Command{
 		"for an agent operating run-kit (when to reach for it, its capabilities, how " +
 		"it composes, and the gotchas). The bytes are identical on every invocation " +
 		"and byte-identical to the repo's canonical docs/site/skill.md. Pass a topic " +
-		"(e.g. `run-kit skill display`) to print that topic page instead. The bundle " +
-		"is static-only — derive your location directly (get the server URL from " +
-		"`run-kit url`).",
+		"(e.g. `run-kit skill display`) to print that topic page instead, or `run-kit " +
+		"skill topics` to list the topic names one per line. The bundle is static-only " +
+		"— derive your location directly (get the server URL from `run-kit url`).\n\n" +
+		"Topics: " + strings.Join(skillTopicNames(), ", "),
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		bundle := skillBundle
 		if len(args) == 1 {
 			topic := args[0]
+			if topic == reservedTopicsName {
+				_, err := fmt.Fprint(cmd.OutOrStdout(),
+					strings.Join(skillTopicNames(), "\n")+"\n")
+				return err
+			}
 			b, ok := skillTopics[topic]
 			if !ok {
 				return usageError(fmt.Errorf("unknown topic %q (valid: %s)",

--- a/app/backend/cmd/rk/skill_test.go
+++ b/app/backend/cmd/rk/skill_test.go
@@ -280,8 +280,15 @@ func TestSkillReservedTopicsNameStaysReserved(t *testing.T) {
 // consulting --help before paying the core bundle's context cost can see what
 // exists. The line enumerates content topics only — never the reserved name.
 func TestSkillHelpEnumeratesTopics(t *testing.T) {
-	if !strings.Contains(skillCmd.Long, "Topics: "+strings.Join(skillTopicNames(), ", ")) {
-		t.Errorf("skillCmd.Long missing the Topics: line naming %v", skillTopicNames())
+	var topicsLine string
+	for _, line := range strings.Split(skillCmd.Long, "\n") {
+		if strings.HasPrefix(line, "Topics: ") {
+			topicsLine = line
+			break
+		}
+	}
+	if want := "Topics: " + strings.Join(skillTopicNames(), ", "); topicsLine != want {
+		t.Errorf("skillCmd.Long Topics: line = %q, want exactly %q", topicsLine, want)
 	}
 	for _, name := range skillTopicNames() {
 		if name == reservedTopicsName {

--- a/app/backend/cmd/rk/skill_test.go
+++ b/app/backend/cmd/rk/skill_test.go
@@ -247,6 +247,49 @@ func TestSkillUnknownTopicFailsFast(t *testing.T) {
 	}
 }
 
+// TestSkillReservedTopicsEnumerates pins the toolkit-standard reserved topic:
+// `rk skill topics` prints the content-topic names one per line (sorted, a
+// trailing newline, nothing else) to stdout with empty stderr and exit 0 — the
+// scriptable enumeration the shll composer reaches as `shll skill rk topics`.
+func TestSkillReservedTopicsEnumerates(t *testing.T) {
+	stdout, stderr, err := runSkill(t, "topics")
+	if err != nil {
+		t.Fatalf("skill topics err = %v, want nil (exit 0)", err)
+	}
+	want := strings.Join(skillTopicNames(), "\n") + "\n"
+	if stdout != want {
+		t.Errorf("skill topics stdout = %q, want %q", stdout, want)
+	}
+	if stderr != "" {
+		t.Errorf("skill topics wrote to stderr: %q", stderr)
+	}
+}
+
+// TestSkillReservedTopicsNameStaysReserved guards the reserved-name rule:
+// `topics` must never become a content topic (no skillTopics key, no canonical
+// page) — a key would leak it into skillTopicNames(), the Topics: help line,
+// and the unknown-topic error message.
+func TestSkillReservedTopicsNameStaysReserved(t *testing.T) {
+	if _, ok := skillTopics[reservedTopicsName]; ok {
+		t.Fatalf("skillTopics contains reserved name %q — the standard reserves it in every tool's topic namespace", reservedTopicsName)
+	}
+}
+
+// TestSkillHelpEnumeratesTopics pins the help-text mandate: the long help
+// carries a Topics: line naming every shipped content topic, so a caller
+// consulting --help before paying the core bundle's context cost can see what
+// exists. The line enumerates content topics only — never the reserved name.
+func TestSkillHelpEnumeratesTopics(t *testing.T) {
+	if !strings.Contains(skillCmd.Long, "Topics: "+strings.Join(skillTopicNames(), ", ")) {
+		t.Errorf("skillCmd.Long missing the Topics: line naming %v", skillTopicNames())
+	}
+	for _, name := range skillTopicNames() {
+		if name == reservedTopicsName {
+			t.Errorf("skillTopicNames() includes reserved name %q", reservedTopicsName)
+		}
+	}
+}
+
 // TestSkillTooManyArgsFailsFast pins the MaximumNArgs(1)+usageArgs contract: a
 // second positional arg is a usage error (exit 2) with empty stdout and the
 // diagnostic on stderr — the validator rejects it before RunE runs, so no bundle

--- a/docs/memory/run-kit/toolkit-standards.md
+++ b/docs/memory/run-kit/toolkit-standards.md
@@ -745,6 +745,24 @@ via the `usageError` helper with all four valid topics named on stderr and
 inlines** a topic page. Topic pages are a clause of the already-passing `skill`
 standard, not a separate standard. (6uu0)
 
+**Topic discovery.** The standard's two topic-discovery mandates both hold
+(`app/backend/cmd/rk/skill.go`): the `skill` subcommand's long help carries a
+`Topics: code, display, mux, tutorial` line composed from `skillTopicNames()`
+(static by construction — topic embeds are fixed at build time; a new
+`skillTopics` row updates the help line, the unknown-topic error, and the
+enumeration in one place), and the **reserved positional topic** `rk skill
+topics` prints the content-topic names one per line, sorted, raw to stdout with
+empty stderr and exit 0 — the scriptable enumeration the shll composer reaches
+as `shll skill rk topics`. The name `topics` is reserved outside the topic
+namespace: it is intercepted in `RunE` before the `skillTopics` map lookup,
+never becomes a map key (`TestSkillReservedTopicsNameStaysReserved`), has no
+canonical `docs/site/skill/topics.md`, and appears in neither the `Topics:`
+help line nor the core bundle's `## Topics` index. A `--list` flag is ruled out
+by the standard itself: the shll composer forwards positional args verbatim,
+so a flag would be intercepted by the composer's own flag parsing.
+`TestSkillReservedTopicsEnumerates` pins the output shape and
+`TestSkillHelpEnumeratesTopics` pins the help-line mandate. (mzpw)
+
 The `display` topic documents the same-origin target form
 `rk present "$(rk url)/path"`: the stored target is `/path`, so the viewer loads
 it from its own run-kit origin. This form is covered by the parser and caller

--- a/docs/memory/run-kit/toolkit-standards.md
+++ b/docs/memory/run-kit/toolkit-standards.md
@@ -747,7 +747,7 @@ standard, not a separate standard. (6uu0)
 
 **Topic discovery.** The standard's two topic-discovery mandates both hold
 (`app/backend/cmd/rk/skill.go`): the `skill` subcommand's long help carries a
-`Topics: code, display, mux, tutorial` line composed from `skillTopicNames()`
+`Topics:` line naming the shipped content topics, composed from `skillTopicNames()`
 (static by construction — topic embeds are fixed at build time; a new
 `skillTopics` row updates the help line, the unknown-topic error, and the
 enumeration in one place), and the **reserved positional topic** `rk skill

--- a/fab/changes/260902-mzpw-skill-topics-discovery/.history.jsonl
+++ b/fab/changes/260902-mzpw-skill-topics-discovery/.history.jsonl
@@ -1,0 +1,9 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-09-02T17:38:06Z"}
+{"args":"rk skill topics conformance — Topics: line in help text + reserved 'topics' positional per shll skill standard","cmd":"fab-new","event":"command","ts":"2026-09-02T17:38:06Z"}
+{"delta":"+5.0","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-09-02T17:39:02Z"}
+{"cmd":"fab-fff","event":"command","ts":"2026-09-02T17:48:02Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-09-02T17:48:07Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-09-02T17:52:51Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-09-02T18:00:19Z"}
+{"event":"review","result":"passed","ts":"2026-09-02T18:00:19Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-09-02T18:01:22Z"}

--- a/fab/changes/260902-mzpw-skill-topics-discovery/.history.jsonl
+++ b/fab/changes/260902-mzpw-skill-topics-discovery/.history.jsonl
@@ -8,3 +8,4 @@
 {"event":"review","result":"passed","ts":"2026-09-02T18:00:19Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-09-02T18:01:22Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-09-02T18:02:31Z"}
+{"event":"review","result":"passed","ts":"2026-09-02T18:08:03Z"}

--- a/fab/changes/260902-mzpw-skill-topics-discovery/.history.jsonl
+++ b/fab/changes/260902-mzpw-skill-topics-discovery/.history.jsonl
@@ -7,3 +7,4 @@
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-09-02T18:00:19Z"}
 {"event":"review","result":"passed","ts":"2026-09-02T18:00:19Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-09-02T18:01:22Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-09-02T18:02:31Z"}

--- a/fab/changes/260902-mzpw-skill-topics-discovery/.status.yaml
+++ b/fab/changes/260902-mzpw-skill-topics-discovery/.status.yaml
@@ -10,7 +10,7 @@ progress:
     review: done
     hydrate: done
     ship: done
-    review-pr: active
+    review-pr: done
 plan:
     generated: true
     task_count: 4
@@ -34,7 +34,7 @@ stage_metrics:
     review: {started_at: "2026-09-02T17:52:51Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-02T18:00:19Z"}
     hydrate: {started_at: "2026-09-02T18:00:19Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-02T18:01:22Z"}
     ship: {started_at: "2026-09-02T18:01:22Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-02T18:02:31Z"}
-    review-pr: {started_at: "2026-09-02T18:02:31Z", driver: git-pr, iterations: 1}
+    review-pr: {started_at: "2026-09-02T18:02:31Z", driver: git-pr, iterations: 1, completed_at: "2026-09-02T18:08:03Z"}
 prs:
     - https://github.com/sahil87/run-kit/pull/795
 change_type_source: explicit
@@ -54,4 +54,4 @@ true_impact:
     computed_at_stage: ship
 summary: 'rk skill topic discovery: Topics: help line + reserved ''rk skill topics'' enumeration per the shll skill standard'
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-09-02T18:02:31Z
+last_updated: 2026-09-02T18:08:03Z

--- a/fab/changes/260902-mzpw-skill-topics-discovery/.status.yaml
+++ b/fab/changes/260902-mzpw-skill-topics-discovery/.status.yaml
@@ -9,8 +9,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 plan:
     generated: true
     task_count: 4
@@ -33,23 +33,25 @@ stage_metrics:
     apply: {started_at: "2026-09-02T17:48:07Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-02T17:52:51Z"}
     review: {started_at: "2026-09-02T17:52:51Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-02T18:00:19Z"}
     hydrate: {started_at: "2026-09-02T18:00:19Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-02T18:01:22Z"}
-    ship: {started_at: "2026-09-02T18:01:22Z", driver: fab-fff, iterations: 1}
-prs: []
+    ship: {started_at: "2026-09-02T18:01:22Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-02T18:02:31Z"}
+    review-pr: {started_at: "2026-09-02T18:02:31Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/sahil87/run-kit/pull/795
 change_type_source: explicit
 true_impact:
-    added: 0
-    deleted: 0
-    net: 0
+    added: 336
+    deleted: 4
+    net: 332
     excluding:
-        added: 0
-        deleted: 0
-        net: 0
+        added: 61
+        deleted: 4
+        net: 57
     tests:
-        added: 0
+        added: 43
         deleted: 0
-        net: 0
-    computed_at: "2026-09-02T18:01:22Z"
-    computed_at_stage: hydrate
+        net: 43
+    computed_at: "2026-09-02T18:02:31Z"
+    computed_at_stage: ship
 summary: 'rk skill topic discovery: Topics: help line + reserved ''rk skill topics'' enumeration per the shll skill standard'
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-09-02T18:01:22Z
+last_updated: 2026-09-02T18:02:31Z

--- a/fab/changes/260902-mzpw-skill-topics-discovery/.status.yaml
+++ b/fab/changes/260902-mzpw-skill-topics-discovery/.status.yaml
@@ -1,0 +1,55 @@
+id: mzpw
+name: 260902-mzpw-skill-topics-discovery
+created: 2026-09-02T17:38:06Z
+created_by: sahil-noon
+change_type: feat
+issues: []
+progress:
+    intake: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+plan:
+    generated: true
+    task_count: 4
+    acceptance_count: 9
+    acceptance_completed: 9
+confidence:
+    certain: 5
+    confident: 0
+    tentative: 0
+    unresolved: 0
+    score: 5.0
+    fuzzy: true
+    dimensions:
+        signal: 89.0
+        reversibility: 90.0
+        competence: 94.0
+        disambiguation: 89.0
+stage_metrics:
+    intake: {started_at: "2026-09-02T17:38:06Z", driver: fab-new, iterations: 1, completed_at: "2026-09-02T17:48:07Z"}
+    apply: {started_at: "2026-09-02T17:48:07Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-02T17:52:51Z"}
+    review: {started_at: "2026-09-02T17:52:51Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-02T18:00:19Z"}
+    hydrate: {started_at: "2026-09-02T18:00:19Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-02T18:01:22Z"}
+    ship: {started_at: "2026-09-02T18:01:22Z", driver: fab-fff, iterations: 1}
+prs: []
+change_type_source: explicit
+true_impact:
+    added: 0
+    deleted: 0
+    net: 0
+    excluding:
+        added: 0
+        deleted: 0
+        net: 0
+    tests:
+        added: 0
+        deleted: 0
+        net: 0
+    computed_at: "2026-09-02T18:01:22Z"
+    computed_at_stage: hydrate
+summary: 'rk skill topic discovery: Topics: help line + reserved ''rk skill topics'' enumeration per the shll skill standard'
+# true_impact: lazily created on first stage-finish that computes it (no placeholder here).
+last_updated: 2026-09-02T18:01:22Z

--- a/fab/changes/260902-mzpw-skill-topics-discovery/intake.md
+++ b/fab/changes/260902-mzpw-skill-topics-discovery/intake.md
@@ -1,0 +1,86 @@
+# Intake: rk skill Topic Discovery Conformance
+
+**Change**: 260902-mzpw-skill-topics-discovery
+**Created**: 2026-09-02
+
+## Origin
+
+Conversational (`/fab-discuss` session, 2026-09-02). The user asked whether `rk skill` has an easy way to list all topics — `rk skill -h` names none. Investigation found the topic list is only discoverable indirectly (the core bundle's `## Topics` section, or the unknown-topic error message). The user then asked to check the latest `shll standards skill`, which turned out to **mandate** exactly the two missing affordances, making this a conformance gap under the constitution's Toolkit Standards clause. The user approved starting a fab change.
+
+> rk skill topics conformance — add the shll skill-standard's two mandated topic-discovery affordances: (1) enumerate shipped topic names in `rk skill` help text (Topics: code, display, mux, tutorial), (2) implement the reserved positional topic `rk skill topics` printing content-topic names one per line to stdout, exit 0, excluded from the help line and core bundle topic index
+
+Key decisions from the conversation:
+
+- A `--list` flag was considered and is **ruled out** — the `shll standards skill` document explicitly rejected it: the shll composer (`shll skill <tool> <topic>`) forwards positional args verbatim, so `shll skill rk topics` composes with zero composer changes, while a flag would be intercepted by the composer's own flag parsing.
+- Verified current non-conformance against the live standard: `rk skill topics` exits 2 with `unknown topic "topics" (valid: code, display, mux, tutorial)`, and `rk skill -h` says "Pass a topic" while naming none — the exact blind spot the standard calls out ("'Pass a topic' prose that names none is a blind spot").
+- `skillTopicNames()` (app/backend/cmd/rk/skill.go:73) already produces the sorted topic list for the error message; both new affordances reuse it.
+
+## Why
+
+1. **Pain point**: An agent (or user) consulting `rk skill -h` — the surface you check *before* paying the ~150-line core bundle's context cost — cannot learn which topic pages exist. And there is no scriptable way to enumerate topics: the only machine path today is parsing an error message off stderr from a deliberately-invalid invocation.
+2. **Consequence if unfixed**: run-kit is non-conformant with the toolkit `skill` standard, which the constitution (§ Toolkit Standards) binds it to — "Standards added or revised there bind this repo without further amendment." The standard mandates both affordances for **all** adopting tools ("binds every adopting tool"), and `shll skill rk topics` (the composer form) fails against run-kit today.
+3. **Why this approach**: The approach is prescribed by the standard itself, including the rejected alternative (`--list` flag) and the rationale. There is no design latitude to spend — this change implements the published contract.
+
+## What Changes
+
+Both changes are confined to `app/backend/cmd/rk/skill.go` plus its test file. No canonical docs change: the reserved `topics` name is a machine affordance with **no** `docs/site/skill/topics.md`, no line budget, and it must NOT be added to the core bundle's `## Topics` index (`docs/site/skill.md` stays untouched, so the sync + drift-guard mechanism is unaffected).
+
+### 1. `Topics:` enumeration in help text
+
+The `skill` subcommand's help text MUST enumerate the shipped content-topic names. Per the standard: "e.g. a `Topics: code, display, mux, tutorial` line in the long help. The mandate is that the names appear; the exact format is illustrative, not prescribed."
+
+- Append a `Topics:` line to `skillCmd.Long`, composed from `skillTopicNames()` (e.g. `"\n\nTopics: " + strings.Join(skillTopicNames(), ", ")`). Since topics are embedded at build time, composing from the map at init is static by construction — the standard explicitly notes "The enumeration is static by construction (topics are embedded at build time — no runtime lookups)". Composing rather than hardcoding means adding a fifth topic page can never leave the help line stale.
+- The reserved name `topics` MUST NOT appear in this line (it enumerates content topics only).
+- Note: `skillCmd.Long` is currently a `var` initialization; composing with a function call in the same `var` block is fine in Go (initialization order within the file handles `skillTopics` being a composite literal), but if ordering proves awkward, set `Long` in an `init()` or compose the line in a small helper — implementation detail, either is acceptable.
+
+### 2. Reserved positional topic `topics`
+
+`rk skill topics` prints the content-topic names, **one per line**, raw to stdout — stderr empty, exit 0:
+
+```
+code
+display
+mux
+tutorial
+```
+
+- Intercept `args[0] == "topics"` in `RunE` **before** the `skillTopics` map lookup (the map has no `topics` key and must never gain one — the name is reserved in every tool's topic namespace).
+- Ordering: the standard leaves it to the tool; sorted order (what `skillTopicNames()` returns) matches the deterministic error-message ordering. This also matches the core bundle's topic-index ordering, which happens to be alphabetical today.
+- Output is exactly the names joined by `\n` with a trailing newline, nothing else (stdout is data — no header, no framing).
+- The unknown-topic error path is unchanged: `rk skill bogus` still exits non-zero naming the valid content topics (which do not include `topics`).
+
+### 3. Tests
+
+Extend `app/backend/cmd/rk/skill_test.go` following its existing patterns (the `runSkill` seam):
+
+- `rk skill topics` → stdout is exactly the sorted content-topic names one per line, stderr empty, err nil (exit 0).
+- The `Topics:` help line: assert `skillCmd.Long` contains every name from `skillTopicNames()` and does not list `topics` as a topic — so a future topic page added to `skillTopics` without help-text coverage fails the guard automatically (composition makes this structurally true; the test pins the contract).
+- Guard: `skillTopics` map contains no `topics` key (the reserved-name rule with teeth).
+- Existing tests (byte-identical printing, canonical drift guards, line budgets, unknown-topic fail-fast) are unaffected.
+
+## Affected Memory
+
+- `run-kit/toolkit-standards`: (modify) the `skill` standard's conformance posture — record the two topic-discovery affordances (help-text `Topics:` line, reserved `topics` positional) as implemented, and the standard's `--list`-rejected/composer-forwarding rationale as it applies to rk
+
+## Impact
+
+- `app/backend/cmd/rk/skill.go` — help text + one reserved-name branch in `RunE` (small)
+- `app/backend/cmd/rk/skill_test.go` — new test cases per above
+- No API, frontend, tmux, or docs/site changes. No new embed, no sync-script change, no canonical-file change.
+- Conformance checklist (from the standard's "Verifying conformance"): `<tool> skill topics` prints names one per line / stdout only / exit 0; help text names every shipped topic; no content topic named `topics`.
+
+## Open Questions
+
+- (none)
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Positional reserved topic `topics`, not a `--list` flag | Prescribed by `shll standards skill`, which explicitly rejected the flag (composer forwards positionals verbatim) | S:95 R:90 A:100 D:100 |
+| 2 | Certain | `topics` output is sorted names one per line, trailing newline, stdout only, exit 0 | Standard fixes the shape ("one per line, raw to stdout — stderr empty, exit 0"); ordering left to the tool — sorted matches the existing deterministic error-message ordering | S:90 R:95 A:95 D:90 |
+| 3 | Certain | `topics` excluded from the help `Topics:` line and the core bundle's topic index; no `docs/site/skill/topics.md` | Standard: the reserved name "is not listed in the `Topics:` help line or the core bundle's topic index" and "has no canonical docs/site/skill/topics.md" | S:95 R:90 A:100 D:95 |
+| 4 | Confident | Compose the `Topics:` help line from `skillTopicNames()` rather than hardcoding | Standard's format is illustrative not prescribed; composition is static by construction (embeds fixed at build time) and cannot go stale when a topic is added | S:80 R:90 A:85 D:75 |
+| 5 | Confident | Core bundle `docs/site/skill.md` needs no edit | Its `## Topics` index already lists all four content topics; the reserved name is explicitly excluded from that index | S:85 R:85 A:90 D:85 |
+
+5 assumptions (3 certain, 2 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260902-mzpw-skill-topics-discovery/plan.md
+++ b/fab/changes/260902-mzpw-skill-topics-discovery/plan.md
@@ -1,0 +1,107 @@
+# Plan: rk skill Topic Discovery Conformance
+
+**Change**: 260902-mzpw-skill-topics-discovery
+**Intake**: `intake.md`
+
+## Requirements
+
+### CLI: rk skill topic discovery
+
+#### R1: Help text enumerates shipped content topics
+The `skill` subcommand's long help SHALL carry a `Topics:` line naming every shipped content-topic page, composed from `skillTopicNames()` so the enumeration cannot go stale when a topic page is added. The reserved name `topics` SHALL NOT appear in this line.
+
+- **GIVEN** the built `rk` binary with four shipped topic pages
+- **WHEN** a caller runs `rk skill -h` (or `--help`)
+- **THEN** the long help contains a line naming `code`, `display`, `mux`, and `tutorial`
+- **AND** the line does not name `topics`
+
+#### R2: Reserved positional topic `topics` enumerates content topics machine-readably
+`rk skill topics` SHALL print the content-topic names one per line (sorted, matching `skillTopicNames()` order), raw to stdout with a trailing newline and no framing, with empty stderr and exit 0. The name `topics` is reserved: the `skillTopics` map SHALL NOT gain a `topics` key, no canonical `docs/site/skill/topics.md` is created, and the core bundle's `## Topics` index is not modified.
+
+- **GIVEN** the built `rk` binary with four shipped topic pages
+- **WHEN** a caller runs `rk skill topics`
+- **THEN** stdout is exactly `code\ndisplay\nmux\ntutorial\n`, stderr is empty, and the exit code is 0
+
+#### R3: Existing skill contract unchanged
+Bare `rk skill`, each `rk skill <topic>` for a content topic, and the unknown-topic fail-fast path SHALL behave exactly as before: byte-identical bundle printing, and `rk skill <bogus>` exiting non-zero with an error naming the valid content topics (which exclude `topics`).
+
+- **GIVEN** the built `rk` binary
+- **WHEN** a caller runs `rk skill bogus`
+- **THEN** the command exits non-zero with `unknown topic "bogus" (valid: code, display, mux, tutorial)` on stderr
+- **AND** bare `rk skill` and `rk skill display` still print their embedded bundles byte-identically
+
+### Non-Goals
+
+- No `--list` flag — explicitly rejected by the `shll standards skill` document (the shll composer forwards positional args verbatim; a flag would be intercepted by the composer's flag parsing)
+- No change to `docs/site/skill.md`, any `docs/site/skill/*.md` page, or `scripts/sync-skill.sh` — the reserved name is a code-only machine affordance with no canonical file
+
+### Design Decisions
+
+#### Compose the Topics: help line from skillTopicNames()
+**Decision**: Append the `Topics:` line to `skillCmd.Long` by composing it from `skillTopicNames()` at package init, rather than hardcoding the names.
+**Why**: The standard's format is illustrative, not prescribed; only the names must appear. Composition is static by construction (topic embeds are fixed at build time) and cannot go stale when a fifth topic page is added — the map row is the single point of truth.
+**Rejected**: Hardcoding `Topics: code, display, mux, tutorial` — a future topic addition would need a second edit site and could silently violate the standard's "help text MUST enumerate the shipped topic names" mandate.
+*Introduced by*: 260902-mzpw-skill-topics-discovery
+
+#### Intercept the reserved name before the map lookup
+**Decision**: Handle `args[0] == "topics"` in `RunE` before consulting `skillTopics`, printing `skillTopicNames()` joined with newlines plus a trailing newline.
+**Rejected**: Adding a synthetic `topics` entry to the `skillTopics` map — the standard reserves the name outside the topic namespace (no canonical file, no line budget, excluded from indexes), and a map entry would leak it into `skillTopicNames()` and the error message.
+**Why**: Keeps the reserved name out of the content-topic namespace entirely; `skillTopicNames()` and the unknown-topic error message stay correct with no filtering.
+*Introduced by*: 260902-mzpw-skill-topics-discovery
+
+## Tasks
+
+### Phase 2: Core Implementation
+
+- [x] T001 In `app/backend/cmd/rk/skill.go`, add the reserved-topic branch to `skillCmd.RunE`: when `args[0] == "topics"`, print `strings.Join(skillTopicNames(), "\n") + "\n"` to stdout and return nil, before the `skillTopics` map lookup <!-- R2 -->
+- [x] T002 In `app/backend/cmd/rk/skill.go`, append a `Topics: ...` line to the `skill` command's long help composed from `skillTopicNames()` (e.g. set `Long` in an `init()` or compose via a helper if var-init ordering with the `skillTopics` composite literal is awkward), and mention the `topics` enumeration form in the prose <!-- R1 -->
+
+### Phase 3: Integration & Edge Cases
+
+- [x] T003 In `app/backend/cmd/rk/skill_test.go`, add tests: (a) `rk skill topics` via the `runSkill` seam → stdout exactly the sorted content-topic names one per line with trailing newline, stderr empty, err nil; (b) `skillCmd.Long` contains every name from `skillTopicNames()` and the `skillTopics` map has no `topics` key; (c) unknown-topic error message still lists exactly the content topics <!-- R2 -->
+- [x] T004 Run the Go test gate for the package: `cd app/backend && go test ./cmd/rk/` — all existing skill tests (byte-identical, canonical drift, line budget, fail-fast) plus the new ones pass <!-- R3 -->
+
+## Acceptance
+
+### Functional Completeness
+
+- [x] A-001 R1: `rk skill --help` long output contains a `Topics:` line naming code, display, mux, and tutorial, and not naming `topics`
+- [x] A-002 R2: `rk skill topics` prints exactly the four content-topic names, one per line, sorted, to stdout with empty stderr and exit 0
+
+### Behavioral Correctness
+
+- [x] A-003 R2: The `skillTopics` map carries no `topics` key; `skillTopicNames()` output and the unknown-topic error message are unchanged (content topics only)
+
+### Scenario Coverage
+
+- [x] A-004 R2: A test covers the `rk skill topics` output shape (exact bytes, stderr, error) via the existing `runSkill` test seam
+- [x] A-005 R1: A test pins the help-line contract (every `skillTopicNames()` name appears in `skillCmd.Long`; no `topics` map key)
+
+### Edge Cases & Error Handling
+
+- [x] A-006 R3: `rk skill <bogus>` still fails fast non-zero naming the valid content topics; bare `rk skill` and every content topic still print byte-identically (existing tests remain green)
+
+### Code Quality
+
+- [x] A-007 Pattern consistency: New code follows the existing skill.go/skill_test.go patterns (runSkill seam, table-driven cases, comment style stating constraints not narration)
+- [x] A-008 No unnecessary duplication: `skillTopicNames()` is the single source for both new affordances — no second sorted-name list
+- [x] A-009 No comment provenance: no change-IDs, R#/T# references, or reviewer-addressed narration in code comments
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All acceptance items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] A-NNN **N/A**: {reason}`
+
+## Deletion Candidates
+
+- None — this change adds new functionality without making existing code redundant
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Trailing newline after the last topic name | "One per line" with raw-stdout convention; matches line-oriented consumption (`wc -l`, `while read`) and every other toolkit data output | S:80 R:95 A:90 D:85 |
+| 2 | Confident | Help-line placement at the end of `Long`, prose mentioning `rk skill topics` | Standard prescribes only that the names appear in help text; end-of-Long matches cobra convention | S:75 R:95 A:85 D:80 |
+
+2 assumptions (1 certain, 1 confident, 0 tentative).


### PR DESCRIPTION
## Meta

| Change ID | Type | Confidence | Plan | Review |
|-----------|------|------------|------|--------|
| `mzpw` | feat | 5.0/5.0 | 4/4 tasks, 9/9 acceptance ✓ | ✓ 1 cycle |

| Impact | +/− | Net |
|--------|----:|----:|
| raw | +336 / −4 | +332 |
| **true** | **+61 / −4** | **+57** |
| └ impl | +18 / −4 | +14 |
| └ tests | +43 / −0 | +43 |

<sub>excludes `fab/`, `docs/` · generated by fab-kit v2.23.11</sub>

**Pipeline:** [intake](https://github.com/sahil87/run-kit/blob/260902-mzpw-skill-topics-discovery/fab/changes/260902-mzpw-skill-topics-discovery/intake.md) ✓ → [apply](https://github.com/sahil87/run-kit/blob/260902-mzpw-skill-topics-discovery/fab/changes/260902-mzpw-skill-topics-discovery/plan.md) ✓ → review ✓ → hydrate ✓ → ship → review-pr

## Summary

Adds the two topic-discovery affordances the shll `skill` standard mandates for every adopting tool: the `skill` subcommand's long help now carries a `Topics:` line enumerating the shipped content topics, and the reserved positional `rk skill topics` prints the content-topic names one per line to stdout (exit 0) — the scriptable enumeration the shll composer reaches as `shll skill rk topics`. Both compose from the existing `skillTopicNames()`, so a future topic page updates every discovery surface in one place.

## Changes

- `Topics:` enumeration in `rk skill` help text (composed, static by construction)
- Reserved positional topic `rk skill topics` — sorted names, one per line, stdout, exit 0; intercepted before the topic-map lookup so `topics` never enters the content-topic namespace
- Tests: output-shape pin, help-line mandate pin, reserved-name guard
- Memory: `docs/memory/run-kit/toolkit-standards.md` skill-standard posture updated
