### PR TITLE
feat: Agent-setup tutorial invoker skill

### DIFF
--- a/app/backend/cmd/rk/agent_setup.go
+++ b/app/backend/cmd/rk/agent_setup.go
@@ -657,7 +657,13 @@ func installTutorialSkill(sink outputSink, reader *bufio.Reader, ac agentConfig,
 	// marker-less foreign files were skipped above, so this write is only ever
 	// fresh-install or rk-owned→rk-owned (same rendering split as the shim).
 	if cons.dryRun {
-		header := fmt.Sprintf("%s: will install the run-kit-tutorial skill at %s", ac.name, skillPath)
+		verb := "install"
+		if exists {
+			// An existing file here is rk-owned (marker-less files were skipped
+			// above), so the preview is an update of a stale generation.
+			verb = "update"
+		}
+		header := fmt.Sprintf("%s: will %s the run-kit-tutorial skill at %s", ac.name, verb, skillPath)
 		renderArtifactDiff(cons.diffWriter(sink), header, strings.TrimSuffix(current, "\n"), strings.TrimSuffix(tutorialSkillPayload, "\n"))
 	} else if exists {
 		fmt.Fprintf(cons.diffWriter(sink), "%s: will update the rk-owned run-kit-tutorial skill at %s.\n", ac.name, skillPath)

--- a/app/backend/cmd/rk/agent_setup.go
+++ b/app/backend/cmd/rk/agent_setup.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -31,19 +32,23 @@ import (
 // entries. All file writes go through Go; the hook command is a fixed literal per
 // state with nothing user-provided interpolated (Constitution §I).
 //
-// rk agent setup manages two artifact families: the per-agent hooks merge above,
-// and the user-global tmux guard shim (shim file + PATH block — see
-// applyTmuxShim below and tmux_guard.go for the guard itself). It used to write
-// a third managed artifact — a user-global "rk-display" SKILL.md that put
-// run-kit's visual-display capability into an agent's context — but that context-injection
-// responsibility has moved to the `rk skill` bundle (served by the skill
-// subcommand, aggregated by the coming `shll agent-setup`). All rk agent setup does
-// with the legacy skill now is a one-release CLEANUP courtesy: on BOTH the
-// install and uninstall passes it offers to remove a stale, marker-owned
-// rk-display skill left by an older run-kit (see removeLegacySkill). An absent
-// file is silent in both modes — a fresh machine sees zero rk-display output.
-// The cleanup path (and agentConfig.skillsDir, which locates the legacy skill)
-// is scheduled for removal one release after this change.
+// rk agent setup manages three artifact families: the per-agent hooks merge
+// above; the user-global tmux guard shim (shim file + PATH block — see
+// applyTmuxShim below and tmux_guard.go for the guard itself); and the per-agent
+// run-kit-tutorial invoker skill (installTutorialSkill below) — a thin discovery
+// router at {skillsDir}/run-kit-tutorial/SKILL.md whose description lets an agent
+// find the guided tour from natural phrasing while the tour CONTENT stays behind
+// `rk skill tutorial` in the binary, tracking `brew upgrade rk` with no skill
+// churn. That content-vs-router split is why a managed skill is back: the
+// retired "rk-display" SKILL.md carried context-injection CONTENT, which now
+// belongs to the `rk skill` bundle (served by the skill subcommand, aggregated
+// by the coming `shll agent-setup`). All rk agent setup does with that legacy
+// skill is a one-release CLEANUP courtesy: on BOTH the install and uninstall
+// passes it offers to remove a stale, marker-owned rk-display skill left by an
+// older run-kit (see removeLegacySkill). An absent file is silent in both modes
+// — a fresh machine sees zero rk-display output. The cleanup path is scheduled
+// for removal one release after the retirement change (agentConfig.skillsDir
+// stays — the tutorial skill is its consumer now).
 
 // rkHookMarker is the LEGACY substring that identifies an rk-owned hook command:
 // the pre-indirection self-contained one-liner inlined `tmux set-option … @rk_agent_state`,
@@ -89,6 +94,35 @@ const (
 	rkDisplaySkillFile   = "SKILL.md"
 	skillManagedByMarker = "managed-by: rk agent-setup"
 )
+
+// The run-kit-tutorial invoker skill is the THIRD managed artifact: a thin
+// discovery router installed at {skillsDir}/run-kit-tutorial/SKILL.md so an
+// agent running inside a run-kit pane finds the guided tour from natural
+// tutorial/tour/onboarding phrasing. Unlike the retired rk-display skill it
+// carries no injectable content — the body gates on rk+$TMUX_PANE and routes to
+// `rk skill tutorial`, whose content ships in the binary — so the skill file is
+// stable across releases and a stale generation is simply replaced in place on
+// the next `rk agent setup` re-run (byte-compare against the embedded payload;
+// the marker identifies ownership, content equality identifies currency).
+//
+// tutorialSkillMarker is embedded as a YAML comment in the payload's
+// frontmatter. Its TEXT is frozen once shipped (it must keep matching artifacts
+// already installed on user machines — same rule as tmuxShimMarker), and it
+// deliberately extends the legacy skillManagedByMarker with a parenthesized
+// family, mirroring the shim's marker shape. The legacy cleanup cannot confuse
+// the two: removeLegacySkill is path-scoped to rk-display/.
+const (
+	tutorialSkillDir    = "run-kit-tutorial"
+	tutorialSkillFile   = "SKILL.md"
+	tutorialSkillMarker = "managed-by: rk agent-setup (run-kit-tutorial skill)"
+)
+
+// tutorialSkillPayload is the full SKILL.md the installer writes — tracked
+// in-repo beside the installer (agentskill/ is an agent-setup payload dir, NOT
+// part of the docs/site-synced `rk skill` bundle under skill/).
+//
+//go:embed agentskill/run-kit-tutorial.md
+var tutorialSkillPayload string
 
 // agentStateHookCommand builds the STABLE delegating hook command for a given
 // state: a thin wrapper that invokes `rk agent hook` (the family form — the
@@ -209,11 +243,12 @@ type agentHook struct {
 // pid-resolution walk), the ordered event→state hook mapping, and the harness's
 // user-global skills directory.
 //
-// skillsDir locates the LEGACY rk-display skill for one-release cleanup only
-// (as {skillsDir}/rk-display/SKILL.md — see removeLegacySkill). rk agent setup no
-// longer installs any skill; an EMPTY skillsDir means "no legacy skill to clean"
-// — only the hooks merge runs for that agent. v1 sets it only for Claude Code.
-// This field is scheduled for removal one release after this change.
+// skillsDir roots the per-agent skill artifacts: the run-kit-tutorial invoker
+// skill installed at {skillsDir}/run-kit-tutorial/SKILL.md (installTutorialSkill)
+// and the legacy rk-display cleanup at {skillsDir}/rk-display/SKILL.md
+// (removeLegacySkill, one release only). An EMPTY skillsDir means the agent has
+// no skills convention — only the hooks merge runs for it. v1 sets it only for
+// Claude Code.
 type agentConfig struct {
 	name         string
 	settingsPath string
@@ -352,9 +387,11 @@ func newAgentSetupCmd(use string, deprecated bool) *cobra.Command {
 			"is shown for confirmation before anything is written. Also installs the " +
 			"tmux guard shim (~/.local/share/rk/shims/tmux plus a marker-owned PATH " +
 			"block in the shell startup files) so `tmux kill-server` without an " +
-			"explicit -L/-S socket is blocked via `rk mux guard`. Use --yes to write " +
-			"without prompting (non-interactive), or --dry-run to preview the diff and " +
-			"write nothing.",
+			"explicit -L/-S socket is blocked via `rk mux guard`, and the " +
+			"run-kit-tutorial invoker skill (~/.claude/skills/run-kit-tutorial/SKILL.md) " +
+			"so an agent asked for a tour routes to `rk skill tutorial`. Use --yes to " +
+			"write without prompting (non-interactive), or --dry-run to preview the " +
+			"diff and write nothing.",
 		Args:         usageArgs(cobra.NoArgs),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -423,19 +460,27 @@ func runAgentSetup(sink outputSink, in io.Reader, uninstall bool, cons consent) 
 	return applyTmuxShim(sink, reader, home, os.Getenv("ZDOTDIR"), rkPath, uninstall, cons)
 }
 
-// applyAgentConfig applies the hooks merge for one agent and, on BOTH the install
-// and uninstall passes, cleans up any stale legacy rk-display skill. The hooks
-// merge is the only artifact rk agent setup still INSTALLS; the legacy cleanup is a
-// one-release courtesy that removes a marker-owned rk-display skill left by an
-// older run-kit. Each step is handled independently — its own tolerant read,
-// diff/prompt, and no-op report — so declining or no-op-ing one does not skip the
-// other. The legacy cleanup is skipped entirely when skillsDir is empty (e.g. a
-// future codex/copilot row with no skills convention).
+// applyAgentConfig runs one agent's per-agent steps in order: the hooks merge,
+// the run-kit-tutorial invoker skill (installed, or removed under --uninstall),
+// and — on BOTH passes — the one-release cleanup of any stale legacy rk-display
+// skill. Each step is handled independently — its own tolerant read,
+// diff/prompt, and no-op report — so declining or no-op-ing one does not skip
+// the others. Both skill steps are skipped entirely when skillsDir is empty
+// (e.g. a future codex/copilot row with no skills convention).
 func applyAgentConfig(sink outputSink, reader *bufio.Reader, ac agentConfig, rkPath string, uninstall bool, cons consent) error {
 	if err := applyAgentHooks(sink, reader, ac, rkPath, uninstall, cons); err != nil {
 		return err
 	}
 	if ac.skillsDir != "" {
+		if uninstall {
+			if err := removeTutorialSkill(sink, reader, ac, cons); err != nil {
+				return err
+			}
+		} else {
+			if err := installTutorialSkill(sink, reader, ac, cons); err != nil {
+				return err
+			}
+		}
 		if err := removeLegacySkill(sink, reader, ac, cons); err != nil {
 			return err
 		}
@@ -568,6 +613,117 @@ func removeLegacySkill(sink outputSink, reader *bufio.Reader, ac agentConfig, co
 		if !cons.dryRun {
 			// Status line — chatter.
 			sink.Notef("%s: legacy rk-display skill left in place (nothing removed).\n", ac.name)
+		}
+		return nil
+	}
+
+	if err := os.RemoveAll(skillDir); err != nil {
+		return fmt.Errorf("%s: remove %s: %w", ac.name, skillDir, err)
+	}
+	// Status line — chatter.
+	sink.Notef("%s: removed %s.\n", ac.name, skillDir)
+	return nil
+}
+
+// installTutorialSkill writes the run-kit-tutorial invoker skill at
+// {skillsDir}/run-kit-tutorial/SKILL.md from the embedded payload. It follows
+// the managed-artifact contract of installTmuxShimFile: a pre-existing
+// marker-less file — INCLUDING a zero-byte one, hence the existence-aware read —
+// is left untouched (rk only overwrites files it owns); content byte-equal to
+// the payload is a reported no-op; otherwise (fresh install or a stale
+// generation) the change is summarized (full body only under --dry-run, where
+// renderArtifactDiff shows the requested preview) and written on consent. Dir
+// 0755 / file 0644 — the skill is not sensitive user config, so settings.json's
+// 0600 does not apply.
+func installTutorialSkill(sink outputSink, reader *bufio.Reader, ac agentConfig, cons consent) error {
+	skillDir := filepath.Join(ac.skillsDir, tutorialSkillDir)
+	skillPath := filepath.Join(skillDir, tutorialSkillFile)
+
+	current, exists, err := readFileIfExists(skillPath)
+	if err != nil {
+		return fmt.Errorf("%s: read %s: %w", ac.name, skillPath, err)
+	}
+	if exists && !strings.Contains(current, tutorialSkillMarker) {
+		// Chatter — rk only overwrites files it owns.
+		sink.Notef("%s: %s exists without the %q marker — leaving it untouched (rk only overwrites files it owns).\n", ac.name, skillPath, tutorialSkillMarker)
+		return nil
+	}
+	if current == tutorialSkillPayload {
+		sink.Notef("%s: run-kit-tutorial skill already installed at %s — nothing to do.\n", ac.name, skillPath)
+		return nil
+	}
+
+	// Full body only under --dry-run; elsewhere one summary line suffices —
+	// marker-less foreign files were skipped above, so this write is only ever
+	// fresh-install or rk-owned→rk-owned (same rendering split as the shim).
+	if cons.dryRun {
+		header := fmt.Sprintf("%s: will install the run-kit-tutorial skill at %s", ac.name, skillPath)
+		renderArtifactDiff(cons.diffWriter(sink), header, strings.TrimSuffix(current, "\n"), strings.TrimSuffix(tutorialSkillPayload, "\n"))
+	} else if exists {
+		fmt.Fprintf(cons.diffWriter(sink), "%s: will update the rk-owned run-kit-tutorial skill at %s.\n", ac.name, skillPath)
+	} else {
+		fmt.Fprintf(cons.diffWriter(sink), "%s: will install the run-kit-tutorial skill at %s (rk-owned router to `rk skill tutorial`).\n", ac.name, skillPath)
+	}
+	dryRunNote := fmt.Sprintf("%s: dry run — no skill written.", ac.name)
+	ok, err := cons.authorizeWrite(sink.data, reader, dryRunNote, "\nWrite the run-kit-tutorial skill? [y/N] ")
+	if err != nil {
+		return err
+	}
+	if !ok {
+		if !cons.dryRun {
+			// Status line — chatter.
+			sink.Notef("%s: skipped (no skill written).\n", ac.name)
+		}
+		return nil
+	}
+
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		return fmt.Errorf("%s: create %s: %w", ac.name, skillDir, err)
+	}
+	if err := os.WriteFile(skillPath, []byte(tutorialSkillPayload), 0o644); err != nil {
+		return fmt.Errorf("%s: write %s: %w", ac.name, skillPath, err)
+	}
+	// Status line — chatter.
+	sink.Notef("%s: wrote %s.\n", ac.name, skillPath)
+	return nil
+}
+
+// removeTutorialSkill removes a marker-owned run-kit-tutorial skill on
+// --uninstall. An absent file is silent (a machine that never installed it must
+// see zero output); a marker-less file is left untouched with a skip note; a
+// marker-owned file is removed on consent — os.RemoveAll of the whole
+// run-kit-tutorial/ directory, confirmed first because it deletes the entire
+// directory including any user-added files within it (the removeLegacySkill
+// shape).
+func removeTutorialSkill(sink outputSink, reader *bufio.Reader, ac agentConfig, cons consent) error {
+	skillDir := filepath.Join(ac.skillsDir, tutorialSkillDir)
+	skillPath := filepath.Join(skillDir, tutorialSkillFile)
+
+	current, exists, err := readFileIfExists(skillPath)
+	if err != nil {
+		return fmt.Errorf("%s: read %s: %w", ac.name, skillPath, err)
+	}
+	if !exists {
+		return nil
+	}
+	// A marker-less file — including a zero-byte one (existence, not content,
+	// is what makes it the user's) — is never removed.
+	if !strings.Contains(current, tutorialSkillMarker) {
+		sink.Notef("%s: %s was rewritten without the %q marker — leaving it untouched (rk only removes files it owns).\n", ac.name, skillPath, tutorialSkillMarker)
+		return nil
+	}
+
+	sink.Notef("%s: found the run-kit-tutorial skill at %s.\n\n", ac.name, skillPath)
+	dryRunNote := fmt.Sprintf("%s: dry run — run-kit-tutorial skill left in place (nothing removed).", ac.name)
+	promptSuffix := fmt.Sprintf("Remove the %s directory? [y/N] ", skillDir)
+	ok, err := cons.authorizeWrite(sink.data, reader, dryRunNote, promptSuffix)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		if !cons.dryRun {
+			// Status line — chatter.
+			sink.Notef("%s: run-kit-tutorial skill left in place (nothing removed).\n", ac.name)
 		}
 		return nil
 	}

--- a/app/backend/cmd/rk/agent_setup_test.go
+++ b/app/backend/cmd/rk/agent_setup_test.go
@@ -798,8 +798,9 @@ func TestApplyAgentConfigCleansLegacySkillOnInstall(t *testing.T) {
 	skillDir, _ := seedLegacySkill(t, skillsDir, legacyMarkerSkill)
 
 	var out bytes.Buffer
-	// First "y" confirms the hooks write; second "y" confirms the legacy removal.
-	if err := applyAgentConfig(newSinkWriters(&out, &out), bufio.NewReader(strings.NewReader("y\ny\n")), ac, "/opt/homebrew/bin/rk", false, consent{stdinIsTTY: true}); err != nil {
+	// "y" × 3 confirms the per-agent steps in order: hooks write, tutorial skill
+	// write, legacy removal.
+	if err := applyAgentConfig(newSinkWriters(&out, &out), bufio.NewReader(strings.NewReader("y\ny\ny\n")), ac, "/opt/homebrew/bin/rk", false, consent{stdinIsTTY: true}); err != nil {
 		t.Fatalf("applyAgentConfig error: %v", err)
 	}
 	if _, err := os.Stat(skillDir); !os.IsNotExist(err) {
@@ -808,8 +809,8 @@ func TestApplyAgentConfigCleansLegacySkillOnInstall(t *testing.T) {
 }
 
 // TestApplyAgentConfigFreshMachineWritesNoSkill proves a fresh machine (no legacy
-// skill) sees ZERO rk-display output and no skill file is ever created — the
-// hooks-only reality.
+// skill) sees ZERO rk-display output and no rk-display file is ever created —
+// only the hooks merge and the run-kit-tutorial skill install run.
 func TestApplyAgentConfigFreshMachineWritesNoSkill(t *testing.T) {
 	dir := t.TempDir()
 	settingsPath := filepath.Join(dir, "settings.json")
@@ -817,8 +818,9 @@ func TestApplyAgentConfigFreshMachineWritesNoSkill(t *testing.T) {
 	ac := agentConfig{name: "Test", settingsPath: settingsPath, comm: "claude", skillsDir: skillsDir, hooks: claudeHooks()}
 
 	var out bytes.Buffer
-	// Single "y" confirms the hooks write; no skill prompt should ever be reached.
-	if err := applyAgentConfig(newSinkWriters(&out, &out), bufio.NewReader(strings.NewReader("y\n")), ac, "/opt/homebrew/bin/rk", false, consent{stdinIsTTY: true}); err != nil {
+	// "y" × 2 confirms the hooks write and the tutorial skill write; no legacy
+	// prompt should ever be reached.
+	if err := applyAgentConfig(newSinkWriters(&out, &out), bufio.NewReader(strings.NewReader("y\ny\n")), ac, "/opt/homebrew/bin/rk", false, consent{stdinIsTTY: true}); err != nil {
 		t.Fatalf("applyAgentConfig error: %v", err)
 	}
 	if strings.Contains(out.String(), "rk-display") {
@@ -826,6 +828,10 @@ func TestApplyAgentConfigFreshMachineWritesNoSkill(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(skillsDir, rkDisplaySkillDir)); !os.IsNotExist(err) {
 		t.Errorf("no rk-display directory should be created on a fresh machine")
+	}
+	// The tutorial skill IS the fresh-machine skill artifact.
+	if _, err := os.Stat(filepath.Join(skillsDir, tutorialSkillDir, tutorialSkillFile)); err != nil {
+		t.Errorf("fresh install should write the run-kit-tutorial skill, stat err = %v", err)
 	}
 }
 
@@ -844,6 +850,9 @@ func TestApplyAgentConfigSkipsSkillWhenSkillsDirEmpty(t *testing.T) {
 	}
 	if strings.Contains(out.String(), "rk-display") {
 		t.Errorf("empty skillsDir must skip the skill artifact entirely, got:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "run-kit-tutorial") {
+		t.Errorf("empty skillsDir must skip the tutorial skill entirely, got:\n%s", out.String())
 	}
 	// No rk-display directory was created under the temp dir.
 	if _, err := os.Stat(filepath.Join(dir, ".claude", "skills", rkDisplaySkillDir)); !os.IsNotExist(err) {
@@ -2090,5 +2099,252 @@ func TestTmuxShimDryRunFullBodies(t *testing.T) {
 	// The shim script itself is the requested preview data on this path.
 	if !strings.Contains(got, tmuxShimMarker) {
 		t.Errorf("--dry-run shim preview should include the script body, got: %q", got)
+	}
+}
+
+// --- run-kit-tutorial invoker skill (third managed artifact) ---------------------
+
+// seedTutorialSkill writes content to {skillsDir}/run-kit-tutorial/SKILL.md and
+// returns the skill dir + file paths (the tutorial analogue of seedLegacySkill).
+func seedTutorialSkill(t *testing.T, skillsDir, content string) (skillDir, skillPath string) {
+	t.Helper()
+	skillDir = filepath.Join(skillsDir, tutorialSkillDir)
+	skillPath = filepath.Join(skillDir, tutorialSkillFile)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(skillPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return skillDir, skillPath
+}
+
+// TestTutorialSkillPayloadCarriesMarkerAndRoute guards the embedded payload
+// itself: dropping the ownership marker would orphan every installed copy
+// (re-runs would refuse to touch them as "user files"), and the router must
+// name `rk skill tutorial` — the binary-served content it exists to route to.
+func TestTutorialSkillPayloadCarriesMarkerAndRoute(t *testing.T) {
+	if !strings.Contains(tutorialSkillPayload, tutorialSkillMarker) {
+		t.Fatalf("embedded payload must carry the ownership marker %q", tutorialSkillMarker)
+	}
+	if !strings.Contains(tutorialSkillPayload, "rk skill tutorial") {
+		t.Error("payload must route to `rk skill tutorial`")
+	}
+	if !strings.Contains(tutorialSkillPayload, "name: run-kit-tutorial") {
+		t.Error("payload frontmatter must name the skill run-kit-tutorial")
+	}
+	if !strings.Contains(tutorialSkillPayload, "TMUX_PANE") {
+		t.Error("payload must gate on TMUX_PANE")
+	}
+	if !strings.Contains(tutorialSkillPayload, "ONBOARDING.md") {
+		t.Error("payload description must forbid the ONBOARDING.md detour")
+	}
+}
+
+func TestInstallTutorialSkill(t *testing.T) {
+	t.Run("fresh install writes the payload on confirm", func(t *testing.T) {
+		dir := t.TempDir()
+		ac := agentConfig{name: "Test", skillsDir: dir}
+
+		var out bytes.Buffer
+		if err := installTutorialSkill(newSinkWriters(&out, &out), bufio.NewReader(strings.NewReader("y\n")), ac, consent{stdinIsTTY: true}); err != nil {
+			t.Fatalf("installTutorialSkill error: %v", err)
+		}
+		got, err := os.ReadFile(filepath.Join(dir, tutorialSkillDir, tutorialSkillFile))
+		if err != nil {
+			t.Fatalf("skill file should exist after confirm: %v", err)
+		}
+		if string(got) != tutorialSkillPayload {
+			t.Error("installed content must be byte-identical to the embedded payload")
+		}
+	})
+
+	t.Run("current install is a reported no-op, no prompt consumed", func(t *testing.T) {
+		dir := t.TempDir()
+		ac := agentConfig{name: "Test", skillsDir: dir}
+		seedTutorialSkill(t, dir, tutorialSkillPayload)
+
+		var out bytes.Buffer
+		// Empty reader: a no-op must never prompt.
+		if err := installTutorialSkill(newSinkWriters(&out, &out), bufio.NewReader(strings.NewReader("")), ac, consent{stdinIsTTY: true}); err != nil {
+			t.Fatalf("installTutorialSkill error: %v", err)
+		}
+		if !strings.Contains(out.String(), "nothing to do") {
+			t.Errorf("re-install over current content should report a no-op, got: %s", out.String())
+		}
+	})
+
+	t.Run("stale marker-owned generation is replaced in place", func(t *testing.T) {
+		dir := t.TempDir()
+		ac := agentConfig{name: "Test", skillsDir: dir}
+		stale := "---\nname: run-kit-tutorial\n# " + tutorialSkillMarker + "\n---\n# old generation\n"
+		_, skillPath := seedTutorialSkill(t, dir, stale)
+
+		var out bytes.Buffer
+		if err := installTutorialSkill(newSinkWriters(&out, &out), bufio.NewReader(strings.NewReader("y\n")), ac, consent{stdinIsTTY: true}); err != nil {
+			t.Fatalf("installTutorialSkill error: %v", err)
+		}
+		got, _ := os.ReadFile(skillPath)
+		if string(got) != tutorialSkillPayload {
+			t.Errorf("stale generation should be replaced with the embedded payload, got: %s", got)
+		}
+		if !strings.Contains(out.String(), "update") {
+			t.Errorf("replacing a stale generation should report an update, got: %s", out.String())
+		}
+	})
+
+	t.Run("marker-less user file is never overwritten (zero-byte included)", func(t *testing.T) {
+		for _, content := range []string{"---\nname: run-kit-tutorial\n---\n# my own\n", ""} {
+			dir := t.TempDir()
+			ac := agentConfig{name: "Test", skillsDir: dir}
+			_, skillPath := seedTutorialSkill(t, dir, content)
+
+			var out bytes.Buffer
+			// Empty reader: a marker-less skip must never prompt.
+			if err := installTutorialSkill(newSinkWriters(&out, &out), bufio.NewReader(strings.NewReader("")), ac, consent{stdinIsTTY: true}); err != nil {
+				t.Fatalf("installTutorialSkill error: %v", err)
+			}
+			got, _ := os.ReadFile(skillPath)
+			if string(got) != content {
+				t.Errorf("marker-less user file content changed (seed %q): %s", content, got)
+			}
+			if !strings.Contains(out.String(), "leaving it untouched") {
+				t.Errorf("output should note the marker-less skip, got: %s", out.String())
+			}
+		}
+	})
+
+	t.Run("decline writes nothing", func(t *testing.T) {
+		dir := t.TempDir()
+		ac := agentConfig{name: "Test", skillsDir: dir}
+
+		var out bytes.Buffer
+		if err := installTutorialSkill(newSinkWriters(&out, &out), bufio.NewReader(strings.NewReader("n\n")), ac, consent{stdinIsTTY: true}); err != nil {
+			t.Fatalf("installTutorialSkill error: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(dir, tutorialSkillDir)); !os.IsNotExist(err) {
+			t.Errorf("declining must not create the skill directory, stat err = %v", err)
+		}
+	})
+
+	t.Run("--dry-run renders the artifact diff and writes nothing, winning over --yes", func(t *testing.T) {
+		dir := t.TempDir()
+		ac := agentConfig{name: "Test", skillsDir: dir}
+
+		var out bytes.Buffer
+		if err := installTutorialSkill(newSinkWriters(&out, &out), bufio.NewReader(strings.NewReader("")), ac, consent{dryRun: true, yes: true}); err != nil {
+			t.Fatalf("installTutorialSkill error: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(dir, tutorialSkillDir)); !os.IsNotExist(err) {
+			t.Errorf("dry-run must not create the skill directory, stat err = %v", err)
+		}
+		if !strings.Contains(out.String(), "will install the run-kit-tutorial skill") {
+			t.Errorf("dry-run should render the diff header, got: %s", out.String())
+		}
+		if !strings.Contains(out.String(), "+++ proposed") {
+			t.Errorf("dry-run should render the full artifact diff, got: %s", out.String())
+		}
+	})
+
+	t.Run("non-TTY with neither flag refuses before any write", func(t *testing.T) {
+		dir := t.TempDir()
+		ac := agentConfig{name: "Test", skillsDir: dir}
+
+		var out bytes.Buffer
+		err := installTutorialSkill(newSinkWriters(&out, &out), bufio.NewReader(strings.NewReader("")), ac, consent{})
+		if err == nil {
+			t.Fatal("non-TTY no-flag run must refuse with an error, got nil")
+		}
+		if !strings.Contains(err.Error(), "--yes") {
+			t.Errorf("refusal error must name --yes, got: %v", err)
+		}
+		if _, statErr := os.Stat(filepath.Join(dir, tutorialSkillDir)); !os.IsNotExist(statErr) {
+			t.Errorf("refusal must not create the skill directory, stat err = %v", statErr)
+		}
+	})
+}
+
+func TestRemoveTutorialSkill(t *testing.T) {
+	t.Run("marker-owned directory removed on confirm", func(t *testing.T) {
+		dir := t.TempDir()
+		ac := agentConfig{name: "Test", skillsDir: dir}
+		skillDir, _ := seedTutorialSkill(t, dir, tutorialSkillPayload)
+
+		var out bytes.Buffer
+		if err := removeTutorialSkill(newSinkWriters(&out, &out), bufio.NewReader(strings.NewReader("y\n")), ac, consent{stdinIsTTY: true}); err != nil {
+			t.Fatalf("removeTutorialSkill error: %v", err)
+		}
+		if _, err := os.Stat(skillDir); !os.IsNotExist(err) {
+			t.Errorf("marker-owned skill directory should be removed, stat err = %v", err)
+		}
+	})
+
+	t.Run("absent file is silent", func(t *testing.T) {
+		dir := t.TempDir()
+		ac := agentConfig{name: "Test", skillsDir: dir}
+		var out bytes.Buffer
+		if err := removeTutorialSkill(newSinkWriters(&out, &out), bufio.NewReader(strings.NewReader("")), ac, consent{}); err != nil {
+			t.Fatalf("removeTutorialSkill error: %v", err)
+		}
+		if out.Len() != 0 {
+			t.Errorf("absent tutorial skill must be silent on uninstall, got: %s", out.String())
+		}
+	})
+
+	t.Run("marker-less user file untouched with skip note", func(t *testing.T) {
+		dir := t.TempDir()
+		ac := agentConfig{name: "Test", skillsDir: dir}
+		rewritten := "---\nname: run-kit-tutorial\n---\n# my own version\n"
+		_, skillPath := seedTutorialSkill(t, dir, rewritten)
+
+		var out bytes.Buffer
+		if err := removeTutorialSkill(newSinkWriters(&out, &out), bufio.NewReader(strings.NewReader("")), ac, consent{}); err != nil {
+			t.Fatalf("removeTutorialSkill error: %v", err)
+		}
+		got, _ := os.ReadFile(skillPath)
+		if string(got) != rewritten {
+			t.Errorf("marker-less user file content changed: %s", got)
+		}
+		if !strings.Contains(out.String(), "leaving it untouched") {
+			t.Errorf("output should note the marker-less skip, got: %s", out.String())
+		}
+	})
+
+	t.Run("--dry-run leaves a marker-owned copy in place", func(t *testing.T) {
+		dir := t.TempDir()
+		ac := agentConfig{name: "Test", skillsDir: dir}
+		_, skillPath := seedTutorialSkill(t, dir, tutorialSkillPayload)
+
+		var out bytes.Buffer
+		if err := removeTutorialSkill(newSinkWriters(&out, &out), bufio.NewReader(strings.NewReader("")), ac, consent{dryRun: true}); err != nil {
+			t.Fatalf("removeTutorialSkill error: %v", err)
+		}
+		if _, err := os.Stat(skillPath); err != nil {
+			t.Errorf("dry-run must leave the skill in place, stat err = %v", err)
+		}
+		if !strings.Contains(out.String(), "dry run") {
+			t.Errorf("dry-run should note the no-write, got: %s", out.String())
+		}
+	})
+}
+
+// TestApplyAgentConfigUninstallRemovesTutorialSkill proves the --uninstall pass
+// routes the skill step to removal: a marker-owned installed copy is removed
+// alongside the hooks unmerge.
+func TestApplyAgentConfigUninstallRemovesTutorialSkill(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+	skillsDir := filepath.Join(dir, "skills")
+	ac := agentConfig{name: "Test", settingsPath: settingsPath, comm: "claude", skillsDir: skillsDir, hooks: claudeHooks()}
+	skillDir, _ := seedTutorialSkill(t, skillsDir, tutorialSkillPayload)
+
+	var out bytes.Buffer
+	// No settings file exists → the hooks unmerge is a silent no-op; the single
+	// "y" confirms the tutorial skill removal.
+	if err := applyAgentConfig(newSinkWriters(&out, &out), bufio.NewReader(strings.NewReader("y\n")), ac, "", true, consent{stdinIsTTY: true}); err != nil {
+		t.Fatalf("applyAgentConfig uninstall error: %v", err)
+	}
+	if _, err := os.Stat(skillDir); !os.IsNotExist(err) {
+		t.Errorf("--uninstall should remove the marker-owned tutorial skill, stat err = %v", err)
 	}
 }

--- a/app/backend/cmd/rk/agentskill/run-kit-tutorial.md
+++ b/app/backend/cmd/rk/agentskill/run-kit-tutorial.md
@@ -1,0 +1,24 @@
+---
+name: run-kit-tutorial
+description: Guided live tour of run-kit. Use when the user asks for a tutorial, tour, walkthrough, onboarding, or to be shown around run-kit, its web dashboard, or this workspace's agent orchestration. This skill is the route for such requests — do not improvise a tour and do not reach for a repo's ONBOARDING.md.
+# managed-by: rk agent-setup (run-kit-tutorial skill)
+---
+# run-kit tutorial — invoker
+
+This is a thin router: the tour itself is served by the rk binary, so its
+content always matches the installed run-kit version. Never narrate a tour
+from memory.
+
+1. Gate:
+
+   ```sh
+   command -v rk >/dev/null 2>&1 && [ -n "$TMUX_PANE" ]
+   ```
+
+   If either check fails, STOP: tell the user to open the run-kit dashboard,
+   create a session/window for this directory, run the agent inside it, then
+   ask for the tutorial again.
+
+2. Run `rk skill tutorial` and follow its output exactly — it owns the
+   chapters, pacing, degradation posture, and cleanup. Do not summarize,
+   reorder, or substitute its content.

--- a/docs/memory/run-kit/agent-state.md
+++ b/docs/memory/run-kit/agent-state.md
@@ -261,8 +261,11 @@ terminal, which would make the refusal silently not fire. A non-`*os.File` reade
 non-interactive path unless they set `stdinIsTTY` explicitly. Pinned by
 `TestIsTerminalRejectsNonTTYFiles`.
 
-**It installs TWO artifact families**: the **per-agent settings-hooks merge**
-(described here) and the **user-global tmux guard shim** — a shim script plus a
+**It installs THREE artifact families**: the **per-agent settings-hooks merge**
+(described here); the **per-agent run-kit-tutorial invoker skill** — a thin
+discovery router at `{skillsDir}/run-kit-tutorial/SKILL.md` that routes an
+agent's tutorial/tour/onboarding asks to `rk skill tutorial` (see
+§ run-kit-tutorial Invoker Skill); and the **user-global tmux guard shim** — a shim script plus a
 marker-owned `PATH` block that puts `rk mux guard` in front of every
 PATH-resolved `tmux` invocation, so `tmux kill-server` without an explicit
 `-L`/`-S` socket is refused. The shim script is in its **second generation** —
@@ -277,13 +280,15 @@ summary-on-consent / full-diff-on-`--dry-run` rendering split, and its
 (260805-blyf-tmux-guard-path-shim)
 
 The command surface is `rk agent setup` / `rk agent setup --uninstall`, and
-`--uninstall` reverses both families. The
+`--uninstall` reverses all three families. The
 visual-display context-injection role belongs to the **`rk skill` bundle** (served
 by the `skill` subcommand, aggregated by the coming `shll agent-setup`), described
-in [architecture](/run-kit/architecture.md) § CLI Subcommands; the only skill trace
-in `rk agent setup` is a **one-release legacy cleanup** that removes a stale
-`rk-display` copy left by an older run-kit (see § Legacy `rk-display` Cleanup).
-(260717-agst)
+in [architecture](/run-kit/architecture.md) § CLI Subcommands — the tutorial
+invoker skill is compatible with that split because it carries no injectable
+content, only the route (see its section's design decision); the only other
+skill trace in `rk agent setup` is a **one-release legacy cleanup** that removes
+a stale `rk-display` copy left by an older run-kit (see § Legacy `rk-display`
+Cleanup). (260717-agst)
 
 **Per-agent registry** (`agentRegistry(home) []agentConfig`): each `agentConfig`
 carries a display `name`, a `settingsPath`, the agent binary's `comm` (process
@@ -414,16 +419,59 @@ at its boundary (so everything below stays pure over injected paths), then runs:
 `applyAgentConfig` is the thin per-agent wrapper, running in order:
 
 1. **`applyAgentHooks`** — the settings-hooks merge (described above). Always runs.
-2. **`removeLegacySkill`** — the one-release cleanup of the legacy `rk-display`
-   skill (below). Runs only when the agent's `skillsDir` is non-empty.
+2. **`installTutorialSkill`** (install pass) / **`removeTutorialSkill`**
+   (`--uninstall` pass) — the run-kit-tutorial invoker skill (below). Runs only
+   when the agent's `skillsDir` is non-empty.
+3. **`removeLegacySkill`** — the one-release cleanup of the legacy `rk-display`
+   skill (below). Runs on BOTH passes, only when `skillsDir` is non-empty.
 
 Each step runs **independently** — its own tolerant read, diff/prompt, and no-op
 report — so declining or no-op-ing one does not skip the others. `agentConfig`
-carries a `skillsDir string` field; the Claude Code registry row sets it to
-`filepath.Join(home, ".claude", "skills")`, and an **empty `skillsDir` means "no
-legacy skill to clean for that agent"** — only the hooks merge runs (future
-codex/copilot/gemini/opencode rows may leave it empty). `skillsDir` exists
-**solely to locate the legacy skill for cleanup**.
+carries a `skillsDir string` field rooting the per-agent skill artifacts (the
+tutorial skill install and the legacy cleanup); the Claude Code registry row sets
+it to `filepath.Join(home, ".claude", "skills")`, and an **empty `skillsDir`
+means the agent has no skills convention** — only the hooks merge runs (future
+codex/copilot/gemini/opencode rows may leave it empty).
+
+### run-kit-tutorial Invoker Skill (`installTutorialSkill` / `removeTutorialSkill`)
+
+The third managed artifact: a user-global Claude Code skill at
+`{skillsDir}/run-kit-tutorial/SKILL.md` (`~/.claude/skills/run-kit-tutorial/SKILL.md`)
+that gives an agent already running in a run-kit pane a **discovery route to the
+guided tour** — its frontmatter `description:` triggers on tutorial / tour /
+walkthrough / onboarding phrasing about run-kit and forbids the `ONBOARDING.md`
+detour, and its body is a two-step router: gate
+`command -v rk && [ -n "$TMUX_PANE" ]` (on failure, tell the user to run the
+agent inside a run-kit window and ask again), then run `rk skill tutorial` and
+follow it exactly. It complements the human-typed entry `rk tutorial` — this
+skill covers the ask-a-running-agent entry. (260903-kqps-agent-setup-tutorial-invoker-skill)
+
+- **Payload**: tracked in-repo at `cmd/rk/agentskill/run-kit-tutorial.md` and
+  embedded via `//go:embed` (`tutorialSkillPayload`). `agentskill/` is an
+  agent-setup payload dir, deliberately outside `cmd/rk/skill/` (the
+  docs/site-synced `rk skill` bundle namespace with embed drift guards).
+- **Ownership marker**: `managed-by: rk agent-setup (run-kit-tutorial skill)`
+  (`tutorialSkillMarker`), a YAML comment inside the payload's frontmatter —
+  frozen text once shipped (must keep matching installed artifacts, the
+  `tmuxShimMarker` rule). It extends the legacy bare `skillManagedByMarker` with
+  a parenthesized family; the two cannot collide because `removeLegacySkill` is
+  path-scoped to `rk-display/`. A payload-carries-marker test guards against an
+  edit dropping the marker (which would orphan installed copies as "user files").
+- **Currency**: byte-compare against the embedded payload — the marker
+  identifies *ownership*, content equality identifies *staleness*; a stale
+  generation is replaced in place on the next `rk agent setup` re-run (the
+  documented upgrade action). No numeric generation counter, and no `rk doctor`
+  row (absence is a valid not-set-up state).
+- **Contract** (the `installTmuxShimFile` shape): marker-less existing file —
+  including zero-byte, via the existence-aware `readFileIfExists` — is left
+  untouched with a skip note; byte-current content is a reported no-op, no
+  prompt; otherwise a one-line summary on the interactive/`--yes` paths, the
+  full `renderArtifactDiff` body only under `--dry-run`, and the write gated
+  through `consent.authorizeWrite`. On consent: dir 0755, file 0644 (skill
+  content is not sensitive user config — settings.json's 0600 does not apply).
+- **Uninstall**: `removeTutorialSkill` removes a marker-owned
+  `run-kit-tutorial/` directory (`os.RemoveAll` after consent, dir-level like
+  the legacy cleanup); absent is silent, marker-less is skipped with a note.
 
 ### Legacy `rk-display` Cleanup (`removeLegacySkill`, one release only)
 
@@ -833,6 +881,22 @@ content in place, never touch anything else" is satisfiable.
 per-project install (defeats the "any session anywhere" goal — the whole point is
 user-global registration).
 *Introduced by*: `260705-dmex-generic-agent-state-tier`
+
+### Managed skill as discovery router, content behind the binary
+**Decision**: `rk agent setup` installs the run-kit-tutorial invoker skill as a
+thin router — frontmatter description for discovery, a gate, and a route to
+`rk skill tutorial` — with zero tour content in the skill file.
+**Why**: a skill description is the harness's own discovery mechanism (an agent
+asked for a tour finds the route from natural phrasing), while keeping content
+binary-served means tour updates track `brew upgrade rk` with no skill churn and
+no session restarts — the same freeze-avoidance that moved hook logic into
+`rk agent hook`. This is what makes a managed skill compatible with the split
+that retired the content-carrying rk-display skill.
+**Rejected**: a content-carrying skill (re-creates the rk-display freeze: content
+snapshots at install time and drifts from the binary); relying on the `rk skill`
+bundle alone (an agent has no reason to run `rk skill` unprompted — discovery
+needs a harness-registered description).
+*Introduced by*: `260903-kqps-agent-setup-tutorial-invoker-skill`
 
 ### Non-interactive consent: `--yes`/`--dry-run` + non-TTY refusal (not a silent decline)
 **Decision**: gate every `rk agent setup` write through a `consent` struct

--- a/fab/changes/260903-kqps-agent-setup-tutorial-invoker-skill/.history.jsonl
+++ b/fab/changes/260903-kqps-agent-setup-tutorial-invoker-skill/.history.jsonl
@@ -1,0 +1,10 @@
+{"action":"enter","driver":"fab-new","event":"stage-transition","stage":"intake","ts":"2026-09-03T11:30:10Z"}
+{"args":"rk agent setup should install the run-kit-tutorial invoker skill (backlog kqps)","cmd":"fab-new","event":"command","ts":"2026-09-03T11:30:10Z"}
+{"delta":"+4.3","event":"confidence","score":4.3,"trigger":"calc-score","ts":"2026-09-03T11:32:59Z"}
+{"cmd":"fab-new","event":"command","ts":"2026-09-03T11:33:05Z"}
+{"cmd":"fab-fff","event":"command","ts":"2026-09-04T16:56:34Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"apply","ts":"2026-09-04T16:56:53Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"review","ts":"2026-09-04T17:05:37Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-09-04T17:10:19Z"}
+{"event":"review","result":"passed","ts":"2026-09-04T17:10:19Z"}
+{"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-09-04T17:13:03Z"}

--- a/fab/changes/260903-kqps-agent-setup-tutorial-invoker-skill/.history.jsonl
+++ b/fab/changes/260903-kqps-agent-setup-tutorial-invoker-skill/.history.jsonl
@@ -8,3 +8,4 @@
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"hydrate","ts":"2026-09-04T17:10:19Z"}
 {"event":"review","result":"passed","ts":"2026-09-04T17:10:19Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-09-04T17:13:03Z"}
+{"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-09-04T17:14:55Z"}

--- a/fab/changes/260903-kqps-agent-setup-tutorial-invoker-skill/.history.jsonl
+++ b/fab/changes/260903-kqps-agent-setup-tutorial-invoker-skill/.history.jsonl
@@ -9,3 +9,4 @@
 {"event":"review","result":"passed","ts":"2026-09-04T17:10:19Z"}
 {"action":"enter","driver":"fab-fff","event":"stage-transition","stage":"ship","ts":"2026-09-04T17:13:03Z"}
 {"action":"enter","driver":"git-pr","event":"stage-transition","stage":"review-pr","ts":"2026-09-04T17:14:55Z"}
+{"event":"review","result":"passed","ts":"2026-09-04T17:20:15Z"}

--- a/fab/changes/260903-kqps-agent-setup-tutorial-invoker-skill/.status.yaml
+++ b/fab/changes/260903-kqps-agent-setup-tutorial-invoker-skill/.status.yaml
@@ -1,0 +1,55 @@
+id: kqps
+name: 260903-kqps-agent-setup-tutorial-invoker-skill
+created: 2026-09-03T11:30:10Z
+created_by: sahil-noon
+change_type: feat
+issues: []
+progress:
+    intake: done
+    apply: done
+    review: done
+    hydrate: done
+    ship: active
+    review-pr: pending
+plan:
+    generated: true
+    task_count: 5
+    acceptance_count: 10
+    acceptance_completed: 10
+confidence:
+    certain: 3
+    confident: 5
+    tentative: 0
+    unresolved: 0
+    score: 4.3
+    fuzzy: true
+    dimensions:
+        signal: 71.9
+        reversibility: 80.0
+        competence: 82.5
+        disambiguation: 74.4
+stage_metrics:
+    intake: {started_at: "2026-09-03T11:30:10Z", driver: fab-new, iterations: 1, completed_at: "2026-09-04T16:56:53Z"}
+    apply: {started_at: "2026-09-04T16:56:53Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T17:05:37Z"}
+    review: {started_at: "2026-09-04T17:05:37Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T17:10:19Z"}
+    hydrate: {started_at: "2026-09-04T17:10:19Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T17:13:03Z"}
+    ship: {started_at: "2026-09-04T17:13:03Z", driver: fab-fff, iterations: 1}
+prs: []
+change_type_source: explicit
+true_impact:
+    added: 0
+    deleted: 0
+    net: 0
+    excluding:
+        added: 0
+        deleted: 0
+        net: 0
+    tests:
+        added: 0
+        deleted: 0
+        net: 0
+    computed_at: "2026-09-04T17:13:03Z"
+    computed_at_stage: hydrate
+summary: 'rk agent setup installs the run-kit-tutorial invoker skill (third managed artifact): embedded router payload, marker-owned install/uninstall at ~/.claude/skills/run-kit-tutorial/'
+# true_impact: lazily created on first stage-finish that computes it (no placeholder here).
+last_updated: 2026-09-04T17:13:03Z

--- a/fab/changes/260903-kqps-agent-setup-tutorial-invoker-skill/.status.yaml
+++ b/fab/changes/260903-kqps-agent-setup-tutorial-invoker-skill/.status.yaml
@@ -9,8 +9,8 @@ progress:
     apply: done
     review: done
     hydrate: done
-    ship: active
-    review-pr: pending
+    ship: done
+    review-pr: active
 plan:
     generated: true
     task_count: 5
@@ -33,23 +33,25 @@ stage_metrics:
     apply: {started_at: "2026-09-04T16:56:53Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T17:05:37Z"}
     review: {started_at: "2026-09-04T17:05:37Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T17:10:19Z"}
     hydrate: {started_at: "2026-09-04T17:10:19Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T17:13:03Z"}
-    ship: {started_at: "2026-09-04T17:13:03Z", driver: fab-fff, iterations: 1}
-prs: []
+    ship: {started_at: "2026-09-04T17:13:03Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T17:14:55Z"}
+    review-pr: {started_at: "2026-09-04T17:14:55Z", driver: git-pr, iterations: 1}
+prs:
+    - https://github.com/sahil87/run-kit/pull/838
 change_type_source: explicit
 true_impact:
-    added: 0
-    deleted: 0
-    net: 0
+    added: 850
+    deleted: 49
+    net: 801
     excluding:
-        added: 0
-        deleted: 0
-        net: 0
+        added: 471
+        deleted: 35
+        net: 436
     tests:
-        added: 0
-        deleted: 0
-        net: 0
-    computed_at: "2026-09-04T17:13:03Z"
-    computed_at_stage: hydrate
+        added: 262
+        deleted: 6
+        net: 256
+    computed_at: "2026-09-04T17:14:55Z"
+    computed_at_stage: ship
 summary: 'rk agent setup installs the run-kit-tutorial invoker skill (third managed artifact): embedded router payload, marker-owned install/uninstall at ~/.claude/skills/run-kit-tutorial/'
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-09-04T17:13:03Z
+last_updated: 2026-09-04T17:14:55Z

--- a/fab/changes/260903-kqps-agent-setup-tutorial-invoker-skill/.status.yaml
+++ b/fab/changes/260903-kqps-agent-setup-tutorial-invoker-skill/.status.yaml
@@ -10,7 +10,7 @@ progress:
     review: done
     hydrate: done
     ship: done
-    review-pr: active
+    review-pr: done
 plan:
     generated: true
     task_count: 5
@@ -34,7 +34,7 @@ stage_metrics:
     review: {started_at: "2026-09-04T17:05:37Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T17:10:19Z"}
     hydrate: {started_at: "2026-09-04T17:10:19Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T17:13:03Z"}
     ship: {started_at: "2026-09-04T17:13:03Z", driver: fab-fff, iterations: 1, completed_at: "2026-09-04T17:14:55Z"}
-    review-pr: {started_at: "2026-09-04T17:14:55Z", driver: git-pr, iterations: 1}
+    review-pr: {started_at: "2026-09-04T17:14:55Z", driver: git-pr, iterations: 1, completed_at: "2026-09-04T17:20:15Z"}
 prs:
     - https://github.com/sahil87/run-kit/pull/838
 change_type_source: explicit
@@ -54,4 +54,4 @@ true_impact:
     computed_at_stage: ship
 summary: 'rk agent setup installs the run-kit-tutorial invoker skill (third managed artifact): embedded router payload, marker-owned install/uninstall at ~/.claude/skills/run-kit-tutorial/'
 # true_impact: lazily created on first stage-finish that computes it (no placeholder here).
-last_updated: 2026-09-04T17:14:55Z
+last_updated: 2026-09-04T17:20:15Z

--- a/fab/changes/260903-kqps-agent-setup-tutorial-invoker-skill/intake.md
+++ b/fab/changes/260903-kqps-agent-setup-tutorial-invoker-skill/intake.md
@@ -1,0 +1,86 @@
+# Intake: Agent-setup tutorial invoker skill
+
+**Change**: 260903-kqps-agent-setup-tutorial-invoker-skill
+**Created**: 2026-09-03
+
+## Origin
+
+One-shot `/fab-new kqps` from the backlog:
+
+> [kqps] 2026-09-03: rk agent setup should install the run-kit-tutorial invoker skill: write ~/.claude/skills/run-kit-tutorial/SKILL.md (tracked source in-repo beside the other agent-setup payloads, generation-stamped like the guard shim) — a thin router: gate rk+TMUX_PANE, run 'rk skill tutorial', follow it exactly; description triggers on tutorial/tour/onboarding phrasing and forbids the ONBOARDING.md detour. Found live: latest rk on another machine has the tour content but no discovery route (2026-09-03). Complements [7ajq] rk tutorial (human-typed entry); this covers the ask-a-running-agent entry.
+
+No prior conversation on this topic — the intake is grounded in the backlog entry plus a code read of `cmd/rk/agent_setup.go`, `cmd/rk/tmux_guard.go`, `cmd/rk/skill.go`, `cmd/rk/skill/tutorial.md`, and `cmd/rk/doctor.go`.
+
+## Why
+
+1. **The pain point**: the run-kit tutorial content ships in the binary (`rk skill tutorial`, PR #799) and has a human-typed entry (`rk tutorial`, backlog [7ajq], done), but the most natural entry for the target audience — asking an agent already running in a run-kit pane "give me a tour of run-kit" — has **no discovery route**. Observed live 2026-09-03: a machine with the latest rk had the full tour content installed, and an agent asked for a tour could not find it; the known failure mode is improvising or detouring into a repo's `ONBOARDING.md`.
+2. **If we don't fix it**: the tutorial investment is invisible exactly where new users are — in front of an agent. Every "show me around" ask lands on improvisation, which is inconsistent, misses the live companion pages, and skips the pacing/cleanup contract the real tour carries.
+3. **Why this approach**: a user-global Claude Code skill is the discovery mechanism the harness itself provides — a skill description is what makes an agent find the tour from natural phrasing. `rk agent setup` is the existing user-global installer with the exact managed-artifact contract this needs (marker ownership, diff + consent, idempotent replace-in-place, `--uninstall`). The skill is a **thin router**, not content: the tour itself stays behind `rk skill tutorial` served by the binary, so content updates track `brew upgrade rk` with zero skill churn — the same freeze-avoidance rationale that moved the agent-state hooks to `rk agent hook` delegation and retired the fat `rk-display` skill. The router only encodes what cannot live in the binary: the trigger description and the two-line invocation route.
+
+## What Changes
+
+### 1. New tracked payload: the invoker skill source
+
+A new markdown payload, tracked in-repo and embedded in the binary via `//go:embed`, containing the full `SKILL.md` to install. Location: a dedicated path under `cmd/rk/` (e.g. `cmd/rk/agentskill/run-kit-tutorial.md`) — deliberately **not** under `cmd/rk/skill/` (that directory is the `rk skill` bundle namespace, synced from `docs/site/` by `scripts/sync-skill.sh` with embed drift-guard tests; this payload is an installer artifact, not a servable topic and not docs/site-synced) and **not** a Go string const (multiline markdown reviews and diffs better as a file). The exact subdir name is decided at apply (Assumption 5).
+
+Payload content (the installed `~/.claude/skills/run-kit-tutorial/SKILL.md`):
+
+- **Frontmatter**: `name: run-kit-tutorial`; an ownership/generation marker comment (see §3); a `description:` written to trigger on tutorial / tour / onboarding / walkthrough / "show me around" phrasing about run-kit, and stating explicitly that this skill — not a repo's `ONBOARDING.md`, and not an improvised tour — is the route for such requests.
+- **Body** (thin router, mirroring the gate `rk skill tutorial` itself opens with):
+  1. Gate: `command -v rk >/dev/null 2>&1 && [ -n "$TMUX_PANE" ]` — if either fails, STOP and tell the user to open the run-kit dashboard, create a session/window for this directory, run the agent inside it, and ask again.
+  2. On pass: run `rk skill tutorial` and follow its output **exactly** — it owns the chapters, pacing, degradation posture, and cleanup. Do not summarize, reorder, or substitute content.
+
+### 2. Installer: a third managed artifact family in `rk agent setup`
+
+`rk agent setup` currently manages two artifact families (per-agent hooks merge; user-global tmux guard shim). This change adds a third: the tutorial invoker skill, installed per-agent at `{skillsDir}/run-kit-tutorial/SKILL.md` for every registry row with a non-empty `skillsDir` (v1: Claude Code only → `~/.claude/skills/run-kit-tutorial/SKILL.md`).
+
+The install step follows the existing managed-artifact contract verbatim (pattern: `installTmuxShimFile` + `removeLegacySkill`):
+
+- **Ownership**: only a file carrying the rk ownership marker is ever overwritten or removed. An existing marker-less file at the path (user-authored, including zero-byte — existence-aware read via `readFileIfExists`) is left untouched with a skip note.
+- **Idempotence**: installed content byte-equal to the embedded payload → reported no-op, no prompt. Content drift (an older generation) → replace in place after consent.
+- **Consent**: reuses the `consent{yes, dryRun, stdinIsTTY}` machinery — interactive [y/N] with a summary, `--dry-run` full diff via `renderArtifactDiff`, `--yes` narration to chatter (Principle 9 channel routing as in the existing steps), non-TTY refusal unchanged.
+- **`--uninstall`**: removes the marker-owned `run-kit-tutorial/` directory (`os.RemoveAll` after consent, dir-level like the legacy rk-display cleanup); absent file is silent.
+- **Ordering**: runs inside the per-agent loop (`applyAgentConfig`), independent of the hooks merge — declining or no-op-ing one step never skips the other, matching the existing step independence.
+
+Housekeeping in the same file: the `agent_setup.go` header comment ("manages two artifact families", "no longer installs any skill") and the `agentConfig.skillsDir` doc comment are updated — `skillsDir` gains a real consumer again and its "scheduled for removal" note is rescinded; the **legacy rk-display cleanup** (`removeLegacySkill` and its constants) is untouched and keeps its own one-release removal schedule. The `rk agent setup` `Long` help text gains a line naming the skill install.
+
+### 3. Generation stamping
+
+Ownership marker embedded in the payload's frontmatter comment, following the shim's parenthesized-family pattern: `managed-by: rk agent-setup (run-kit-tutorial skill)` — frozen text once shipped (it must match artifacts already on user machines, same rule as `tmuxShimMarker`). Currency is determined by byte-comparing the installed file against the embedded payload — the marker identifies *ownership*, the content compare identifies *staleness*, and a re-run of `rk agent setup` (the documented upgrade action) replaces a stale generation in place. No numeric generation counter (Assumption 6).
+
+### 4. Out of scope (non-goals)
+
+- **No `rk doctor` row** for the skill in v1: absence is a valid state (setup not run), drift is repaired by the documented re-run of `rk agent setup`, and the backlog doesn't ask for one. A doctor row (mirroring the agent-hooks generation row) is a clean follow-up if drift proves common (Assumption 7).
+- **No other-agent rows**: only the Claude Code registry row has a `skillsDir`; codex/copilot/gemini rows remain additive follow-ups.
+- **No change to `rk skill tutorial` content** and no change to `rk tutorial` ([7ajq]).
+
+## Affected Memory
+
+- `run-kit/agent-state.md`: (modify) the `rk agent setup` installer section — document the third managed artifact family (run-kit-tutorial invoker skill): install path, marker, contract, uninstall; note the `skillsDir` field's revived consumer alongside the still-scheduled legacy rk-display cleanup.
+
+## Impact
+
+- `app/backend/cmd/rk/agent_setup.go` — new install/uninstall step + registry/comment updates (primary surface)
+- `app/backend/cmd/rk/agent_setup_test.go` — new cases: fresh install, idempotent re-run, stale-generation replace, marker-less file skip, `--uninstall`, `--dry-run`, non-TTY refusal unchanged
+- New embedded payload file under `app/backend/cmd/rk/` (+ its `//go:embed` wiring)
+- No frontend, API, daemon, or tmux-substrate changes; no new settings keys (Constitution IV untouched)
+- Note for apply: new `cmd/rk` tests must run with `env -u TMUX -u TMUX_PANE` to avoid ambient-tmux false greens (known project gotcha)
+
+## Open Questions
+
+- None — the backlog entry is specific and the installer contract is fully established by existing code.
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Certain | v1 installs for Claude Code only, at `{skillsDir}/run-kit-tutorial/SKILL.md` (`~/.claude/skills/...`), located via the registry's existing `skillsDir` field | Backlog names the exact path; the registry already carries `skillsDir` for exactly one agent | S:90 R:85 A:95 D:90 |
+| 2 | Certain | Managed-artifact contract mirrors `installTmuxShimFile`/`removeLegacySkill`: marker ownership, marker-less skip, content-equal no-op, consent modes, dir-level `--uninstall` | The contract is established three times over in the same file; deviating would be the surprising choice | S:85 R:80 A:95 D:90 |
+| 3 | Certain | Router content: gate `command -v rk` + `TMUX_PANE`, then run `rk skill tutorial` and follow exactly; description triggers on tutorial/tour/onboarding phrasing and forbids the ONBOARDING.md detour | Backlog states this verbatim; the gate mirrors `rk skill tutorial`'s own opening gate | S:95 R:90 A:90 D:90 |
+| 4 | Confident | Marker text `managed-by: rk agent-setup (run-kit-tutorial skill)` in the skill frontmatter, frozen once shipped | Follows `tmuxShimMarker`'s parenthesized-family pattern; contains the legacy bare marker as a substring, harmless since `removeLegacySkill` keys on the rk-display path | S:70 R:60 A:80 D:70 |
+| 5 | Confident | Payload is a standalone embedded `.md` under `cmd/rk/` outside `cmd/rk/skill/` (exact subdir at apply), not a Go const and not an `rk skill` topic | `cmd/rk/skill/` is the docs/site-synced bundle namespace with drift guards; an installer payload doesn't belong in it; markdown-as-file reviews better | S:70 R:75 A:80 D:65 |
+| 6 | Confident | Generation currency = byte-compare against the embedded payload; no numeric generation counter | Matches how shim/hook generations are recognized (marker + content sniffing); a counter adds state with no consumer | S:65 R:80 A:75 D:60 |
+| 7 | Confident | No `rk doctor` row in v1; drift repaired by re-running `rk agent setup` | Backlog silent on doctor; add-only follow-up if needed, easily reversed | S:40 R:85 A:60 D:55 |
+| 8 | Confident | `skillsDir`'s "scheduled for removal" note is rescinded (field regains a consumer); legacy rk-display cleanup keeps its own removal schedule untouched | Direct consequence of reusing the field; the two schedules were always independent | S:60 R:85 A:85 D:75 |
+
+8 assumptions (3 certain, 5 confident, 0 tentative, 0 unresolved).

--- a/fab/changes/260903-kqps-agent-setup-tutorial-invoker-skill/plan.md
+++ b/fab/changes/260903-kqps-agent-setup-tutorial-invoker-skill/plan.md
@@ -1,0 +1,150 @@
+# Plan: Agent-setup tutorial invoker skill
+
+**Change**: 260903-kqps-agent-setup-tutorial-invoker-skill
+**Intake**: `intake.md`
+
+## Requirements
+
+### Installer: run-kit-tutorial invoker skill
+
+#### R1: Tracked, embedded payload
+The invoker skill's full `SKILL.md` content MUST be tracked in-repo as a standalone markdown file under `app/backend/cmd/rk/` (new subdir `agentskill/`, outside the docs/site-synced `cmd/rk/skill/` bundle namespace) and embedded into the binary via `//go:embed`. The payload MUST contain, in order:
+
+1. YAML frontmatter with `name: run-kit-tutorial`, a `description:` that (a) triggers on tutorial / tour / walkthrough / onboarding / "show me around" phrasing about run-kit or its dashboard, and (b) states that this skill — not a repo's `ONBOARDING.md` and not an improvised tour — is the route for such requests; and the ownership marker as a YAML comment line `# managed-by: rk agent-setup (run-kit-tutorial skill)`.
+2. A thin router body: gate `command -v rk >/dev/null 2>&1 && [ -n "$TMUX_PANE" ]` — on failure STOP and tell the user to open the run-kit dashboard, create a session/window for this directory, run the agent inside it, and ask again; on pass run `rk skill tutorial` and follow its output exactly (it owns chapters, pacing, degradation, cleanup — never summarize, reorder, or substitute).
+
+- **GIVEN** the repo at this change
+- **WHEN** `go build ./cmd/rk` runs
+- **THEN** the payload is embedded and available to the installer as a string, and no tour content is duplicated into it (the router names `rk skill tutorial` as the sole content source)
+
+#### R2: Install step — third managed artifact family
+`rk agent setup` MUST install the payload at `{skillsDir}/run-kit-tutorial/SKILL.md` for every registry row with a non-empty `skillsDir` (v1: Claude Code → `~/.claude/skills/run-kit-tutorial/SKILL.md`), as a step of `applyAgentConfig` running between the hooks merge and the legacy rk-display cleanup, independently of both (declining or no-op-ing one never skips another). The step MUST follow the established managed-artifact contract:
+
+- An existing file WITHOUT the marker (including zero-byte — existence-aware read via `readFileIfExists`) is left untouched with a skip note (chatter).
+- Content byte-equal to the embedded payload → reported no-op (chatter), no prompt.
+- Otherwise (fresh install or stale generation): a one-line summary on the interactive/`--yes` paths, the full current/proposed body via `renderArtifactDiff` only under `--dry-run`, and the write gated through `consent.authorizeWrite` (interactive `[y/N]`, `--yes` writes, `--dry-run` writes nothing and wins over `--yes`, non-TTY with neither flag refuses via `errNonInteractiveConsent`).
+- On consent: `MkdirAll` the skill dir 0755, write `SKILL.md` 0644 (skill content is not secret — settings.json's 0600 does not apply), replacing a stale rk-owned file in place.
+
+- **GIVEN** a fresh machine with no `~/.claude/skills/run-kit-tutorial/`
+- **WHEN** `rk agent setup --yes` runs
+- **THEN** the file is written with the embedded content and the run reports it (chatter)
+- **GIVEN** an installed current copy
+- **WHEN** `rk agent setup --yes` re-runs
+- **THEN** the step reports "already installed — nothing to do" and writes nothing
+- **GIVEN** a user-rewritten (marker-less) file at the path
+- **WHEN** `rk agent setup --yes` runs
+- **THEN** the file is left byte-identical and a skip note names the marker
+
+#### R3: Uninstall
+`rk agent setup --uninstall` MUST remove a marker-owned `{skillsDir}/run-kit-tutorial/` directory (`os.RemoveAll` after consent through the same `authorizeWrite` seam, dir-level like the legacy rk-display cleanup). An absent file is silent; a marker-less file is left untouched with a skip note.
+
+- **GIVEN** an installed marker-owned copy
+- **WHEN** `rk agent setup --uninstall --yes` runs
+- **THEN** the `run-kit-tutorial/` directory is removed
+- **GIVEN** no installed copy
+- **WHEN** `rk agent setup --uninstall --yes` runs
+- **THEN** the step produces zero output
+
+#### R4: Housekeeping — comments and help
+The `agent_setup.go` header comment MUST be updated from "two artifact families" to three, and its "no longer installs any skill" narrative revised: the retired artifact was the *content-injection* rk-display skill; the new artifact is a *discovery router* whose content stays behind `rk skill tutorial` (binary-served, upgrade-tracking). The `agentConfig.skillsDir` doc comment MUST drop its "scheduled for removal" note (the field regains a consumer; the legacy rk-display cleanup keeps its own one-release schedule untouched). The `rk agent setup` `Long` help text SHOULD name the skill install alongside hooks and the shim.
+
+- **GIVEN** the merged change
+- **WHEN** a reader opens `agent_setup.go` or runs `rk agent setup --help`
+- **THEN** the described artifact inventory matches what the command actually manages
+
+#### R5: Tests
+`agent_setup_test.go` MUST cover the new step: fresh install, idempotent re-run no-op, stale-content replace-in-place, marker-less skip (install and uninstall), uninstall removal, absent-file silence on uninstall, `--dry-run` writes nothing, and the marker constant appearing in the embedded payload (guarding against a payload edit dropping the marker, which would orphan installed copies). Tests MUST be verified with `env -u TMUX -u TMUX_PANE go test` (ambient tmux env produces false local greens for cmd/rk tests).
+
+- **GIVEN** the test suite
+- **WHEN** `env -u TMUX -u TMUX_PANE go test ./cmd/rk/` runs
+- **THEN** all new and existing cases pass
+
+### Non-Goals
+
+- No `rk doctor` row for the skill (drift is repaired by the documented `rk agent setup` re-run; add-only follow-up).
+- No non-Claude registry rows; no change to `rk skill tutorial` content or `rk tutorial`.
+- No numeric generation counter — marker identifies ownership, byte-compare identifies staleness.
+
+### Design Decisions
+
+#### Payload as embedded file, not Go const, outside the skill bundle dir
+**Decision**: the payload lives at `cmd/rk/agentskill/run-kit-tutorial.md`, embedded via `//go:embed agentskill/run-kit-tutorial.md`.
+**Why**: multiline markdown reviews and diffs better as a file; `cmd/rk/skill/` is the `rk skill` bundle namespace synced from docs/site with embed drift-guard tests, and an installer payload is neither a servable topic nor docs/site-synced.
+**Rejected**: a Go string const (the shim's approach — right for a shell script full of format verbs, noisy for prose markdown); placing it in `cmd/rk/skill/` (would conflate two artifact families and invite the sync script to fight it).
+*Introduced by*: 260903-kqps-agent-setup-tutorial-invoker-skill
+
+#### Ownership marker as a YAML comment inside the frontmatter
+**Decision**: `# managed-by: rk agent-setup (run-kit-tutorial skill)` as a comment line inside the frontmatter block; recognition is whole-file `strings.Contains` (the `skillHasMarker` shape).
+**Why**: invisible to skill consumers (YAML comments are dropped by frontmatter parsers), follows `tmuxShimMarker`'s parenthesized-family pattern, frozen text once shipped.
+**Rejected**: a frontmatter *field* (unknown fields risk harness validation churn); an HTML comment in the body (works, but the frontmatter is the file's identity block and the legacy precedent put the marker there).
+*Introduced by*: 260903-kqps-agent-setup-tutorial-invoker-skill
+
+## Tasks
+
+### Phase 1: Setup
+
+- [x] T001 Create `app/backend/cmd/rk/agentskill/run-kit-tutorial.md` — full SKILL.md payload per R1 (frontmatter with name/description/marker comment; gate + route body) — and wire `//go:embed agentskill/run-kit-tutorial.md` plus the `tutorialSkillDir`/`tutorialSkillFile`/`tutorialSkillMarker` constants in `app/backend/cmd/rk/agent_setup.go` <!-- R1 -->
+
+### Phase 2: Core Implementation
+
+- [x] T002 Implement `installTutorialSkill` (install path: marker-less skip, byte-equal no-op, summary/diff + consent, MkdirAll 0755 + write 0644) and `removeTutorialSkill` (uninstall path: absent silent, marker-less skip, consent + `os.RemoveAll`) in `app/backend/cmd/rk/agent_setup.go`, wired into `applyAgentConfig` between `applyAgentHooks` and `removeLegacySkill`, gated on non-empty `skillsDir`, branching on `uninstall` <!-- R2 -->
+- [x] T003 Update `agent_setup.go` header comment (three artifact families; router-vs-content rationale), `agentConfig.skillsDir` doc comment (rescind removal note), and the `Long` help text (name the skill install) <!-- R4 -->
+
+### Phase 3: Integration & Edge Cases
+
+- [x] T004 Add `agent_setup_test.go` cases per R5 (fresh install, idempotent, stale replace, marker-less skip both modes, uninstall removal, absent silence, dry-run, payload-carries-marker guard); run `env -u TMUX -u TMUX_PANE go test ./cmd/rk/` <!-- R5 -->
+
+### Phase 4: Polish
+
+- [x] T005 Full-package verification: `env -u TMUX -u TMUX_PANE go test ./...` in `app/backend` and `go vet ./cmd/rk/` <!-- R5 -->
+
+## Acceptance
+
+### Functional Completeness
+
+- [x] A-001 R1: The embedded payload exists at `cmd/rk/agentskill/run-kit-tutorial.md` with frontmatter (name, triggering description forbidding the ONBOARDING.md detour, marker comment) and the gate-then-`rk skill tutorial` router body; no tour content duplicated
+- [x] A-002 R2: `rk agent setup` installs `{skillsDir}/run-kit-tutorial/SKILL.md` as an independent `applyAgentConfig` step following the full managed-artifact contract (marker-less skip, no-op detection, consent modes, replace-in-place)
+- [x] A-003 R3: `--uninstall` removes a marker-owned `run-kit-tutorial/` dir after consent; absent silent; marker-less untouched
+
+### Behavioral Correctness
+
+- [x] A-004 R2: `--dry-run` renders the full artifact diff and writes nothing (wins over `--yes`); non-TTY with neither flag refuses with `errNonInteractiveConsent` before any write
+
+### Scenario Coverage
+
+- [x] A-005 R5: Tests cover every R5 scenario and pass under `env -u TMUX -u TMUX_PANE`
+
+### Edge Cases & Error Handling
+
+- [x] A-006 R2: A zero-byte user file at the skill path is treated as user-owned (existence-aware read) and never overwritten
+
+### Code Quality
+
+- [x] A-007 Pattern consistency: the new step reuses `consent`/`authorizeWrite`, `readFileIfExists`, `renderArtifactDiff`, and the chatter/data channel routing — no parallel consent or diff machinery
+- [x] A-008 No unnecessary duplication: recognition and removal mirror the established helpers; no re-implementation of marker matching beyond a whole-file contains
+- [x] A-009 Comment discipline: updated comments state constraints (ownership, frozen marker, why-router), never narrate the change or cite the change ID
+
+### Security
+
+- [x] A-010 R2: All writes are Go file ops with fixed embedded content — nothing user-provided or machine-derived is interpolated into the payload or any shell string
+
+## Notes
+
+- Check items as you review: `- [x]`
+- All acceptance items must pass before `/fab-continue` (hydrate)
+- If an item is not applicable, mark checked and prefix with **N/A**: `- [x] A-NNN **N/A**: {reason}`
+
+## Deletion Candidates
+
+None — this change adds new functionality without making existing code redundant (`readSkill`/`skillHasMarker`/`removeLegacySkill` remain consumed by the legacy rk-display cleanup, which keeps its own one-release removal schedule).
+
+## Assumptions
+
+| # | Grade | Decision | Rationale | Scores |
+|---|-------|----------|-----------|--------|
+| 1 | Confident | Payload subdir named `cmd/rk/agentskill/` | Any name outside `skill/` works; this one states the family | S:60 R:85 A:75 D:60 |
+| 2 | Confident | Marker as YAML comment inside frontmatter | Invisible to consumers, matches legacy frontmatter placement; HTML comment equally viable | S:65 R:60 A:75 D:60 |
+| 3 | Confident | Step ordering: hooks → tutorial skill → legacy cleanup | Install-before-cleanup keeps the two skill flows adjacent; steps are independent so order is cosmetic | S:55 R:90 A:80 D:70 |
+| 4 | Confident | File modes 0755 dir / 0644 file | Skill content is not secret; matches startup-file/shim posture rather than settings.json's 0600 | S:60 R:85 A:85 D:75 |
+
+4 assumptions (0 certain, 4 confident, 0 tentative).


### PR DESCRIPTION
## Meta

| Change ID | Type | Confidence | Plan | Review |
|-----------|------|------------|------|--------|
| `kqps` | feat | 4.3/5.0 | 5/5 tasks, 10/10 acceptance ✓ | ✓ 1 cycle |

| Impact | +/− | Net |
|--------|----:|----:|
| raw | +850 / −49 | +801 |
| **true** | **+471 / −35** | **+436** |
| └ impl | +209 / −29 | +180 |
| └ tests | +262 / −6 | +256 |

<sub>excludes `fab/`, `docs/` · generated by fab-kit v2.23.13</sub>

**Pipeline:** [intake](https://github.com/sahil87/run-kit/blob/260903-kqps-agent-setup-tutorial-invoker-skill/fab/changes/260903-kqps-agent-setup-tutorial-invoker-skill/intake.md) ✓ → [apply](https://github.com/sahil87/run-kit/blob/260903-kqps-agent-setup-tutorial-invoker-skill/fab/changes/260903-kqps-agent-setup-tutorial-invoker-skill/plan.md) ✓ → review ✓ → hydrate ✓ → ship → review-pr
## Summary

The run-kit guided tour ships in the binary (`rk skill tutorial`) and has a human-typed entry (`rk tutorial`), but an agent already running in a run-kit pane had no discovery route — a tour request landed on improvisation or an `ONBOARDING.md` detour. `rk agent setup` now installs a third managed artifact: a thin invoker skill at `~/.claude/skills/run-kit-tutorial/SKILL.md` whose description triggers on tutorial/tour/onboarding phrasing and whose body gates on rk+`$TMUX_PANE`, then routes to `rk skill tutorial` — content stays binary-served, so tours track `brew upgrade rk` with no skill churn.

## Changes

- New tracked payload: the invoker skill source (`cmd/rk/agentskill/run-kit-tutorial.md`, embedded via go:embed)
- Installer: a third managed artifact family in `rk agent setup` (`installTutorialSkill`/`removeTutorialSkill`, full marker/consent contract, dir-level `--uninstall`)
- Generation stamping: frozen frontmatter marker for ownership, byte-compare against the embedded payload for staleness
- Housekeeping: header comment, `skillsDir` doc, `--help` text; 12 new test cases
