### PR TITLE
feat: Test-Run Phase Progress Banners

### DIFF
--- a/docs/memory/run-kit/architecture.md
+++ b/docs/memory/run-kit/architecture.md
@@ -971,6 +971,8 @@ proves; healing is covered elsewhere).
 
 Tests whose lifetime is tied to a compatibility shim carry `// retire-with: {shim-name}` immediately above the test, or in the file header when the whole spec is shim-bound. Shim-removal sweeps use `grep -r "retire-with"` to locate the full cross-language set.
 
+The aggregate `just test` recipe delegates to `scripts/test-all.sh`, which runs the three phases by invoking their own recipes (`just test-backend` → `just test-frontend` → `just test-e2e`, preserving per-recipe deps like `_ensure-tmux-conf`), frames each with timestamped append-only banners (`[N/3] <phase> — started HH:MM:SS` / `— ok in XmYYs` / `— FAILED in XmYYs (exit E)`) plus a final per-phase summary (ok / failed / not-run), fails fast with the failing phase's exit code, and tees the whole run to `/tmp/rk-test-<timestamp>.log` (path echoed as the first line, for `tail -f` / capture-pane peeks mid-run). Orchestrator output is append-only by design — no spinners, `\r` rewriting, or cursor control (rewrites garble captured logs and capture-pane peeks). The three sub-recipes and CI (which calls them directly, never `test`) are unaffected (260904-6o28-test-progress-banners).
+
 ### Go Unit Tests
 
 Go `testing` package with table-driven tests. Test files co-located with source using `_test.go` suffix. Test scripts: `go test ./...` from `app/backend/`.

--- a/fab/changes/260904-6o28-test-progress-banners/.history.jsonl
+++ b/fab/changes/260904-6o28-test-progress-banners/.history.jsonl
@@ -8,3 +8,4 @@
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-09-04T09:15:27Z"}
 {"event":"review","result":"passed","ts":"2026-09-04T09:15:27Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-09-04T09:15:57Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-09-04T09:17:22Z"}

--- a/fab/changes/260904-6o28-test-progress-banners/.history.jsonl
+++ b/fab/changes/260904-6o28-test-progress-banners/.history.jsonl
@@ -9,3 +9,4 @@
 {"event":"review","result":"passed","ts":"2026-09-04T09:15:27Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-09-04T09:15:57Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-09-04T09:17:22Z"}
+{"event":"review","result":"passed","ts":"2026-09-04T09:21:24Z"}

--- a/fab/changes/260904-6o28-test-progress-banners/.history.jsonl
+++ b/fab/changes/260904-6o28-test-progress-banners/.history.jsonl
@@ -1,0 +1,10 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-09-04T09:04:12Z"}
+{"args":"Test-run phase progress banners for just test: replace the bare dependency chain with scripts/test-all.sh printing timestamped append-only phase banners + per-phase summary, tee to a per-run log file","cmd":"fab-new","event":"command","ts":"2026-09-04T09:04:12Z"}
+{"delta":"+4.6","event":"confidence","score":4.6,"trigger":"calc-score","ts":"2026-09-04T09:06:59Z"}
+{"cmd":"fab-switch","event":"command","ts":"2026-09-04T09:08:36Z"}
+{"cmd":"fab-fff","event":"command","ts":"2026-09-04T09:10:04Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-09-04T09:10:50Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-09-04T09:13:04Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-09-04T09:15:27Z"}
+{"event":"review","result":"passed","ts":"2026-09-04T09:15:27Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-09-04T09:15:57Z"}

--- a/fab/changes/260904-6o28-test-progress-banners/.status.yaml
+++ b/fab/changes/260904-6o28-test-progress-banners/.status.yaml
@@ -10,7 +10,7 @@ progress:
     review: done
     hydrate: done
     ship: done
-    review-pr: active
+    review-pr: done
 plan:
     generated: true
     task_count: 3
@@ -34,7 +34,7 @@ stage_metrics:
     review: {started_at: "2026-09-04T09:13:04Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T09:15:27Z"}
     hydrate: {started_at: "2026-09-04T09:15:27Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T09:15:57Z"}
     ship: {started_at: "2026-09-04T09:15:57Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T09:17:22Z"}
-    review-pr: {started_at: "2026-09-04T09:17:22Z", driver: git-pr, iterations: 1}
+    review-pr: {started_at: "2026-09-04T09:17:22Z", driver: git-pr, iterations: 1, completed_at: "2026-09-04T09:21:24Z"}
 prs:
     - https://github.com/sahil87/run-kit/pull/824
 change_type_source: explicit
@@ -54,4 +54,4 @@ true_impact:
     computed_at_stage: ship
 summary: 'just test now delegates to scripts/test-all.sh: sequential phases with timestamped append-only banners, fail-fast, per-phase summary, per-run log tee'
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-09-04T09:17:22Z
+last_updated: 2026-09-04T09:21:24Z

--- a/fab/changes/260904-6o28-test-progress-banners/.status.yaml
+++ b/fab/changes/260904-6o28-test-progress-banners/.status.yaml
@@ -9,8 +9,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 plan:
     generated: true
     task_count: 3
@@ -33,23 +33,25 @@ stage_metrics:
     apply: {started_at: "2026-09-04T09:10:50Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T09:13:04Z"}
     review: {started_at: "2026-09-04T09:13:04Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T09:15:27Z"}
     hydrate: {started_at: "2026-09-04T09:15:27Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T09:15:57Z"}
-    ship: {started_at: "2026-09-04T09:15:57Z", driver: fab-fff, iterations: 1}
-prs: []
+    ship: {started_at: "2026-09-04T09:15:57Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T09:17:22Z"}
+    review-pr: {started_at: "2026-09-04T09:17:22Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/sahil87/run-kit/pull/824
 change_type_source: explicit
 true_impact:
-    added: 0
-    deleted: 0
-    net: 0
+    added: 353
+    deleted: 2
+    net: 351
     excluding:
-        added: 0
-        deleted: 0
-        net: 0
+        added: 58
+        deleted: 2
+        net: 56
     tests:
         added: 0
         deleted: 0
         net: 0
-    computed_at: "2026-09-04T09:15:57Z"
-    computed_at_stage: hydrate
+    computed_at: "2026-09-04T09:17:22Z"
+    computed_at_stage: ship
 summary: 'just test now delegates to scripts/test-all.sh: sequential phases with timestamped append-only banners, fail-fast, per-phase summary, per-run log tee'
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-09-04T09:15:57Z
+last_updated: 2026-09-04T09:17:22Z

--- a/fab/changes/260904-6o28-test-progress-banners/.status.yaml
+++ b/fab/changes/260904-6o28-test-progress-banners/.status.yaml
@@ -1,0 +1,55 @@
+id: 6o28
+name: 260904-6o28-test-progress-banners
+created: 2026-09-04T09:04:12Z
+created_by: sahil-noon
+change_type: feat
+issues: []
+progress:
+    intake: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+plan:
+    generated: true
+    task_count: 3
+    acceptance_count: 9
+    acceptance_completed: 9
+confidence:
+    certain: 6
+    confident: 4
+    tentative: 0
+    unresolved: 0
+    score: 4.6
+    fuzzy: true
+    dimensions:
+        signal: 80.0
+        reversibility: 85.0
+        competence: 84.5
+        disambiguation: 82.5
+stage_metrics:
+    intake: {started_at: "2026-09-04T09:04:12Z", driver: fab-new, iterations: 1, completed_at: "2026-09-04T09:10:50Z"}
+    apply: {started_at: "2026-09-04T09:10:50Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T09:13:04Z"}
+    review: {started_at: "2026-09-04T09:13:04Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T09:15:27Z"}
+    hydrate: {started_at: "2026-09-04T09:15:27Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T09:15:57Z"}
+    ship: {started_at: "2026-09-04T09:15:57Z", driver: fab-fff, iterations: 1}
+prs: []
+change_type_source: explicit
+true_impact:
+    added: 0
+    deleted: 0
+    net: 0
+    excluding:
+        added: 0
+        deleted: 0
+        net: 0
+    tests:
+        added: 0
+        deleted: 0
+        net: 0
+    computed_at: "2026-09-04T09:15:57Z"
+    computed_at_stage: hydrate
+summary: 'just test now delegates to scripts/test-all.sh: sequential phases with timestamped append-only banners, fail-fast, per-phase summary, per-run log tee'
+# true_impact: lazily created on first stage-finish that computes it (no placeholder here).
+last_updated: 2026-09-04T09:15:57Z

--- a/fab/changes/260904-6o28-test-progress-banners/intake.md
+++ b/fab/changes/260904-6o28-test-progress-banners/intake.md
@@ -1,0 +1,107 @@
+# Intake: Test-Run Phase Progress Banners
+
+**Change**: 260904-6o28-test-progress-banners
+**Created**: 2026-09-04
+
+## Origin
+
+Promptless dispatch (`/fab-proceed` create-new path) from a user conversation about `just test` legibility. Synthesized description:
+
+> `just test` (backend + frontend + e2e) blocks for 20+ minutes with no phase-level progress indication. The recipe is a bare just dependency chain (`test: test-backend test-frontend test-e2e` in `justfile`), so terminal scrollback never says which phase is running, when it started, or how long it has been running. Replace the dependency chain with a new `scripts/test-all.sh` that runs the three phases in sequence and prints timestamped, append-only phase banners plus a final per-phase summary, and tee the run into a per-run log file.
+
+Key decisions were made in the conversation (recorded in What Changes and the Assumptions table): script-over-chain with a one-liner justfile recipe, invoke existing recipes rather than duplicate bodies, preserve fail-fast semantics, leave sub-suite reporters alone, append-only output only (no spinners/`\r`/cursor control), and optionally tee to a per-run log file.
+
+## Why
+
+1. **The pain point**: `just test` runs three phases (Go tests, Vitest, Playwright e2e) for 20+ minutes with zero phase-level indication. The recipe is a bare dependency chain, so nothing in scrollback says which phase is running, when it started, or how long it has been going. `go test ./...`'s initial compile is a multi-minute silent stretch with nothing printed in front of it. The e2e phase is ~15 of the 20 minutes (509 tests across 85 spec files).
+2. **The consequence if unfixed**: a human watching the terminal — or an agent peeking at a background run via `tmux capture-pane` — cannot tell where in the run they are, whether it is stuck, or how much is left. A peek landing mid-run shows raw sub-suite output with no phase framing.
+3. **Why this approach**: the sub-suites already emit good per-unit line output (`go test` prints one `ok <pkg> <time>` line per package; `vitest run` prints per-file results; Playwright's list reporter prints a numbered line per test plus a "Running N tests using 1 worker" header; `scripts/test-e2e.sh` already echoes its setup milestones). What is missing is only the phase seam: which of the three phases is active, since when, and how each ended. A thin orchestration script that banners the seams and delegates everything else is the smallest change that fixes the gap — no new dependencies, no reporter reconfiguration.
+
+Context note: per a standing user directive (2026-09-03), the full `just test` suite is on-demand/CI only, never an agent change gate — this change serves humans and on-demand runs; it is polish for legibility, not an agent-throughput fix.
+
+## What Changes
+
+### 1. New `scripts/test-all.sh` — the phase orchestrator
+
+A new bash script (following the existing `scripts/` conventions: `#!/usr/bin/env bash`, `set -euo pipefail`, `REPO_ROOT` derivation as in `scripts/build.sh`) that runs the three test phases **in sequence** and frames each with timestamped, append-only banners:
+
+```
+Log: /tmp/rk-test-20260904-140211.log
+[1/3] backend — started 14:02:11
+...  (go test output passes through untouched)
+[1/3] backend — ok in 1m42s
+[2/3] frontend — started 14:03:53
+...
+[2/3] frontend — ok in 0m58s
+[3/3] e2e — started 14:04:51
+...
+[3/3] e2e — ok in 14m37s
+
+Summary:
+  [1/3] backend   ok      1m42s
+  [2/3] frontend  ok      0m58s
+  [3/3] e2e       ok      14m37s
+```
+
+(Exact wording/alignment of the banner and summary lines is the implementer's choice within this shape — `[N/3] <phase>`, a wall-clock start time, a per-phase duration, and a final per-phase summary of phase, status, duration.)
+
+- **Phases invoke the existing recipes** — `just test-backend`, `just test-frontend`, `just test-e2e` — never duplicate their bodies, so each phase's own dependencies (e.g. `_ensure-tmux-conf` before `test-backend`) are preserved and future recipe edits are inherited automatically.
+- **Fail-fast, preserved failure semantics**: a failing phase stops the run (matching today's just dependency-chain behavior), the script exits non-zero, and the summary still prints, marking the failed phase (e.g. `[2/3] frontend — FAILED in 0m41s (exit 1)` and a `failed` row in the summary; phases after the failed one are not run and appear as skipped/not-run in the summary).
+- **Append-only output only**: NO spinners, NO `\r`-rewriting progress bars, NO ANSI cursor control. Rationale (agent-friendliness): rewriting output garbles captured logs, and `tmux capture-pane` peeks show only the final frame — append-only timestamped lines are what makes a background-run peek informative.
+- **Per-run log file**: the script tees the full run (banners + sub-suite output) into a per-run log file, e.g. `/tmp/rk-test-<timestamp>.log`, and echoes the path as the first line of the run, so a `tail -f` or an agent peek can land mid-run. The tee must not mask phase exit codes (e.g. tee via a single `exec > >(tee ...)` redirection of the whole script, or `pipefail`-guarded pipes — implementer's choice).
+
+### 2. `justfile` — `test` recipe becomes a one-liner delegate
+
+```just
+# Run all tests (backend + frontend + e2e) with phase banners
+test:
+    scripts/test-all.sh
+```
+
+- Constitution VIII (Thin Justfile): the recipe MUST remain a one-liner delegating to `scripts/` — all logic lives in `scripts/test-all.sh`.
+- The recipe **name stays `test`** — the `verify` recipe (`verify: check test build`) consumes it by name.
+- The recipe takes no arguments today and continues to take none.
+
+### 3. Explicitly NOT changed
+
+- **No sub-suite reporter changes**: no `reporter` added to `app/frontend/playwright.config.ts`, no Vitest reporter flags, no gotestsum or other new dependency for the Go phase. The existing per-unit line output (verified: `go test` per-package `ok` lines, vitest per-file lines, Playwright list reporter's numbered N-of-M lines, `test-e2e.sh`'s setup-milestone echoes) is kept as-is; both vitest and Playwright already auto-degrade to non-interactive line output when non-TTY.
+- **No product code paths**: this is developer-tooling/harness work — no API/UI changes, no Go/TS source changes. Note `scripts/` IS in `source_paths` in `fab/project/config.yaml`.
+- **CI unaffected**: `.github/workflows/ci.yml` invokes `just test-backend` / `just test-frontend` / `just test-e2e` directly, never the aggregate `test` recipe — the new script changes only local `just test` / `just verify` runs.
+
+### Rejected alternatives (from the conversation)
+
+- **Spinners / live progress bars** — agent-hostile: rewriting output garbles captures and capture-pane peeks show only the final frame.
+- **Custom Playwright reporter or reporter config changes** — the default list reporter already numbers tests and prints the total ("Running N tests using 1 worker").
+- **gotestsum or other new dependencies for the Go phase** — per-package `ok` lines plus a phase banner in front of the silent compile stretch is enough.
+
+## Affected Memory
+
+- `run-kit/architecture`: (modify) § Testing — note that the aggregate `just test` entry point delegates to `scripts/test-all.sh` (sequential phases with timestamped append-only banners, fail-fast, per-run log file); sub-recipes and CI invocation are unchanged.
+
+## Impact
+
+- **Files**: `justfile` (the `test` recipe body — one line), `scripts/test-all.sh` (new, roughly 60–100 lines of bash). No other files.
+- **Consumers of `just test`**: local human runs and on-demand agent runs; `just verify` (`check test build`) inherits the banners. CI does not call `test`.
+- **No new dependencies**: bash + coreutils (`date`, `tee`) only — all already required by existing `scripts/`.
+- **Testing**: no shell-test framework exists in this repo (existing `scripts/` have no automated tests); verification is a smoke run — exercise the script's phase/banner/failure paths without paying the full 20-minute suite (e.g. run with a phase forced to fail fast, or a short scoped run), consistent with the standing directive that the full suite is on-demand only.
+
+## Open Questions
+
+- None — the conversation resolved the design; remaining choices (exact banner wording, tee mechanics, log filename format) are graded assumptions below.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | Replace the `test` dependency chain with new `scripts/test-all.sh`; justfile recipe stays a one-liner delegate named `test` | Discussed — decision 1; Constitution VIII mandates the thin-justfile shape; `verify` consumes the name | S:90 R:85 A:95 D:95 |
+| 2 | Certain | The script invokes the existing recipes (`just test-backend/test-frontend/test-e2e`), never duplicates their bodies | Discussed — decision 2; preserves per-recipe deps like `_ensure-tmux-conf` | S:90 R:80 A:90 D:90 |
+| 3 | Certain | Fail-fast preserved: failing phase stops the run, non-zero exit, summary marks the failed phase and unrun phases | Discussed — decision 3; matches today's dependency-chain behavior | S:90 R:85 A:90 D:90 |
+| 4 | Certain | No sub-suite reporter changes and no new dependencies (no gotestsum, no custom Playwright reporter, no reporter config) | Discussed — decision 4 with rejected alternatives recorded | S:90 R:90 A:90 D:95 |
+| 5 | Certain | Output is append-only lines only — no spinners, no `\r` rewriting, no ANSI cursor control | Discussed — decision 5 with explicit agent-friendliness rationale | S:95 R:85 A:90 D:95 |
+| 6 | Confident | Include the per-run log tee, path echoed at run start | User gave a general go-ahead to a recommendation that listed this as an optional third item — strong but not explicit | S:70 R:80 A:75 D:75 |
+| 7 | Confident | Log path `/tmp/rk-test-<timestamp>.log` (timestamped, unique per run) | User's own example ("e.g. /tmp/rk-test-<timestamp>.log or similar"); alternatives ($XDG_STATE_HOME/run-kit/, mktemp dir) exist but /tmp matches the transient nature and the example | S:55 R:90 A:60 D:55 |
+| 8 | Confident | Banner shape `[N/3] <phase> — started HH:MM:SS` / `[N/3] <phase> — ok in XmYYs` / `FAILED in XmYYs (exit N)` + final per-phase summary block; exact wording implementer's choice within that shape | Discussed — examples given in the conversation ("e.g. [1/3] backend — started 14:02:11"); precise wording not pinned | S:75 R:90 A:80 D:65 |
+| 9 | Certain | `just test` interface unchanged: recipe name `test`, no arguments, `verify: check test build` untouched | Constraint stated in the conversation; `justfile` verified | S:85 R:80 A:95 D:95 |
+| 10 | Confident | Verification is a smoke run of the script's banner/failure paths, not the full 20-minute suite and no new shell-test framework | Existing `scripts/` have no automated tests; standing directive (2026-09-03) keeps the full suite on-demand only | S:60 R:85 A:80 D:70 |
+
+10 assumptions (5 certain, 5 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260904-6o28-test-progress-banners/plan.md
+++ b/fab/changes/260904-6o28-test-progress-banners/plan.md
@@ -1,0 +1,121 @@
+# Plan: Test-Run Phase Progress Banners
+
+**Change**: 260904-6o28-test-progress-banners
+**Intake**: `intake.md`
+
+## Requirements
+
+### Dev Tooling: Test-Run Phase Orchestrator
+
+#### R1: Phase orchestrator script with timestamped banners
+A new `scripts/test-all.sh` SHALL run the three test phases in sequence by invoking the existing recipes — `just test-backend`, `just test-frontend`, `just test-e2e` — never duplicating their bodies, and SHALL frame each phase with timestamped banners plus a final per-phase summary. Banner shape: `[N/3] <phase> — started HH:MM:SS` at entry and `[N/3] <phase> — ok in XmYYs` at success; the summary block lists each phase with status and duration.
+
+- **GIVEN** a developer runs `just test` on a clean checkout
+- **WHEN** all three phases pass
+- **THEN** scrollback shows a start banner before each phase's own output, a completion banner with the phase duration after it, and a final summary listing all three phases as ok with durations
+- **AND** each phase's own dependencies (e.g. `_ensure-tmux-conf` before `test-backend`) run because the phase is invoked as its `just` recipe
+
+#### R2: Fail-fast with truthful summary and exit code
+The script SHALL preserve today's dependency-chain failure semantics: a failing phase stops the run, later phases do not execute, and the script exits non-zero. The failure banner and summary SHALL mark the failed phase (`[N/3] <phase> — FAILED in XmYYs (exit E)`) and show unrun phases as not-run.
+
+- **GIVEN** the frontend phase exits non-zero
+- **WHEN** `just test` runs
+- **THEN** the e2e phase never starts, the script exits with a non-zero status, and the summary shows backend ok, frontend failed (with exit code), e2e not-run
+
+#### R3: Per-run log tee
+The script SHALL tee the full run (banners + sub-suite output, stdout and stderr) into a per-run log file `/tmp/rk-test-<timestamp>.log` and SHALL echo the log path as the first line of the run. The tee MUST NOT mask phase exit codes.
+
+- **GIVEN** a `just test` run in progress
+- **WHEN** an agent or human tails the echoed log path from another shell
+- **THEN** the log contains the same banners and sub-suite output the terminal shows, appended live
+- **AND** a failing phase still exits the script non-zero despite the tee
+
+#### R4: Thin justfile delegate
+The `test` recipe SHALL become a one-liner delegating to `scripts/test-all.sh` (Constitution VIII). The recipe name stays `test` (the `verify` recipe consumes it by name) and it continues to take no arguments. The `test-backend`/`test-frontend`/`test-e2e` recipes and CI invocations are untouched.
+
+- **GIVEN** the updated justfile
+- **WHEN** `just verify` runs
+- **THEN** its `test` step runs `scripts/test-all.sh` with banners, and `check`/`build` behave as before
+
+#### R5: Append-only output, no reporter or dependency changes
+All output the script itself emits SHALL be append-only lines — no spinners, no `\r` rewriting, no ANSI cursor control (agent-friendliness: rewrites garble captured logs and `tmux capture-pane` peeks). The script SHALL introduce no new dependencies beyond bash + coreutils and SHALL NOT change any sub-suite reporter configuration (`playwright.config.ts`, Vitest config, no gotestsum).
+
+- **GIVEN** a background `just test` run captured via `tmux capture-pane`
+- **WHEN** the capture is inspected mid-run
+- **THEN** every orchestrator-emitted line is a complete, timestamped, append-only line
+
+### Design Decisions
+
+#### Invoke recipes, not bodies
+**Decision**: Each phase runs `just <recipe>` rather than inlining the recipe's commands.
+**Why**: Preserves per-recipe dependencies (`_ensure-tmux-conf`) and inherits future recipe edits automatically.
+**Rejected**: Duplicating recipe bodies in the script — a second copy to keep in sync.
+*Introduced by*: 260904-6o28-test-progress-banners
+
+#### Append-only lines over live progress UI
+**Decision**: Timestamped append-only banners; no spinners or `\r` progress bars.
+**Why**: Rewriting output garbles captured logs and capture-pane peeks show only the final frame; append-only lines make a mid-run peek informative for humans and agents alike.
+**Rejected**: Spinners/progress bars (agent-hostile); custom Playwright reporter or gotestsum (the existing per-unit line output already carries N-of-M signal; new deps for no gain).
+*Introduced by*: 260904-6o28-test-progress-banners
+
+### Non-Goals
+
+- No changes to sub-suite reporters, CI workflows, or the `test-backend`/`test-frontend`/`test-e2e` recipes.
+- No shell-test framework; verification is a smoke run (standing directive 2026-09-03: the full suite is on-demand only).
+
+## Tasks
+
+### Phase 1: Core Implementation
+
+- [x] T001 Create `scripts/test-all.sh` (executable, `#!/usr/bin/env bash`, `set -euo pipefail`, `REPO_ROOT` derivation per `scripts/build.sh`): echo the log path, `exec`-tee stdout+stderr into `/tmp/rk-test-<timestamp>.log`, run the three phases via `just test-backend` / `just test-frontend` / `just test-e2e` with `[N/3]` start/ok/FAILED banners and per-phase durations, fail-fast on a phase failure, and print the final per-phase summary (ok / failed / not-run) with matching exit code <!-- R1 R2 R3 R5 -->
+- [x] T002 Update `justfile`: replace `test: test-backend test-frontend test-e2e` with a one-liner `test:` recipe delegating to `scripts/test-all.sh`; update the recipe comment; leave `verify` and the three sub-recipes untouched <!-- R4 -->
+
+### Phase 2: Verification
+
+- [x] T003 Smoke-verify without paying the full suite: run the script with the phase commands exercised cheaply (e.g. a temporary run where a phase is forced to fail fast, plus a pass-path run against fast stand-ins) to confirm banners, durations, summary rows (ok/failed/not-run), non-zero exit on failure, log-file creation with the echoed path, and absence of `\r`/cursor-control bytes in the log <!-- R2 -->
+
+## Acceptance
+
+### Functional Completeness
+
+- [x] A-001 R1: `scripts/test-all.sh` runs the three phases sequentially via their `just` recipes, with a start banner (wall-clock time), a completion banner (duration), and a final per-phase summary
+- [x] A-002 R4: the `test` recipe is a one-liner delegating to `scripts/test-all.sh`; recipe name, argument surface, `verify`, sub-recipes, and CI are unchanged
+- [x] A-003 R3: the run is teed to `/tmp/rk-test-<timestamp>.log`, the path is echoed as the first line, and the log carries banners plus sub-suite output
+
+### Behavioral Correctness
+
+- [x] A-004 R2: a failing phase stops the run (later phases not executed), the script exits non-zero, and the summary marks the failed phase with its exit code and unrun phases as not-run
+- [x] A-005 R3: the tee does not mask exit codes — a failed phase propagates through to the script's exit status
+
+### Scenario Coverage
+
+- [x] A-006 R2: the failure path was exercised in a smoke run (forced failing phase) and the success path on fast stand-ins — both verified against banners, summary, exit code, and log file
+
+### Edge Cases & Error Handling
+
+- [x] A-007 R5: orchestrator-emitted output contains no `\r` rewriting or ANSI cursor-control sequences; sub-suite output passes through untouched
+
+### Code Quality
+
+- [x] A-008 Pattern consistency: the script follows `scripts/` conventions (`#!/usr/bin/env bash`, `set -euo pipefail`, `REPO_ROOT` derivation) and the justfile stays a thin index (Constitution VIII)
+- [x] A-009 No unnecessary duplication: phases invoke existing recipes; no recipe bodies, reporter configs, or dependencies are duplicated or added
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All acceptance items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] A-NNN **N/A**: {reason}`
+
+## Deletion Candidates
+
+None — this change adds new functionality without making existing code redundant (the old `test:` dependency-chain body was replaced in place in the same edit; no leftover redundant code remains).
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Confident | Tee mechanics: one `exec > >(tee "$LOG") 2>&1` redirection of the whole script rather than per-phase pipes | Intake names both as implementer's choice; a single redirection cannot mask phase exit codes (no pipeline around the phase commands) and keeps the script simple | S:70 R:90 A:85 D:75 |
+| 2 | Confident | Duration format `XmYYs` computed from epoch seconds (`date +%s`); timestamp `HH:MM:SS` via `date +%H:%M:%S` | Matches the intake's banner examples; coreutils-only | S:75 R:95 A:90 D:85 |
+| 3 | Confident | Log filename `rk-test-$(date +%Y%m%d-%H%M%S).log` in `/tmp` | Intake example shows `/tmp/rk-test-20260904-140211.log`; per-run uniqueness at second granularity is sufficient for a manual entry point | S:70 R:90 A:80 D:75 |
+
+3 assumptions (0 certain, 3 confident, 0 tentative).

--- a/justfile
+++ b/justfile
@@ -83,8 +83,9 @@ build-desktop *args:
 
 # ─── Test ────────────────────────────────────────────────────
 
-# Run all tests (backend + frontend + e2e)
-test: test-backend test-frontend test-e2e
+# Run all tests (backend + frontend + e2e) with phase banners + per-run log
+test:
+    scripts/test-all.sh
 
 # Run Go tests
 test-backend: _ensure-tmux-conf

--- a/justfile
+++ b/justfile
@@ -85,7 +85,7 @@ build-desktop *args:
 
 # Run all tests (backend + frontend + e2e) with phase banners + per-run log
 test:
-    scripts/test-all.sh
+    @scripts/test-all.sh
 
 # Run Go tests
 test-backend: _ensure-tmux-conf

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Tee the whole run (banners + sub-suite output) into a per-run log so a
+# tail -f or a mid-run capture-pane peek sees the same append-only lines the
+# terminal does. A single exec redirection wraps no phase command in a
+# pipeline, so phase exit codes are never masked by the tee.
+LOG="/tmp/rk-test-$(date +%Y%m%d-%H%M%S).log"
+exec > >(tee "$LOG") 2>&1
+echo "Log: $LOG"
+
+# Phases invoke the existing just recipes — never their bodies — so each
+# phase's own dependencies (e.g. _ensure-tmux-conf before test-backend) are
+# preserved and future recipe edits are inherited automatically.
+names=(backend frontend e2e)
+recipes=(test-backend test-frontend test-e2e)
+statuses=("not-run" "not-run" "not-run")
+durations=("-" "-" "-")
+total=${#names[@]}
+overall=0
+
+fmt_duration() {
+  printf '%dm%02ds' $(( $1 / 60 )) $(( $1 % 60 ))
+}
+
+for i in "${!names[@]}"; do
+  n=$(( i + 1 ))
+  name=${names[$i]}
+  phase_start=$(date +%s)
+  echo "[$n/$total] $name — started $(date +%H:%M:%S)"
+  rc=0
+  just "${recipes[$i]}" || rc=$?
+  duration=$(fmt_duration $(( $(date +%s) - phase_start )))
+  durations[$i]=$duration
+  if [ "$rc" -eq 0 ]; then
+    statuses[$i]="ok"
+    echo "[$n/$total] $name — ok in $duration"
+  else
+    statuses[$i]="FAILED (exit $rc)"
+    echo "[$n/$total] $name — FAILED in $duration (exit $rc)"
+    overall=$rc
+    break
+  fi
+done
+
+echo
+echo "Summary:"
+for i in "${!names[@]}"; do
+  printf '  [%d/%d] %-9s %-16s %s\n' \
+    $(( i + 1 )) "$total" "${names[$i]}" "${statuses[$i]}" "${durations[$i]}"
+done
+exit "$overall"

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -8,7 +8,7 @@ cd "$REPO_ROOT"
 # tail -f or a mid-run capture-pane peek sees the same append-only lines the
 # terminal does. A single exec redirection wraps no phase command in a
 # pipeline, so phase exit codes are never masked by the tee.
-LOG="/tmp/rk-test-$(date +%Y%m%d-%H%M%S).log"
+LOG="/tmp/rk-test-$(date +%Y%m%d-%H%M%S)-$$.log"
 exec > >(tee "$LOG") 2>&1
 echo "Log: $LOG"
 


### PR DESCRIPTION
## Meta

| Change ID | Type | Confidence | Plan | Review |
|-----------|------|------------|------|--------|
| `6o28` | feat | 4.6/5.0 | 3/3 tasks, 9/9 acceptance ✓ | ✓ 1 cycle |

| Impact | +/− | Net |
|--------|----:|----:|
| raw | +353 / −2 | +351 |
| **true** | **+58 / −2** | **+56** |
| └ impl | +58 / −2 | +56 |
| └ tests | +0 / −0 | +0 |

<sub>excludes `fab/`, `docs/` · generated by fab-kit v2.23.13</sub>

**Pipeline:** [intake](https://github.com/sahil87/run-kit/blob/260904-6o28-test-progress-banners/fab/changes/260904-6o28-test-progress-banners/intake.md) ✓ → [apply](https://github.com/sahil87/run-kit/blob/260904-6o28-test-progress-banners/fab/changes/260904-6o28-test-progress-banners/plan.md) ✓ → review ✓ → hydrate ✓ → ship → review-pr

## Summary

`just test` runs three phases for 20+ minutes with no phase-level progress indication — the recipe was a bare dependency chain, so scrollback never said which phase was running, since when, or how each ended. A new `scripts/test-all.sh` frames the phases with timestamped, append-only banners and a per-phase summary, and tees the full run to a per-run log for mid-run tailing and agent peeks.

## Changes

- New `scripts/test-all.sh` — the phase orchestrator: invokes `just test-backend` / `just test-frontend` / `just test-e2e` in sequence, `[N/3]` start/ok/FAILED banners with durations, fail-fast with truthful summary and exit code, run teed to `/tmp/rk-test-<timestamp>.log`
- `justfile` — the `test` recipe becomes a one-liner delegate (Constitution VIII); recipe name, sub-recipes, `verify`, and CI untouched
- Explicitly NOT changed: no sub-suite reporter changes, no new dependencies, no product code paths
