### PR TITLE
docs: document just dev --port and the derived-port default in the install guide

### DIFF
--- a/docs/site/install.md
+++ b/docs/site/install.md
@@ -90,10 +90,13 @@ run-kit doctor
 Run `just doctor` to check development prerequisites (Node 20+, pnpm, tmux, just, Go 1.22+, air, direnv), then:
 
 ```bash
-just setup
-just dev       # watch mode (Go backend + Vite dev server)
-just prod      # run from built binary
+just setup             # one-time: frontend deps, Playwright browsers, .env.local, tmux.conf embed staging
+just dev               # watch mode (Go backend + Vite dev server) on this worktree's derived port
+just dev --port 4000   # same, on an explicit port (Vite on 4000, backend on 4001, code-server on 4002)
+just prod              # run from built binary
 ```
+
+`just dev` defaults to the worktree's derived e2e port triple, so parallel worktrees never collide; pass `--port` only when you need a specific port. Re-run `just setup` after pulling dependency changes.
 
 ## Tailscale HTTPS
 


### PR DESCRIPTION
## Summary

The Development section of `docs/site/install.md` (where the README points contributors for development setup) listed `just setup` and `just dev` but not the `just dev --port xxxx` form, nor the derived per-worktree default port or the setup re-run guidance. This documents all three: the explicit-port invocation (Vite on N, backend on N+1, code-server on N+2), the worktree-derived default that keeps parallel worktrees from colliding, and re-running `just setup` after dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)