### PR TITLE
fix: Transparent xterm Theme Must Be Alpha-Zero Hex

### DIFF
--- a/app/frontend/src/components/terminal-client.test.tsx
+++ b/app/frontend/src/components/terminal-client.test.tsx
@@ -230,6 +230,16 @@ describe("TerminalClient transparent variant", () => {
     expect(getByRole("application").className).toContain("rk-terminal-transparent");
   });
 
+  it("constructs xterm with allowTransparency and an alpha-zero HEX background — the `transparent` keyword is unparseable to xterm and falls back to opaque black", async () => {
+    renderWithTransparency(true);
+    await waitFor(() => expect(vi.mocked(Terminal)).toHaveBeenCalled());
+    const opts = vi.mocked(Terminal).mock.calls.at(-1)![0]!;
+    expect(opts.allowTransparency).toBe(true);
+    expect(opts.theme?.background).toBe("#00000000");
+    // Never the keyword: xterm's css parser accepts only #hex/rgb()/rgba().
+    expect(opts.theme?.background).not.toBe("transparent");
+  });
+
   it("omits the class on the default opaque variant", () => {
     const { getByRole } = renderWithTransparency(false);
     expect(getByRole("application").className).not.toContain("rk-terminal-transparent");

--- a/app/frontend/src/components/terminal-client.tsx
+++ b/app/frontend/src/components/terminal-client.tsx
@@ -46,10 +46,19 @@ function deviceDefaultScrollback(): number {
  * `allowTransparency` set at construction, and needs the container's
  * `rk-terminal-transparent` class alongside it (globals.css): xterm.css
  * hardcodes an opaque black `.xterm-viewport` that the theme never overrides.
+ *
+ * The value MUST be alpha-zero HEX, never the `transparent` keyword: xterm's
+ * color parser accepts only #hex/rgb()/rgba() forms and throws "Unsupported
+ * css format" on keywords — the ThemeService swallows the throw and falls
+ * back to OPAQUE BLACK, which it also writes inline onto
+ * `.xterm-scrollable-element` (an inline style no stylesheet override can
+ * reach), so the keyword silently defeats the whole variant.
  */
+export const TRANSPARENT_XTERM_BG = "#00000000";
+
 function effectiveXtermTheme(palette: Parameters<typeof deriveXtermTheme>[0], transparent: boolean) {
   const theme = deriveXtermTheme(palette);
-  return transparent ? { ...theme, background: "transparent" } : theme;
+  return transparent ? { ...theme, background: TRANSPARENT_XTERM_BG } : theme;
 }
 
 /**


### PR DESCRIPTION
## What

Completes the operator-console opacity fix from #866 — this commit was pushed to that PR's branch but the merge snapshot predated it, stranding it (recovered via cherry-pick).

#866's CSS override handled the stylesheet layer (`.xterm-viewport`'s hardcoded #000), but the drawer still rendered opaque: `theme.background: "transparent"` is a color xterm's css parser cannot read (#hex/rgb()/rgba() only — keywords throw "Unsupported css format"), so the ThemeService silently fell back to opaque black and wrote it **inline** onto `.xterm-scrollable-element`, where no stylesheet override can reach. That inline write lands a few seconds after mount, which is why the first fix looked verified in early screenshots.

The transparent variant now uses `#00000000` (parseable 9-char hex with alpha, exported as `TRANSPARENT_XTERM_BG`), so the inline write and every other theme-background consumer carry true transparency. The `rk-terminal-transparent` viewport override from #866 stays — xterm never writes the viewport's background from the theme.

## Verification

- terminal-client unit suite 47/47, including a new test pinning the alpha-zero-hex contract (a revert to the keyword fails loudly); `tsc --noEmit` clean
- Verified visually on the dev rig against a bright backdrop at α=0.5, after a 6s settle so xterm's late inline scrollable-element write lands: `.xterm-scrollable-element` inline style now reads `rgba(0, 0, 0, 0)` and the terminal body blends with the glass