### PR TITLE
fix(sidebar): rename the SERVER panel label to SERVERS

### DIFF
--- a/app/frontend/src/components/sidebar/index.core.test.tsx
+++ b/app/frontend/src/components/sidebar/index.core.test.tsx
@@ -688,7 +688,7 @@ describe("Sidebar", () => {
       // coupling to nested text-node layout) compared with indexing into
       // `document.body.querySelectorAll("*")`.
       const boardsHeader = screen.getByText("Boards");
-      const serverHeader = screen.getByText("Server", { selector: "span" });
+      const serverHeader = screen.getByText("Servers", { selector: "span" });
       const sessionsHeader = screen.getByText("Sessions", { selector: "span" });
 
       // Node.DOCUMENT_POSITION_FOLLOWING (4): the argument node follows the

--- a/app/frontend/src/components/sidebar/index.test.tsx
+++ b/app/frontend/src/components/sidebar/index.test.tsx
@@ -1791,7 +1791,7 @@ describe("Sidebar — section-visibility rail + gating (iha5)", () => {
     renderSidebar();
     expect(screen.getByTestId("section-rail")).toBeInTheDocument();
     expect(railToggle("Boards").getAttribute("aria-pressed")).toBe("true");
-    expect(railToggle("Server").getAttribute("aria-pressed")).toBe("true");
+    expect(railToggle("Servers").getAttribute("aria-pressed")).toBe("true");
     expect(railToggle("Pane").getAttribute("aria-pressed")).toBe("false");
     expect(railToggle("Host").getAttribute("aria-pressed")).toBe("false");
     expect(boardsHeader()).toBeInTheDocument();

--- a/app/frontend/src/components/sidebar/section-rail.test.tsx
+++ b/app/frontend/src/components/sidebar/section-rail.test.tsx
@@ -25,7 +25,7 @@ describe("SectionRail", () => {
     render(<SectionRail />);
     expect(railButtons().map((b) => b.getAttribute("aria-label"))).toEqual([
       "Toggle Boards section",
-      "Toggle Server section",
+      "Toggle Servers section",
       "Toggle Pane section",
       "Toggle Host section",
       "Toggle Clock section",
@@ -50,7 +50,7 @@ describe("SectionRail", () => {
     render(<SectionRail />);
     expect(railButtons().map((b) => b.getAttribute("aria-label"))).toEqual([
       "Toggle Boards section",
-      "Toggle Server section",
+      "Toggle Servers section",
       "Toggle Pane section",
       "Toggle Host section",
     ]);

--- a/app/frontend/src/components/sidebar/server-panel.test.tsx
+++ b/app/frontend/src/components/sidebar/server-panel.test.tsx
@@ -363,7 +363,7 @@ describe("ServerPanel", () => {
     seedCollapsed();
     renderPanel({ server: "work" });
 
-    expect(screen.getByText("Server")).toBeInTheDocument();
+    expect(screen.getByText("Servers")).toBeInTheDocument();
 
     // The name is shown by the highlighted tile and the top-bar heading — the
     // headerRight slot no longer duplicates it.

--- a/app/frontend/src/components/sidebar/server-panel.tsx
+++ b/app/frontend/src/components/sidebar/server-panel.tsx
@@ -119,7 +119,7 @@ export function ServerPanel({
 
   return (
     <CollapsiblePanel
-      title="Server"
+      title="Servers"
       storageKey="runkit-panel-server"
       defaultOpen={true}
       onToggle={handleToggle}

--- a/app/frontend/src/hooks/use-global-palette-actions.test.tsx
+++ b/app/frontend/src/hooks/use-global-palette-actions.test.tsx
@@ -218,7 +218,7 @@ describe("useGlobalPaletteActions", () => {
     renderHook();
     const byId = new Map(captured.map((a) => [a.id, a]));
     expect(byId.get("panel-toggle-boards")?.label).toBe("Panel: Toggle Boards");
-    expect(byId.get("panel-toggle-server")?.label).toBe("Panel: Toggle Server");
+    expect(byId.get("panel-toggle-server")?.label).toBe("Panel: Toggle Servers");
     expect(byId.get("panel-toggle-pane")?.label).toBe("Panel: Toggle Pane");
     expect(byId.get("panel-toggle-host")?.label).toBe("Panel: Toggle Host");
     expect(byId.get("panel-toggle-clock")?.label).toBe("Panel: Toggle Clock");

--- a/app/frontend/src/hooks/use-global-palette-actions.ts
+++ b/app/frontend/src/hooks/use-global-palette-actions.ts
@@ -211,7 +211,7 @@ export function useGlobalPaletteActions(): PaletteAction[] {
   const panelActions: PaletteAction[] = useMemo(
     () => [
       { id: "panel-toggle-boards", label: "Panel: Toggle Boards", onSelect: () => setBoardsVisible(!boardsVisible) },
-      { id: "panel-toggle-server", label: "Panel: Toggle Server", onSelect: () => setServerVisible(!serverVisible) },
+      { id: "panel-toggle-server", label: "Panel: Toggle Servers", onSelect: () => setServerVisible(!serverVisible) },
       { id: "panel-toggle-pane", label: "Panel: Toggle Pane", onSelect: () => setPaneVisible(!paneVisible) },
       { id: "panel-toggle-host", label: "Panel: Toggle Host", onSelect: () => setHostVisible(!hostVisible) },
       { id: "panel-toggle-clock", label: "Panel: Toggle Clock", onSelect: () => setClockVisible(!clockVisible) },

--- a/app/frontend/src/hooks/use-sidebar-sections.test.ts
+++ b/app/frontend/src/hooks/use-sidebar-sections.test.ts
@@ -22,7 +22,7 @@ function renderSection(section: SidebarSection) {
 describe("SIDEBAR_SECTIONS", () => {
   it("lists exactly Boards · Server · Pane · Host · Clock in order (no Sessions)", () => {
     expect(SIDEBAR_SECTIONS.map((e) => e.section)).toEqual(["boards", "server", "pane", "host", "clock"]);
-    expect(SIDEBAR_SECTIONS.map((e) => e.label)).toEqual(["Boards", "Server", "Pane", "Host", "Clock"]);
+    expect(SIDEBAR_SECTIONS.map((e) => e.label)).toEqual(["Boards", "Servers", "Pane", "Host", "Clock"]);
   });
 
   it("uses runkit-sidebar-section-{section} keys with boards/server on, pane/host/clock off by default", () => {

--- a/app/frontend/src/hooks/use-sidebar-sections.ts
+++ b/app/frontend/src/hooks/use-sidebar-sections.ts
@@ -20,7 +20,7 @@ export const SIDEBAR_SECTIONS: readonly {
   desktopOnly?: boolean;
 }[] = [
   { section: "boards", key: "runkit-sidebar-section-boards", defaultValue: true, label: "Boards" },
-  { section: "server", key: "runkit-sidebar-section-server", defaultValue: true, label: "Server" },
+  { section: "server", key: "runkit-sidebar-section-server", defaultValue: true, label: "Servers" },
   { section: "pane", key: "runkit-sidebar-section-pane", defaultValue: false, label: "Pane" },
   { section: "host", key: "runkit-sidebar-section-host", defaultValue: false, label: "Host" },
   { section: "clock", key: "runkit-sidebar-section-clock", defaultValue: false, label: "Clock", desktopOnly: true },

--- a/app/frontend/tests/e2e/sidebar-section-rail.spec.ts
+++ b/app/frontend/tests/e2e/sidebar-section-rail.spec.ts
@@ -86,7 +86,7 @@ test.describe("Sidebar section-visibility rail", () => {
     );
     expect(labels).toEqual([
       "Toggle Boards section",
-      "Toggle Server section",
+      "Toggle Servers section",
       "Toggle Pane section",
       "Toggle Host section",
       "Toggle Clock section",
@@ -96,7 +96,7 @@ test.describe("Sidebar section-visibility rail", () => {
     // Defaults: Boards/Server pressed, Pane/Host/Clock not — and the gated
     // sections render accordingly (PANE/HOST/CLOCK absent by default).
     await expect(railToggle(page, "Boards")).toHaveAttribute("aria-pressed", "true");
-    await expect(railToggle(page, "Server")).toHaveAttribute("aria-pressed", "true");
+    await expect(railToggle(page, "Servers")).toHaveAttribute("aria-pressed", "true");
     await expect(railToggle(page, "Pane")).toHaveAttribute("aria-pressed", "false");
     await expect(railToggle(page, "Host")).toHaveAttribute("aria-pressed", "false");
     await expect(railToggle(page, "Clock")).toHaveAttribute("aria-pressed", "false");
@@ -211,7 +211,7 @@ test.describe("Sidebar section-visibility rail", () => {
 
       await expect(drawer.getByRole("button", { name: "Toggle Clock section" })).toHaveCount(0);
       await expect(railToggle(page, "Boards")).toBeVisible();
-      await expect(railToggle(page, "Server")).toBeVisible();
+      await expect(railToggle(page, "Servers")).toBeVisible();
       await expect(railToggle(page, "Pane")).toBeVisible();
       await expect(railToggle(page, "Host")).toBeVisible();
     });


### PR DESCRIPTION
Renames the left-panel server label from SERVER to SERVERS across the panel title, sidebar rail, command-palette action, and their tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)