### PR TITLE
fix: Pin web tile address bar and find bar rows to the tile header height

### DIFF
--- a/app/frontend/src/components/find-bar.tsx
+++ b/app/frontend/src/components/find-bar.tsx
@@ -66,7 +66,7 @@ export function FindBar({
 
   return (
     <div
-      className="flex items-center gap-1.5 px-2 py-1 border-b border-border bg-bg-primary shrink-0"
+      className="flex items-center gap-1.5 px-2 h-[35px] border-b border-border bg-bg-primary shrink-0"
       data-testid={testId}
     >
       <input
@@ -76,7 +76,7 @@ export function FindBar({
         onChange={(e) => onQueryChange(e.target.value)}
         onKeyDown={handleKeyDown}
         disabled={disabled}
-        className={`w-60 max-w-[40%] shrink bg-bg-card text-text-primary text-sm px-2 py-1 rounded border border-border ${INPUT_FOCUS} disabled:opacity-40`}
+        className={`w-60 max-w-[40%] shrink bg-bg-card text-text-primary text-sm px-2 h-[28px] py-0 rounded border border-border ${INPUT_FOCUS} disabled:opacity-40`}
         aria-label="Find query"
         placeholder={placeholder}
         spellCheck={false}

--- a/app/frontend/src/components/iframe-window.tsx
+++ b/app/frontend/src/components/iframe-window.tsx
@@ -1453,7 +1453,7 @@ export function IframeWindow({
           terminal button was removed, 260819-v6y4 R13 — the top-bar surface
           toggles own view switching). */}
       <TipGroup>
-      <div className="flex items-center gap-1.5 px-2 py-1 border-b border-border bg-bg-primary shrink-0">
+      <div className="flex items-center gap-1.5 px-2 h-[35px] border-b border-border bg-bg-primary shrink-0">
         {!onboarding && !crossOrigin && (
           <>
             <Tip label="Back">
@@ -1511,7 +1511,7 @@ export function IframeWindow({
             setInputUrl(rawAddress);
           }}
           onKeyDown={handleKeyDown}
-          className={`flex-1 min-w-0 bg-bg-card text-text-primary text-sm px-2 py-1 rounded border border-border ${INPUT_FOCUS}`}
+          className={`flex-1 min-w-0 bg-bg-card text-text-primary text-sm px-2 h-[28px] py-0 rounded border border-border ${INPUT_FOCUS}`}
           aria-label="URL"
           aria-invalid={submitError !== null}
           spellCheck={false}


### PR DESCRIPTION
## Summary

The web tile's address bar row and the shared find bar derived their height from a `text-sm` input with its own `py-1` inside a `py-1` row, landing at 39px: taller than the 35px tile header above and out of step with the 28px nav, search, and zoom buttons beside it. Both rows are now pinned to 35px and both inputs to 28px, so the input sits flush with the buttons and the row matches the header. The tab strip stays content-sized.

## Changes

- `iframe-window.tsx`: address bar row `py-1` → `h-[35px]`; URL input `py-1` → `h-[28px] py-0`
- `find-bar.tsx`: same two edits, so the terminal and web find bars stay in lockstep with the address bar

Verified with `tsc --noEmit`, Vitest for find-bar / iframe-window / surface-layout (191 pass), and Playwright `web-tile-chrome`, `web-tile-find`, `terminal-tile-find` (11 pass). The control gallery does not render these rows, so its baselines are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
