### PR TITLE
fix: Echo Probe Recognizes the [Image #N] Composer Chip

### DIFF
--- a/app/backend/internal/inject/inject.go
+++ b/app/backend/internal/inject/inject.go
@@ -543,9 +543,11 @@ var pasteCollapseRe = regexp.MustCompile(`\[Pastedtext#\d+(?:\+\d+lines?)?\]`)
 var imageCollapseRe = regexp.MustCompile(`\[Image#\d+\]`)
 
 // imageExtensions are the path suffixes the image-chip gate recognizes — the
-// Claude API image media types, which is also the set CC 2.1.260 was observed
-// to chip. Matched case-insensitively. A wrongly-gated extension is harmless:
-// the TUI leaves such a paste as raw text and the needle arm still verifies it.
+// Claude API image media types. .png/.jpg/.gif/.webp were observed to chip on
+// CC 2.1.260; .jpeg is included by inference (image/jpeg covers both suffixes)
+// without direct observation. Matched case-insensitively. A wrongly-gated
+// extension is harmless: the TUI leaves such a paste as raw text and the
+// needle arm still verifies it.
 var imageExtensions = []string{".png", ".jpg", ".jpeg", ".gif", ".webp"}
 
 // isBareImagePath reports whether text, whitespace-trimmed, is a single line

--- a/app/backend/internal/inject/inject.go
+++ b/app/backend/internal/inject/inject.go
@@ -241,7 +241,8 @@ func (e *Engine) PressEnter(ctx context.Context, t Tmux, server, paneID string) 
 // their own boundary so the emptiness decision sees the cleaned text.
 //
 // The probe verifies NOVELTY, not mere presence: it counts the needle (and, for
-// a COLLAPSIBLE paste, the paste-collapse placeholder) in a PRE-PASTE baseline
+// a COLLAPSIBLE paste, the paste-collapse placeholder; for an IMAGEISH paste,
+// the "[Image #N]" chip — see imageCollapseRe) in a PRE-PASTE baseline
 // capture and requires the count to strictly INCREASE after the paste. This is
 // what makes the guard sound: a stale "[Pasted text #N …]" chip already
 // in-frame (a prior probe failure leaves the pasted text in the composer) or a
@@ -272,6 +273,10 @@ func (e *Engine) Send(ctx context.Context, t Tmux, server, paneID, text string, 
 	// echo signal (see CollapseMinRunes). Short single-line pastes keep
 	// exact-needle-only matching.
 	collapsible := strings.Contains(text, "\n") || utf8.RuneCountInString(text) >= CollapseMinRunes
+	// A bare image path MAY render as an "[Image #N]" chip instead of echoing
+	// (see imageCollapseRe); the gate admits the chip as a second valid echo
+	// signal without dropping the raw-needle arm.
+	imageish := isBareImagePath(text)
 
 	// Serialize the WHOLE sequence per (server, paneID): a second send to the SAME
 	// pane only begins after this one has fully finished (baseline → set → paste →
@@ -290,7 +295,7 @@ func (e *Engine) Send(ctx context.Context, t Tmux, server, paneID, text string, 
 	if err != nil {
 		return fmt.Errorf("capture-pane (baseline): %w", err)
 	}
-	baseCount := CountOccurrences(baseline, needle, collapsible)
+	baseCount := CountOccurrences(baseline, needle, collapsible, imageish)
 
 	// The set → paste critical section is additionally serialized across ALL panes
 	// (setPasteMu) because the named buffer is shared by this engine; held only
@@ -300,7 +305,7 @@ func (e *Engine) Send(ctx context.Context, t Tmux, server, paneID, text string, 
 		return err
 	}
 
-	preFrame, err := e.probeEcho(ctx, t, server, paneID, needle, collapsible, baseCount)
+	preFrame, err := e.probeEcho(ctx, t, server, paneID, needle, collapsible, imageish, baseCount)
 	if err != nil {
 		var probeErr ProbeFailure
 		if errors.As(err, &probeErr) {
@@ -317,7 +322,7 @@ func (e *Engine) Send(ctx context.Context, t Tmux, server, paneID, text string, 
 		return StagedSendFailure{Err: fmt.Errorf("send-keys: %w", err)}
 	}
 
-	verdict, err := verifySubmit(ctx, t, server, paneID, preFrame, needle, collapsible, baseCount, SubmitBackoff)
+	verdict, err := verifySubmit(ctx, t, server, paneID, preFrame, needle, collapsible, imageish, baseCount, SubmitBackoff)
 	if err != nil {
 		return SubmitUnverified{Err: err}
 	}
@@ -327,11 +332,11 @@ func (e *Engine) Send(ctx context.Context, t Tmux, server, paneID, text string, 
 	case observationInconclusive:
 		return SubmitUnverified{}
 	default:
-		return e.retrySubmit(ctx, t, server, paneID, text, needle, collapsible, baseline)
+		return e.retrySubmit(ctx, t, server, paneID, text, needle, collapsible, imageish, baseline)
 	}
 }
 
-func (e *Engine) retrySubmit(ctx context.Context, t Tmux, server, paneID, text, needle string, collapsible bool, baseline string) error {
+func (e *Engine) retrySubmit(ctx context.Context, t Tmux, server, paneID, text, needle string, collapsible, imageish bool, baseline string) error {
 	for range SubmitRetries {
 		clearedFrame, err := clearComposer(ctx, t, server, paneID, baseline)
 		if errors.Is(err, errComposerNotCleared) {
@@ -341,11 +346,11 @@ func (e *Engine) retrySubmit(ctx context.Context, t Tmux, server, paneID, text, 
 			return SubmitUnverified{Err: err}
 		}
 
-		retryBaseCount := CountOccurrences(clearedFrame, needle, collapsible)
+		retryBaseCount := CountOccurrences(clearedFrame, needle, collapsible, imageish)
 		if err := e.setAndPaste(ctx, t, server, paneID, text); err != nil {
 			return err
 		}
-		preFrame, err := e.probeEcho(ctx, t, server, paneID, needle, collapsible, retryBaseCount)
+		preFrame, err := e.probeEcho(ctx, t, server, paneID, needle, collapsible, imageish, retryBaseCount)
 		if err != nil {
 			var probeErr ProbeFailure
 			if errors.As(err, &probeErr) {
@@ -361,7 +366,7 @@ func (e *Engine) retrySubmit(ctx context.Context, t Tmux, server, paneID, text, 
 		if SubmitRetryBackoffSteps < len(steps) {
 			steps = steps[:max(SubmitRetryBackoffSteps, 0)]
 		}
-		verdict, err := verifySubmit(ctx, t, server, paneID, preFrame, needle, collapsible, retryBaseCount, steps)
+		verdict, err := verifySubmit(ctx, t, server, paneID, preFrame, needle, collapsible, imageish, retryBaseCount, steps)
 		if err != nil {
 			return SubmitUnverified{Err: err}
 		}
@@ -402,7 +407,7 @@ func (e *Engine) setAndPaste(ctx context.Context, t Tmux, server, paneID, text s
 // failure is returned wrapped (distinct from a clean probe miss); an exhausted
 // retry returns ProbeFailure. All captures and sleeps share the caller's ctx
 // deadline.
-func (e *Engine) probeEcho(ctx context.Context, t Tmux, server, paneID, needle string, collapsible bool, baseCount int) (string, error) {
+func (e *Engine) probeEcho(ctx context.Context, t Tmux, server, paneID, needle string, collapsible, imageish bool, baseCount int) (string, error) {
 	for attempt := 0; attempt < ProbeAttempts; attempt++ {
 		d := ProbeGap
 		if attempt == 0 {
@@ -418,7 +423,7 @@ func (e *Engine) probeEcho(ctx context.Context, t Tmux, server, paneID, needle s
 		if err != nil {
 			return "", fmt.Errorf("capture-pane: %w", err)
 		}
-		if CountOccurrences(capture, needle, collapsible) > baseCount {
+		if CountOccurrences(capture, needle, collapsible, imageish) > baseCount {
 			return capture, nil
 		}
 	}
@@ -428,7 +433,7 @@ func (e *Engine) probeEcho(ctx context.Context, t Tmux, server, paneID, needle s
 // verifySubmit compares complete normalized frames without interpreting a
 // repaint; only a frame unchanged through every step can establish that Enter
 // had no visible effect.
-func verifySubmit(ctx context.Context, t Tmux, server, paneID, preFrame, needle string, collapsible bool, baseCount int, steps []time.Duration) (observationVerdict, error) {
+func verifySubmit(ctx context.Context, t Tmux, server, paneID, preFrame, needle string, collapsible, imageish bool, baseCount int, steps []time.Duration) (observationVerdict, error) {
 	preFrame = stripForProbe(preFrame)
 	var capture string
 	for _, delay := range steps {
@@ -445,9 +450,10 @@ func verifySubmit(ctx context.Context, t Tmux, server, paneID, preFrame, needle 
 		}
 	}
 	// Evidence must use the same predicate that established the echo: the chip
-	// term keeps collapsed pastes recovery-eligible where chips are rendered and
-	// matches nothing elsewhere, so it adds no portability constraint.
-	if CountOccurrences(capture, needle, collapsible) > baseCount {
+	// terms (paste-collapse and image) keep collapsed and image-chipped pastes
+	// recovery-eligible where chips are rendered and match nothing elsewhere,
+	// so they add no portability constraint.
+	if CountOccurrences(capture, needle, collapsible, imageish) > baseCount {
 		return observationNonSubmission, nil
 	}
 	return observationInconclusive, nil
@@ -517,6 +523,51 @@ var ansiEscapeRe = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07\x1
 // is optional and tolerant of singular/plural "line"/"lines" and any digit counts.
 var pasteCollapseRe = regexp.MustCompile(`\[Pastedtext#\d+(?:\+\d+lines?)?\]`)
 
+// imageCollapseRe matches Claude Code's image-attachment placeholder — the TUI
+// replaces a bracketed paste that is exactly one existing image-file path with
+// an "[Image #N]" chip instead of echoing the path text, so the raw needle
+// would never be found and the probe would fail exactly the image-attachment
+// case (the dashboard's attachment-only send shape). Empirical, CC 2.1.260:
+//   - the chip renders for bare paths to EXISTING .png/.jpg/.gif/.webp files
+//     (.svg/.bmp and nonexistent paths stay raw text), at EVERY paste length —
+//     a 293-char image path chips as "[Image #N]", never "[Pasted text #N]",
+//     so the collapsible arm can never catch it;
+//   - a trailing newline still chips; mixed text+path and multiple
+//     newline-separated paths stay raw text;
+//   - the chip number increments per paste within a session.
+//
+// Like pasteCollapseRe, the pattern matches the WHITESPACE-STRIPPED capture,
+// i.e. "[Image#1]". The chip counts as a successful echo ONLY when the paste
+// is IMAGEISH (see isBareImagePath / CountOccurrences) and ONLY as a fresh
+// occurrence vs the pre-paste baseline.
+var imageCollapseRe = regexp.MustCompile(`\[Image#\d+\]`)
+
+// imageExtensions are the path suffixes the image-chip gate recognizes — the
+// Claude API image media types, which is also the set CC 2.1.260 was observed
+// to chip. Matched case-insensitively. A wrongly-gated extension is harmless:
+// the TUI leaves such a paste as raw text and the needle arm still verifies it.
+var imageExtensions = []string{".png", ".jpg", ".jpeg", ".gif", ".webp"}
+
+// isBareImagePath reports whether text, whitespace-trimmed, is a single line
+// ending in a recognized image extension — the only paste shape Claude Code
+// renders as an "[Image #N]" chip. Whether a gated paste actually chips
+// depends on filesystem state the engine cannot see (the file must exist), so
+// the gate WIDENS the accepted echo signals (fresh chip OR fresh raw needle)
+// rather than selecting between them.
+func isBareImagePath(text string) bool {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" || strings.Contains(trimmed, "\n") {
+		return false
+	}
+	lower := strings.ToLower(trimmed)
+	for _, ext := range imageExtensions {
+		if strings.HasSuffix(lower, ext) {
+			return true
+		}
+	}
+	return false
+}
+
 // Sanitize strips terminal control bytes from a message before it is pasted
 // into an agent pane. Bracketed paste makes ordinary text inert, but control
 // bytes ride through verbatim — most sharply ESC (0x1B), which can embed the
@@ -564,27 +615,35 @@ func Needle(text string) string {
 
 // CountOccurrences counts how many times this paste's echo signal appears
 // in the pane capture: the raw needle occurrences PLUS, when the paste is
-// COLLAPSIBLE, the paste-collapse placeholder occurrences. Both the capture and
+// COLLAPSIBLE, the paste-collapse placeholder occurrences PLUS, when the paste
+// is IMAGEISH, the image-chip placeholder occurrences. Both the capture and
 // the needle have ALL whitespace removed (stripForProbe) so a TUI wrap that
 // inserts spaces/newlines mid-fragment (or a leading prompt glyph on the wrapped
 // row) cannot defeat the match.
 //
 // The engine compares this count against a pre-paste BASELINE and requires a
 // strict increase, so a stale needle/placeholder already in-frame is a floor to
-// beat rather than a false positive. The collapsible gate matters: `collapsible`
-// means the TUI may have collapsed THIS paste into a chip (multiline text, or a
-// single line long enough to collapse — CollapseMinRunes), so the chip is
-// a valid fresh-echo signal; a short single-line paste never collapses, so
-// counting the chip for it would only widen the concurrent-fresh-chip
-// false-positive window. A short/common single-line needle ("y", "ok") could
+// beat rather than a false positive. The gates matter: `collapsible` means the
+// TUI may have collapsed THIS paste into a chip (multiline text, or a
+// single line long enough to collapse — CollapseMinRunes), and `imageish` means
+// the TUI may have rendered THIS paste as an "[Image #N]" chip (a bare
+// single-line image path — isBareImagePath), so each chip is a valid fresh-echo
+// signal only for a paste of its shape; counting a chip for any other paste
+// would only widen the concurrent-fresh-chip false-positive window. Both chip
+// arms are additive to the needle arm — the imageish gate cannot know whether
+// the TUI chipped (that depends on the file existing), so a raw-text echo of an
+// image path still counts. A short/common single-line needle ("y", "ok") could
 // substring-match unrelated stale content, but that content is in the baseline
 // too — the caller's strict-increase requirement, not this counter, is what makes
 // short needles fail closed against stale content.
-func CountOccurrences(capture, needle string, collapsible bool) int {
+func CountOccurrences(capture, needle string, collapsible, imageish bool) int {
 	stripped := stripForProbe(capture)
 	n := strings.Count(stripped, needle)
 	if collapsible {
 		n += len(pasteCollapseRe.FindAllString(stripped, -1))
+	}
+	if imageish {
+		n += len(imageCollapseRe.FindAllString(stripped, -1))
 	}
 	return n
 }

--- a/app/backend/internal/inject/inject_test.go
+++ b/app/backend/internal/inject/inject_test.go
@@ -859,7 +859,7 @@ func TestVerifySubmitClassifiesChangesAsNoClaim(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ft := &fakeTmux{captureResults: []string{tt.post}}
-			verdict, err := verifySubmit(context.Background(), ft, "default", "%5", tt.pre, Needle("hello"), false, 0, []time.Duration{time.Millisecond})
+			verdict, err := verifySubmit(context.Background(), ft, "default", "%5", tt.pre, Needle("hello"), false, false, 0, []time.Duration{time.Millisecond})
 			if err != nil {
 				t.Fatalf("verifySubmit: %v", err)
 			}
@@ -884,7 +884,7 @@ func TestVerifySubmitEvidenceUsesProbePredicate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ft := &fakeTmux{captureResults: []string{tt.frame}}
-			verdict, err := verifySubmit(context.Background(), ft, "default", "%5", tt.frame, needle, true, 0, []time.Duration{time.Millisecond})
+			verdict, err := verifySubmit(context.Background(), ft, "default", "%5", tt.frame, needle, true, false, 0, []time.Duration{time.Millisecond})
 			if err != nil {
 				t.Fatalf("verifySubmit: %v", err)
 			}
@@ -946,34 +946,143 @@ func TestNeedle(t *testing.T) {
 
 // TestCountOccurrences pins the counting rules the baseline-comparison probe
 // rests on: raw needle, collapsible-gated placeholder (BOTH chip forms),
-// ANSI/whitespace normalization.
+// imageish-gated image chip, ANSI/whitespace normalization.
 func TestCountOccurrences(t *testing.T) {
 	needle := Needle("please run the tests")
 	tests := []struct {
 		name        string
 		capture     string
 		collapsible bool
+		imageish    bool
 		want        int
 	}{
-		{"echo present once", "❯ please run the tests", false, 1},
-		{"echo absent", "unrelated scrollback\n❯ ", false, 0},
-		{"echo present twice", "❯ please run the tests\n❯ please run the tests", false, 2},
-		{"wrapped across rows", "❯ please run the\n  tests", false, 1},
-		{"ansi-styled echo", "\x1b[1m❯\x1b[0m please run \x1b[32mthe tests\x1b[0m", false, 1},
-		{"multiline chip counted when collapsible", "❯ [Pasted text #1 +12 lines]", true, 1},
-		{"multiline chip ignored when not collapsible", "❯ [Pasted text #1 +12 lines]", false, 0},
-		{"suffix-less chip counted when collapsible", "❯ [Pasted text #7]", true, 1},
-		{"suffix-less chip ignored when not collapsible", "❯ [Pasted text #7]", false, 0},
-		{"placeholder singular line", "❯ [Pasted text #3 +1 line]", true, 1},
-		{"ansi-styled placeholder", "\x1b[2m[Pasted text #2 +40 lines]\x1b[0m", true, 1},
-		{"two chips both forms", "[Pasted text #1 +2 lines]\n[Pasted text #2]", true, 2},
-		{"non-placeholder bracketed text", "❯ [some other note]", true, 0},
+		{"echo present once", "❯ please run the tests", false, false, 1},
+		{"echo absent", "unrelated scrollback\n❯ ", false, false, 0},
+		{"echo present twice", "❯ please run the tests\n❯ please run the tests", false, false, 2},
+		{"wrapped across rows", "❯ please run the\n  tests", false, false, 1},
+		{"ansi-styled echo", "\x1b[1m❯\x1b[0m please run \x1b[32mthe tests\x1b[0m", false, false, 1},
+		{"multiline chip counted when collapsible", "❯ [Pasted text #1 +12 lines]", true, false, 1},
+		{"multiline chip ignored when not collapsible", "❯ [Pasted text #1 +12 lines]", false, false, 0},
+		{"suffix-less chip counted when collapsible", "❯ [Pasted text #7]", true, false, 1},
+		{"suffix-less chip ignored when not collapsible", "❯ [Pasted text #7]", false, false, 0},
+		{"placeholder singular line", "❯ [Pasted text #3 +1 line]", true, false, 1},
+		{"ansi-styled placeholder", "\x1b[2m[Pasted text #2 +40 lines]\x1b[0m", true, false, 1},
+		{"two chips both forms", "[Pasted text #1 +2 lines]\n[Pasted text #2]", true, false, 2},
+		{"non-placeholder bracketed text", "❯ [some other note]", true, false, 0},
+		{"image chip counted when imageish", "❯ [Image #1]", false, true, 1},
+		{"image chip ignored when not imageish", "❯ [Image #1]", false, false, 0},
+		{"image chip ignored under collapsible alone", "❯ [Image #1]", true, false, 0},
+		{"paste chip not counted by imageish alone", "❯ [Pasted text #7]", false, true, 0},
+		{"ansi-styled image chip", "\x1b[2m[Image #4]\x1b[0m", false, true, 1},
+		{"two image chips", "[Image #1]\n❯ [Image #2]", false, true, 2},
+		{"needle and image chip add", "❯ please run the tests\n❯ [Image #3]", false, true, 2},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := CountOccurrences(tt.capture, needle, tt.collapsible); got != tt.want {
-				t.Errorf("CountOccurrences(%q, %q, collapsible=%v) = %d, want %d", tt.capture, needle, tt.collapsible, got, tt.want)
+			if got := CountOccurrences(tt.capture, needle, tt.collapsible, tt.imageish); got != tt.want {
+				t.Errorf("CountOccurrences(%q, %q, collapsible=%v, imageish=%v) = %d, want %d", tt.capture, needle, tt.collapsible, tt.imageish, got, tt.want)
 			}
 		})
 	}
+}
+
+// TestIsBareImagePath pins the image-chip gate: only a whitespace-trimmed
+// single line ending in a recognized image extension qualifies — the one paste
+// shape the TUI may render as an "[Image #N]" chip.
+func TestIsBareImagePath(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{"bare png path", "/wt/.uploads/260904-shot.png", true},
+		{"bare jpg path", "/wt/.uploads/a.jpg", true},
+		{"bare jpeg path", "/wt/.uploads/a.jpeg", true},
+		{"bare gif path", "/wt/.uploads/a.gif", true},
+		{"bare webp path", "/wt/.uploads/a.webp", true},
+		{"uppercase extension", "/wt/.uploads/SHOT.PNG", true},
+		{"trailing newline trimmed", "/wt/.uploads/a.png\n", true},
+		{"surrounding whitespace trimmed", "  /wt/.uploads/a.png\t", true},
+		{"path with spaces", "/wt/.uploads/screen shot 1.png", true},
+		{"relative path", "shot.png", true},
+		{"svg excluded", "/wt/.uploads/a.svg", false},
+		{"bmp excluded", "/wt/.uploads/a.bmp", false},
+		{"mixed text and path", "look at /wt/.uploads/a.png please", false},
+		{"two newline-separated paths", "/a/b.png\n/c/d.jpg", false},
+		{"extension not at end", "/wt/.uploads/a.png.txt", false},
+		{"empty", "", false},
+		{"whitespace only", " \n\t", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isBareImagePath(tt.text); got != tt.want {
+				t.Errorf("isBareImagePath(%q) = %v, want %v", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSendImageChipEcho covers the imageish echo arm end to end: a bare
+// image-path paste the TUI renders as an "[Image #N]" chip (never the raw
+// path) passes the probe via the chip, a stale chip stays a baseline floor,
+// a fresh chip beats a stale one, and a raw-text echo (the file does not
+// exist, so no chip renders) still passes via the needle arm.
+func TestSendImageChipEcho(t *testing.T) {
+	fastProbe(t)
+	fastSubmit(t)
+	const path = "/wt/.uploads/260904-121530-shot.png"
+
+	t.Run("fresh chip passes without raw echo", func(t *testing.T) {
+		ft := &fakeTmux{captureResults: []string{"❯ ", "❯ [Image #1]", "working"}}
+		if err := NewEngine("rk-img-fresh").Send(context.Background(), ft, "default", "%5", path, true); err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+		if !ft.enterCalled {
+			t.Fatal("Enter was not sent after a fresh image chip")
+		}
+	})
+
+	t.Run("stale chip is a floor to beat", func(t *testing.T) {
+		ft := &fakeTmux{captureResult: "❯ [Image #1]"}
+		err := NewEngine("rk-img-stale").Send(context.Background(), ft, "default", "%5", path, true)
+		var pf ProbeFailure
+		if !errors.As(err, &pf) {
+			t.Fatalf("err = %v, want ProbeFailure", err)
+		}
+		if ft.enterCalled {
+			t.Fatal("Enter sent on a stale image chip")
+		}
+	})
+
+	t.Run("fresh chip beats a stale one", func(t *testing.T) {
+		ft := &fakeTmux{captureResults: []string{"sent [Image #1]\n❯ ", "sent [Image #1]\n❯ [Image #2]", "working"}}
+		if err := NewEngine("rk-img-incr").Send(context.Background(), ft, "default", "%5", path, true); err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+		if !ft.enterCalled {
+			t.Fatal("Enter was not sent after the count rose past the stale chip")
+		}
+	})
+
+	t.Run("raw echo still passes for an imageish paste", func(t *testing.T) {
+		ft := &fakeTmux{captureResults: []string{"❯ ", "❯ " + path, "working"}}
+		if err := NewEngine("rk-img-raw").Send(context.Background(), ft, "default", "%5", path, true); err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+		if !ft.enterCalled {
+			t.Fatal("Enter was not sent after a raw-needle echo of an image path")
+		}
+	})
+
+	t.Run("chip does not pass a non-imageish paste", func(t *testing.T) {
+		ft := &fakeTmux{captureResult: "❯ [Image #1]"}
+		err := NewEngine("rk-img-plain").Send(context.Background(), ft, "default", "%5", "hello world", true)
+		var pf ProbeFailure
+		if !errors.As(err, &pf) {
+			t.Fatalf("err = %v, want ProbeFailure", err)
+		}
+		if ft.enterCalled {
+			t.Fatal("Enter sent for plain text on the strength of an image chip")
+		}
+	})
 }

--- a/docs/memory/run-kit/chat.md
+++ b/docs/memory/run-kit/chat.md
@@ -415,7 +415,8 @@ path.
 ### Requirement: NOVELTY echo probe (fail-closed), settle + bounded retry
 Before Enter the handler SHALL verify the pasted text ECHOED into the pane's live
 input buffer, using **novelty**, not mere presence: it counts a probe **needle**
-(and, when the paste is *collapsible*, the paste-collapse placeholder) in the
+(and, when the paste is *collapsible*, the paste-collapse placeholder; and, when
+the paste is *imageish*, the image-chip placeholder) in the
 pre-paste **baseline** capture, then requires that count to strictly INCREASE in a
 post-paste capture. The needle is derived from the LAST non-empty line of the text,
 whitespace-stripped (both needle and capture stripped of ANSI + all whitespace so
@@ -428,7 +429,18 @@ signal. `pasteCollapseRe` matches BOTH chip forms whitespace-stripped:
 `[Pasted text #N]` (long-single-line collapse), with the `+M lines` suffix optional.
 The chip counts as a successful echo ONLY when the paste is collapsible and ONLY as
 a *fresh* occurrence vs baseline; a short single-line send keeps exact-needle-only
-matching. A short settle (`inject.ProbeSettle = 80ms`)
+matching. A paste is **imageish** when the text, whitespace-trimmed, is a single
+line ending in an image extension (case-insensitive `.png`/`.jpg`/`.jpeg`/`.gif`/
+`.webp` — `isBareImagePath`): the Claude Code TUI renders exactly that paste shape
+as an `[Image #N]` chip instead of echoing the path (empirical, CC 2.1.260 — chips
+at every length for EXISTING files, beating the paste-collapse chip; `.svg`/`.bmp`,
+nonexistent paths, mixed text+path, and multiple newline-separated paths stay raw
+text). `imageCollapseRe` matches the whitespace-stripped `[Image #N]` chip, counted
+ONLY when the paste is imageish and only as a fresh occurrence vs baseline. The
+imageish arm is EITHER-signal — chip-vs-raw depends on filesystem state the engine
+cannot see, so a fresh raw-needle echo of an image path also passes; the
+attachment-only dashboard send (a bare uploaded-path line) rides this arm.
+A short settle (`inject.ProbeSettle = 80ms`)
 precedes the first capture, then up to `inject.ProbeAttempts = 8` captures with an
 `inject.ProbeGap = 80ms` gap (settle/gap are package **vars** solely so tests can
 shrink them). The wall-clock probe ceiling is about 640ms (`80 + 7*80`), shared
@@ -460,8 +472,8 @@ After each Enter the engine SHALL compare `stripForProbe`-normalized whole-pane
 captures with the echo probe's winning capture. The first changed frame SHALL
 return success immediately without claiming that submission occurred. Only a
 frame unchanged through every `SubmitBackoff` step with the paste echo still
-present under `CountOccurrences(capture, needle, collapsible)` SHALL authorize
-recovery. Any unchanged frame without that echo SHALL return
+present under `CountOccurrences(capture, needle, collapsible, imageish)` SHALL
+authorize recovery. Any unchanged frame without that echo SHALL return
 `inject.SubmitUnverified` without recovery. Context cancellation and capture
 errors during observation SHALL surface as `inject.SubmitUnverified` wrapping the
 cause — Enter was already sent, so submit-unconfirmed is the honest state.
@@ -743,11 +755,12 @@ negative posts the message twice even with a retry limit).
 
 ### Non-submission evidence reuses the echo probe predicate
 **Decision**: The unchanged-frame evidence arm checks the echo with
-`CountOccurrences(capture, needle, collapsible)`, including the paste-collapse
-chip term; the changed-frame no-claim arm remains pure whole-frame comparison.
+`CountOccurrences(capture, needle, collapsible, imageish)`, including the gated
+chip terms (paste-collapse and image); the changed-frame no-claim arm remains
+pure whole-frame comparison.
 **Why**: The evidence question must use the same predicate that established the
 echo. A chip-rendering TUI replaces a collapsed paste's raw text with a chip, while
-the chip term matches nothing on TUIs that do not render one.
+the chip terms match nothing on TUIs that do not render one.
 **Rejected**: Raw-needle-only evidence (classifies collapsed long or multi-line
 pastes as echo-absent and withholds recovery); using chip recognition in the
 changed-frame comparison (adds provider shape where none is needed).
@@ -776,6 +789,28 @@ Claude Code release can lower it silently); counting the chip unconditionally fo
 ALL sends (needlessly widens the concurrent-fresh-chip false-positive window to
 short interactive sends that never collapse).
 *Introduced by*: `260719-yxi0-chat-send-single-line-collapse-probe`
+
+### Image chip is a gated third echo signal, either-signal with the raw needle
+**Decision**: Count `[Image #N]` chips (`imageCollapseRe`, whitespace-stripped
+form) as fresh echo only when the paste is *imageish* — a bare single-line image
+path, trimmed, case-insensitive `.png`/`.jpg`/`.jpeg`/`.gif`/`.webp`
+(`isBareImagePath`) — and accept EITHER a fresh chip OR a fresh raw-needle echo
+for such pastes, under the unchanged strict-increase-over-baseline rule.
+**Why**: Claude Code chips only a paste that is exactly one existing image path
+(verified CC 2.1.260 — mixed text, multi-path, `.svg`/`.bmp`, and nonexistent
+paths all stay raw text; the image chip renders at every paste length, beating
+the paste-collapse chip, so the collapsible arm can never catch it), and
+chip-vs-raw depends on filesystem state the engine cannot see. Gating mirrors
+the collapsible-gate stance: keep the concurrent-fresh-chip false-positive
+window off ordinary sends. Without this arm, every attachment-only dashboard
+send (a bare uploaded-path line) failed the probe and 409'd despite the paste
+demonstrably landing as a chip.
+**Rejected**: counting the image chip unconditionally (widens the false-positive
+window for all sends); matching Claude Code's exact chip-eligibility rule via
+file existence/media sniffing (unknowable from text; either-signal makes it
+unnecessary); a frontend workaround wrapping the path in text (changes what the
+agent receives).
+*Introduced by*: `260904-svfv-inject-image-chip-probe`
 
 ### Allow + probe busy policy — no server-side gate, no queue
 **Decision**: There is NO `agentState` gate on send and NO server-side queue. A busy

--- a/fab/changes/260904-svfv-inject-image-chip-probe/.history.jsonl
+++ b/fab/changes/260904-svfv-inject-image-chip-probe/.history.jsonl
@@ -1,0 +1,11 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-09-04T07:42:53Z"}
+{"args":"Echo probe recognizes the [Image #N] composer chip: sending a bare image path from the dashboard compose strip always fails the injection engine echo probe because Claude Code converts a single-image-path bracketed paste into an [Image #N] chip the probe does not recognize; add a gated imageCollapseRe signal to CountOccurrences mirroring the paste-collapse chip arm","cmd":"fab-new","event":"command","ts":"2026-09-04T07:42:53Z"}
+{"delta":"+5.0","event":"confidence","score":5,"trigger":"calc-score","ts":"2026-09-04T07:44:22Z"}
+{"cmd":"fab-proceed","event":"command","ts":"2026-09-04T07:44:30Z"}
+{"cmd":"fab-switch","event":"command","ts":"2026-09-04T07:45:29Z"}
+{"cmd":"fab-fff","event":"command","ts":"2026-09-04T07:46:58Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-09-04T07:47:17Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-09-04T07:53:04Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-09-04T07:56:56Z"}
+{"event":"review","result":"passed","ts":"2026-09-04T07:56:56Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-09-04T07:58:15Z"}

--- a/fab/changes/260904-svfv-inject-image-chip-probe/.history.jsonl
+++ b/fab/changes/260904-svfv-inject-image-chip-probe/.history.jsonl
@@ -10,3 +10,4 @@
 {"event":"review","result":"passed","ts":"2026-09-04T07:56:56Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-09-04T07:58:15Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-09-04T07:59:37Z"}
+{"event":"review","result":"passed","ts":"2026-09-04T08:03:42Z"}

--- a/fab/changes/260904-svfv-inject-image-chip-probe/.history.jsonl
+++ b/fab/changes/260904-svfv-inject-image-chip-probe/.history.jsonl
@@ -9,3 +9,4 @@
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-09-04T07:56:56Z"}
 {"event":"review","result":"passed","ts":"2026-09-04T07:56:56Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-09-04T07:58:15Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-09-04T07:59:37Z"}

--- a/fab/changes/260904-svfv-inject-image-chip-probe/.status.yaml
+++ b/fab/changes/260904-svfv-inject-image-chip-probe/.status.yaml
@@ -10,7 +10,7 @@ progress:
     review: done
     hydrate: done
     ship: done
-    review-pr: active
+    review-pr: done
 plan:
     generated: true
     task_count: 4
@@ -34,7 +34,7 @@ stage_metrics:
     review: {started_at: "2026-09-04T07:53:04Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T07:56:56Z"}
     hydrate: {started_at: "2026-09-04T07:56:56Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T07:58:15Z"}
     ship: {started_at: "2026-09-04T07:58:15Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T07:59:37Z"}
-    review-pr: {started_at: "2026-09-04T07:59:37Z", driver: git-pr, iterations: 1}
+    review-pr: {started_at: "2026-09-04T07:59:37Z", driver: git-pr, iterations: 1, completed_at: "2026-09-04T08:03:42Z"}
 prs:
     - https://github.com/sahil87/run-kit/pull/821
 change_type_source: explicit
@@ -54,4 +54,4 @@ true_impact:
     computed_at_stage: ship
 summary: 'Echo probe gains a gated [Image #N] image-chip arm (either-signal with the raw needle) so bare image-path sends verify instead of 409ing'
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-09-04T07:59:37Z
+last_updated: 2026-09-04T08:03:42Z

--- a/fab/changes/260904-svfv-inject-image-chip-probe/.status.yaml
+++ b/fab/changes/260904-svfv-inject-image-chip-probe/.status.yaml
@@ -1,0 +1,55 @@
+id: svfv
+name: 260904-svfv-inject-image-chip-probe
+created: 2026-09-04T07:42:53Z
+created_by: sahil-noon
+change_type: fix
+issues: []
+progress:
+    intake: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+plan:
+    generated: true
+    task_count: 4
+    acceptance_count: 9
+    acceptance_completed: 9
+confidence:
+    certain: 5
+    confident: 2
+    tentative: 0
+    unresolved: 0
+    score: 5.0
+    fuzzy: true
+    dimensions:
+        signal: 84.3
+        reversibility: 88.6
+        competence: 87.1
+        disambiguation: 83.6
+stage_metrics:
+    intake: {started_at: "2026-09-04T07:42:53Z", driver: fab-new, iterations: 1, completed_at: "2026-09-04T07:47:17Z"}
+    apply: {started_at: "2026-09-04T07:47:17Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T07:53:04Z"}
+    review: {started_at: "2026-09-04T07:53:04Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T07:56:56Z"}
+    hydrate: {started_at: "2026-09-04T07:56:56Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T07:58:15Z"}
+    ship: {started_at: "2026-09-04T07:58:15Z", driver: fab-fff, iterations: 1}
+prs: []
+change_type_source: explicit
+true_impact:
+    added: 0
+    deleted: 0
+    net: 0
+    excluding:
+        added: 0
+        deleted: 0
+        net: 0
+    tests:
+        added: 0
+        deleted: 0
+        net: 0
+    computed_at: "2026-09-04T07:58:15Z"
+    computed_at_stage: hydrate
+summary: 'Echo probe gains a gated [Image #N] image-chip arm (either-signal with the raw needle) so bare image-path sends verify instead of 409ing'
+# true_impact: lazily created on first stage-finish that computes it (no placeholder here).
+last_updated: 2026-09-04T07:58:15Z

--- a/fab/changes/260904-svfv-inject-image-chip-probe/.status.yaml
+++ b/fab/changes/260904-svfv-inject-image-chip-probe/.status.yaml
@@ -9,8 +9,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 plan:
     generated: true
     task_count: 4
@@ -33,23 +33,25 @@ stage_metrics:
     apply: {started_at: "2026-09-04T07:47:17Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T07:53:04Z"}
     review: {started_at: "2026-09-04T07:53:04Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T07:56:56Z"}
     hydrate: {started_at: "2026-09-04T07:56:56Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T07:58:15Z"}
-    ship: {started_at: "2026-09-04T07:58:15Z", driver: fab-fff, iterations: 1}
-prs: []
+    ship: {started_at: "2026-09-04T07:58:15Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T07:59:37Z"}
+    review-pr: {started_at: "2026-09-04T07:59:37Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/sahil87/run-kit/pull/821
 change_type_source: explicit
 true_impact:
-    added: 0
-    deleted: 0
-    net: 0
+    added: 518
+    deleted: 48
+    net: 470
     excluding:
-        added: 0
-        deleted: 0
-        net: 0
+        added: 209
+        deleted: 41
+        net: 168
     tests:
-        added: 0
-        deleted: 0
-        net: 0
-    computed_at: "2026-09-04T07:58:15Z"
-    computed_at_stage: hydrate
+        added: 127
+        deleted: 18
+        net: 109
+    computed_at: "2026-09-04T07:59:37Z"
+    computed_at_stage: ship
 summary: 'Echo probe gains a gated [Image #N] image-chip arm (either-signal with the raw needle) so bare image-path sends verify instead of 409ing'
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-09-04T07:58:15Z
+last_updated: 2026-09-04T07:59:37Z

--- a/fab/changes/260904-svfv-inject-image-chip-probe/intake.md
+++ b/fab/changes/260904-svfv-inject-image-chip-probe/intake.md
@@ -1,0 +1,93 @@
+# Intake: Echo Probe Recognizes the `[Image #N]` Composer Chip
+
+**Change**: 260904-svfv-inject-image-chip-probe
+**Created**: 2026-09-04
+
+## Origin
+
+> Sending a bare image path from the dashboard compose strip (the exact shape an attachment-only send produces) always fails the injection engine's echo probe: Claude Code converts a bracketed paste whose entire content is one existing image-file path into an `[Image #N]` composer chip, so the raw path text never echoes, the probe exhausts its retries, and Enter is withheld (`ProbeFailure`) even though delivery succeeded. Reported by the user 2026-09-04 ("generally when sending just the image link"); root cause verified empirically on Claude Code 2.1.260 on an isolated tmux rig using the engine's own set-buffer → bracketed `paste-buffer -d -p` mechanism.
+
+Created via promptless dispatch (`/fab-proceed` create-new). All facts below were verified during the preceding investigation session — the empirical chip matrix, the code anchors, and the fix shape were user-approved before dispatch. No open design questions remain.
+
+## Why
+
+1. **The pain point**: A dashboard user who uploads an image (or types a bare image path) and hits Send gets the error toast "Text is staged in the pane but unsent. Pressing Send again would duplicate it." (`app/frontend/src/components/compose-strip.tsx:546`, fired on ApiError codes `probe_failure`/`staged_send_failure`) — every time, for the most common attachment-only send shape. Uploads append the uploaded file path as a line of textarea text (`compose-strip.tsx:749`), so an attachment-only send is exactly a bare image path. The delivery actually succeeded — the path landed in Claude Code's composer as an `[Image #N]` chip — but the engine's fail-closed probe withheld Enter, so the user must manually press Enter in the pane after every image send.
+
+2. **The consequence if unfixed**: The image-attachment flow is effectively broken for its primary use case. The fail-closed design (correct in general — never blind-Enter unverified text) is producing a guaranteed false negative for a whole input class, training users to distrust the staged-send toast.
+
+3. **Why this approach**: The probe currently accepts two echo signals — the raw needle and the `[Pasted text #N]` collapse chip (gated on `collapsible`). Claude Code has a third composer transformation the probe doesn't know about: the image chip. Teaching the probe that third signal, gated the same way the collapse chip is gated, is the minimal fix consistent with the file's existing design stance (narrow false-positive windows via content-shape gates, strict-increase-over-baseline for staleness). The fix is engine-side only; the frontend toast behavior is correct once the probe passes.
+
+## What Changes
+
+Scope: `app/backend/internal/inject/inject.go` + its package tests. No frontend change, no API change, no new subprocess surface.
+
+### Root cause (verified, CC 2.1.260)
+
+Claude Code converts a bracketed paste whose entire (whitespace-trimmed) content is exactly ONE existing image-file path into an `[Image #N]` composer chip — the raw path text never echoes into the pane. The probe in `inject.go` accepts only:
+
+- the raw needle — last ≤40 chars of the last non-empty line (`Needle()`, `NeedleMaxLen`), and
+- the paste-collapse chip `pasteCollapseRe` (pattern `\[Pastedtext#\d+(?:\+\d+lines?)?\]`, matching the whitespace-stripped form), gated on `collapsible` (multiline or ≥200 runes, `CollapseMinRunes`).
+
+Neither matches `[Image #N]`, so `CountOccurrences` never exceeds the pre-paste baseline → `probeEcho` exhausts its 8 attempts → `ProbeFailure` → Enter withheld → the handler's 409 → the frontend toast.
+
+### Verified empirical matrix (CC 2.1.260, 2026-09-04, isolated tmux rig, engine's own paste mechanism)
+
+| Paste content | Result in composer |
+|---------------|--------------------|
+| Bare existing image path | `[Image #N]` chip. Extensions that chip: `.png`, `.jpg`, `.gif`, `.webp` (matches Claude API image media types; `.jpeg` untested but assumed — include it) |
+| Bare existing `.svg` / `.bmp` path | Raw text (no chip) |
+| Nonexistent image path | Raw text (no chip) — chip-vs-raw depends on filesystem state the engine cannot predict from text alone |
+| 293-char existing image path | `[Image #N]`, NOT `[Pasted text #N]` — the image chip wins at every length; the existing collapsible arm can never catch it |
+| Bare path + trailing newline | Still chips |
+| Mixed text + path in one paste ("look at this /path.png please") | Raw text, no chip (today's probe passes this case) |
+| Two newline-separated paths in one paste | Raw text, no chips (today's probe passes) |
+| Unquoted path containing spaces | Chips (dashboard upload paths are timestamp-sanitized and space-free anyway — `app/backend/api/upload.go:127-128`) |
+| Repeated pastes in a session | Chip numbering increments per paste (`[Image #2]`, `#3`, …) — the engine's strict-increase-over-baseline rule already handles stale chips correctly |
+
+The nonexistent-path row is why the fix MUST accept **either signal** (fresh chip OR fresh raw needle): the engine cannot predict from text alone whether the TUI will chip or leave raw text.
+
+### Fix shape (user-approved)
+
+1. **New regex**: `imageCollapseRe` with pattern `\[Image#\d+\]` (via `regexp.MustCompile` with a raw-string literal, like `pasteCollapseRe`) matching the whitespace-stripped capture (`stripForProbe` output), mirroring `pasteCollapseRe`'s style and doc-comment conventions. The file documents empirical CC behavior with version numbers (e.g. the `CollapseMinRunes` comment at inject.go:75-84 cites CC 2.1.215) — follow that pattern, citing CC 2.1.260 and the observed extension set.
+2. **New gate**: compute in `Send` alongside `collapsible`: the text, whitespace-trimmed, is a **single line ending in a recognized image extension** (case-insensitive: `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`). When the gate is on, `CountOccurrences` counts fresh `[Image #N]` chips IN ADDITION to raw needle occurrences, under the unchanged strict-increase-over-baseline rule. Gated rather than unconditional to keep the concurrent-fresh-chip false-positive window as narrow as the existing collapsible gate keeps its own — that reasoning is documented in the `CountOccurrences` doc comment (inject.go:573-582); mirror it.
+3. **Threading**: thread the flag through the internal call chain: `Send` → `retrySubmit` → `probeEcho` → `verifySubmit` → `CountOccurrences`. `CountOccurrences` has NO callers outside `internal/inject/` (verified by grep), so the signature change is package-local (plus the package's own tests). Consider whether a small probe-spec struct (needle + collapsible + imageish) reads better than a third bool parameter — follow existing file style; either is acceptable.
+4. **Tests**: unit tests in the inject package mirroring the existing paste-collapse tests:
+   - chip counted only under the gate (mixed-text case NOT gated),
+   - baseline strict-increase with stale chips already in-frame,
+   - either-signal acceptance (raw needle still passes when the file doesn't exist / the TUI leaves raw text),
+   - extension-set and case-insensitivity coverage of the gate predicate.
+
+### Alternatives rejected (from the investigation)
+
+- **Counting `[Image #N]` unconditionally (no gate)**: rejected to keep the false-positive window narrow, consistent with the existing collapsible-gate design stance.
+- **Matching Claude Code's exact chip-eligibility rule (file existence + media sniffing)**: impossible from text alone; the either-signal design makes it unnecessary.
+- **Frontend workaround (e.g. wrapping the path in text)**: would change what the agent receives; rejected.
+
+## Affected Memory
+
+- `run-kit/chat`: (modify) chat.md documents the shared pane-typed injection engine including the "novelty echo probe" and its signal set — add the third echo signal (the gated `[Image #N]` image-chip arm alongside the raw needle and paste-collapse chip) and the either-signal rationale. No other memory file covers the probe; `docs/specs/api.md` needs no change (no API surface change).
+
+## Impact
+
+- `app/backend/internal/inject/inject.go` — new package-level regex, new gate predicate, extended `CountOccurrences` signal set, flag threaded through `Send`/`retrySubmit`/`probeEcho`/`verifySubmit` (all package-internal signatures).
+- `app/backend/internal/inject/*_test.go` — new unit tests mirroring the paste-collapse test shape.
+- Consumers unchanged: `POST /api/windows/{id}/send` (incl. `target:"agent"` mode) and the operator-request routes get the fix for free through the shared engine. Frontend untouched.
+- Constitution I (exec.CommandContext, argv slices): no new subprocess surface expected — the change is pure string/regex logic over existing captures.
+
+## Open Questions
+
+None — all design decisions were resolved and user-approved during the preceding investigation session.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Fix is engine-side only: `app/backend/internal/inject/inject.go` + package tests; no frontend, API, or subprocess change | Discussed — user-approved fix shape after the investigation; toast behavior is correct once the probe passes | S:95 R:85 A:95 D:95 |
+| 2 | Certain | Add `imageCollapseRe` = `\[Image#\d+\]` over the whitespace-stripped capture, mirroring `pasteCollapseRe` style and the file's empirical doc-comment convention (cite CC 2.1.260) | Verified empirically on CC 2.1.260; exact regex and convention specified in the approved design | S:95 R:90 A:95 D:90 |
+| 3 | Certain | Chip arm is GATED (single trimmed line ending in a recognized image extension) and EITHER-signal (fresh chip OR fresh raw needle), under the unchanged strict-increase-over-baseline rule | Verified matrix: nonexistent paths stay raw text, so either-signal is required; gating mirrors the documented collapsible-gate false-positive stance (inject.go:573-582) | S:95 R:85 A:90 D:90 |
+| 4 | Confident | Extension set is `.png .jpg .jpeg .gif .webp` case-insensitive — `.jpeg` included though empirically untested (matches Claude API image media types); `.svg`/`.bmp` excluded (verified: no chip) | User directed including `.jpeg`; low risk — a wrongly-gated raw-text send still passes via the raw-needle signal (either-signal) | S:75 R:90 A:70 D:80 |
+| 5 | Confident | Parameter threading shape (probe-spec struct vs a third bool through `Send`→`retrySubmit`→`probeEcho`→`verifySubmit`→`CountOccurrences`) left to apply's judgment per existing file style | User-approved delegation ("either is acceptable"); `CountOccurrences` has no callers outside `internal/inject/` (verified by grep), so fully reversible and package-local | S:70 R:90 A:85 D:60 |
+| 6 | Certain | Affected memory is `run-kit/chat` (modify) — it documents the injection engine's echo-probe signal set; `docs/specs/api.md` unchanged | Domain index confirms chat.md owns "novelty echo probe, probe-gated Enter"; no API surface changes | S:85 R:95 A:90 D:90 |
+| 7 | Confident | Test scope: package unit tests only, mirroring the existing paste-collapse tests; no e2e (the probe is a backend-internal signal with no UI contract change) | Fix shape names unit tests explicitly; existing paste-collapse behavior is covered the same way | S:75 R:85 A:85 D:80 |
+
+7 assumptions (4 certain, 3 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260904-svfv-inject-image-chip-probe/plan.md
+++ b/fab/changes/260904-svfv-inject-image-chip-probe/plan.md
@@ -1,0 +1,108 @@
+# Plan: Echo Probe Recognizes the `[Image #N]` Composer Chip
+
+**Change**: 260904-svfv-inject-image-chip-probe
+**Intake**: `intake.md`
+
+## Requirements
+
+### Inject Engine: Image-Chip Echo Signal
+
+#### R1: Gated `[Image #N]` chip counts as a fresh echo signal
+`CountOccurrences` SHALL count occurrences of the image-chip placeholder — pattern `\[Image#\d+\]` over the `stripForProbe`-normalized capture, declared as a package-level `imageCollapseRe` mirroring `pasteCollapseRe` — IN ADDITION to raw needle occurrences, but ONLY when the paste is *imageish* (R2). The strict-increase-over-baseline rule is unchanged: a stale chip already in the pre-paste baseline is a floor to beat, never a false positive. The chip arm is EITHER-signal: a fresh raw-needle occurrence still satisfies the probe on its own (the TUI leaves raw text when the file does not exist, and the engine cannot predict chip-vs-raw from text alone). The regex doc comment SHALL record the empirical basis (Claude Code 2.1.260, 2026-09-04: bare existing image path → chip at every length, beating the `[Pasted text #N]` collapse; nonexistent path → raw text) following the file's existing empirical-comment convention (`CollapseMinRunes`, `pasteCollapseRe`).
+
+- **GIVEN** an imageish paste whose pre-paste baseline contains zero `[Image #N]` chips
+- **WHEN** the TUI renders the paste as `[Image #1]` and `probeEcho` captures the frame
+- **THEN** the occurrence count strictly exceeds the baseline and the probe passes (Enter proceeds for `submit:true`).
+- **AND GIVEN** a stale `[Image #1]` already in the baseline and no fresh chip or needle appears, **THEN** the count does not rise and the probe fails closed (`ProbeFailure`, Enter withheld).
+- **AND GIVEN** an imageish paste of a nonexistent file that echoes as raw text, **THEN** the raw-needle arm satisfies the probe (either-signal).
+
+#### R2: Imageish gate predicate
+The engine SHALL compute the imageish gate in `Send` alongside `collapsible`: the sanitized text, after trimming leading/trailing whitespace, is a **single line** (no interior `\n`) **ending in a recognized image extension**, case-insensitive: `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`. A non-imageish paste keeps today's exact signal set (needle, plus the collapse chip when collapsible) — the chip arm never widens the false-positive window for ordinary text. `.svg`/`.bmp` are deliberately excluded (verified: CC does not chip them).
+
+- **GIVEN** text `"/wt/.uploads/260904-shot.PNG"` (bare path, uppercase extension) or the same with a trailing newline
+- **WHEN** the gate is computed
+- **THEN** imageish is true.
+- **AND GIVEN** `"look at /a/b.png please"` (mixed text), `"/a/b.png\n/c/d.jpg"` (two paths), or `"/a/b.svg"`, **THEN** imageish is false.
+
+#### R3: Flag threaded through the package-internal probe chain
+The imageish flag SHALL be threaded from `Send` through `retrySubmit`, `probeEcho`, and `verifySubmit` into `CountOccurrences`, so the post-Enter non-submission evidence arm and the recovery re-probe use the same predicate that established the echo (the existing collapse-chip principle). `CountOccurrences` has no callers outside `internal/inject/` (verified), so the signature change is package-local; the threading shape (an added parameter vs a small probe-signals value) follows the file's existing style at the author's discretion. `SendRaw`, `PressEnter`, `Sanitize`, `Needle`, and every exported error type are unchanged.
+
+- **GIVEN** an imageish paste whose chip established the echo and Enter produced a frame unchanged through the full `SubmitBackoff` ladder with the chip still present
+- **WHEN** `verifySubmit` evaluates evidence
+- **THEN** the chip counts as the still-present echo (via the same gated predicate) and the non-submission verdict authorizes the existing bounded recovery.
+
+#### R4: Unit tests mirror the paste-collapse coverage
+The inject package tests SHALL cover: the gate predicate over the extension set, case-insensitivity, trimming, trailing-newline, mixed-text, multi-path, and excluded-extension cases; chip counting only under the gate; strict-increase with a stale chip in baseline; either-signal acceptance (raw needle passes for an imageish paste with no chip); and an end-to-end `Send` pass where the fake tmux renders the paste as a chip. No e2e tests — the probe is a backend-internal signal with no UI contract change.
+
+- **GIVEN** the inject package test suite
+- **WHEN** `go test ./internal/inject/...` runs
+- **THEN** all cases above pass alongside the existing paste-collapse tests, unchanged.
+
+### Design Decisions
+
+#### Image chip is a gated third echo signal, either-signal with the raw needle
+**Decision**: Count `[Image #N]` chips as fresh echo only when the paste is a bare single-line image path (trimmed, case-insensitive `.png/.jpg/.jpeg/.gif/.webp`), and accept EITHER a fresh chip OR a fresh raw needle for such pastes.
+**Why**: Claude Code chips only a paste that is exactly one existing image path (verified CC 2.1.260 — mixed text, multi-path, `.svg`/`.bmp`, and nonexistent paths all stay raw text), and chip-vs-raw depends on filesystem state the engine cannot see; gating mirrors the collapsible-gate stance of keeping the concurrent-fresh-chip false-positive window off ordinary sends.
+**Rejected**: counting the chip unconditionally (widens the false-positive window for all sends); matching CC's exact chip-eligibility rule via file existence/media sniffing (unknowable from text; either-signal makes it unnecessary); a frontend workaround (changes what the agent receives).
+*Introduced by*: 260904-svfv-inject-image-chip-probe
+
+### Non-Goals
+
+- No frontend or API change — the staged-send toast behavior is already correct once the probe passes.
+- No change to `pasteCollapseRe`, `CollapseMinRunes`, or the collapsible gate.
+- No attempt to recognize other composer transformations (e.g. attachment chips of other agent TUIs) — additive later behind the same gate pattern.
+
+## Tasks
+
+### Phase 2: Core Implementation
+
+- [x] T001 Add `imageCollapseRe` (pattern `\[Image#\d+\]`) and the imageish gate predicate (trimmed single line ending in `.png/.jpg/.jpeg/.gif/.webp`, case-insensitive) to `app/backend/internal/inject/inject.go`, with doc comments recording the CC 2.1.260 empirical matrix per the file's convention <!-- R1, R2 -->
+- [x] T002 Compute the gate in `Send` alongside `collapsible` and thread it through `retrySubmit`, `probeEcho`, `verifySubmit` into `CountOccurrences`, counting fresh chips additively under the unchanged strict-increase rule (`app/backend/internal/inject/inject.go`) <!-- R1, R3 -->
+
+### Phase 3: Integration & Edge Cases
+
+- [x] T003 Unit tests in `app/backend/internal/inject/` mirroring the paste-collapse tests: gate predicate matrix (extensions, case, trim, trailing newline, mixed text, multi-path, `.svg`/`.bmp`), chip counted only under the gate, stale-chip baseline strict-increase, either-signal raw-needle pass, and a full `Send` pass via a chip-rendering fake tmux <!-- R4 -->
+- [x] T004 Run `go test ./internal/inject/...` then `go test ./...` in `app/backend/`; fix any fallout <!-- R4 -->
+
+## Acceptance
+
+### Functional Completeness
+
+- [x] A-001 R1: A bare-image-path send whose paste renders as `[Image #N]` passes the probe and (for `submit`) sends Enter — no `ProbeFailure`, no staged-send toast path.
+- [x] A-002 R2: The gate predicate matches exactly the trimmed single-line image-path shape for the five extensions case-insensitively, and rejects mixed text, multi-path, and excluded extensions.
+- [x] A-003 R3: The flag reaches `verifySubmit`/`retrySubmit` so post-Enter evidence and recovery re-probe use the same gated predicate; no signature leaks outside `internal/inject/`.
+
+### Behavioral Correctness
+
+- [x] A-004 R1: A stale `[Image #N]` chip in the pre-paste baseline does not satisfy the probe (strict increase preserved); non-imageish sends have byte-identical behavior to today.
+- [x] A-005 R1: An imageish paste that echoes as raw text (nonexistent file) still passes via the needle arm (either-signal).
+
+### Scenario Coverage
+
+- [x] A-006 R4: Unit tests cover the R2 gate matrix, the R1 baseline/either-signal scenarios, and an end-to-end `Send` chip pass; `go test ./internal/inject/...` is green.
+
+### Code Quality
+
+- [x] A-007 Pattern consistency: new regex, gate, and comments mirror `pasteCollapseRe`/`CollapseMinRunes` style, including the empirical-version doc-comment convention (CC 2.1.260 cited).
+- [x] A-008 No unnecessary duplication: reuse `stripForProbe`/`CountOccurrences` plumbing; no parallel counting path.
+- [x] A-009 Comment discipline: comments state constraints the code can't show (the empirical CC behavior, the gate rationale); no narration, no change-ID/PR citations in code or tests.
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All acceptance items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] A-NNN **N/A**: {reason}`
+
+## Deletion Candidates
+
+- None — this change adds new functionality without making existing code redundant
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Confident | Threading shape left as an implementation-time choice (added parameter vs small signals value), following the file's plain-parameter style | Intake assumption 5 delegates this; package-local and fully reversible | S:70 R:90 A:85 D:65 |
+| 2 | Certain | Gate requires a single trimmed line (interior `\n` disqualifies) — a trailing newline is trimmed away, matching the verified still-chips behavior | Empirical matrix: trailing newline chips, two newline-separated paths do not | S:90 R:90 A:90 D:90 |
+| 3 | Confident | Verification scope: `go test` on the inject package then the backend module; no frontend type check or e2e (no frontend/API surface touched) | Intake assumption 7 + code-quality gates scoped to changed surface | S:80 R:85 A:85 D:80 |
+
+3 assumptions (1 certain, 2 confident, 0 tentative).


### PR DESCRIPTION
## Meta

| Change ID | Type | Confidence | Plan | Review |
|-----------|------|------------|------|--------|
| `svfv` | fix | 5.0/5.0 | 4/4 tasks, 9/9 acceptance ✓ | ✓ 1 cycle |

| Impact | +/− | Net |
|--------|----:|----:|
| raw | +518 / −48 | +470 |
| **true** | **+209 / −41** | **+168** |
| └ impl | +82 / −23 | +59 |
| └ tests | +127 / −18 | +109 |

<sub>excludes `fab/`, `docs/` · generated by fab-kit v2.23.13</sub>

**Pipeline:** [intake](https://github.com/sahil87/run-kit/blob/260904-svfv-inject-image-chip-probe/fab/changes/260904-svfv-inject-image-chip-probe/intake.md) ✓ → [apply](https://github.com/sahil87/run-kit/blob/260904-svfv-inject-image-chip-probe/fab/changes/260904-svfv-inject-image-chip-probe/plan.md) ✓ → review ✓ → hydrate ✓ → ship → review-pr

## Summary

Sending a bare image path from the dashboard compose strip — the exact shape an attachment-only send produces — always failed the injection engine's echo probe: Claude Code renders such a paste as an `[Image #N]` chip, so the raw text never echoes, Enter is withheld, and the user gets the "Text is staged in the pane but unsent" toast despite the delivery having succeeded. The probe now counts a fresh `[Image #N]` chip as a valid echo signal, gated on the paste being a bare single-line image path and either-signal with the raw needle (verified empirically on Claude Code 2.1.260).

## Changes

- Root cause (verified, CC 2.1.260): image chip replaces the raw path for bare pastes of existing `.png/.jpg/.gif/.webp` paths, at every length — neither the needle nor the `[Pasted text #N]` collapse arm can match it
- Fix: gated `imageCollapseRe` arm in `CountOccurrences`, imageish gate (`isBareImagePath`) computed in `Send`, flag threaded through the package-internal probe chain (strict-increase-over-baseline unchanged)
- Tests: gate-predicate matrix, chip-only-under-gate counting, stale-chip baseline, either-signal, and end-to-end `Send` chip pass
