### PR TITLE
docs(gui): link the GUI guide from Help topics, rk gui help, the skill topic, and the install guide

### DIFF
--- a/app/backend/cmd/rk/gui.go
+++ b/app/backend/cmd/rk/gui.go
@@ -229,6 +229,9 @@ hint) and refuse while a human drove the display in the last 3s (retry, or
 --force to override). Coordinates are display pixels; 'shot' reports its
 source geometry and scale on stderr.
 
+Guide (desktops, resolution, phone controls, troubleshooting):
+  https://shll.ai/run-kit/gui/
+
 See 'run-kit gui <subcommand> --help' for details.`,
 }
 

--- a/app/backend/cmd/rk/gui_wm.go
+++ b/app/backend/cmd/rk/gui_wm.go
@@ -76,7 +76,10 @@ the GUI is off or the daemon is down).
 first, then the known-but-missing ones with their install lines — and exits
 0 (read-only: LookPath only, no settings write, no tmux). --list --json
 emits the wm_candidates array verbatim (the same JSON GET /api/gui/host
-carries).`,
+carries).
+
+The desktop table, install lines, and the bare-binary caveat are written up
+for humans at https://shll.ai/run-kit/gui/.`,
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	RunE:         runGuiWM,

--- a/app/backend/cmd/rk/skill/gui.md
+++ b/app/backend/cmd/rk/skill/gui.md
@@ -1,6 +1,6 @@
 # HexoKit skill: gui
 
-Depth for one job: **driving and screenshotting the host GUI display** — the host's desktop, run by the `rk-gui` session and rendered for the human as the GUI tile: they see the same pixels you act on. This is a static topic page (`rk skill gui`); the [core bundle](../skill.md) covers when to reach for HexoKit at all. Everything here is byte-identical on every invocation.
+Depth for one job: **driving and screenshotting the host GUI display** — the host's desktop, run by the `rk-gui` session and rendered for the human as the GUI tile: they see the same pixels you act on. This is a static topic page (`rk skill gui`); the [core bundle](../skill.md) covers when to reach for HexoKit at all; the human-facing guide (desktops, resolution, phone controls) is [gui](../gui.md). Everything here is byte-identical on every invocation.
 
 Reach for it when the job needs a real display: chromium, `xdg-open`, Playwright headed mode, or a computer-use loop. One screen per host (`id = host`), shared with the human.
 

--- a/app/frontend/src/components/top-bar-overflow-menu.test.tsx
+++ b/app/frontend/src/components/top-bar-overflow-menu.test.tsx
@@ -215,7 +215,7 @@ describe("HelpTopicsMenuRow", () => {
     expect(screen.queryByRole("group", { name: "Help topics" })).not.toBeInTheDocument();
   });
 
-  it("click expands to the six registry rows in order and keeps the menu open", () => {
+  it("click expands to the seven registry rows in order and keeps the menu open", () => {
     renderMenu({ daemonVersion: "0.6.2", updateAvailable: null }, { rows: [helpTopicsRow(false)] });
     openMenu();
     fireEvent.click(disclosure());
@@ -236,13 +236,13 @@ describe("HelpTopicsMenuRow", () => {
     renderMenu({ daemonVersion: "0.6.2", updateAvailable: null }, { rows: [helpTopicsRow(false)] });
     openMenu();
     fireEvent.click(disclosure());
-    expect(topicRows()).toHaveLength(6);
+    expect(topicRows()).toHaveLength(7);
     fireEvent.click(disclosure());
     expect(topicRows()).toHaveLength(0);
     expect(disclosure()).toHaveAttribute("aria-expanded", "false");
 
     fireEvent.keyDown(disclosure(), { key: "ArrowRight" });
-    expect(topicRows()).toHaveLength(6);
+    expect(topicRows()).toHaveLength(7);
     fireEvent.keyDown(disclosure(), { key: "ArrowLeft" });
     expect(topicRows()).toHaveLength(0);
     expect(disclosure()).toHaveAttribute("aria-expanded", "false");
@@ -270,7 +270,7 @@ describe("HelpTopicsMenuRow", () => {
     openMenu();
     fireEvent.click(disclosure());
     const rows = topicRows();
-    expect(rows).toHaveLength(6);
+    expect(rows).toHaveLength(7);
     for (const row of rows) expect(row).toHaveTextContent("↗");
   });
 

--- a/app/frontend/src/hooks/use-global-palette-actions.test.tsx
+++ b/app/frontend/src/hooks/use-global-palette-actions.test.tsx
@@ -114,6 +114,7 @@ describe("useGlobalPaletteActions", () => {
       "help-topic-cron-schedule-kinds",
       "help-topic-boards",
       "help-topic-notifications",
+      "help-topic-gui",
       "help-topic-merge-topologies",
       "help-topic-fkf",
       "settings-open",

--- a/app/frontend/src/lib/help-topics.test.ts
+++ b/app/frontend/src/lib/help-topics.test.ts
@@ -13,12 +13,13 @@ afterEach(() => {
 });
 
 describe("HELP_TOPICS registry", () => {
-  it("lists the six curated topics in display order", () => {
+  it("lists the seven curated topics in display order", () => {
     expect(HELP_TOPICS.map((t) => t.id)).toEqual([
       "status-dot",
       "cron-schedule-kinds",
       "boards",
       "notifications",
+      "gui",
       "merge-topologies",
       "fkf",
     ]);
@@ -41,12 +42,12 @@ describe("HELP_TOPICS registry", () => {
     }
   });
 
-  it("tags the two fab-kit pages and the four run-kit pages by tool", () => {
+  it("tags the two fab-kit pages and the five run-kit pages by tool", () => {
     expect(HELP_TOPICS.filter((t) => t.tool === "fab-kit").map((t) => t.id)).toEqual([
       "merge-topologies",
       "fkf",
     ]);
-    expect(HELP_TOPICS.filter((t) => t.tool === "run-kit")).toHaveLength(4);
+    expect(HELP_TOPICS.filter((t) => t.tool === "run-kit")).toHaveLength(5);
   });
 });
 

--- a/app/frontend/src/lib/help-topics.ts
+++ b/app/frontend/src/lib/help-topics.ts
@@ -39,6 +39,7 @@ export const HELP_TOPICS: readonly HelpTopic[] = [
   { id: "cron-schedule-kinds", label: "Cron schedule kinds", url: "https://shll.ai/run-kit/cron-schedule-kinds/", tool: "run-kit" },
   { id: "boards", label: "Boards", url: "https://shll.ai/run-kit/boards/", tool: "run-kit" },
   { id: "notifications", label: "Notifications", url: "https://shll.ai/run-kit/notifications/", tool: "run-kit" },
+  { id: "gui", label: "GUI desktop", url: "https://shll.ai/run-kit/gui/", tool: "run-kit" },
   { id: "merge-topologies", label: "Merge topologies", url: "https://shll.ai/fab-kit/merge-topologies/", tool: "fab-kit" },
   { id: "fkf", label: "FKF", url: "https://shll.ai/fab-kit/fkf/", tool: "fab-kit" },
 ];

--- a/app/frontend/tests/e2e/help-topics.spec.ts
+++ b/app/frontend/tests/e2e/help-topics.spec.ts
@@ -39,6 +39,7 @@ const TOPIC_LABELS = [
   "Cron schedule kinds",
   "Boards",
   "Notifications",
+  "GUI desktop",
   "Merge topologies",
   "FKF",
 ];
@@ -64,7 +65,7 @@ function openedUrls(page: Page): Promise<string[]> {
 }
 
 /** Open the chevron menu and expand the Help topics disclosure; returns the
- *  menu locator with the six topic rows visible. */
+ *  menu locator with the seven topic rows visible. */
 async function expandHelpTopics(page: Page) {
   await page.getByRole("button", { name: "More controls" }).click();
   const menu = page.getByRole("menu", { name: "More controls" });
@@ -104,7 +105,7 @@ test.describe("Help topics", () => {
    * Steps:
    * 1. Navigate to the menu window and confirm it has no web tab
    *    (`@rk_win_web_1` is empty).
-   * 2. Open the `More controls` menu and click `Help topics`; assert the six
+   * 2. Open the `More controls` menu and click `Help topics`; assert the seven
    *    rows render in registry order and none contains ↗.
    * 3. Click `Cron schedule kinds`; assert the menu closes.
    * 4. Poll tmux: `@rk_win_web_1` equals the topic URL, `@rk_win_web_active`

--- a/docs/site/install.md
+++ b/docs/site/install.md
@@ -86,7 +86,7 @@ It binds loopback-only on `RK_PORT+2`; set `RK_CODE_SERVER_PORT` only to point H
 - A running tmux session (`$TMUX` set).
 - [`wt`](https://github.com/sahil87/wt) on your `PATH` — included with the [full-toolkit install](https://shll.ai), or `shll install wt`.
 - The launcher (default `claude --dangerously-skip-permissions`) available.
-- Optional — the GUI tile (the host's desktop in the dashboard) needs a VNC X server and a window manager: `sudo apt install --no-install-recommends tigervnc-standalone-server icewm` on Debian/Ubuntu; `rk gui status` prints the line for your package manager. See the [GUI guide](gui.md).
+- Optional — the GUI tile (the host's desktop in the dashboard) needs a VNC X server and a window manager: `sudo apt install --no-install-recommends tigervnc-standalone-server icewm` on Debian/Ubuntu; `rk gui status` prints the line for your package manager. Desktops, resolution, and troubleshooting: the [GUI guide](gui.md). See the [GUI guide](gui.md).
 
 When something breaks, run:
 

--- a/docs/site/skill/gui.md
+++ b/docs/site/skill/gui.md
@@ -1,6 +1,6 @@
 # HexoKit skill: gui
 
-Depth for one job: **driving and screenshotting the host GUI display** — the host's desktop, run by the `rk-gui` session and rendered for the human as the GUI tile: they see the same pixels you act on. This is a static topic page (`rk skill gui`); the [core bundle](../skill.md) covers when to reach for HexoKit at all. Everything here is byte-identical on every invocation.
+Depth for one job: **driving and screenshotting the host GUI display** — the host's desktop, run by the `rk-gui` session and rendered for the human as the GUI tile: they see the same pixels you act on. This is a static topic page (`rk skill gui`); the [core bundle](../skill.md) covers when to reach for HexoKit at all; the human-facing guide (desktops, resolution, phone controls) is [gui](../gui.md). Everything here is byte-identical on every invocation.
 
 Reach for it when the job needs a real display: chromium, `xdg-open`, Playwright headed mode, or a computer-use loop. One screen per host (`id = host`), shared with the human.
 


### PR DESCRIPTION
## Summary

The GUI guide (`docs/site/gui.md`, shipped in #946) was linked only from the README. This wires it into run-kit's own help surfaces:

- **Top-right chevron menu → Help topics** gains a `GUI desktop` row, with its palette twin `Help: GUI desktop` (one registry entry in `help-topics.ts`, Constitution V holds).
- **`rk gui --help`** and **`rk gui wm --help`** name the guide URL.
- **`rk skill gui`** (agent topic) points at the human guide in its intro line; the embedded copy is re-synced, page stays at 140/150 lines.
- **Install guide** optional-packages line links the guide.

## Test plan

- [x] `just test-backend` — green (skill drift guard included)
- [x] `just test-frontend` — 222 files / 4607 tests green (three hardcoded six-topic counts bumped to seven)
- [x] `just test-e2e "e2e/help-topics"` — 4 passed
- [x] `pnpm exec tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)