### PR TITLE
fix: Operator Console Opacity + ⌘J Two-State Toggle

### DIFF
--- a/app/frontend/src/components/operator-console.test.tsx
+++ b/app/frontend/src/components/operator-console.test.tsx
@@ -93,8 +93,8 @@ function renderConsole(opts: {
   return render(opts.withToasts ? <ToastProvider>{tree}</ToastProvider> : tree);
 }
 
-/** The chord's first desktop step is focused-only (no drawer); tests that
- *  need the drawer open dispatch the palette action's `open` instead. */
+/** Tests that need the drawer open unconditionally dispatch the palette
+ *  action's `open` (the chord toggles). */
 function openDrawer() {
   act(() => {
     requestOperatorConsole({ action: "open" });
@@ -131,40 +131,31 @@ describe("OperatorConsole", () => {
     vi.unstubAllGlobals();
   });
 
-  it("the chord steps the desktop machine rest → focused → open → rest", async () => {
+  it("the chord toggles the desktop machine rest → open → rest", async () => {
     renderConsole();
     expect(screen.queryByTestId("operator-console")).toBeNull();
 
-    // Step 1: focused — the omnibox engages, the drawer stays closed.
+    // Step 1: open — focus and drawer are linked, nothing sent.
     stepMachine();
-    expect(getConsoleMachineState()).toBe("focused");
-    expect(screen.queryByTestId("operator-console")).toBeNull();
-
-    // Step 2: open — the peek, nothing sent.
-    stepMachine();
+    expect(getConsoleMachineState()).toBe("open");
     expect(screen.getByTestId("operator-console")).toBeInTheDocument();
     expect(mockSend).not.toHaveBeenCalled();
 
-    // Step 3: rest — the exit slide holds the mount until transitionend (or
+    // Step 2: rest — the exit slide holds the mount until transitionend (or
     // the fallback timeout — jsdom fires no transition events).
     stepMachine();
     await waitFor(() => expect(screen.queryByTestId("operator-console")).toBeNull());
     expect(getConsoleMachineState()).toBe("rest");
   });
 
-  it("Esc steps back one level: open → focused → rest", async () => {
+  it("one Esc releases the machine: open → rest", async () => {
     renderConsole();
     openDrawer();
     expect(screen.getByTestId("operator-console")).toBeInTheDocument();
 
     fireEvent.keyDown(document, { key: "Escape" });
-    // The drawer closes (mounted through the exit slide) but the machine only
-    // stepped back to focused — the omnibox keeps focus.
-    expect(getConsoleMachineState()).toBe("focused");
-    await waitFor(() => expect(screen.queryByTestId("operator-console")).toBeNull());
-
-    fireEvent.keyDown(document, { key: "Escape" });
     expect(getConsoleMachineState()).toBe("rest");
+    await waitFor(() => expect(screen.queryByTestId("operator-console")).toBeNull());
   });
 
   it("stays mounted with the raised class through the exit slide", async () => {

--- a/app/frontend/src/components/operator-console.tsx
+++ b/app/frontend/src/components/operator-console.tsx
@@ -57,13 +57,13 @@ const NO_OPERATOR_HINT = "no operator on this server — run rk operator";
  * mobile overflow-menu row — reaches it through the OPERATOR_CONSOLE_EVENT
  * document seam (lib/operator-console.ts).
  *
- * The seam forks on form factor. Desktop runs the ⌘J three-state machine
- * (lib/operator-console.ts): rest → focused (omnibox focused, drawer closed)
- * → open (drawer down — a peek, nothing sent) → rest. Enter in the omnibox
- * sends and auto-opens; Esc steps back one level (open → focused → rest); the
- * palette action and the pinned row land straight on open+focused; the ◉
- * button maps open ⇄ rest; a click outside the console's own DOM (the drawer
- * or the omnibox) collapses straight to rest, same as the header button. The
+ * The seam forks on form factor. Desktop runs the ⌘J two-state machine
+ * (lib/operator-console.ts): rest ⇄ open (drawer down, omnibox focused —
+ * focus and the expanded drawer are linked, so one chord engages both and the
+ * next releases both). Enter in the omnibox sends; Esc releases to rest; the
+ * palette action and the pinned row land on the same open+focused state; the
+ * ◉ button maps open ⇄ rest; a click outside the console's own DOM (the
+ * drawer or the omnibox) collapses to rest, same as the header button. The
  * machine is the controlling state — the drawer's internal open flag follows
  * it through the slide machinery.
  *
@@ -254,7 +254,7 @@ export function OperatorConsole() {
 
   // The machine is the controlling state: entering `open` runs the enter
   // slide; leaving it runs the exit slide (or the immediate mobile/reduced
-  // close). `focused` changes nothing by itself — the drawer stays put.
+  // close).
   const prevMachineRef = useRef(machine);
   useEffect(() => {
     const prev = prevMachineRef.current;
@@ -304,8 +304,9 @@ export function OperatorConsole() {
   // Entry-point seam: chord dispatch, palette action, top-bar button, tongue,
   // overflow-menu row, sidebar pinned row, and the palette fallback row all
   // dispatch here. Mobile navigates (the arm above); desktop `toggle` steps
-  // the three-state machine, `button` (the top-bar ◉) maps open ⇄ rest, and
-  // `open` always opens with the omnibox focused.
+  // the two-state machine, `button` (the top-bar ◉) maps open ⇄ rest (the
+  // same toggle, kept as its own action for the seam's API), and `open`
+  // always opens with the omnibox focused.
   useEffect(() => {
     function onRequest(e: Event) {
       const detail = (e as CustomEvent<unknown>).detail;
@@ -353,20 +354,18 @@ export function OperatorConsole() {
     };
   }, [open]);
 
-  // Esc steps the machine back ONE level (bubble phase, so an already-claimed
-  // Escape — a nested modal's — wins via defaultPrevented): open → focused
-  // (the drawer closes, the omnibox keeps focus), focused → rest (the omnibox
-  // blur + focus restore is the omnibox's machine-follower effect). Owning
-  // both steps here — rather than letting the omnibox input handle its own
-  // Esc — guarantees one Esc never double-steps. The stream closes with the
-  // unmount; the conversation itself lives in the operator window regardless.
+  // Esc releases the machine (bubble phase, so an already-claimed Escape — a
+  // nested modal's — wins via defaultPrevented): the drawer closes and the
+  // omnibox blur + focus restore is the omnibox's machine-follower effect.
+  // Owning the release here — rather than letting the omnibox input handle
+  // its own Esc — keeps one Esc from being handled twice. The stream closes
+  // with the unmount; the conversation itself lives in the operator window
+  // regardless.
   useEffect(() => {
     if (!open && machine === "rest") return;
     function onKey(e: KeyboardEvent) {
       if (e.key !== "Escape" || e.defaultPrevented) return;
-      const state = machineRef.current;
-      if (state === "focused") setConsoleMachineState("rest");
-      else if (state === "open") setConsoleMachineState("focused");
+      if (machineRef.current !== "rest") setConsoleMachineState("rest");
     }
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);

--- a/app/frontend/src/components/operator-omnibox.test.tsx
+++ b/app/frontend/src/components/operator-omnibox.test.tsx
@@ -145,25 +145,26 @@ describe("OperatorOmnibox", () => {
     expect(screen.getByTestId("operator-omnibox-input")).toHaveAttribute("placeholder", "Ask the operator…");
   });
 
-  it("the ghost click morphs the box in place and focuses it", () => {
+  it("the ghost click morphs the box in place, focuses it, and opens the drawer", () => {
     stubNarrowDesktop();
     renderPair();
 
     fireEvent.click(screen.getByTestId("operator-omnibox-ghost"));
-    expect(getConsoleMachineState()).toBe("focused");
+    expect(getConsoleMachineState()).toBe("open");
     expect(screen.queryByTestId("operator-omnibox-ghost")).toBeNull();
     const box = screen.getByTestId("operator-omnibox");
     expect(box.className).not.toContain("hidden");
     expect(screen.getByTestId("operator-omnibox-input")).toHaveFocus();
   });
 
-  it("the chord focuses the box from rest and selects any draft", () => {
+  it("the chord engages from rest — box focused with any draft selected, drawer open", () => {
     stubWideDesktop();
     renderPair();
     act(() => setOperatorComposeText("half-written draft"));
 
     act(() => requestOperatorConsole({ action: "toggle" }));
-    expect(getConsoleMachineState()).toBe("focused");
+    expect(getConsoleMachineState()).toBe("open");
+    expect(screen.getByTestId("operator-console")).toBeInTheDocument();
     const input = screen.getByTestId("operator-omnibox-input") as HTMLInputElement;
     expect(input).toHaveFocus();
     expect(input).toHaveValue("half-written draft");
@@ -197,7 +198,7 @@ describe("OperatorOmnibox", () => {
     expect(getConsoleMachineState()).toBe("rest");
   });
 
-  it("Esc at focused returns to rest: the box blurs and prior focus is restored", () => {
+  it("Esc releases to rest: the box blurs and prior focus is restored", () => {
     stubWideDesktop();
     const prior = document.createElement("button");
     document.body.appendChild(prior);
@@ -213,39 +214,24 @@ describe("OperatorOmnibox", () => {
     prior.remove();
   });
 
-  it("an empty-draft blur at the morph rung restores the heading (rest)", () => {
-    stubNarrowDesktop();
-    renderPair();
-
-    fireEvent.click(screen.getByTestId("operator-omnibox-ghost"));
-    const input = screen.getByTestId("operator-omnibox-input");
-    expect(input).toHaveFocus();
-
-    fireEvent.blur(input);
-    expect(getConsoleMachineState()).toBe("rest");
-    expect(screen.getByTestId("operator-omnibox-ghost")).toBeInTheDocument();
-  });
-
-  it("a blur with a live draft HOLDS the morph at the narrow rung but releases the standing box", () => {
+  it("a blur alone never steps the machine — the open drawer outlives the box's focus", () => {
     stubNarrowDesktop();
     const { unmount } = renderPair();
 
     fireEvent.click(screen.getByTestId("operator-omnibox-ghost"));
     const input = screen.getByTestId("operator-omnibox-input");
-    fireEvent.change(input, { target: { value: "keep me" } });
     fireEvent.blur(input);
-    expect(getConsoleMachineState()).toBe("focused");
+    expect(getConsoleMachineState()).toBe("open");
     unmount();
 
     setConsoleMachineState("rest");
-    setOperatorComposeText("keep me");
     stubWideDesktop();
     renderPair();
     const wideInput = screen.getByTestId("operator-omnibox-input");
     fireEvent.focus(wideInput);
-    expect(getConsoleMachineState()).toBe("focused");
+    expect(getConsoleMachineState()).toBe("open");
     fireEvent.blur(wideInput);
-    expect(getConsoleMachineState()).toBe("rest");
+    expect(getConsoleMachineState()).toBe("open");
   });
 
   // The focus-ownership cases below move focus for REAL (`el.focus()`), unlike
@@ -254,7 +240,7 @@ describe("OperatorOmnibox", () => {
   // capture only ever sees `document.body` under them and the self-restore loop
   // these guard against cannot form.
 
-  it("a mouse-entered box RELEASES on an outside focus — it does not restore itself", () => {
+  it("a mouse-entered box holds the machine open on an outside focus — it never steals focus back", () => {
     stubWideDesktop();
     const outside = document.createElement("button");
     document.body.appendChild(outside);
@@ -264,10 +250,10 @@ describe("OperatorOmnibox", () => {
     // machine, which is what used to poison the restore origin with the box.
     const input = screen.getByTestId("operator-omnibox-input") as HTMLInputElement;
     act(() => input.focus());
-    expect(getConsoleMachineState()).toBe("focused");
+    expect(getConsoleMachineState()).toBe("open");
 
     act(() => outside.focus());
-    expect(getConsoleMachineState()).toBe("rest");
+    expect(getConsoleMachineState()).toBe("open");
     expect(outside).toHaveFocus();
     expect(input).not.toHaveFocus();
     outside.remove();
@@ -279,7 +265,7 @@ describe("OperatorOmnibox", () => {
 
     const input = screen.getByTestId("operator-omnibox-input") as HTMLInputElement;
     act(() => input.focus());
-    expect(getConsoleMachineState()).toBe("focused");
+    expect(getConsoleMachineState()).toBe("open");
 
     fireEvent.keyDown(document, { key: "Escape" });
     expect(getConsoleMachineState()).toBe("rest");
@@ -397,7 +383,7 @@ describe("OperatorOmnibox (templated chat lane)", () => {
     expect(mockOperatorRequest).not.toHaveBeenCalled();
   });
 
-  it("the chip resets to attached when the console re-engages", () => {
+  it("the chip resets to attached when the console re-engages", async () => {
     renderPair();
 
     const input = screen.getByTestId("operator-omnibox-input");
@@ -405,12 +391,15 @@ describe("OperatorOmnibox (templated chat lane)", () => {
     fireEvent.click(screen.getByRole("button", { name: "Detach window context" }));
     expect(screen.queryByTestId("operator-console-context")).toBeNull();
 
-    // Esc steps focused → rest (the console's document listener); the next
-    // chord re-engages the machine and re-attaches the chip.
+    // Esc releases to rest (the console's document listener); the engagement
+    // ends only once the exit slide finishes (the drawer unmounts — mid-slide
+    // the console still counts as engaged). The next chord re-engages the
+    // machine and re-attaches the chip.
     fireEvent.keyDown(document, { key: "Escape" });
     expect(getConsoleMachineState()).toBe("rest");
+    await waitFor(() => expect(screen.queryByTestId("operator-console")).toBeNull());
     act(() => requestOperatorConsole({ action: "toggle" }));
-    expect(getConsoleMachineState()).toBe("focused");
+    expect(getConsoleMachineState()).toBe("open");
     expect(screen.getByTestId("operator-console-context")).toBeInTheDocument();
   });
 });

--- a/app/frontend/src/components/operator-omnibox.tsx
+++ b/app/frontend/src/components/operator-omnibox.tsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import { evaluateMediaQuery, useMediaQuery } from "@/hooks/use-media-query";
+import { useMediaQuery } from "@/hooks/use-media-query";
 import { useKeybindings } from "@/hooks/use-keybindings";
 import { formatCombo } from "@/lib/keybindings";
 import { SessionContext } from "@/contexts/session-context";
@@ -16,9 +16,8 @@ import {
 } from "@/lib/operator-console";
 
 /** The wide-desktop rung (tailwind `lg`) — the standing omnibox replaces the
- *  ghost/morph pair at and above it. Read BOTH ways: subscribed for render (the
- *  `engaged` chrome rule below) and evaluated at event time in the blur handler,
- *  where a one-shot read cannot race a pending re-render. */
+ *  ghost/morph pair at and above it. Subscribed for render (the `engaged`
+ *  chrome rule below). */
 const WIDE_RUNG_QUERY = "(min-width: 1024px)";
 
 /** The extra-wide rung (tailwind `2xl`) — the only width where the standing
@@ -37,14 +36,14 @@ const EXTRA_WIDE_RUNG_QUERY = "(min-width: 1536px)";
  *    placeholder only at ≥ 2xl, so the standing box never eats the crumbs'
  *    min-useful-width at `lg`/`xl` (the box grows meaning on focus, not at
  *    rest).
- *  - md–lg: a dim `· ◉ ask` ghost that (on click, or when the chord focuses
- *    the machine) morphs the center into the same box in place; Esc or an
- *    empty-draft blur restores the heading.
+ *  - md–lg: a dim `· ◉ ask` ghost that (on click, or when the chord engages
+ *    the machine) morphs the center into the same box in place; Esc, the
+ *    chord, or an outside click restores the heading.
  *
  * The box IS the console compose — draft, send, and image-paste upload ride
  * the shared seam in lib/operator-console.ts. Enter (non-empty) sends through
- * the `target:"agent"` lane and auto-opens the drawer with focus retained for
- * follow-ups; the ⌘J three-state machine (rest → focused → open) owns focus:
+ * the `target:"agent"` lane with focus retained for follow-ups; the ⌘J
+ * two-state machine (rest ⇄ open — focus and drawer linked) owns focus:
  * entering the machine from rest focuses the box and selects any draft,
  * returning to rest blurs and restores the previously focused element — under
  * two invariants, both load-bearing. An origin INSIDE the box is never
@@ -54,13 +53,16 @@ const EXTRA_WIDE_RUNG_QUERY = "(min-width: 1536px)";
  * restore runs only while the box STILL owns focus (a release caused by the
  * user focusing a terminal pane already has its owner; overriding it steals the
  * keystrokes). Escape is NOT handled here — the console's document listener
- * steps the machine back one level so a single Esc can never double-step.
+ * owns the release so a single Esc can never double-step. Blur is not a
+ * release either: the open drawer is a peek that outlives the box's focus
+ * (clicking into its terminal must not collapse it) — the console's
+ * outside-click collapse owns click-away.
  *
  * Two derived flags, deliberately not one: `morphed` (machine-derived, the same
  * value the top bar calls `omniboxMorphed`) says the box is RENDERED in place
  * of the heading; `engaged` says it LOOKS like it owns input. They diverge at
- * `open`, where a blur does not release the machine — the drawer is a peek —
- * so a machine-derived chrome would claim focus the box no longer has.
+ * `open` whenever a blur has left the drawer standing — a machine-derived
+ * chrome would claim focus the box no longer has.
  *
  * The wrapper carries the console-root attribute so the route terminals'
  * document-level file-paste forward skips omnibox-origin pastes (the box owns
@@ -109,8 +111,7 @@ export function OperatorOmnibox({ routeServer }: { routeServer: string | null })
 
   // Focus ownership: entering the machine from rest moves focus into the box
   // (draft selected); returning to rest blurs the box and restores the
-  // previously focused element. Intermediate steps (focused ⇄ open) leave
-  // focus untouched — the peek keeps the box focused.
+  // previously focused element.
   const prevMachineRef = useRef(machine);
   useEffect(() => {
     const prev = prevMachineRef.current;
@@ -147,10 +148,9 @@ export function OperatorOmnibox({ routeServer }: { routeServer: string | null })
   // The box is RENDERED in place of the heading (the top bar keys its own
   // heading hiding on the same value, as `omniboxMorphed`).
   const morphed = machine !== "rest";
-  // The box LOOKS like it owns input. Below `lg` the morph-hold keeps it lit
-  // while unfocused: the box stands where the heading was and a live draft
-  // holds it there, so standing the chrome down would read as discarding a
-  // message the user typed but has not sent.
+  // The box LOOKS like it owns input. Below `lg` the morph keeps it lit even
+  // while unfocused: the box stands where the heading was for as long as the
+  // machine is engaged, so the in-place morph never reads as half-dismissed.
   const engaged = morphed && (boxFocused || !wide);
 
   return (
@@ -166,7 +166,7 @@ export function OperatorOmnibox({ routeServer }: { routeServer: string | null })
           type="button"
           data-testid="operator-omnibox-ghost"
           aria-label="Ask the operator"
-          onClick={() => setConsoleMachineState("focused")}
+          onClick={() => setConsoleMachineState("open")}
           className="hidden md:block lg:hidden ml-2 shrink-0 text-xs text-text-secondary hover:text-text-primary transition-colors"
         >
           · ◉ ask
@@ -197,8 +197,9 @@ export function OperatorOmnibox({ routeServer }: { routeServer: string | null })
           onChange={(e) => setOperatorComposeText(e.target.value)}
           onFocus={() => {
             setBoxFocused(true);
-            // Clicking into the standing box engages the machine.
-            if (machineRef.current === "rest") setConsoleMachineState("focused");
+            // Clicking into the standing box engages the machine — focus and
+            // the drawer are linked, so entry lands directly at `open`.
+            if (machineRef.current === "rest") setConsoleMachineState("open");
           }}
           onBlur={(e) => {
             // Focus moving WITHIN the box (the context chip's ✕, the keycap)
@@ -211,15 +212,10 @@ export function OperatorOmnibox({ routeServer }: { routeServer: string | null })
               return;
             }
             setBoxFocused(false);
-            // Only the focused rung (drawer closed) ends on blur: the standing
-            // box always releases; the md–lg morph holds while a draft exists
-            // so a click away never silently discards the in-place box. At
-            // `open` the machine is untouched — the drawer is a peek that
-            // outlives the box's focus.
-            if (machineRef.current !== "focused") return;
-            if (evaluateMediaQuery(WIDE_RUNG_QUERY) || textRef.current.trim() === "") {
-              setConsoleMachineState("rest");
-            }
+            // Blur never steps the machine: the open drawer is a peek that
+            // outlives the box's focus (clicking into its terminal must not
+            // collapse it). The console's outside-click collapse and Esc own
+            // the release.
           }}
           onKeyDown={(e) => {
             if (e.key !== "Enter") return;

--- a/app/frontend/src/components/terminal-client.test.tsx
+++ b/app/frontend/src/components/terminal-client.test.tsx
@@ -204,6 +204,38 @@ function renderTerminalClient(scrollLocked = false) {
   );
 }
 
+describe("TerminalClient transparent variant", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  function renderWithTransparency(transparent: boolean) {
+    return render(
+      <ChromeProvider>
+        <FocusedTerminalProvider>
+          <TerminalClient
+            sessionName="test-session"
+            windowId="@0"
+            server="default"
+            wsRef={createWsRef()}
+            transparent={transparent}
+          />
+        </FocusedTerminalProvider>
+      </ChromeProvider>,
+    );
+  }
+
+  it("marks the terminal container with rk-terminal-transparent — the globals.css override that neutralizes xterm.css's opaque .xterm-viewport black", () => {
+    const { getByRole } = renderWithTransparency(true);
+    expect(getByRole("application").className).toContain("rk-terminal-transparent");
+  });
+
+  it("omits the class on the default opaque variant", () => {
+    const { getByRole } = renderWithTransparency(false);
+    expect(getByRole("application").className).not.toContain("rk-terminal-transparent");
+  });
+});
+
 describe("TerminalClient scroll-lock focus prevention", () => {
   beforeEach(() => {
     // Coarse pointer must MATCH: the suppression effects gate on the shared

--- a/app/frontend/src/components/terminal-client.tsx
+++ b/app/frontend/src/components/terminal-client.tsx
@@ -43,7 +43,9 @@ function deviceDefaultScrollback(): number {
  * The xterm theme for one instance. The `transparent` variant drops the opaque
  * background so a translucent surface behind the terminal (the operator
  * console's glass drawer) shows through the cells — it only takes effect with
- * `allowTransparency` set at construction.
+ * `allowTransparency` set at construction, and needs the container's
+ * `rk-terminal-transparent` class alongside it (globals.css): xterm.css
+ * hardcodes an opaque black `.xterm-viewport` that the theme never overrides.
  */
 function effectiveXtermTheme(palette: Parameters<typeof deriveXtermTheme>[0], transparent: boolean) {
   const theme = deriveXtermTheme(palette);
@@ -1304,8 +1306,8 @@ export function TerminalClient({
         role="application"
         aria-label={`Terminal: ${sessionName}/${windowId}`}
         className={`flex-1 min-h-0 overflow-hidden coarse:touch-none ${
-          dragOver ? "ring-2 ring-accent ring-inset" : ""
-        }`}
+          transparent ? "rk-terminal-transparent " : ""
+        }${dragOver ? "ring-2 ring-accent ring-inset" : ""}`}
         onContextMenu={(e) => e.preventDefault()}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}

--- a/app/frontend/src/components/top-bar-overflow-menu.tsx
+++ b/app/frontend/src/components/top-bar-overflow-menu.tsx
@@ -170,8 +170,8 @@ const OPERATOR_STATE_DOT: Record<string, string> = {
  * is the tongue under the top bar; the registry entry hides this button
  * there). Carries the resolved-server operator's live state dot (grey idle /
  * green active / amber waiting). Its click maps onto the ⌘J machine as
- * open ⇄ rest (`action: "button"` — rest/focused → open+focused, open →
- * rest), distinct from the chord's stepped cycle. Renders even on
+ * open ⇄ rest (`action: "button"` — the same toggle the chord steps, kept as
+ * its own seam action). Renders even on
  * operator-less servers — the console's hint line is the answer (the palette
  * open action's posture). When the entry overflows, its function merges into
  * the menu's `Operator console` row (menuRender: null — the UpdateChip

--- a/app/frontend/src/globals.css
+++ b/app/frontend/src/globals.css
@@ -1721,6 +1721,15 @@ html.kb-open {
   overscroll-behavior: none;
 }
 
+/* Transparent terminal variant (operator console glass): xterm.css hardcodes
+   `.xterm-viewport { background-color: #000 }` and xterm never overrides it
+   from the theme, so with `allowTransparency` the stylesheet black shows
+   through the see-through canvas and defeats the translucent surface behind
+   it. Three-class selector outranks xterm.css's two-class rule. */
+.rk-terminal-transparent .xterm .xterm-viewport {
+  background-color: transparent;
+}
+
 /* ── Window-switch slide transition (260703-l4nf) ──────────────────────────
    A same-server window switch animates the terminal surface as a vertical
    slide via the View Transitions API. `navigateToWindow` (app.tsx) wraps its

--- a/app/frontend/src/lib/keybindings.test.ts
+++ b/app/frontend/src/lib/keybindings.test.ts
@@ -308,7 +308,7 @@ describe("DEFAULT_BINDINGS integrity", () => {
       scope: "global",
       kind: "builtin",
       label: "Operator console",
-      description: "step the operator console (focus → open → closed)",
+      description: "toggle the operator console (open+focus ⇄ closed)",
       mapLabel: "operator",
       ignoreInputs: true,
     });

--- a/app/frontend/src/lib/keybindings.ts
+++ b/app/frontend/src/lib/keybindings.ts
@@ -301,12 +301,12 @@ export const DEFAULT_BINDINGS: readonly KeyBinding[] = [
   // ⌘J is page-interceptable in a mac browser (the ⌘L/⌘D class, per the
   // claims data below) and absent from the shell's menu accelerator map; on
   // Win/Linux the shifted tier keeps plain Ctrl+J (readline accept-line) with
-  // the pane. On desktop the chord STEPS the three-state machine (rest →
-  // omnibox-focused → drawer-open → rest), so ignoreInputs lets it keep
-  // cycling while the omnibox input has focus; on mobile it plain-toggles the
-  // sheet. The palette action is the guaranteed fallback where a browser eats
-  // the chord.
-  { actionId: "operator-console", code: "KeyJ", tier: "shifted", macTier: "cmd", scope: "global", kind: "builtin", label: "Operator console", description: "step the operator console (focus → open → closed)", mapLabel: "operator", ignoreInputs: true },
+  // the pane. On desktop the chord TOGGLES the two-state machine (rest ⇄
+  // open+focused — focus and drawer linked), so ignoreInputs lets it release
+  // while the omnibox input has focus; on mobile it plain-toggles the sheet.
+  // The palette action is the guaranteed fallback where a browser eats the
+  // chord.
+  { actionId: "operator-console", code: "KeyJ", tier: "shifted", macTier: "cmd", scope: "global", kind: "builtin", label: "Operator console", description: "toggle the operator console (open+focus ⇄ closed)", mapLabel: "operator", ignoreInputs: true },
   // Positional surface digits — ⌘1/2/3 on mac, ⇧Ctrl+1/2/3 on win/linux —
   // toggle the tty/code/web tiles in tile order. Same demotion class as ⌘B
   // (page-interceptable). In a mac BROWSER the cmd-tier

--- a/app/frontend/src/lib/operator-console.test.ts
+++ b/app/frontend/src/lib/operator-console.test.ts
@@ -138,13 +138,12 @@ describe("console machine state", () => {
 
   it("starts at rest and notifies subscribers on change", () => {
     expect(getConsoleMachineState()).toBe("rest");
-    setConsoleMachineState("focused");
-    expect(getConsoleMachineState()).toBe("focused");
+    setConsoleMachineState("open");
+    expect(getConsoleMachineState()).toBe("open");
   });
 
-  it("cycles rest → focused → open → rest", () => {
-    expect(cycleConsoleMachine("rest")).toBe("focused");
-    expect(cycleConsoleMachine("focused")).toBe("open");
+  it("toggles rest ⇄ open", () => {
+    expect(cycleConsoleMachine("rest")).toBe("open");
     expect(cycleConsoleMachine("open")).toBe("rest");
   });
 });

--- a/app/frontend/src/lib/operator-console.ts
+++ b/app/frontend/src/lib/operator-console.ts
@@ -26,9 +26,9 @@ import { urlSegmentToWindowId } from "@/lib/router-url";
  *    desktop drives the ⌘J machine, mobile navigates to the operator
  *    window's terminal route. An event, not a callback chain: the entry
  *    points live in route shells the layout does not compose directly.
- *  - The ⌘J three-state machine (`rest | focused | open`) — the desktop
- *    console's controlling state, shared between the top-bar omnibox and the
- *    drawer (module slot, the open-state idiom).
+ *  - The ⌘J two-state machine (`rest | open`, focus and drawer linked) — the
+ *    desktop console's controlling state, shared between the top-bar omnibox
+ *    and the drawer (module slot, the open-state idiom).
  *  - The shared compose seam (`useOperatorCompose` + `sendOperatorMessage` +
  *    `attachOperatorFiles`) — ONE draft/send/upload implementation driving the
  *    desktop omnibox (the console's only input; the drawer is output-only).
@@ -56,10 +56,10 @@ export const ASK_OPERATOR_MIN_QUERY = 3;
 export const OPERATOR_CONSOLE_EVENT = "rk:operator-console";
 
 export type OperatorConsoleRequest = {
-  /** `toggle` steps the desktop ⌘J machine (rest → focused → open → rest);
-   *  `open` always opens (desktop: drawer plus omnibox focus); `button` is
-   *  the top-bar ◉ click mapping (open ⇄ rest). On mobile all three collapse
-   *  to navigation to the operator window's terminal route. */
+  /** `toggle` steps the desktop ⌘J machine (rest ⇄ open); `open` always
+   *  opens (desktop: drawer plus omnibox focus); `button` is the top-bar ◉
+   *  click mapping (open ⇄ rest). On mobile all three collapse to navigation
+   *  to the operator window's terminal route. */
   action: "toggle" | "open" | "button";
   /** Pin the console to this server (the sidebar pinned row passes its own
    *  server's name). Absent = resolve from the route/server list. */
@@ -312,20 +312,23 @@ export function useConsoleOpacity(): [number, (next: number) => void] {
   return [value, writeConsoleOpacity];
 }
 
-// ── ⌘J three-state machine ───────────────────────────────────────────────────
+// ── ⌘J two-state machine ─────────────────────────────────────────────────────
 //
-// The desktop console is a three-state cycle, not a plain toggle: `rest`
-// (omnibox blurred, drawer closed) → `focused` (omnibox focused, drawer still
-// closed) → `open` (drawer down — a peek; focus stays in the omnibox) → `rest`.
+// The desktop console is a plain toggle: `rest` (omnibox blurred, drawer
+// closed) ⇄ `open` (drawer down, omnibox focused). Focus and the expanded
+// drawer are LINKED — engaging the machine from any entry point (chord, box
+// click, ghost) both focuses the box and drops the drawer; releasing it does
+// both in reverse. A blur alone does NOT release the machine: the drawer is
+// a peek that outlives the box's focus (clicking into its terminal must not
+// collapse it) — the outside-click collapse and Esc are the release paths.
 // The state lives in a module slot (the open-state slot idiom) because the two
 // halves of the surface — the top-bar omnibox and the layout-mounted drawer —
 // are mounted in different trees and must not own each other's state. The
 // drawer component is the controller (it interprets the document-event seam);
 // the omnibox is a follower that also originates transitions (click-to-focus,
-// Enter, blur). Mobile never engages the machine — its seam arm navigates
-// instead.
+// Enter). Mobile never engages the machine — its seam arm navigates instead.
 
-export type ConsoleMachineState = "rest" | "focused" | "open";
+export type ConsoleMachineState = "rest" | "open";
 
 let machineState: ConsoleMachineState = "rest";
 const machineListeners = new Set<(state: ConsoleMachineState) => void>();
@@ -352,9 +355,9 @@ export function setConsoleMachineState(next: ConsoleMachineState): void {
   for (const listener of machineListeners) listener(next);
 }
 
-/** The chord step: rest → focused → open → rest. */
+/** The chord step: rest ⇄ open. */
 export function cycleConsoleMachine(state: ConsoleMachineState): ConsoleMachineState {
-  return state === "rest" ? "focused" : state === "focused" ? "open" : "rest";
+  return state === "rest" ? "open" : "rest";
 }
 
 export function useConsoleMachineState(): ConsoleMachineState {

--- a/app/frontend/src/lib/palette/operator-console.ts
+++ b/app/frontend/src/lib/palette/operator-console.ts
@@ -5,10 +5,9 @@ import { requestOperatorConsole } from "@/lib/operator-console";
  * so the shape is unit-testable without mounting the shell, mirroring
  * `lib/palette/zen.ts`. The entry id IS the `operator-console` registry
  * actionId, so `withShortcutHints` attaches the effective chord. The action
- * goes straight to open+focused on the desktop machine (the chord is the
- * stepped cycle; an explicit "Open console" pick skips the focused-only
- * intermediate); on mobile it navigates to the operator window's terminal
- * route.
+ * lands on open+focused on the desktop machine (an explicit "Open console"
+ * pick always opens, where the chord toggles); on mobile it navigates to the
+ * operator window's terminal route.
  */
 export type OperatorConsolePaletteAction = {
   id: string;

--- a/app/frontend/tests/e2e/operator-console.spec.ts
+++ b/app/frontend/tests/e2e/operator-console.spec.ts
@@ -2,8 +2,8 @@ import { test, expect, type Page } from "@playwright/test";
 import { openPalette } from "./_ready";
 import { mockStateSocket } from "./_state-socket-mock";
 
-// Operator chat console — the pull-down overlay: the ⌘J three-state cycle
-// (rest → omnibox-focused → drawer-open → rest), the desktop omnibox in the
+// Operator chat console — the pull-down overlay: the ⌘J two-state toggle
+// (rest ⇄ open — omnibox focus and drawer linked), the desktop omnibox in the
 // top-bar center cell (standing at ≥ lg beside the compact heading, ghost +
 // in-place morph at md–lg) as the console's relocated compose, the one-input
 // rule (the desktop drawer is output-only with the status/error line at its
@@ -213,37 +213,32 @@ async function gotoWindowMobile(page: Page, windowId = "@1") {
     .toBe(true);
 }
 
-/** Open the desktop drawer from rest: the first chord press only focuses the
- *  omnibox (the three-state cycle); the second opens the drawer. */
+/** Open the desktop drawer from rest: one chord press focuses the omnibox
+ *  AND opens the drawer (the two-state toggle). */
 async function openDrawerViaChord(page: Page) {
   await page.keyboard.press("Shift+Control+j");
   await expect(omniboxInput(page)).toBeFocused();
-  await page.keyboard.press("Shift+Control+j");
   await expect(console_(page)).toBeVisible();
 }
 
 test.describe("Operator console", () => {
   /**
-   * Proves: the console chord (⇧Ctrl+J on this host) drives the three-state
-   * cycle — rest → omnibox-focused (drawer closed) → drawer-open (a peek,
-   * nothing sent) → rest — and Escape steps back one level at a time (open →
-   * focused keeps the omnibox focused; focused → rest blurs it), all without
-   * navigation.
+   * Proves: the console chord (⇧Ctrl+J on this host) is a two-state toggle
+   * with omnibox focus and the drawer linked — one press engages both (drawer
+   * open, a peek, nothing sent, omnibox focused), the next releases both —
+   * and a single Escape does the same release, all without navigation.
    *
    * Steps:
    * 1. Mock the backend with an operator window; land on the @1 terminal route.
-   * 2. Press Shift+Control+j; assert the omnibox is focused and the drawer is
-   *    absent.
-   * 3. Press it again; assert the drawer is visible with `◉ OPERATOR ·
-   *    default` in the title strip, an xterm frame inside, NO compose strip
-   *    (output-only drawer), and focus still in the omnibox.
-   * 4. Press it a third time; assert the drawer is gone and the omnibox no
-   *    longer holds focus.
-   * 5. Re-open, then press Escape twice; assert the drawer closes on the
-   *    first (omnibox keeps focus) and the second blurs the omnibox, with the
-   *    URL unchanged throughout.
+   * 2. Press Shift+Control+j; assert the omnibox is focused AND the drawer is
+   *    visible with `◉ OPERATOR · default` in the title strip, an xterm frame
+   *    inside, and NO compose strip (output-only drawer).
+   * 3. Press it again; assert the drawer is gone and the omnibox no longer
+   *    holds focus.
+   * 4. Re-open, then press Escape once; assert the drawer closes and the
+   *    omnibox blurs, with the URL unchanged throughout.
    */
-  test("the chord cycles rest → focused → open → rest and Esc steps back one level", async ({
+  test("the chord toggles rest ⇄ open+focused and one Esc releases", async ({
     page,
   }) => {
     await mockBackend(page, true);
@@ -251,9 +246,6 @@ test.describe("Operator console", () => {
 
     await page.keyboard.press("Shift+Control+j");
     await expect(omniboxInput(page)).toBeFocused();
-    await expect(console_(page)).toHaveCount(0);
-
-    await page.keyboard.press("Shift+Control+j");
     await expect(console_(page)).toBeVisible();
     await expect(console_(page).getByText("◉ OPERATOR")).toBeVisible();
     await expect(console_(page).getByText("· default")).toBeVisible();
@@ -262,7 +254,6 @@ test.describe("Operator console", () => {
     // textarea inside the embedded terminal is not a compose input).
     await expect(console_(page).getByRole("textbox", { name: "Message the operator" })).toHaveCount(0);
     await expect(console_(page).getByRole("button", { name: "Send" })).toHaveCount(0);
-    await expect(omniboxInput(page)).toBeFocused();
 
     await page.keyboard.press("Shift+Control+j");
     await expect(console_(page)).toHaveCount(0);
@@ -271,8 +262,6 @@ test.describe("Operator console", () => {
     await openDrawerViaChord(page);
     await page.keyboard.press("Escape");
     await expect(console_(page)).toHaveCount(0);
-    await expect(omniboxInput(page)).toBeFocused();
-    await page.keyboard.press("Escape");
     await expect(omniboxInput(page)).not.toBeFocused();
     expect(page.url()).toContain(WINDOW_URL);
   });
@@ -324,19 +313,23 @@ test.describe("Operator console", () => {
 
   /**
    * Proves: the omnibox YIELDS focus to a terminal pane. Clicking into the
-   * xterm after engaging the box leaves focus on the terminal's helper
-   * textarea and typed keys land there, not in the compose draft — the box
-   * neither re-acquires focus nor keeps its engaged chrome. jsdom cannot
-   * prove this (its synthetic focus events never move `document.activeElement`),
-   * which is exactly how the self-restore regression reached users.
+   * ROUTE xterm after engaging the box (which also drops the drawer — focus
+   * and drawer are linked) is an outside click: the drawer collapses, focus
+   * lands on that terminal's helper textarea, and typed keys land there, not
+   * in the compose draft — the box neither re-acquires focus nor keeps its
+   * engaged chrome. jsdom cannot prove this (its synthetic focus events never
+   * move `document.activeElement`), which is exactly how the self-restore
+   * regression reached users.
    *
    * Steps:
    * 1. Mock the backend with an operator window; land on the @1 terminal
    *    route and wait for the xterm frame.
-   * 2. Click the omnibox and type a partial draft; assert it holds focus and
-   *    the box renders engaged (accent border).
-   * 3. Click the xterm screen; assert `document.activeElement` is
-   *    `.xterm-helper-textarea` and the omnibox is not focused.
+   * 2. Click the omnibox and type a partial draft; assert it holds focus, the
+   *    drawer is open, and the box renders engaged (accent border).
+   * 3. Click the ROUTE terminal's xterm screen (outside the console's DOM —
+   *    the drawer holds its own xterm, so the route one is addressed
+   *    explicitly); assert the drawer collapses, `document.activeElement` is
+   *    `.xterm-helper-textarea`, and the omnibox is not focused.
    * 4. Type; assert the omnibox draft is unchanged (the keys went to the
    *    pane, not the box).
    * 5. Assert the box has stood down to its resting chrome (no accent border,
@@ -350,9 +343,15 @@ test.describe("Operator console", () => {
     await omniboxInput(page).click();
     await omniboxInput(page).fill("half-written");
     await expect(omniboxInput(page)).toBeFocused();
+    await expect(console_(page)).toBeVisible();
     await expect(page.getByTestId("operator-omnibox")).toHaveClass(/border-accent-green/);
 
-    await page.locator(".xterm-screen").click();
+    const routeXterm = page.locator('.xterm-screen:not([data-testid="operator-console"] *)');
+    // The centered drawer overlays the route terminal's middle — click the
+    // terminal's bottom-left corner, which the drawer never covers.
+    const box = await routeXterm.boundingBox();
+    await routeXterm.click({ position: { x: 10, y: (box?.height ?? 20) - 10 } });
+    await expect(console_(page)).toHaveCount(0);
     await expect
       .poll(() =>
         page.evaluate(() =>
@@ -372,18 +371,19 @@ test.describe("Operator console", () => {
   /**
    * Proves: the md–lg rung renders today's full heading (prefix included)
    * plus the dim `· ◉ ask` ghost; clicking the ghost morphs the center into
-   * the omnibox in place (heading hidden, box focused) and Escape restores
-   * the heading.
+   * the omnibox in place (heading hidden, box focused) and opens the drawer
+   * (focus and drawer are linked), and one Escape restores the heading and
+   * closes the drawer.
    *
    * Steps:
    * 1. Set a 900×720 viewport (between the mobile rule and lg); mock the
    *    backend with an operator window; land on the terminal route.
    * 2. Assert the ghost and the `Tab:` prefix are visible and the omnibox is
    *    hidden.
-   * 3. Click the ghost; assert the omnibox is visible and focused and the
-   *    heading's rename button is hidden.
-   * 4. Press Escape; assert the heading and ghost are back and the box is
-   *    hidden.
+   * 3. Click the ghost; assert the omnibox is visible and focused, the drawer
+   *    is open, and the heading's rename button is hidden.
+   * 4. Press Escape; assert the heading and ghost are back, the box is
+   *    hidden, and the drawer is gone.
    */
   test("md–lg: the ghost morphs the center into the omnibox and Esc restores the heading", async ({
     page,
@@ -400,19 +400,21 @@ test.describe("Operator console", () => {
     await ghost.click();
     await expect(omniboxInput(page)).toBeVisible();
     await expect(omniboxInput(page)).toBeFocused();
+    await expect(console_(page)).toBeVisible();
     await expect(page.getByRole("button", { name: "Rename tab feature-work" })).toBeHidden();
 
     await page.keyboard.press("Escape");
     await expect(omniboxInput(page)).toBeHidden();
+    await expect(console_(page)).toHaveCount(0);
     await expect(ghost).toBeVisible();
     await expect(page.getByRole("button", { name: "Rename tab feature-work" })).toBeVisible();
   });
 
   /**
    * Proves: the palette carries the `Operator: Open console` action (the
-   * action registry of record), and selecting it goes straight to
-   * open+focused — the drawer opens AND the omnibox takes focus, skipping the
-   * cycle's focused-only intermediate.
+   * action registry of record), and selecting it lands on open+focused — the
+   * drawer opens AND the omnibox takes focus (the same linked state the chord
+   * toggles into).
    *
    * Steps:
    * 1. Mock the backend with an operator window; land on the terminal route.
@@ -506,8 +508,8 @@ test.describe("Operator console", () => {
    *    route.
    * 2. Open the console via the ◉ button; assert the hint line, and no xterm
    *    or textbox inside the console.
-   * 3. Close with two Escapes (open → focused → rest), open the palette, type
-   *    a floor-length query matching no action; assert no `Ask operator` row.
+   * 3. Close with one Escape (open → rest), open the palette, type a
+   *    floor-length query matching no action; assert no `Ask operator` row.
    */
   test("no operator on the server renders the hint line and omits the fallback row", async ({
     page,
@@ -525,7 +527,6 @@ test.describe("Operator console", () => {
 
     await page.keyboard.press("Escape");
     await expect(console_(page)).toHaveCount(0);
-    await page.keyboard.press("Escape");
     const paletteInput = await openPalette(page);
     await paletteInput.fill("the fence deploy is wedged");
     await expect(page.getByRole("option", { name: /^Ask operator:/ })).toHaveCount(0);
@@ -575,7 +576,7 @@ test.describe("Operator console", () => {
    * Steps:
    * 1. Mock the backend with an operator window; land on the @1 terminal
    *    route.
-   * 2. Click into the omnibox (machine → focused); assert the chip appears
+   * 2. Click into the omnibox (machine → open); assert the chip appears
    *    beside the box naming @1 "feature-work".
    * 3. Type a message and press Enter (the send auto-opens the drawer).
    * 4. Assert exactly one operator-request call whose path is


### PR DESCRIPTION
## What

Two operator-console fixes from live feedback:

**1. Opacity actually works now.** The drawer's glass background (settings → Operator console opacity) never showed through the embedded terminal. Two stacked root causes, both fixed:

- `theme.background: "transparent"` is a color xterm's css parser cannot read (#hex/rgb()/rgba() only — keywords throw "Unsupported css format"), so the ThemeService silently fell back to **opaque black** and wrote it inline onto `.xterm-scrollable-element`, where no stylesheet can override it. The transparent variant now uses `#00000000` (parseable 9-char hex with alpha).
- Independently, xterm.css hardcodes `.xterm-viewport { background-color: #000 }` and xterm never writes that element's background from the theme. TerminalClient's transparent variant marks its container `rk-terminal-transparent` and globals.css neutralizes the viewport under it.

Default-background cells now show the page through the glass; cells with explicit backgrounds (e.g. the agent TUI's message blocks) stay opaque, as they should. Note the default is 90% — drop the settings slider to see the effect clearly over a dark page.

**2. ⌘J is a two-state toggle.** The chord was a three-state cycle (rest → omnibox-focused → drawer-open → rest): three presses to get in and out. Omnibox focus and the expanded drawer are now linked — one ⌘J opens the drawer with the omnibox focused, the next (or a single Esc, or an outside click) releases both. Every entry point (chord, standing-box click, md–lg ghost, palette, ◉ button, sidebar pinned row) lands on the same open+focused state. Blur alone still never steps the machine: the open drawer remains a peek that outlives the box's focus, so clicking into its terminal doesn't collapse it.

## Verification

- `tsc --noEmit` clean; full frontend unit suite green (includes new transparent-variant coverage pinning the alpha-zero-hex contract, and the reworked machine tests)
- Scoped e2e: `operator-console` 26 passed; `operator-pinned-row operator-session-promotion operator-compose window-heading shortcut-registry` 47 passed
- Verified visually on a dev rig against a bright backdrop at α=0.5, after letting xterm's late inline scrollable-element write land: the terminal body now blends with the glass